### PR TITLE
fix(features): update code execution demo and fix keyboard listener

### DIFF
--- a/apps/web/src/features/landing/components/features/FeaturesGrid.tsx
+++ b/apps/web/src/features/landing/components/features/FeaturesGrid.tsx
@@ -48,8 +48,8 @@ export function FeaturesGrid() {
         inputRef.current?.focus();
       }
     }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   return (

--- a/apps/web/src/features/landing/components/features/demos/CodeExecutionDemo.tsx
+++ b/apps/web/src/features/landing/components/features/demos/CodeExecutionDemo.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Tick01Icon } from "@icons";
 import ChatDemo from "../../demo/founders-demo/ChatDemo";
 import type { ChatMessage } from "../../demo/founders-demo/types";
 import type { ToolStep } from "../../demo/types";
@@ -10,49 +11,100 @@ const CODE_EXECUTION_TOOLS: ToolStep[] = [
   {
     category: "e2b",
     name: "execute_code",
-    message: `import matplotlib.pyplot as plt
-months = ['Jan', 'Feb', 'Mar']
-sales = [42000, 61000, 58000]
-plt.bar(months, sales, color='#00bbff')
-plt.title('Q1 Sales')
-plt.show()`,
+    message: `import pandas as pd
+df = pd.read_csv("sales.csv")
+top = df.groupby("region").sum().sort_values(ascending=False)
+print(top.head(3))`,
   },
 ];
 
-// ─── Chart Card ───────────────────────────────────────────────────────────────
+// ─── Code Output Card ─────────────────────────────────────────────────────────
 
-const BAR_DATA = [
-  { label: "Jan", value: 42000, height: 77 },
-  { label: "Feb", value: 61000, height: 112 },
-  { label: "Mar", value: 58000, height: 107 },
+const OUTPUT_ROWS = [
+  { region: "North America", value: "$2.4M", up: true },
+  { region: "Europe", value: "$1.8M", up: true },
+  { region: "APAC", value: "$1.1M", up: false },
 ];
 
-function Q1SalesChartCard() {
+function CodeOutputCard() {
   return (
     <div className="rounded-2xl bg-zinc-800 p-4">
-      <p className="mb-3 text-sm font-semibold text-zinc-100">Q1 Sales</p>
-      <div className="rounded-2xl bg-zinc-900 p-3">
-        <div className="relative flex h-28 items-end gap-4 px-2">
-          {BAR_DATA.map((bar) => (
-            <div
-              key={bar.label}
-              className="flex flex-1 flex-col items-center justify-end h-full gap-1"
-            >
-              <span className="text-[10px] font-medium text-zinc-400">
-                ${(bar.value / 1000).toFixed(0)}k
-              </span>
-              <div
-                className="w-full rounded-t-md"
-                style={{
-                  height: bar.height,
-                  backgroundColor: "#00bbff",
-                  opacity: 0.85,
-                }}
-              />
-              <span className="text-xs text-zinc-500">{bar.label}</span>
-            </div>
-          ))}
+      {/* Header */}
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex h-5 w-5 items-center justify-center rounded bg-emerald-400/10">
+          <span className="text-[9px] font-bold text-emerald-400">e2b</span>
         </div>
+        <span className="text-[11px] font-medium text-zinc-400">
+          execute_code
+        </span>
+        <span className="ml-auto flex items-center gap-1 text-[10px] text-emerald-400">
+          <Tick01Icon height={12} />
+          done in 1.2s
+        </span>
+      </div>
+
+      {/* Code panel */}
+      <div className="mb-2 rounded-2xl bg-zinc-900 p-3 font-mono text-[11px] leading-relaxed">
+        <div>
+          <span className="text-blue-400">import</span>{" "}
+          <span className="text-zinc-300">pandas</span>{" "}
+          <span className="text-blue-400">as</span>{" "}
+          <span className="text-zinc-300">pd</span>
+        </div>
+        <div className="mt-1">
+          <span className="text-zinc-300">df</span>{" "}
+          <span className="text-zinc-500">=</span>{" "}
+          <span className="text-zinc-300">pd</span>
+          <span className="text-zinc-500">.</span>
+          <span className="text-amber-400">read_csv</span>
+          <span className="text-zinc-500">(</span>
+          <span className="text-emerald-400">"sales.csv"</span>
+          <span className="text-zinc-500">)</span>
+        </div>
+        <div>
+          <span className="text-zinc-300">top</span>{" "}
+          <span className="text-zinc-500">=</span>{" "}
+          <span className="text-zinc-300">df</span>
+          <span className="text-zinc-500">.</span>
+          <span className="text-amber-400">groupby</span>
+          <span className="text-zinc-500">(</span>
+          <span className="text-emerald-400">"region"</span>
+          <span className="text-zinc-500">).</span>
+          <span className="text-amber-400">sum</span>
+          <span className="text-zinc-500">().</span>
+          <span className="text-amber-400">sort_values</span>
+          <span className="text-zinc-500">(</span>
+          <span className="text-amber-400">ascending</span>
+          <span className="text-zinc-500">=</span>
+          <span className="text-blue-400">False</span>
+          <span className="text-zinc-500">)</span>
+        </div>
+        <div>
+          <span className="text-amber-400">print</span>
+          <span className="text-zinc-500">(</span>
+          <span className="text-zinc-300">top</span>
+          <span className="text-zinc-500">.</span>
+          <span className="text-amber-400">head</span>
+          <span className="text-zinc-500">(</span>
+          <span className="text-purple-400">3</span>
+          <span className="text-zinc-500">))</span>
+        </div>
+      </div>
+
+      {/* Output panel */}
+      <div className="space-y-1 rounded-2xl bg-zinc-900 p-3 font-mono text-[11px]">
+        <div className="mb-1 flex items-center justify-between text-[10px] text-zinc-500">
+          <span>region</span>
+          <span>revenue</span>
+        </div>
+        {OUTPUT_ROWS.map((row) => (
+          <div key={row.region} className="flex items-center justify-between">
+            <span className="text-zinc-300">{row.region}</span>
+            <span className={row.up ? "text-emerald-400" : "text-zinc-400"}>
+              {row.value}
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -64,7 +116,7 @@ const CODE_EXECUTION_MESSAGES: ChatMessage[] = [
   {
     id: "ce1",
     role: "user",
-    content: "Plot my sales data for Q1 as a bar chart",
+    content: "Summarize regional sales from sales.csv",
   },
   {
     id: "ce2",
@@ -83,14 +135,14 @@ const CODE_EXECUTION_MESSAGES: ChatMessage[] = [
     id: "ce4",
     role: "card",
     content: "",
-    cardContent: <Q1SalesChartCard />,
+    cardContent: <CodeOutputCard />,
     delay: 500,
   },
   {
     id: "ce5",
     role: "assistant",
     content:
-      "February was your strongest month at $61k. March held steady at $58k. January was the lowest at $42k — likely seasonality.",
+      "North America leads at $2.4M, followed by Europe at $1.8M. APAC is third at $1.1M — solid growth but still a gap to close.",
     delay: 700,
   },
 ];


### PR DESCRIPTION
## Summary

- Replaces the matplotlib bar chart in `CodeExecutionDemo` with a pandas tabular output card — more realistic and better showcases what code execution actually looks like
- Replaces the unicode `✓` checkmark in the done status badge with `Tick01Icon` per design rules
- Fixes `FeaturesGrid` keyboard shortcut (`Ctrl+F`) to attach to `document` instead of `window`

## What was not changed

- `DashboardDemo` — already 2-col on develop, no change needed
- `EmailDemo` — already has merged tool steps on develop, no change needed
- `FeaturesGrid` hero/layout — kept as-is from develop