### PR TITLE
ci(workflow): switch to reusable workflow_call for build and deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   repository_dispatch:
     types: [build]
   workflow_dispatch:
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io
@@ -63,33 +64,11 @@ jobs:
 
   trigger-deploy:
     needs: [build-backend]
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-
-    steps:
-      - name: Trigger deployment workflow
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: deploy
-          client-payload: |
-            {
-              "ref": "${{ github.ref }}",
-              "sha": "${{ github.sha }}"
-            }
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit
 
   trigger-frontend:
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    
-    steps:
-      - name: Trigger Frontend Deployment
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: deploy-frontend
-          client-payload: |
-            {
-              "ref": "${{ github.ref }}",
-              "sha": "${{ github.sha }}"
-            }
+    uses: ./.github/workflows/deploy-frontend.yml
+    secrets: inherit

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -4,6 +4,7 @@ on:
   repository_dispatch:
     types: [deploy-frontend]
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,12 +153,5 @@ jobs:
 
   trigger-build:
     needs: [changes, frontend-build, backend-checks]
-    runs-on: ubuntu-latest
     if: always() && !cancelled() && github.ref == 'refs/heads/master' && (needs.frontend-build.result == 'success' || needs.frontend-build.result == 'skipped') && (needs.backend-checks.result == 'success' || needs.backend-checks.result == 'skipped') && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true')
-
-    steps:
-      - name: Trigger build workflow
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: build
+    uses: ./.github/workflows/build.yml


### PR DESCRIPTION
- add workflow_call to build.yml and deploy-frontend.yml
- replace repository-dispatch steps with reusable workflow usage (uses: ./.github/workflows/...)
- inherit secrets for deploy jobs and remove redundant runs-on/dispatch steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub Actions workflow configuration to improve build and deployment pipeline structure.
  * Enhanced CI/CD orchestration and workflow reusability across the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->