### PR TITLE
ci(build): Add libglib2.0-0 dependency to voice agent Dockerfile.

### DIFF
--- a/apps/api/Dockerfile.voice-agent
+++ b/apps/api/Dockerfile.voice-agent
@@ -12,7 +12,8 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   build-essential \
   curl \
-  libpq-dev && \
+  libpq-dev \
+  libglib2.0-0 && \
   rm -rf /var/lib/apt/lists/*
 
 # Copy dependency files


### PR DESCRIPTION
This pull request makes a minor update to the `apps/api/Dockerfile.voice-agent` file by adding a new system package dependency required for the application.

- Added the `libglib2.0-0` package to the list of installed dependencies in the Dockerfile to support additional runtime requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image system dependencies to include additional libraries required for the voice-agent API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->