### PR TITLE
feat: add Figma MCP integration

### DIFF
--- a/apps/api/app/agents/prompts/memory_prompts.py
+++ b/apps/api/app/agents/prompts/memory_prompts.py
@@ -1649,6 +1649,33 @@ BROWSER PATTERNS:
 """,
 )
 
+FIGMA_MEMORY_PROMPT = BASE_MEMORY_EXTRACTION_PROMPT.format(
+    provider_name="Figma",
+    entity_instructions="""
+## FIGMA-SPECIFIC EXTRACTION:
+
+1. FILE REFERENCES:
+   - File keys and names (e.g., "main design system file key: abc123")
+   - Frequently accessed frame or component node IDs
+
+2. COMPONENT PATTERNS:
+   - Component set names and key variants
+   - Design token / variable collection names
+""",
+    provider_specific_instructions="""
+## FIGMA-SPECIFIC MEMORIES:
+
+DESIGN SYSTEM PATTERNS:
+- Preferred component libraries
+- Variable collection naming conventions
+- Frame naming conventions
+
+WORKFLOW PREFERENCES:
+- Export format preferences
+- Inspection depth preferences
+""",
+)
+
 POSTHOG_MEMORY_PROMPT = BASE_MEMORY_EXTRACTION_PROMPT.format(
     provider_name="PostHog",
     entity_instructions="""

--- a/apps/api/app/agents/prompts/subagent_prompts.py
+++ b/apps/api/app/agents/prompts/subagent_prompts.py
@@ -2179,6 +2179,39 @@ Report: URL visited, actions taken, data extracted, any errors encountered.
 """,
 )
 
+FIGMA_AGENT_SYSTEM_PROMPT = BASE_SUBAGENT_PROMPT.format(
+    provider_name="Figma",
+    domain_expertise="design file navigation, component inspection, variable management, and design system exploration",
+    provider_specific_content="""
+— DOMAIN OVERVIEW
+Figma is a collaborative design platform. Core capabilities:
+- Reading and navigating design files and frames
+- Inspecting components, styles, and design tokens
+- Accessing file variables and local variable collections
+- Browsing project and team structures
+- Reading comments and annotations on designs
+
+— NAVIGATION STRATEGY
+- Always get-file first to understand top-level structure before diving into nodes
+- Use get-file-nodes to fetch specific frames or components by node ID
+- Prefer get-file-components to discover reusable components before searching nodes
+- For design tokens: use get-local-variables to retrieve variables and variable collections
+
+— PARALLEL EXECUTION
+When asked for multiple independent design elements:
+- 2-3 independent node lookups → call tools in parallel directly
+- Deep component trees → fetch parent node first, then children in parallel
+
+— SKILL ROUTING
+If "Available Skills:" includes a Figma skill (figma-inspect-component, figma-export-tokens, etc.),
+read it with vfs_read before executing — it contains optimized workflows for design tasks.
+
+— COMPLETION STANDARD
+Task complete when: file contents retrieved, components listed, variables exported, or comments read.
+Always present design data in structured format: node name, type, properties, and relevant children.
+""",
+)
+
 POSTHOG_AGENT_SYSTEM_PROMPT = BASE_SUBAGENT_PROMPT.format(
     provider_name="PostHog",
     domain_expertise="product analytics, user behavior analysis, A/B experiments, and feature flag management",

--- a/apps/api/app/config/oauth_config.py
+++ b/apps/api/app/config/oauth_config.py
@@ -17,6 +17,7 @@ from app.agents.prompts.memory_prompts import (
     CLICKUP_MEMORY_PROMPT,
     CONTEXT7_MEMORY_PROMPT,
     DEEPWIKI_MEMORY_PROMPT,
+    FIGMA_MEMORY_PROMPT,
     GITHUB_MEMORY_PROMPT,
     GMAIL_MEMORY_PROMPT,
     GOALS_MEMORY_PROMPT,
@@ -54,6 +55,7 @@ from app.agents.prompts.subagent_prompts import (
     CLICKUP_AGENT_SYSTEM_PROMPT,
     CONTEXT7_AGENT_SYSTEM_PROMPT,
     DEEPWIKI_AGENT_SYSTEM_PROMPT,
+    FIGMA_AGENT_SYSTEM_PROMPT,
     GITHUB_AGENT_SYSTEM_PROMPT,
     GMAIL_AGENT_SYSTEM_PROMPT,
     GOALS_AGENT_SYSTEM_PROMPT,
@@ -1646,6 +1648,75 @@ OAUTH_INTEGRATIONS: List[OAuthIntegration] = [
                 "CLICKUP_GET_FOLDERS",
             ],
             memory_prompt=CLICKUP_MEMORY_PROMPT,
+        ),
+    ),
+    # MCP Integrations (OAuth-authenticated)
+    OAuthIntegration(
+        id="figma",
+        name="Figma",
+        description="Access and inspect Figma design files, components, variables, and design system assets.",
+        category="design",
+        provider="figma",
+        scopes=[
+            OAuthScope(
+                scope="files:read",
+                description="Read Figma files, frames, and components",
+            ),
+            OAuthScope(
+                scope="file_variables:read",
+                description="Read design tokens and local variable collections",
+            ),
+            OAuthScope(
+                scope="file_comments:write",
+                description="Post and resolve comments on design files",
+            ),
+        ],
+        available=True,
+        is_featured=True,
+        short_name="figma",
+        managed_by="mcp",
+        mcp_config=MCPConfig(
+            server_url="https://mcp.figma.com/mcp",
+            requires_auth=True,
+            auth_type="oauth",
+            client_id_env="FIGMA_MCP_CLIENT_ID",
+            client_secret_env="FIGMA_MCP_CLIENT_SECRET",  # nosec B106  # pragma: allowlist secret
+            oauth_scopes=[
+                "current_user:read",
+                "files:read",
+                "file_versions:read",
+                "file_metadata:read",
+                "file_content:read",
+                "file_comments:read",
+                "file_comments:write",
+                "library_assets:read",
+                "library_content:read",
+                "team_library_content:read",
+                "file_variables:read",
+                "file_variables:write",
+                "library_analytics:read",
+            ],
+            # Figma's RFC 8414 discovery endpoint (api.figma.com/.well-known/oauth-authorization-server)
+            # returns 404, so we hardcode the OAuth endpoints directly.
+            # DCR is blocked (403) — pre-registered app required.
+            oauth_metadata={
+                "authorization_endpoint": "https://www.figma.com/oauth",
+                "token_endpoint": "https://api.figma.com/v1/oauth/token",  # nosec B105
+                "registration_endpoint": "https://api.figma.com/v1/oauth/mcp/register",
+                "code_challenge_methods_supported": ["S256"],
+            },
+        ),
+        subagent_config=SubAgentConfig(
+            has_subagent=True,
+            agent_name="figma_agent",
+            tool_space="figma",
+            handoff_tool_name="call_figma_agent",
+            domain="design file navigation and component inspection",
+            capabilities="reading Figma files, inspecting frames and components, accessing design tokens, browsing variable collections, reading comments",
+            use_cases="design system exploration, component inspection, design token export, file structure navigation, design review",
+            system_prompt=FIGMA_AGENT_SYSTEM_PROMPT,
+            use_direct_tools=False,
+            memory_prompt=FIGMA_MEMORY_PROMPT,
         ),
     ),
     # MCP Integrations (no authentication required)

--- a/apps/api/app/models/mcp_config.py
+++ b/apps/api/app/models/mcp_config.py
@@ -1,6 +1,6 @@
 """MCP configuration models (Pydantic)."""
 
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel
 
@@ -17,7 +17,7 @@ class MCPConfig(BaseModel):
     client_id_env: Optional[str] = None
     client_secret_env: Optional[str] = None
     oauth_scopes: Optional[List[str]] = None
-    oauth_metadata: Optional[Dict[str, str]] = None
+    oauth_metadata: Optional[Dict[str, Any]] = None
 
 
 class OAuthScope(BaseModel):


### PR DESCRIPTION
## Summary

- Adds Figma as an MCP-managed OAuth integration with full subagent support
- Registers the Figma MCP server (`https://mcp.figma.com/mcp`) with all relevant design scopes
- Adds `FIGMA_MEMORY_PROMPT` for extracting file keys, component patterns, and design token context
- Adds `FIGMA_AGENT_SYSTEM_PROMPT` for the Figma subagent (design file navigation, component inspection, variable management)
- Fixes `oauth_metadata` type from `Dict[str, str]` to `Dict[str, Any]` to support list values (e.g. `code_challenge_methods_supported`)

## Notes

- Figma's RFC 8414 discovery endpoint returns 404, so OAuth endpoints are hardcoded
- DCR (`https://api.figma.com/v1/oauth/mcp/register`) was probed and confirmed blocked (403) — pre-registered developer app required
- Integration will be functional once the Figma developer app is approved

## Test plan

- [ ] Connect Figma integration once developer app is approved by Figma
- [ ] Verify OAuth flow completes and tokens are stored
- [ ] Verify Figma subagent can read files and components