### PR TITLE
fix: Enhance MCPClient connection handling with token refresh and status updates on auth errors

### DIFF
--- a/apps/api/app/services/mcp/mcp_client.py
+++ b/apps/api/app/services/mcp/mcp_client.py
@@ -289,7 +289,11 @@ class MCPClient:
                 event.set()
 
     async def _do_connect(self, integration_id: str) -> list[BaseTool]:
-        """Internal connect implementation."""
+        """Internal connect implementation.
+
+        Includes a single retry on auth-related failures (401, 405 from
+        OAuth fallback, etc.) — refreshes the token and retries once.
+        """
         # Resolve integration from platform config or MongoDB
         resolved = await IntegrationResolver.resolve(integration_id)
         if not resolved or not resolved.mcp_config:
@@ -347,6 +351,11 @@ class MCPClient:
                         try:
                             loop = asyncio.get_running_loop()
                             loop.create_task(self._safe_close_client(stale_client))
+                            loop.create_task(
+                                update_user_integration_status(
+                                    self.user_id, iid, "created"
+                                )
+                            )
                         except RuntimeError:
                             pass  # No running loop — skip async cleanup
                     logger.info(f"[{iid}] Evicted stale session after connection error")
@@ -444,9 +453,64 @@ class MCPClient:
                 )
                 raise StepUpAuthRequired(integration_id, required_scopes) from e
 
+            # Retry once on auth-related failures: 401 (expired token) or
+            # 405 (mcp-use OAuth fallback hit a wrong endpoint because the
+            # token we passed was rejected). Refresh the token and retry.
+            is_auth_error = (
+                any(code in str(e) for code in ("401", "405", "403"))
+                or "unauthorized" in error_str
+                or "method not allowed" in error_str
+            )
+            retry_flag = f"_retry_{integration_id}"
+            if (
+                is_auth_error
+                and mcp_config.requires_auth
+                and not getattr(self, retry_flag, False)
+            ):
+                logger.info(
+                    f"[{integration_id}] Auth-related connection failure, "
+                    "attempting token refresh and retry"
+                )
+                setattr(self, retry_flag, True)
+                try:
+                    refreshed = await self._try_refresh_token(
+                        integration_id, mcp_config
+                    )
+                    if refreshed:
+                        logger.info(
+                            f"[{integration_id}] Token refreshed, retrying connection"
+                        )
+                        return await self._do_connect(integration_id)
+                    else:
+                        logger.warning(
+                            f"[{integration_id}] Token refresh "
+                            "failed, user may need to re-authorize"
+                        )
+                finally:
+                    try:
+                        delattr(self, retry_flag)
+                    except AttributeError:
+                        pass
+
             logger.error(f"Failed to connect to MCP {integration_id}: {e}")
-            # Note: Status is managed in MongoDB user_integrations, not PostgreSQL
-            # PostgreSQL mcp_credentials only stores auth tokens
+            # Reset MongoDB status so frontend shows re-auth flow
+            try:
+                await update_user_integration_status(
+                    self.user_id, integration_id, "created"
+                )
+            except Exception:
+                logger.warning(
+                    f"[{integration_id}] Failed to reset status after connection failure"
+                )
+            # If auth-related, clear cached OAuth discovery so next attempt
+            # does fresh discovery instead of reusing stale endpoints
+            if is_auth_error:
+                try:
+                    await delete_cache(f"{OAUTH_DISCOVERY_PREFIX}:{integration_id}")
+                except Exception as cache_err:  # nosec B110
+                    logger.debug(
+                        f"[{integration_id}] Failed to clear OAuth discovery cache: {cache_err}"
+                    )
             raise
 
     async def _handle_custom_integration_connect(
@@ -638,6 +702,21 @@ class MCPClient:
             scope_str = " ".join(mcp_config.oauth_scopes)
         elif oauth_config.get("scopes_supported"):
             scope_str = " ".join(oauth_config["scopes_supported"])
+
+        # Inject offline_access if the server supports it and it's not already present.
+        # This is the key to "connect once, stay forever" — without it many OAuth servers
+        # issue short-lived or session-only refresh tokens (like a browser session cookie).
+        # offline_access tells the server: issue a long-lived refresh token for background use.
+        # We only add it when the server advertises support to avoid breaking servers that
+        # reject unknown scopes.
+        scopes_supported = oauth_config.get("scopes_supported", [])
+        scope_parts = scope_str.split() if scope_str else []
+        if "offline_access" in scopes_supported and "offline_access" not in scope_parts:
+            scope_parts.append("offline_access")
+            scope_str = " ".join(scope_parts)
+            logger.info(
+                f"[{integration_id}] Added offline_access scope for long-lived refresh token"
+            )
 
         # Get resource URL for token binding (RFC 8707)
         # This ensures the token is bound to the specific MCP server
@@ -947,8 +1026,11 @@ class MCPClient:
                 f"  Rolling back tokens to prevent stuck state.\n"
                 f"  Traceback:\n{traceback.format_exc()}"
             )
-            # Delete the tokens we just stored since connection failed
+            # Delete the tokens and DCR registration we just stored since
+            # connection failed — if the DCR client_id is revoked/invalid,
+            # keeping it would trap the user in a re-auth loop
             await self.token_store.delete_credentials(integration_id)
+            await self.token_store.delete_dcr_client(integration_id)
             raise
 
     async def disconnect(self, integration_id: str) -> None:
@@ -1007,6 +1089,16 @@ class MCPClient:
 
         # Delete credentials from PostgreSQL (for both authenticated and unauthenticated MCPs)
         await self.token_store.delete_credentials(integration_id)
+
+        # Update MongoDB status so frontend reflects disconnected state
+        try:
+            await update_user_integration_status(
+                self.user_id, integration_id, "created"
+            )
+        except Exception as e:
+            logger.warning(
+                f"[{integration_id}] Failed to reset MongoDB status on disconnect: {e}"
+            )
 
         logger.info(f"Disconnected MCP {integration_id}")
 
@@ -1086,6 +1178,14 @@ class MCPClient:
             return await self.connect(integration_id)
         except Exception as e:
             logger.warning(f"Failed to connect MCP {integration_id}: {e}")
+            try:
+                await update_user_integration_status(
+                    self.user_id, integration_id, "created"
+                )
+            except Exception as status_err:  # nosec B110
+                logger.debug(
+                    f"Failed to reset status for {integration_id}: {status_err}"
+                )
             return None
 
     async def get_all_connected_tools(self) -> dict[str, list[BaseTool]]:

--- a/apps/api/app/services/mcp/mcp_token_store.py
+++ b/apps/api/app/services/mcp/mcp_token_store.py
@@ -118,9 +118,18 @@ class MCPTokenStore:
     async def is_token_expiring_soon(
         self, integration_id: str, threshold_seconds: int = 300
     ) -> bool:
-        """Check if token expires within threshold (default 5 minutes)."""
+        """Check if token expires within threshold (default 5 minutes).
+
+        Also returns True when token_expires_at is not set but the token
+        was issued more than ``max_age_seconds`` ago — servers can revoke
+        tokens at any time, so proactively refreshing stale tokens avoids
+        connection failures from expired-but-unknown-expiry tokens.
+        """
         cred = await self.get_credential(integration_id)
-        if cred and cred.token_expires_at:
+        if not cred:
+            return False
+
+        if cred.token_expires_at:
             from datetime import timedelta
 
             # Use naive UTC for comparison with stored naive timestamps
@@ -128,6 +137,19 @@ class MCPTokenStore:
                 datetime.now(timezone.utc) + timedelta(seconds=threshold_seconds)
             ).replace(tzinfo=None)
             return cred.token_expires_at < expiry_threshold
+
+        # No expires_at stored — treat tokens older than 1 hour as stale
+        # so we proactively refresh them rather than discovering they're
+        # expired only when mcp-use fails to connect.
+        max_age_seconds = 3600
+        if cred.connected_at:
+            from datetime import timedelta
+
+            age_threshold = (
+                datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds)
+            ).replace(tzinfo=None)
+            return cred.connected_at < age_threshold
+
         return False
 
     async def store_bearer_token(self, integration_id: str, token: str) -> None:
@@ -379,6 +401,27 @@ class MCPTokenStore:
             except json.JSONDecodeError:
                 return None
         return None
+
+    async def delete_dcr_client(self, integration_id: str) -> None:
+        """Delete stored DCR client registration.
+
+        Clears the client_registration field so the next OAuth flow
+        performs fresh Dynamic Client Registration instead of reusing
+        a potentially revoked/invalid client_id.
+        """
+        async with get_db_session() as session:
+            result = await session.execute(
+                select(MCPCredential).where(
+                    MCPCredential.user_id == self.user_id,
+                    MCPCredential.integration_id == integration_id,
+                )
+            )
+            cred = result.scalar_one_or_none()
+            if cred and cred.client_registration:
+                cred.client_registration = None
+                session.add(cred)
+                await session.commit()
+                logger.info(f"Deleted DCR client for {integration_id}")
 
     async def store_dcr_client(self, integration_id: str, dcr_data: dict) -> None:
         """Store DCR client registration from dynamic registration."""

--- a/apps/api/app/services/mcp/token_management.py
+++ b/apps/api/app/services/mcp/token_management.py
@@ -40,11 +40,13 @@ async def try_refresh_token(
     """Attempt to refresh OAuth token using stored refresh_token."""
     refresh_token = await token_store.get_refresh_token(integration_id)
     if not refresh_token:
+        logger.info(f"No refresh token stored for {integration_id}, cannot refresh")
         return False
 
     try:
         token_endpoint = oauth_config.get("token_endpoint")
         if not token_endpoint:
+            logger.warning(f"No token_endpoint in OAuth config for {integration_id}")
             return False
 
         client_id, client_secret = resolve_client_credentials(mcp_config)
@@ -55,6 +57,9 @@ async def try_refresh_token(
                 client_secret = dcr_data.get("client_secret")
 
         if not client_id:
+            logger.warning(
+                f"No client_id for refresh, user must re-authorize {integration_id}"
+            )
             return False
 
         resource = oauth_config.get("resource", mcp_config.server_url.rstrip("/"))
@@ -80,6 +85,10 @@ async def try_refresh_token(
             )
 
             if response.status_code != 200:
+                logger.warning(
+                    f"Token refresh returned {response.status_code} for "
+                    f"{integration_id}: {response.text[:500]}"
+                )
                 return False
 
             tokens = response.json()

--- a/apps/api/app/utils/mcp_utils.py
+++ b/apps/api/app/utils/mcp_utils.py
@@ -33,6 +33,7 @@ def generate_pkce_pair() -> tuple[str, str]:
 _CONNECTION_ERROR_PATTERNS = (
     "timeout",
     "connection reset",
+    "connection reset by peer",
     "broken pipe",
     "unexpected eof",
     "eof error",
@@ -41,6 +42,13 @@ _CONNECTION_ERROR_PATTERNS = (
     "connection closed",
     "server disconnected",
     "connect call failed",
+    "network unreachable",
+    "no route to host",
+    "not connected",
+    "session closed",
+    "session expired",
+    "ssl",
+    "certificate",
 )
 
 


### PR DESCRIPTION
This pull request introduces several improvements to the MCP integration connection logic, focusing on more robust OAuth token handling, better error recovery, and enhanced user experience during authentication failures. The changes ensure that expired or invalid tokens are handled gracefully, users are not trapped in re-auth loops, and the system proactively refreshes tokens to minimize connection issues. Additionally, the connection error patterns have been expanded for more comprehensive error detection.

**OAuth Token Handling and Retry Logic:**

- Added logic in `_do_connect` to automatically retry once on authentication-related failures (e.g., 401, 405, or 403 errors), including refreshing the token and retrying the connection before failing. This helps recover from expired or invalid tokens without requiring immediate user intervention. [[1]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796L292-R296) [[2]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796R456-R513)
- Improved the `try_refresh_token` function to log more detailed reasons when a token refresh cannot proceed (e.g., missing refresh token, missing client_id, or missing token endpoint). [[1]](diffhunk://#diff-4b017db04daec3e8f1aa349328d691726580984e1205bb14221c7d1dfa092ac8R43-R49) [[2]](diffhunk://#diff-4b017db04daec3e8f1aa349328d691726580984e1205bb14221c7d1dfa092ac8R60-R62) [[3]](diffhunk://#diff-4b017db04daec3e8f1aa349328d691726580984e1205bb14221c7d1dfa092ac8R88-R91)
- The `is_token_expiring_soon` method now proactively treats tokens as stale if their expiry time is unknown but they are older than one hour, prompting a refresh to avoid unexpected connection failures.

**User Integration Status and Error Recovery:**

- On connection or disconnection failures, the system now resets the MongoDB user integration status to "created" to trigger the frontend re-auth flow, ensuring users are not stuck in an unusable state. This is applied in multiple places, including connection retry, disconnect, and error handling paths. [[1]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796R354-R358) [[2]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796R456-R513) [[3]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796R1093-R1102) [[4]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796R1181-R1188)
- When OAuth callback fails after token/DCR registration, both the tokens and the dynamic client registration are deleted, preventing users from being trapped in a re-auth loop due to a revoked or invalid client_id. [[1]](diffhunk://#diff-51e6f5b2bf77175d6d6f4b0dfb63b8644bf9e7eaf9081ede349ebdb2f5c80796L950-R1033) [[2]](diffhunk://#diff-693cfb00b9dbbf318ab0546636aff455be6afcd1aac8e3a224882f7dc512e5bcR405-R425)

**OAuth Scope and Connection Error Patterns:**

- The OAuth authorization URL builder now automatically adds the `offline_access` scope if supported by the server, enabling long-lived refresh tokens for background use.
- Expanded the set of connection error patterns to better detect and handle various network and SSL-related failures, increasing robustness against transient network issues. [[1]](diffhunk://#diff-5e33b1c4b3ddec67c97070b2f47bef6679852be262575f2dddb3d80fa3dc4154R36) [[2]](diffhunk://#diff-5e33b1c4b3ddec67c97070b2f47bef6679852be262575f2dddb3d80fa3dc4154R45-R51)