### PR TITLE
ci(workflows): always auto-commit ESLint/prek fixes and simplify git push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,9 +75,7 @@ jobs:
       - name: Run ESLint with autofix
         run: pnpm lint:fix
 
-      # Auto-commit ESLint fixes back to PR (only runs on pull_request events)
       - name: Commit ESLint fixes (if any)
-        if: github.event_name == 'pull_request'
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
@@ -86,7 +84,7 @@ jobs:
             echo "Files were modified by ESLint. Committing changes..."
             git add .
             git commit -m "ci(auto-fix): Apply ESLint formatting"
-            git push origin HEAD:${{ github.head_ref }}
+            git push
           else
             echo "✅ No ESLint fixes needed"
           fi
@@ -152,22 +150,17 @@ jobs:
           echo "Running prek checks..."
           uvx prek run --all-files --show-diff-on-failure
 
-          # Auto-commit fixes on PRs, fail on master if changes detected
-          if ! git diff --exit-code && [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "Files were modified by pre-commit hooks. Changes:"
+          # Auto-commit fixes if changes were made
+          if ! git diff --exit-code; then
+            echo "Files were modified by prek hooks. Changes:"
             git diff --name-only
 
-            # Commit the changes
+            # Commit and push the changes
             git add .
-            git commit -m "ci(auto-fix): Apply pre-commit hooks formatting"
+            git commit -m "ci(auto-fix): Apply formatting"
+            git push
 
-            # Push the changes back to the PR branch
-            git push origin HEAD:${{ github.head_ref }}
-
-            echo "✅ Auto-applied formatting fixes and pushed to PR"
-          elif ! git diff --exit-code; then
-            echo "⚠️ Files were modified but not on a PR - cannot auto-commit"
-            exit 1
+            echo "✅ Auto-applied formatting fixes and pushed"
           else
             echo "✅ No formatting issues found"
           fi


### PR DESCRIPTION
- Remove PR-only guard for frontend ESLint auto-commit so autofixes are committed on any run
- Replace explicit "git push origin HEAD:${{ github.head_ref }}" with plain "git push" to let the runner handle refs
- Simplify backend prek auto-fix flow: remove PR-only/master-fail branches, always commit & push formatting fixes when present
- Normalize commit messages for auto-fixes and update logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * No user-facing changes. Internal improvements to development workflow automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->