### PR TITLE
fix: Build and publish bot Docker images to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,14 @@ jobs:
         # env:
         #   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
+      # Login early so the affected check can query GHCR for missing images.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Map affected project list to deployable backend scopes.
       - name: Check affected projects
         id: affected
@@ -101,17 +109,33 @@ jobs:
             bots=true
           fi
 
+          # Force build if images don't exist in GHCR yet (first-time bootstrap).
+          # Only check on master branch to avoid unnecessary builds on feature branches.
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            image_missing() {
+              ! docker manifest inspect "$1" > /dev/null 2>&1
+            }
+
+            if [ "$api" = "false" ]; then
+              if image_missing "ghcr.io/theexperiencecompany/gaia:latest" || \
+                 image_missing "ghcr.io/theexperiencecompany/gaia-voice-agent:latest"; then
+                echo "⚠️ API/voice-agent image missing from GHCR — forcing build"
+                api=true
+              fi
+            fi
+
+            if [ "$bots" = "false" ]; then
+              if image_missing "ghcr.io/theexperiencecompany/gaia-bot-discord:latest" || \
+                 image_missing "ghcr.io/theexperiencecompany/gaia-bot-slack:latest" || \
+                 image_missing "ghcr.io/theexperiencecompany/gaia-bot-telegram:latest"; then
+                echo "⚠️ Bot image(s) missing from GHCR — forcing build"
+                bots=true
+              fi
+            fi
+          fi
+
           echo "api=$api" >> "$GITHUB_OUTPUT"
           echo "bots=$bots" >> "$GITHUB_OUTPUT"
-
-      # Login/build tooling only when a backend image release is needed.
-      - name: Log in to GHCR
-        if: steps.affected.outputs.api == 'true' || steps.affected.outputs.bots == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1

--- a/apps/bots/discord/package.json
+++ b/apps/bots/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia/bot-discord",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/bots/slack/package.json
+++ b/apps/bots/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia/bot-slack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/bots/telegram/package.json
+++ b/apps/bots/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia/bot-telegram",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Moves GHCR login step before the affected check so `docker manifest inspect` can authenticate against the registry
- Adds a first-time bootstrap check: on master, if any bot/API image is missing from GHCR, force-marks it as affected so the build runs even when no code changed
- Bumps bot package versions (`1.0.0` → `1.0.1`) to ensure Nx detects them as affected on this merge

## Why

The three bot services (discord, slack, telegram) have never had their Docker images pushed to GHCR because CI only builds when Nx detects affected projects — and no bot code changed since CI was set up. This means bots can never start in production.

## Test plan

- [ ] After merging to master, CI logs show "Bot image(s) missing from GHCR — forcing build"
- [ ] `nx release --group=bots` step runs successfully
- [ ] Bot images appear in GHCR packages (`gaia-bot-discord`, `gaia-bot-slack`, `gaia-bot-telegram`)
- [ ] Next production deploy shows bots starting instead of being skipped