### PR TITLE
fix(api): suppress ruff F821 and mypy errors in vulture_whitelist.py

### DIFF
--- a/apps/api/vulture_whitelist.py
+++ b/apps/api/vulture_whitelist.py
@@ -1,3 +1,5 @@
+# ruff: noqa: F821
+# mypy: ignore-errors
 # Vulture whitelist — known false positives.
 #
 # Generated with: vulture app/ --make-whitelist


### PR DESCRIPTION
## Summary

- `vulture_whitelist.py` was introduced in #591 with bare name references that vulture needs, but ruff's F821 rule flags them as undefined names
- This breaks `static-python` on every PR branching from `develop`
- Adds `# ruff: noqa: F821` and `# mypy: ignore-errors` file-level directives to silence both tools

## Root cause

`vulture_whitelist.py` is intentionally full of bare names like `DUMMY_IP`, `GITHUB_TOKEN`, etc. — these are false-positive suppressions for vulture's dead code detector. They are not real Python expressions, so ruff (F821) and mypy (`name-defined`) both flag them.

## Test plan
- [ ] `static-python` CI check passes on this PR
- [ ] All other PRs branching from `develop` will stop failing on this error once merged