### PR TITLE
fix(sitemap): replace workflowApi with direct fetch to fix 405 on child sitemaps

### DIFF
--- a/apps/web/src/lib/sitemapData.ts
+++ b/apps/web/src/lib/sitemapData.ts
@@ -132,10 +132,17 @@ async function getExploreWorkflowPages(
     if (!apiBaseUrl) return [];
 
     const limit = isDevelopment() ? 50 : 1000;
-    const response = await fetch(
-      `${apiBaseUrl}/workflows/explore?limit=${limit}&offset=0`,
-      { next: { revalidate: 3600 } },
-    );
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    let response: Response;
+    try {
+      response = await fetch(
+        `${apiBaseUrl}/workflows/explore?limit=${limit}&offset=0`,
+        { next: { revalidate: 3600 }, signal: controller.signal },
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!response.ok) return [];
 
     const data = await response.json();
@@ -164,10 +171,17 @@ async function getCommunityWorkflowPages(
     if (!apiBaseUrl) return [];
 
     if (isDevelopment()) {
-      const response = await fetch(
-        `${apiBaseUrl}/workflows/community?limit=50&offset=0`,
-        { next: { revalidate: 3600 } },
-      );
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      let response: Response;
+      try {
+        response = await fetch(
+          `${apiBaseUrl}/workflows/community?limit=50&offset=0`,
+          { next: { revalidate: 3600 }, signal: controller.signal },
+        );
+      } finally {
+        clearTimeout(timeout);
+      }
       if (!response.ok) return [];
       const data = await response.json();
       return (data.workflows || []).map(
@@ -182,10 +196,17 @@ async function getCommunityWorkflowPages(
 
     const allWorkflows: Array<{ id: string; created_at: string }> =
       await fetchAllPaginated(async (limit, offset) => {
-        const response = await fetch(
-          `${apiBaseUrl}/workflows/community?limit=${limit}&offset=${offset}`,
-          { next: { revalidate: 3600 } },
-        );
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10_000);
+        let response: Response;
+        try {
+          response = await fetch(
+            `${apiBaseUrl}/workflows/community?limit=${limit}&offset=${offset}`,
+            { next: { revalidate: 3600 }, signal: controller.signal },
+          );
+        } finally {
+          clearTimeout(timeout);
+        }
         if (!response.ok) return { items: [], total: 0, hasMore: false };
         const data = await response.json();
         return {
@@ -222,10 +243,17 @@ async function getIntegrationPages(
     if (!apiBaseUrl) return [];
 
     if (isDevelopment()) {
-      const response = await fetch(
-        `${apiBaseUrl}/integrations/community?limit=50`,
-        { next: { revalidate: 3600 } },
-      );
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      let response: Response;
+      try {
+        response = await fetch(
+          `${apiBaseUrl}/integrations/community?limit=50`,
+          { next: { revalidate: 3600 }, signal: controller.signal },
+        );
+      } finally {
+        clearTimeout(timeout);
+      }
       if (response.ok) {
         const data = await response.json();
         return (data.integrations || []).map(
@@ -251,10 +279,17 @@ async function getIntegrationPages(
       publishedAt?: string;
       createdAt?: string;
     }> = await fetchAllPaginated(async (limit, offset) => {
-      const response = await fetch(
-        `${apiBaseUrl}/integrations/community?limit=${limit}&offset=${offset}`,
-        { next: { revalidate: 3600 } },
-      );
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      let response: Response;
+      try {
+        response = await fetch(
+          `${apiBaseUrl}/integrations/community?limit=${limit}&offset=${offset}`,
+          { next: { revalidate: 3600 }, signal: controller.signal },
+        );
+      } finally {
+        clearTimeout(timeout);
+      }
       if (!response.ok) return { items: [], total: 0, hasMore: false };
 
       const data = await response.json();

--- a/apps/web/src/lib/sitemapData.ts
+++ b/apps/web/src/lib/sitemapData.ts
@@ -4,7 +4,6 @@ import { getAllAlternativeSlugs } from "@/features/alternatives/data/alternative
 import { getAllComparisonSlugs } from "@/features/comparisons/data/comparisonsData";
 import { getAllGlossaryTermSlugs } from "@/features/glossary/data/glossaryData";
 import { getAllCombos } from "@/features/integrations/data/combosData";
-import { workflowApi } from "@/features/workflows/api/workflowApi";
 import { defaultLocale, locales } from "@/i18n/config";
 import { getAllBlogPosts } from "@/lib/blog";
 import { fetchAllPaginated, isDevelopment } from "@/lib/fetchAll";
@@ -129,14 +128,25 @@ async function getExploreWorkflowPages(
   baseUrl: string,
 ): Promise<MetadataRoute.Sitemap> {
   try {
+    const apiBaseUrl = getServerApiBaseUrl();
+    if (!apiBaseUrl) return [];
+
     const limit = isDevelopment() ? 50 : 1000;
-    const exploreResp = await workflowApi.getExploreWorkflows(limit, 0);
-    return exploreResp.workflows.map((wc) => ({
-      url: `${baseUrl}/use-cases/${wc.id}`,
-      lastModified: new Date(wc.created_at),
-      changeFrequency: "weekly" as const,
-      priority: wc.categories?.includes("featured") ? 0.8 : 0.7,
-    }));
+    const response = await fetch(
+      `${apiBaseUrl}/workflows/explore?limit=${limit}&offset=0`,
+      { next: { revalidate: 3600 } },
+    );
+    if (!response.ok) return [];
+
+    const data = await response.json();
+    return (data.workflows || []).map(
+      (wc: { id: string; created_at: string; categories?: string[] }) => ({
+        url: `${baseUrl}/use-cases/${wc.id}`,
+        lastModified: new Date(wc.created_at),
+        changeFrequency: "weekly" as const,
+        priority: wc.categories?.includes("featured") ? 0.8 : 0.7,
+      }),
+    );
   } catch (error) {
     console.error("Error fetching explore workflows for sitemap:", error);
     return [];
@@ -150,24 +160,40 @@ async function getCommunityWorkflowPages(
   baseUrl: string,
 ): Promise<MetadataRoute.Sitemap> {
   try {
+    const apiBaseUrl = getServerApiBaseUrl();
+    if (!apiBaseUrl) return [];
+
     if (isDevelopment()) {
-      const communityResponse = await workflowApi.getCommunityWorkflows(50, 0);
-      return communityResponse.workflows.map((workflow) => ({
-        url: `${baseUrl}/use-cases/${workflow.id}`,
-        lastModified: new Date(workflow.created_at),
-        changeFrequency: "weekly" as const,
-        priority: 0.6,
-      }));
+      const response = await fetch(
+        `${apiBaseUrl}/workflows/community?limit=50&offset=0`,
+        { next: { revalidate: 3600 } },
+      );
+      if (!response.ok) return [];
+      const data = await response.json();
+      return (data.workflows || []).map(
+        (workflow: { id: string; created_at: string }) => ({
+          url: `${baseUrl}/use-cases/${workflow.id}`,
+          lastModified: new Date(workflow.created_at),
+          changeFrequency: "weekly" as const,
+          priority: 0.6,
+        }),
+      );
     }
 
-    const allWorkflows = await fetchAllPaginated(async (limit, offset) => {
-      const resp = await workflowApi.getCommunityWorkflows(limit, offset);
-      return {
-        items: resp.workflows,
-        total: resp.total || 0,
-        hasMore: resp.workflows.length === limit,
-      };
-    }, 100);
+    const allWorkflows: Array<{ id: string; created_at: string }> =
+      await fetchAllPaginated(async (limit, offset) => {
+        const response = await fetch(
+          `${apiBaseUrl}/workflows/community?limit=${limit}&offset=${offset}`,
+          { next: { revalidate: 3600 } },
+        );
+        if (!response.ok) return { items: [], total: 0, hasMore: false };
+        const data = await response.json();
+        return {
+          items: data.workflows || [],
+          total: data.total || 0,
+          hasMore: data.workflows?.length === limit,
+        };
+      }, 100);
 
     console.log(
       `[Sitemap] Generated ${allWorkflows.length} community workflow pages`,
@@ -397,6 +423,8 @@ export async function getSitemapEntries(
       return withLocaleUrls(getAlternativePages(baseUrl), baseUrl);
     case SITEMAP_IDS.INTEGRATION_COMBOS:
       return withLocaleUrls(getIntegrationComboPages(baseUrl), baseUrl);
+    case SITEMAP_IDS.NATIVE_INTEGRATIONS:
+      return [];
     default:
       return [];
   }


### PR DESCRIPTION
## Problem

All `/sitemap/[id].xml` child sitemaps were returning **HTTP 405** on cache MISS, causing Google Search Console to show **0 discovered pages** for `heygaia.io/sitemap.xml`.

Root cause: `sitemapData.ts` imported `workflowApi` → `apiService` → `analytics.ts` + `toast.tsx`. Both files are marked `"use client"` and import browser-only libraries (`posthog-js`, `sileo`). These throw at module initialization when executed server-side in the route handler. Next.js sees no valid GET handler → returns 405.

Cache HITs returned 200 (Vercel served a previously cached response), masking the issue in normal browser access.

## Fix

- Removed `workflowApi` import from `sitemapData.ts`
- Replaced `getExploreWorkflowPages` and `getCommunityWorkflowPages` with direct `fetch` calls — same pattern already used in `getIntegrationPages`
- Added explicit `NATIVE_INTEGRATIONS` case to the switch statement

## Test

After deploying, run:
```bash
for i in $(seq 0 10); do
  code=$(curl -s -o /dev/null -w "%{http_code}" "https://heygaia.io/sitemap/$i.xml")
  echo "sitemap/$i.xml → $code"
done
```
All should return `200`.