### PR TITLE
fix: idempotency for incoming webhhooks from dodpayments ignoring already processed webhooks

### DIFF
--- a/apps/api/app/api/v1/endpoints/payments.py
+++ b/apps/api/app/api/v1/endpoints/payments.py
@@ -103,8 +103,8 @@ async def handle_dodo_webhook(
         # Parse webhook data
         webhook_data = json.loads(payload)
 
-        # Process the webhook
-        result = await payment_webhook_service.process_webhook(webhook_data)
+        # Process the webhook with idempotency check using webhook_id
+        result = await payment_webhook_service.process_webhook(webhook_data, webhook_id)
 
         logger.info(f"Webhook processed: {result.event_type} - {result.status}")
         return {

--- a/apps/api/app/db/mongodb/collections.py
+++ b/apps/api/app/db/mongodb/collections.py
@@ -121,6 +121,7 @@ _COLLECTION_MAPPINGS = {
     "user_integrations_collection": "user_integrations",
     "device_tokens_collection": "device_tokens",
     "workflow_executions_collection": "workflow_executions",
+    "processed_webhooks_collection": "processed_webhooks",
 }
 
 


### PR DESCRIPTION
tested locally using curl by sending same subscription.activated event twice

sample test payload-

curl -X POST http://localhost:8000/api/v1/payments/webhooks/dodo \
  -H "Content-Type: application/json" \
  -H "webhook-id: test-sub-active-002" \
  -H "webhook-timestamp: 1708000000" \
  -H "webhook-signature: dummy" \
  -d '{
    "business_id": "biz_test123",
    "type": "subscription.active",
    "timestamp": "2026-02-15T10:00:00Z",
    "data": {
      "subscription_id": "sub_test_002",
      "product_id": "pdt_uk3I7Vh2GI5oscYoRRoa9",
      "customer": {"customer_id": "cust_1", "email": "45vinitthakkar@gmail.com", "name": "Vinit Thakkar"},
      "billing": {"city": "NYC", "country": "US", "state": "NY", "street": "123 Test St", "zipcode": "10001"},
      "status": "active",
      "currency": "USD",
      "quantity": 1,
      "recurring_pre_tax_amount": 1500,
      "payment_frequency_count": 1,
      "payment_frequency_interval": "month",
      "subscription_period_count": 1,
      "subscription_period_interval": "month",
      "next_billing_date": "2026-03-15T10:00:00Z",
      "created_at": "2026-02-15T10:00:00Z",
      "cancel_at_next_billing_date": false,
      "tax_inclusive": false,
      "trial_period_days": 0,
      "on_demand": false,
      "metadata": {"user_id": "697f5d24eb57a2365ea54c6e"}
    }
  }'