### PR TITLE
ci(workflows): remove global and trigger-build concurrency controls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,6 @@ on:
       - master
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -177,8 +173,5 @@ jobs:
     needs: [changes, frontend-build, backend-checks]
     # Runs if: on master branch + (checks succeeded or were skipped) + changes detected
     if: always() && !cancelled() && github.ref == 'refs/heads/master' && (needs.frontend-build.result == 'success' || needs.frontend-build.result == 'skipped') && (needs.backend-checks.result == 'success' || needs.backend-checks.result == 'skipped') && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true')
-    concurrency:
-      group: build-${{ github.ref }}
-      cancel-in-progress: false
     uses: ./.github/workflows/build.yml
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
Remove the top-level concurrency block and the trigger-build job concurrency setting from main.yml to simplify workflow coordination and avoid automatic cancellation of in-progress runs.