### PR TITLE
fix(ci): trigger-build skipped when TS lanes don't run on master push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -316,8 +316,12 @@ jobs:
           echo "All required jobs passed or were skipped."
 
   # --- Trigger Docker build (master only) ---------------------------------
+  # always() is required to suppress the implicit success() check, which walks
+  # the transitive needs graph and returns false when any ancestor lane
+  # (e.g. static-typescript / build / test-typescript on a Python-only change)
+  # was skipped — even though quality-gate itself succeeded.
   trigger-build:
     needs: [quality-gate]
-    if: github.ref == 'refs/heads/master'
+    if: ${{ always() && needs.quality-gate.result == 'success' && github.ref == 'refs/heads/master' }}
     uses: ./.github/workflows/build.yml
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

On the first master push after the CI pipeline restructure (`115b38635`), `trigger-build` was skipped even though `quality-gate` succeeded — see run [24009456434](https://github.com/theexperiencecompany/gaia/actions/runs/24009456434). The release commit only touched Python-affected files, so `static-typescript`, `build`, and `test-typescript` all skipped on `needs.detect.outputs.has_typescript == 'true'`. `quality-gate` ran anyway via `if: always()` and reported success, but `trigger-build` still skipped.

## Root cause

When a job's `if:` expression contains no status-check function (`success()`, `always()`, `failure()`, `cancelled()`), GitHub Actions implicitly prepends `success()`. That implicit check walks the **transitive** needs graph — so any skipped ancestor lane anywhere upstream causes it to return `false`, regardless of the direct-`needs` job's own conclusion.

`trigger-build` had:

```yaml
if: github.ref == 'refs/heads/master'
```

No status-check function → implicit `success()` → walks back through `quality-gate → build (skipped)` → returns false → job skipped.

## Fix

Add `always()` to the condition to suppress the implicit `success()`, and gate explicitly on the quality-gate result:

```yaml
if: ${{ always() && needs.quality-gate.result == 'success' && github.ref == 'refs/heads/master' }}
```

## Test plan

- [ ] Merge to develop (no effect, trigger-build is master-only)
- [ ] Next release PR merge to master fires `trigger-build` even on Python-only changes
- [ ] Confirm quality-gate failure still blocks trigger-build (explicit `result == 'success'` check)