### PR TITLE
chore(release): configure independent versioning for all apps in monorepo

### DIFF
--- a/apps/mobile/CHANGELOG.md
+++ b/apps/mobile/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gia-mobile",
+  "name": "gaia-mobile",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "scripts": {
     "start": "expo start --port 8083",
     "reset-project": "node ./scripts/reset-project.js",

--- a/config/.release-please-manifest.json
+++ b/config/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "apps/api": "0.10.1",
   "apps/web": "0.10.1",
-  "apps/desktop": "0.1.0"
+  "apps/desktop": "0.1.0",
+  "apps/mobile": "0.1.0"
 }

--- a/config/release-please-config-fallback.json
+++ b/config/release-please-config-fallback.json
@@ -1,14 +1,6 @@
 {
   "separate-pull-requests": false,
-  "include-component-in-tag": false,
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "gaia",
-      "components": ["api", "web", "desktop"],
-      "merge": true
-    }
-  ],
+  "include-component-in-tag": true,
   "packages": {
     "apps/api": {
       "release-type": "python",
@@ -23,6 +15,11 @@
     "apps/desktop": {
       "release-type": "node",
       "component": "desktop",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "apps/mobile": {
+      "release-type": "node",
+      "component": "mobile",
       "changelog-path": "CHANGELOG.md"
     }
   }

--- a/config/release-please-config.json
+++ b/config/release-please-config.json
@@ -1,14 +1,6 @@
 {
   "separate-pull-requests": false,
-  "include-component-in-tag": false,
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "gaia",
-      "components": ["api", "web", "desktop"],
-      "merge": true
-    }
-  ],
+  "include-component-in-tag": true,
   "packages": {
     "apps/api": {
       "release-type": "python",
@@ -25,6 +17,12 @@
     "apps/desktop": {
       "release-type": "node",
       "component": "desktop",
+      "changelog-path": "CHANGELOG.md",
+      "changelog-type": "github"
+    },
+    "apps/mobile": {
+      "release-type": "node",
+      "component": "mobile",
       "changelog-path": "CHANGELOG.md",
       "changelog-type": "github"
     }


### PR DESCRIPTION

## Changes
- Remove `linked-versions` plugin - each app now versions independently
- Add mobile app to release-please configuration
- Enable `include-component-in-tag` for component-prefixed release tags
- Reset mobile to `0.1.0` for fresh versioning
## GitHub Releases After This Change
Each app will have its own release with component-prefixed tags:
| App | Tag Format | Example |
|-----|------------|---------|
| API | `api-v{version}` | `api-v0.10.2` |
| Web | `web-v{version}` | `web-v0.10.2` |
| Desktop | `desktop-v{version}` | `desktop-v0.1.1` |
| Mobile | `mobile-v{version}` | `mobile-v0.1.1` |

This allows each app to evolve on its own release cadence.