### PR TITLE
feat: add handling query parameter for deep linking

### DIFF
--- a/apps/web/src/features/chat/components/interface/ChatPage.tsx
+++ b/apps/web/src/features/chat/components/interface/ChatPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { chatApi } from "@/features/chat/api/chatApi";
 import { VoiceApp } from "@/features/chat/components/composer/VoiceModeOverlay";
@@ -28,8 +28,10 @@ const ChatPage = React.memo(function MainChat() {
   const setActiveConversationId = useChatStore(
     (state) => state.setActiveConversationId,
   );
+  const router = useRouter();
   const searchParams = useSearchParams();
   const shouldSync = searchParams.get("sync") === "true";
+  const queryParam = searchParams.get("q");
 
   // Fetching status on chat-page to resolve caching issues when new integration is connected
   useFetchIntegrationStatus({
@@ -109,6 +111,16 @@ const ChatPage = React.memo(function MainChat() {
       clearPendingPrompt();
     }
   }, [pendingPrompt, clearPendingPrompt, appendToInputRef]);
+
+  // Handle ?q= query parameter for external app deep linking
+  useEffect(() => {
+    if (queryParam && appendToInputRef.current) {
+      appendToInputRef.current(queryParam);
+      const url = new URL(window.location.href);
+      url.searchParams.delete("q");
+      router.replace(url.pathname + url.search, { scroll: false });
+    }
+  }, [queryParam, appendToInputRef, router]);
 
   // Common composer props
   const composerProps = {


### PR DESCRIPTION
This pull request introduces support for deep linking to the chat page via the `?q=` query parameter, allowing external apps to pre-fill the chat input. The implementation ensures that after the input is populated, the query parameter is removed from the URL for a cleaner user experience.

**Deep linking and input handling:**

* Added logic to detect the `?q=` query parameter, pre-fill the chat input with its value, and then remove the parameter from the URL without reloading the page. [[1]](diffhunk://#diff-0d35be4b3a2defa8d65069fdaf2ef759a692bd35a3b54c1ed6da79c02d14ef17R31-R34) [[2]](diffhunk://#diff-0d35be4b3a2defa8d65069fdaf2ef759a692bd35a3b54c1ed6da79c02d14ef17R115-R124)
* Imported `useRouter` from `next/navigation` to enable URL manipulation for removing the query parameter after use.

example: 
- heygaia.io/c?q=hello+gaia+explain+this+to+me
- heygaia.io/c/[id]?q=hello+gaia+explain+this+to+me

Preview from other site:
<img width="528" height="103" alt="image" src="https://github.com/user-attachments/assets/b1215fff-c5bd-4c98-b96d-5e759807de7c" />
