### PR TITLE
fix: resolve PR #618 review comments

### DIFF
--- a/apps/api/app/services/chat_service.py
+++ b/apps/api/app/services/chat_service.py
@@ -301,6 +301,20 @@ def _inject_todo_progress(
         )
 
 
+async def _wait_for_http_subscriber(
+    start_event: Optional[asyncio.Event],
+    stream_id: str,
+) -> None:
+    if not start_event or start_event.is_set():
+        return
+    try:
+        await asyncio.wait_for(start_event.wait(), timeout=5.0)
+    except asyncio.TimeoutError:
+        log.warning(
+            f"Stream {stream_id} HTTP subscriber timeout, proceeding anyway"
+        )
+
+
 async def _run_chat_stream(
     stream_id: str,
     body: MessageRequestWithHistory,
@@ -350,15 +364,7 @@ async def _run_chat_stream(
         else:
             init_data = f"data: {json.dumps({'user_message_id': user_message_id, 'bot_message_id': bot_message_id, 'stream_id': stream_id})}\n\n"
 
-        if start_event:
-            try:
-                # Wait for HTTP StreamingResponse to subscribe to Redis Pub/Sub
-                await asyncio.wait_for(start_event.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
-                log.warning(
-                    f"Stream {stream_id} HTTP subscriber timeout, proceeding anyway"
-                )
-
+        await _wait_for_http_subscriber(start_event, stream_id)
         await stream_manager.publish_chunk(stream_id, init_data)
         async for chunk in await call_agent(
             request=body,
@@ -440,6 +446,7 @@ async def _run_chat_stream(
 
     except Exception as e:
         log.error(f"Background stream error for {stream_id}: {e}")
+        await _wait_for_http_subscriber(start_event, stream_id)
         # IMPORTANT: Publish error chunk FIRST, before calling set_error()
         # set_error() publishes STREAM_ERROR_SIGNAL which breaks the subscriber loop
         # If we call set_error() first, the error message never reaches the client

--- a/apps/web/src/features/weather/components/WeatherCard.tsx
+++ b/apps/web/src/features/weather/components/WeatherCard.tsx
@@ -534,7 +534,7 @@ export const WeatherCard: React.FC<WeatherCardProps> = ({ weatherData }) => {
                   />
                 ),
                 label: "Humidity",
-                value: `${weatherData.main.humidity}%`,
+                value: `${weatherData.main?.humidity ?? 0}%`,
                 tooltipText: "Amount of water vapor in the air",
               },
               ...(weatherData.visibility
@@ -560,7 +560,7 @@ export const WeatherCard: React.FC<WeatherCardProps> = ({ weatherData }) => {
                   />
                 ),
                 label: "Pressure",
-                value: `${weatherData.main.pressure} hPa`,
+                value: `${weatherData.main?.pressure ?? 0} hPa`,
                 tooltipText: "Atmospheric pressure in hectopascals",
               },
               {

--- a/apps/web/src/features/weather/components/WeatherCard.tsx
+++ b/apps/web/src/features/weather/components/WeatherCard.tsx
@@ -321,13 +321,12 @@ export const WeatherCard: React.FC<WeatherCardProps> = ({ weatherData }) => {
     return <div>Loading weather...</div>;
   }
 
-  const weatherId = weatherData?.weather?.[0]?.id;
   const displayTemp = useFahrenheit
-    ? Math.round(celsiusToFahrenheit(weatherData.main.temp))
-    : Math.round(weatherData.main.temp);
+    ? Math.round(celsiusToFahrenheit(weatherData.main?.temp ?? 0))
+    : Math.round(weatherData.main?.temp ?? 0);
   const displayFeelsLike = useFahrenheit
-    ? Math.round(celsiusToFahrenheit(weatherData.main.feels_like))
-    : Math.round(weatherData.main.feels_like);
+    ? Math.round(celsiusToFahrenheit(weatherData.main?.feels_like ?? 0))
+    : Math.round(weatherData.main?.feels_like ?? 0);
   const sunriseTime = weatherData.sys?.sunrise
     ? formatTime(weatherData.sys.sunrise, weatherData.timezone)
     : "N/A";

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -431,6 +431,7 @@ services:
       GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:4000}
       # Slack webhook for alert notifications (leave empty to disable)
       SLACK_ALERT_WEBHOOK_URL: ${SLACK_ALERT_WEBHOOK_URL:-}
+      SLACK_ALERT_CHANNEL: ${SLACK_ALERT_CHANNEL:-#alerts}
     restart: unless-stopped
     depends_on:
       loki:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -456,6 +456,7 @@ services:
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/overview.json
       # Slack webhook consumed by contact-points.yaml (leave empty to disable alerts)
       SLACK_ALERT_WEBHOOK_URL: ${SLACK_ALERT_WEBHOOK_URL:-}
+      SLACK_ALERT_CHANNEL: ${SLACK_ALERT_CHANNEL:-#alerts}
     restart: unless-stopped
     depends_on:
       loki:


### PR DESCRIPTION
Resolves all 4 review comments from #618.

## Changes

### `apps/api/app/services/chat_service.py`
Extracted `_wait_for_http_subscriber()` helper from the inline `start_event` wait block. Called it at the top of the `except` block so that if `_initialize_new_conversation()` or any earlier setup raises, the error chunk and `STREAM_ERROR_SIGNAL` are not published before an HTTP subscriber is attached — preventing the HTTP side from hanging with no terminal event.

### `apps/web/src/features/weather/components/WeatherCard.tsx`
- Removed unused `weatherId` variable (line 324 — a duplicate declaration outside the `useMemo` where it was actually used).
- Added `?.` optional chaining and `?? 0` fallback to `weatherData.main?.temp` and `weatherData.main?.feels_like` so the component doesn't throw when `main` is absent, consistent with the PR's goal of handling incomplete weather data.

### `infra/docker/docker-compose.yml` + `docker-compose.prod.yml`
Added `SLACK_ALERT_CHANNEL: ${SLACK_ALERT_CHANNEL:-#alerts}` to the Grafana service environment block in both compose files, so operators can override the alert channel used in `contact-points.yaml` without modifying provisioning files.