### PR TITLE
feat(bots): add structured lifecycle and event logging

### DIFF
--- a/apps/bots/__tests__/discord/adapter.test.ts
+++ b/apps/bots/__tests__/discord/adapter.test.ts
@@ -153,6 +153,12 @@ vi.mock("@gaia/shared", () => {
 
   return {
     BaseBotAdapter,
+    createBotLogger: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
     formatBotError: vi.fn((err: unknown) =>
       err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
     ),

--- a/apps/bots/__tests__/discord/adapter.test.ts
+++ b/apps/bots/__tests__/discord/adapter.test.ts
@@ -159,6 +159,16 @@ vi.mock("@gaia/shared", () => {
       warn: vi.fn(),
       error: vi.fn(),
     })),
+    hashLogIdentifier: vi.fn((value: string | number | undefined | null) => {
+      if (value === undefined || value === null) return undefined;
+      return `h_${String(value)}`;
+    }),
+    sanitizeErrorForLog: vi.fn((error: unknown) => {
+      if (error instanceof Error) {
+        return { error_name: error.name, error_message: error.message };
+      }
+      return { error_name: "Unknown", error_message: String(error) };
+    }),
     formatBotError: vi.fn((err: unknown) =>
       err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
     ),

--- a/apps/bots/__tests__/shared/mocks/gaiaSharedBase.ts
+++ b/apps/bots/__tests__/shared/mocks/gaiaSharedBase.ts
@@ -93,9 +93,25 @@ export function makeGaiaSharedMock(
     error: vi.fn(),
   }));
 
+  const hashLogIdentifier = vi.fn(
+    (value: string | number | undefined | null) => {
+      if (value === undefined || value === null) return undefined;
+      return `h_${String(value)}`;
+    },
+  );
+
+  const sanitizeErrorForLog = vi.fn((error: unknown) => {
+    if (error instanceof Error) {
+      return { error_name: error.name, error_message: error.message };
+    }
+    return { error_name: "Unknown", error_message: String(error) };
+  });
+
   return {
     BaseBotAdapter,
     createBotLogger,
+    hashLogIdentifier,
+    sanitizeErrorForLog,
     formatBotError: vi.fn((err: unknown) =>
       err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
     ),

--- a/apps/bots/__tests__/shared/mocks/gaiaSharedBase.ts
+++ b/apps/bots/__tests__/shared/mocks/gaiaSharedBase.ts
@@ -86,8 +86,16 @@ export function makeGaiaSharedMock(
     }
   };
 
+  const createBotLogger = vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }));
+
   return {
     BaseBotAdapter,
+    createBotLogger,
     formatBotError: vi.fn((err: unknown) =>
       err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
     ),

--- a/apps/bots/__tests__/slack/adapter.test.ts
+++ b/apps/bots/__tests__/slack/adapter.test.ts
@@ -42,23 +42,17 @@ vi.mock("@slack/bolt", () => ({
 // Mock @gaia/shared
 // ---------------------------------------------------------------------------
 
-vi.mock("@gaia/shared", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@gaia/shared")>();
-
-  return {
-    ...actual,
-    formatBotError: vi.fn((err: unknown) =>
-      err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
-    ),
-    handleStreamingChat: vi.fn().mockResolvedValue(undefined),
-    STREAMING_DEFAULTS: {
+vi.mock("@gaia/shared", async () => {
+  const { makeGaiaSharedMock } = await import("../shared/mocks/gaiaSharedBase");
+  return makeGaiaSharedMock("slack", {
+    streamingDefaults: {
       slack: { editIntervalMs: 1500, streaming: true, platform: "slack" },
     },
-    richMessageToMarkdown: vi.fn().mockReturnValue("## Rich Title\nBody text"),
-    parseTextArgs: vi.fn((text: string) => ({
-      subcommand: text.split(" ")[0] || undefined,
-    })),
-  };
+    converters: {
+      convertToSlackMrkdwn: vi.fn((text: string) => text),
+    },
+    defaultRichMarkdown: "## Rich Title\nBody text",
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -351,7 +345,7 @@ describe("SlackAdapter - handleSlackStreaming", () => {
     ).handleSlackStreaming(client, "C789", "U456", "Plan my day");
 
     expect(handleStreamingChat).toHaveBeenCalledWith(
-      expect.anything(), // gaia client
+      expect.any(Object), // gaia client
       expect.objectContaining({
         message: "Plan my day",
         platform: "slack",
@@ -363,7 +357,7 @@ describe("SlackAdapter - handleSlackStreaming", () => {
       expect.any(Function), // onAuthError callback
       expect.any(Function), // onGenericError callback
       expect.objectContaining({ platform: "slack" }),
-      expect.anything(),
+      undefined,
     );
   });
 
@@ -584,7 +578,7 @@ describe("SlackAdapter - app_mention event handling", () => {
     });
 
     expect(handleStreamingChat).toHaveBeenCalledWith(
-      expect.anything(),
+      expect.any(Object),
       expect.objectContaining({
         message: "What should I do today?",
         platform: "slack",
@@ -596,7 +590,7 @@ describe("SlackAdapter - app_mention event handling", () => {
       expect.any(Function),
       expect.any(Function),
       expect.objectContaining({ platform: "slack" }),
-      expect.anything(),
+      undefined,
     );
   });
 
@@ -680,7 +674,7 @@ describe("SlackAdapter - DM message event handling", () => {
     });
 
     expect(handleStreamingChat).toHaveBeenCalledWith(
-      expect.anything(),
+      expect.any(Object),
       expect.objectContaining({
         message: "Hello GAIA",
         platform: "slack",
@@ -692,7 +686,7 @@ describe("SlackAdapter - DM message event handling", () => {
       expect.any(Function),
       expect.any(Function),
       expect.objectContaining({ platform: "slack" }),
-      expect.anything(),
+      undefined,
     );
   });
 

--- a/apps/bots/__tests__/telegram/adapter.test.ts
+++ b/apps/bots/__tests__/telegram/adapter.test.ts
@@ -112,6 +112,16 @@ vi.mock("@gaia/shared", () => {
       warn: vi.fn(),
       error: vi.fn(),
     })),
+    hashLogIdentifier: vi.fn((value: string | number | undefined | null) => {
+      if (value === undefined || value === null) return undefined;
+      return `h_${String(value)}`;
+    }),
+    sanitizeErrorForLog: vi.fn((error: unknown) => {
+      if (error instanceof Error) {
+        return { error_name: error.name, error_message: error.message };
+      }
+      return { error_name: "Unknown", error_message: String(error) };
+    }),
     formatBotError: vi.fn((err: unknown) =>
       err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
     ),

--- a/apps/bots/__tests__/telegram/adapter.test.ts
+++ b/apps/bots/__tests__/telegram/adapter.test.ts
@@ -106,6 +106,12 @@ vi.mock("@gaia/shared", () => {
 
   return {
     BaseBotAdapter,
+    createBotLogger: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
     formatBotError: vi.fn((err: unknown) =>
       err instanceof Error ? `Error: ${err.message}` : "Something went wrong",
     ),

--- a/apps/bots/discord/src/adapter.ts
+++ b/apps/bots/discord/src/adapter.ts
@@ -171,7 +171,7 @@ export class DiscordAdapter extends BaseBotAdapter {
   private dmWelcomeSent = new Set<string>();
   private statusRotationTimer: ReturnType<typeof setInterval> | null = null;
   private statusIndex = Math.floor(Math.random() * ROTATING_STATUSES.length);
-  private adapterLogger = createBotLogger("discord", "adapter");
+  private readonly adapterLogger = createBotLogger("discord", "adapter");
 
   // ---------------------------------------------------------------------------
   // Lifecycle

--- a/apps/bots/discord/src/adapter.ts
+++ b/apps/bots/discord/src/adapter.ts
@@ -20,6 +20,7 @@
 import {
   BaseBotAdapter,
   type BotCommand,
+  createBotLogger,
   formatBotError,
   handleStreamingChat,
   type PlatformName,
@@ -170,6 +171,7 @@ export class DiscordAdapter extends BaseBotAdapter {
   private dmWelcomeSent = new Set<string>();
   private statusRotationTimer: ReturnType<typeof setInterval> | null = null;
   private statusIndex = Math.floor(Math.random() * ROTATING_STATUSES.length);
+  private adapterLogger = createBotLogger("discord", "adapter");
 
   // ---------------------------------------------------------------------------
   // Lifecycle
@@ -213,7 +215,10 @@ export class DiscordAdapter extends BaseBotAdapter {
    */
   protected async registerEvents(): Promise<void> {
     this.client.once(Events.ClientReady, (c) => {
-      console.log(`Discord bot ready as ${c.user.tag}`);
+      this.adapterLogger.info("client_ready", {
+        bot_tag: c.user.tag,
+        bot_id: c.user.id,
+      });
       this.startStatusRotation(c.user);
     });
 
@@ -232,7 +237,11 @@ export class DiscordAdapter extends BaseBotAdapter {
         try {
           await message.fetch();
         } catch (error) {
-          console.error("Failed to fetch partial message:", error);
+          this.adapterLogger.error(
+            "partial_message_fetch_failed",
+            { message_id: message.id },
+            error,
+          );
           return;
         }
       }
@@ -309,6 +318,11 @@ export class DiscordAdapter extends BaseBotAdapter {
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
     const name = interaction.commandName;
+    this.adapterLogger.info("slash_command_received", {
+      command: name,
+      user_id: interaction.user.id,
+      channel_id: interaction.channelId,
+    });
 
     if (name === "gaia") {
       await this.handleGaiaInteraction(interaction);
@@ -386,6 +400,11 @@ export class DiscordAdapter extends BaseBotAdapter {
     interaction: MessageContextMenuCommandInteraction,
   ): Promise<void> {
     const name = interaction.commandName;
+    this.adapterLogger.info("context_menu_received", {
+      command: name,
+      user_id: interaction.user.id,
+      channel_id: interaction.channelId,
+    });
     const content = interaction.targetMessage.content;
     const userId = interaction.user.id;
     const channelId = interaction.channelId;
@@ -571,6 +590,14 @@ export class DiscordAdapter extends BaseBotAdapter {
 
       clearTyping();
     } catch (error) {
+      this.adapterLogger.error(
+        "dm_message_processing_failed",
+        {
+          user_id: userId,
+          channel_id: message.channelId,
+        },
+        error,
+      );
       await send(formatBotError(error));
     }
   }
@@ -742,6 +769,14 @@ export class DiscordAdapter extends BaseBotAdapter {
 
       clearTyping();
     } catch (error) {
+      this.adapterLogger.error(
+        "mention_message_processing_failed",
+        {
+          user_id: message.author.id,
+          channel_id: message.channelId,
+        },
+        error,
+      );
       await send(formatBotError(error));
     }
   }

--- a/apps/bots/discord/src/index.ts
+++ b/apps/bots/discord/src/index.ts
@@ -1,17 +1,21 @@
-import { allCommands } from "@gaia/shared";
+import { allCommands, createBotLogger } from "@gaia/shared";
 import { DiscordAdapter } from "./adapter";
 
 const adapter = new DiscordAdapter();
+const logger = createBotLogger("discord", "main");
 
 async function main() {
+  logger.info("process_boot_start");
   await adapter.boot(allCommands);
+  logger.info("process_boot_complete");
 }
 
 async function shutdown() {
   try {
+    logger.info("process_shutdown_signal");
     await adapter.shutdown();
   } catch (err) {
-    console.error("Shutdown error:", err);
+    logger.error("process_shutdown_failed", undefined, err);
   }
   process.exit(0);
 }
@@ -20,6 +24,6 @@ process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 
 main().catch((err) => {
-  console.error("Fatal error:", err);
+  logger.error("process_fatal_error", undefined, err);
   process.exit(1);
 });

--- a/apps/bots/slack/src/adapter.ts
+++ b/apps/bots/slack/src/adapter.ts
@@ -24,6 +24,7 @@ import {
   BaseBotAdapter,
   type BotCommand,
   convertToSlackMrkdwn,
+  createBotLogger,
   handleStreamingChat,
   type PlatformName,
   parseTextArgs,
@@ -81,6 +82,7 @@ export class SlackAdapter extends BaseBotAdapter {
   private token!: string;
   private signingSecret!: string;
   private appToken!: string;
+  private adapterLogger = createBotLogger("slack", "adapter");
 
   // ---------------------------------------------------------------------------
   // Lifecycle
@@ -129,6 +131,11 @@ export class SlackAdapter extends BaseBotAdapter {
       this.app.command(
         `/${commandName}`,
         async ({ command, ack, respond, client }) => {
+          this.adapterLogger.info("slash_command_received", {
+            command: commandName,
+            user_id: command.user_id,
+            channel_id: command.channel_id,
+          });
           await ack();
 
           const userId = command.user_id;
@@ -178,6 +185,11 @@ export class SlackAdapter extends BaseBotAdapter {
       const userId = event.user;
       const channelId = event.channel;
 
+      this.adapterLogger.info("app_mention_received", {
+        user_id: userId,
+        channel_id: channelId,
+      });
+
       if (!userId) return;
 
       if (!content) {
@@ -199,6 +211,11 @@ export class SlackAdapter extends BaseBotAdapter {
       if (msg.channel_type !== "im") return;
       if (!msg.text || !msg.user || !msg.channel) return;
 
+      this.adapterLogger.info("dm_message_received", {
+        user_id: msg.user,
+        channel_id: msg.channel,
+      });
+
       await this.handleSlackStreaming(client, msg.channel, msg.user, msg.text);
     });
   }
@@ -206,7 +223,7 @@ export class SlackAdapter extends BaseBotAdapter {
   /** Starts the Slack Bolt app. */
   protected async start(): Promise<void> {
     await this.app.start();
-    console.log("Slack bot is running");
+    this.adapterLogger.info("socket_mode_started");
   }
 
   /** Stops the Slack Bolt app. */
@@ -226,6 +243,11 @@ export class SlackAdapter extends BaseBotAdapter {
    */
   private registerGaiaCommand(): void {
     this.app.command("/gaia", async ({ command, ack, client }) => {
+      this.adapterLogger.info("slash_command_received", {
+        command: "gaia",
+        user_id: command.user_id,
+        channel_id: command.channel_id,
+      });
       await ack();
 
       const userId = command.user_id;
@@ -257,6 +279,12 @@ export class SlackAdapter extends BaseBotAdapter {
     userId: string,
     message: string,
   ): Promise<void> {
+    this.adapterLogger.info("streaming_started", {
+      user_id: userId,
+      channel_id: channelId,
+      message_length: message.length,
+    });
+
     const result = await client.chat.postMessage({
       channel: channelId,
       text: "Thinking...",
@@ -264,7 +292,10 @@ export class SlackAdapter extends BaseBotAdapter {
 
     const ts = (result as { ts?: string }).ts;
     if (!ts) {
-      console.warn("Slack postMessage returned no ts — sending fallback error");
+      this.adapterLogger.warn("post_message_missing_ts", {
+        user_id: userId,
+        channel_id: channelId,
+      });
       try {
         await client.chat.postEphemeral({
           channel: channelId,
@@ -272,7 +303,14 @@ export class SlackAdapter extends BaseBotAdapter {
           text: "Something went wrong processing your message. Please try again.",
         });
       } catch (fallbackErr) {
-        console.error("Slack fallback error message also failed:", fallbackErr);
+        this.adapterLogger.error(
+          "post_ephemeral_fallback_failed",
+          {
+            user_id: userId,
+            channel_id: channelId,
+          },
+          fallbackErr,
+        );
       }
       return;
     }

--- a/apps/bots/slack/src/adapter.ts
+++ b/apps/bots/slack/src/adapter.ts
@@ -82,7 +82,7 @@ export class SlackAdapter extends BaseBotAdapter {
   private token!: string;
   private signingSecret!: string;
   private appToken!: string;
-  private adapterLogger = createBotLogger("slack", "adapter");
+  private readonly adapterLogger = createBotLogger("slack", "adapter");
 
   // ---------------------------------------------------------------------------
   // Lifecycle

--- a/apps/bots/slack/src/index.ts
+++ b/apps/bots/slack/src/index.ts
@@ -1,17 +1,21 @@
-import { allCommands } from "@gaia/shared";
+import { allCommands, createBotLogger } from "@gaia/shared";
 import { SlackAdapter } from "./adapter";
 
 const adapter = new SlackAdapter();
+const logger = createBotLogger("slack", "main");
 
 async function main() {
+  logger.info("process_boot_start");
   await adapter.boot(allCommands);
+  logger.info("process_boot_complete");
 }
 
 async function shutdown() {
   try {
+    logger.info("process_shutdown_signal");
     await adapter.shutdown();
   } catch (err) {
-    console.error("Shutdown error:", err);
+    logger.error("process_shutdown_failed", undefined, err);
   }
   process.exit(0);
 }
@@ -20,6 +24,6 @@ process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 
 main().catch((err) => {
-  console.error("Fatal error:", err);
+  logger.error("process_fatal_error", undefined, err);
   process.exit(1);
 });

--- a/apps/bots/telegram/src/adapter.ts
+++ b/apps/bots/telegram/src/adapter.ts
@@ -25,6 +25,7 @@ import {
   BaseBotAdapter,
   type BotCommand,
   convertToTelegramMarkdown,
+  createBotLogger,
   handleStreamingChat,
   type PlatformName,
   parseTextArgs,
@@ -65,6 +66,7 @@ export class TelegramAdapter extends BaseBotAdapter {
   private bot!: Bot;
   private token!: string;
   private botUsername: string | undefined;
+  private adapterLogger = createBotLogger("telegram", "adapter");
 
   // ---------------------------------------------------------------------------
   // Lifecycle
@@ -80,7 +82,7 @@ export class TelegramAdapter extends BaseBotAdapter {
 
     this.bot = new Bot(this.token);
     this.bot.catch((err) => {
-      console.error("Bot error:", err);
+      this.adapterLogger.error("bot_runtime_error", undefined, err);
     });
     // Cache the bot username upfront to avoid calling getMe() on every message
     const botInfo = await this.bot.api.getMe();
@@ -147,7 +149,7 @@ export class TelegramAdapter extends BaseBotAdapter {
     try {
       await this.bot.api.setMyCommands(telegramCommands);
     } catch (e) {
-      console.error("Failed to register Telegram bot commands:", e);
+      this.adapterLogger.error("set_my_commands_failed", undefined, e);
     }
   }
 
@@ -165,6 +167,12 @@ export class TelegramAdapter extends BaseBotAdapter {
       if (!userId) return;
 
       const isPrivate = ctx.chat.type === "private";
+      this.adapterLogger.info("message_received", {
+        user_id: userId,
+        chat_id: ctx.chat.id,
+        chat_type: ctx.chat.type,
+        is_private: isPrivate,
+      });
 
       if (isPrivate) {
         await this.handleTelegramStreaming(ctx, userId, ctx.message.text);
@@ -189,7 +197,7 @@ export class TelegramAdapter extends BaseBotAdapter {
   /** Starts long polling. */
   protected async start(): Promise<void> {
     this.bot.start({
-      onStart: () => console.log("Telegram bot is running"),
+      onStart: () => this.adapterLogger.info("long_polling_started"),
     });
   }
 
@@ -217,6 +225,12 @@ export class TelegramAdapter extends BaseBotAdapter {
         return;
       }
 
+      this.adapterLogger.info("slash_command_received", {
+        command: "gaia",
+        user_id: userId,
+        chat_id: ctx.chat?.id,
+      });
+
       await this.handleTelegramStreaming(ctx, userId, message);
     });
   }
@@ -234,6 +248,12 @@ export class TelegramAdapter extends BaseBotAdapter {
   ): Promise<void> {
     const chatId = ctx.chat?.id;
     if (!chatId) return;
+
+    this.adapterLogger.info("streaming_started", {
+      user_id: userId,
+      chat_id: chatId,
+      message_length: message.length,
+    });
 
     const loading = await ctx.reply("Thinking...");
     let currentMessageId = loading.message_id;
@@ -290,7 +310,11 @@ export class TelegramAdapter extends BaseBotAdapter {
               } catch {}
               return;
             }
-            console.error("Telegram editMessageText error:", e);
+            this.adapterLogger.error(
+              "edit_message_text_failed",
+              { chat_id: chatId, message_id: currentMessageId },
+              e,
+            );
           }
         },
         async (text: string) => {
@@ -333,7 +357,11 @@ export class TelegramAdapter extends BaseBotAdapter {
                 } catch {}
                 return;
               }
-              console.error("Telegram editMessageText error:", e);
+              this.adapterLogger.error(
+                "edit_message_text_failed",
+                { chat_id: chatId, message_id: newMessage.message_id },
+                e,
+              );
             }
           };
         },
@@ -354,7 +382,11 @@ export class TelegramAdapter extends BaseBotAdapter {
               await ctx.api.editMessageText(chatId, currentMessageId, authMsg);
             }
           } catch (e) {
-            console.error("Telegram auth message error:", e);
+            this.adapterLogger.error(
+              "auth_message_failed",
+              { chat_id: chatId, user_id: userId },
+              e,
+            );
             // DM failed (privacy settings) — update group message with fallback
             try {
               const fallback = this.botUsername
@@ -362,8 +394,9 @@ export class TelegramAdapter extends BaseBotAdapter {
                 : `I couldn't send you a DM — your privacy settings may be blocking bot messages.\n\nPlease message me directly and use /auth to link your account.`;
               await ctx.api.editMessageText(chatId, currentMessageId, fallback);
             } catch (fallbackErr) {
-              console.error(
-                "Telegram fallback group message also failed:",
+              this.adapterLogger.error(
+                "auth_fallback_message_failed",
+                { chat_id: chatId, user_id: userId },
                 fallbackErr,
               );
             }
@@ -374,7 +407,11 @@ export class TelegramAdapter extends BaseBotAdapter {
           try {
             await ctx.api.editMessageText(chatId, currentMessageId, errMsg);
           } catch (e) {
-            console.error("Telegram editMessageText error:", e);
+            this.adapterLogger.error(
+              "edit_message_text_failed",
+              { chat_id: chatId, message_id: currentMessageId },
+              e,
+            );
           }
         },
         STREAMING_DEFAULTS.telegram,
@@ -440,7 +477,11 @@ export class TelegramAdapter extends BaseBotAdapter {
               try {
                 await api.editMessageText(chatId, msg.message_id, t);
               } catch (e) {
-                console.error("Telegram editMessageText error:", e);
+                this.adapterLogger.error(
+                  "edit_message_text_failed",
+                  { chat_id: chatId, message_id: msg.message_id },
+                  e,
+                );
               }
             }
           },
@@ -475,7 +516,11 @@ export class TelegramAdapter extends BaseBotAdapter {
               try {
                 await api.editMessageText(targetChat, msg.message_id, t);
               } catch (e) {
-                console.error("Telegram editMessageText error:", e);
+                this.adapterLogger.error(
+                  "edit_message_text_failed",
+                  { chat_id: targetChat, message_id: msg.message_id },
+                  e,
+                );
               }
             }
           },
@@ -499,7 +544,11 @@ export class TelegramAdapter extends BaseBotAdapter {
             try {
               await api.editMessageText(targetChat, msg.message_id, t);
             } catch (e) {
-              console.error("Telegram editMessageText error:", e);
+              this.adapterLogger.error(
+                "edit_message_text_failed",
+                { chat_id: targetChat, message_id: msg.message_id },
+                e,
+              );
             }
           },
         };

--- a/apps/bots/telegram/src/adapter.ts
+++ b/apps/bots/telegram/src/adapter.ts
@@ -27,6 +27,7 @@ import {
   convertToTelegramMarkdown,
   createBotLogger,
   handleStreamingChat,
+  hashLogIdentifier,
   type PlatformName,
   parseTextArgs,
   type RichMessage,
@@ -168,8 +169,8 @@ export class TelegramAdapter extends BaseBotAdapter {
 
       const isPrivate = ctx.chat.type === "private";
       this.adapterLogger.info("message_received", {
-        user_id: userId,
-        chat_id: ctx.chat.id,
+        user_hash: hashLogIdentifier(userId),
+        chat_hash: hashLogIdentifier(ctx.chat.id),
         chat_type: ctx.chat.type,
         is_private: isPrivate,
       });
@@ -227,8 +228,8 @@ export class TelegramAdapter extends BaseBotAdapter {
 
       this.adapterLogger.info("slash_command_received", {
         command: "gaia",
-        user_id: userId,
-        chat_id: ctx.chat?.id,
+        user_hash: hashLogIdentifier(userId),
+        chat_hash: hashLogIdentifier(ctx.chat?.id),
       });
 
       await this.handleTelegramStreaming(ctx, userId, message);
@@ -250,8 +251,8 @@ export class TelegramAdapter extends BaseBotAdapter {
     if (!chatId) return;
 
     this.adapterLogger.info("streaming_started", {
-      user_id: userId,
-      chat_id: chatId,
+      user_hash: hashLogIdentifier(userId),
+      chat_hash: hashLogIdentifier(chatId),
       message_length: message.length,
     });
 

--- a/apps/bots/telegram/src/adapter.ts
+++ b/apps/bots/telegram/src/adapter.ts
@@ -67,7 +67,7 @@ export class TelegramAdapter extends BaseBotAdapter {
   private bot!: Bot;
   private token!: string;
   private botUsername: string | undefined;
-  private adapterLogger = createBotLogger("telegram", "adapter");
+  private readonly adapterLogger = createBotLogger("telegram", "adapter");
 
   // ---------------------------------------------------------------------------
   // Lifecycle

--- a/apps/bots/telegram/src/index.ts
+++ b/apps/bots/telegram/src/index.ts
@@ -1,17 +1,21 @@
-import { allCommands } from "@gaia/shared";
+import { allCommands, createBotLogger } from "@gaia/shared";
 import { TelegramAdapter } from "./adapter";
 
 const adapter = new TelegramAdapter();
+const logger = createBotLogger("telegram", "main");
 
 async function main() {
+  logger.info("process_boot_start");
   await adapter.boot(allCommands);
+  logger.info("process_boot_complete");
 }
 
 async function shutdown() {
   try {
+    logger.info("process_shutdown_signal");
     await adapter.shutdown();
   } catch (err) {
-    console.error("Shutdown error:", err);
+    logger.error("process_shutdown_failed", undefined, err);
   }
   process.exit(0);
 }
@@ -20,6 +24,6 @@ process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 
 main().catch((err) => {
-  console.error("Fatal error:", err);
+  logger.error("process_fatal_error", undefined, err);
   process.exit(1);
 });

--- a/apps/bots/whatsapp/src/adapter.ts
+++ b/apps/bots/whatsapp/src/adapter.ts
@@ -20,6 +20,7 @@ import {
   BaseBotAdapter,
   type BotCommand,
   convertToWhatsAppMarkdown,
+  createBotLogger,
   handleStreamingChat,
   type PlatformName,
   parseTextArgs,
@@ -73,6 +74,7 @@ export class WhatsAppAdapter extends BaseBotAdapter {
 
   /** Tracks users who have already received a welcome message this process. */
   private readonly welcomeSent = new Set<string>();
+  private adapterLogger = createBotLogger("whatsapp", "adapter");
 
   private get whatsAppClient(): WhatsAppClient {
     if (!this.waClient) {
@@ -99,12 +101,15 @@ export class WhatsAppAdapter extends BaseBotAdapter {
       baseUrl: "https://api.kapso.ai/meta/whatsapp",
       kapsoApiKey: this.waConfig.kapsoApiKey,
     });
-    console.log("WhatsApp client initialized via Kapso");
+    this.adapterLogger.info("client_initialized", {
+      webhook_port: this.waConfig.webhookPort,
+      phone_number_id: this.waConfig.kapsoPhoneNumberId,
+    });
   }
 
   /** WhatsApp has no platform-level command registration step. */
   protected async registerCommands(_commands: BotCommand[]): Promise<void> {
-    console.log("WhatsApp commands registered (text-based matching)");
+    this.adapterLogger.info("commands_registered");
   }
 
   /**
@@ -135,6 +140,9 @@ export class WhatsAppAdapter extends BaseBotAdapter {
       // Event type is in the header for Kapso webhooks, not in the body
       const eventType = c.req.header("x-webhook-event") ?? null;
       if (eventType !== "whatsapp.message.received") {
+        this.adapterLogger.debug("webhook_event_ignored", {
+          event_type: eventType,
+        });
         return c.json({ status: "ignored" });
       }
 
@@ -154,15 +162,29 @@ export class WhatsAppAdapter extends BaseBotAdapter {
       for (const event of events) {
         const waId = extractWaId(event);
         const text = extractTextBody(event);
+        this.adapterLogger.info("webhook_message_received", {
+          wa_id: waId,
+          message_type: event.message.type,
+          has_text: Boolean(text),
+        });
         if (text) {
           // Fire-and-forget — do not await so webhook returns 200 quickly
           this.handleIncomingMessage(waId, text, event.message.id).catch(
-            (err) => console.error("Error handling WhatsApp message:", err),
+            (err) =>
+              this.adapterLogger.error(
+                "incoming_message_processing_failed",
+                { wa_id: waId, message_id: event.message.id },
+                err,
+              ),
           );
         } else if (event.message.type !== "text") {
           // Non-text message (image, audio, video, document, etc.)
           this.handleUnsupportedMedia(waId, event.message.type).catch((err) =>
-            console.error("Error handling unsupported media:", err),
+            this.adapterLogger.error(
+              "unsupported_media_handling_failed",
+              { wa_id: waId, message_type: event.message.type },
+              err,
+            ),
           );
         }
       }
@@ -174,21 +196,21 @@ export class WhatsAppAdapter extends BaseBotAdapter {
       this.httpServer = serve(
         { fetch: app.fetch, port: this.whatsAppConfig.webhookPort },
         () => {
-          console.log(
-            `WhatsApp webhook server listening on port ${this.whatsAppConfig.webhookPort}`,
-          );
+          this.adapterLogger.info("webhook_server_started", {
+            port: this.whatsAppConfig.webhookPort,
+          });
           resolve();
         },
       ) as Server;
       this.httpServer.on("error", (err) => {
-        console.error("WhatsApp webhook server error:", err);
+        this.adapterLogger.error("webhook_server_error", undefined, err);
       });
     });
   }
 
   /** Nothing additional to start — HTTP server is already up after registerEvents. */
   protected async start(): Promise<void> {
-    console.log("WhatsApp bot started and listening for messages");
+    this.adapterLogger.info("bot_started");
   }
 
   /** Closes the HTTP server gracefully. */
@@ -223,6 +245,13 @@ export class WhatsAppAdapter extends BaseBotAdapter {
     text: string,
     messageId: string,
   ): Promise<void> {
+    this.adapterLogger.info("incoming_message_started", {
+      wa_id: waId,
+      message_id: messageId,
+      text_length: text.length,
+      is_command: text.startsWith("/"),
+    });
+
     // Show typing indicator — mark message as read and display "typing..." bubble.
     // WhatsApp auto-dismisses after ~25s, so we refresh every 20s to keep it alive
     // for long-running responses. The interval is cleared when a reply is sent.
@@ -233,8 +262,12 @@ export class WhatsAppAdapter extends BaseBotAdapter {
           messageId,
           typingIndicator: { type: "text" },
         })
-        .catch((err) =>
-          console.error("WhatsApp: failed to show typing indicator:", err),
+        .catch((err: unknown) =>
+          this.adapterLogger.error(
+            "typing_indicator_failed",
+            { wa_id: waId, message_id: messageId },
+            err,
+          ),
         );
 
     showTyping();
@@ -361,14 +394,18 @@ export class WhatsAppAdapter extends BaseBotAdapter {
         this.analytics,
       );
     } catch (err) {
-      console.error("WhatsApp streaming error:", err);
+      this.adapterLogger.error("streaming_failed", { wa_id: waId }, err);
       try {
         await this.sendWhatsAppText(
           waId,
           "An error occurred. Please try again.",
         );
       } catch (sendErr) {
-        console.error("WhatsApp send error:", sendErr);
+        this.adapterLogger.error(
+          "streaming_error_message_send_failed",
+          { wa_id: waId },
+          sendErr,
+        );
       }
     }
   }

--- a/apps/bots/whatsapp/src/adapter.ts
+++ b/apps/bots/whatsapp/src/adapter.ts
@@ -76,7 +76,7 @@ export class WhatsAppAdapter extends BaseBotAdapter {
 
   /** Tracks users who have already received a welcome message this process. */
   private readonly welcomeSent = new Set<string>();
-  private adapterLogger = createBotLogger("whatsapp", "adapter");
+  private readonly adapterLogger = createBotLogger("whatsapp", "adapter");
 
   private get whatsAppClient(): WhatsAppClient {
     if (!this.waClient) {

--- a/apps/bots/whatsapp/src/adapter.ts
+++ b/apps/bots/whatsapp/src/adapter.ts
@@ -22,6 +22,7 @@ import {
   convertToWhatsAppMarkdown,
   createBotLogger,
   handleStreamingChat,
+  hashLogIdentifier,
   type PlatformName,
   parseTextArgs,
   type RichMessage,
@@ -29,6 +30,7 @@ import {
   richMessageToMarkdown,
   type SentMessage,
   STREAMING_DEFAULTS,
+  sanitizeErrorForLog,
 } from "@gaia/shared";
 import { serve } from "@hono/node-server";
 import { WhatsAppClient } from "@kapso/whatsapp-cloud-api";
@@ -161,9 +163,10 @@ export class WhatsAppAdapter extends BaseBotAdapter {
 
       for (const event of events) {
         const waId = extractWaId(event);
+        const waIdHash = hashLogIdentifier(waId);
         const text = extractTextBody(event);
         this.adapterLogger.info("webhook_message_received", {
-          wa_id: waId,
+          wa_hash: waIdHash,
           message_type: event.message.type,
           has_text: Boolean(text),
         });
@@ -171,20 +174,20 @@ export class WhatsAppAdapter extends BaseBotAdapter {
           // Fire-and-forget — do not await so webhook returns 200 quickly
           this.handleIncomingMessage(waId, text, event.message.id).catch(
             (err) =>
-              this.adapterLogger.error(
-                "incoming_message_processing_failed",
-                { wa_id: waId, message_id: event.message.id },
-                err,
-              ),
+              this.adapterLogger.error("incoming_message_processing_failed", {
+                wa_hash: waIdHash,
+                message_id: event.message.id,
+                ...sanitizeErrorForLog(err),
+              }),
           );
         } else if (event.message.type !== "text") {
           // Non-text message (image, audio, video, document, etc.)
           this.handleUnsupportedMedia(waId, event.message.type).catch((err) =>
-            this.adapterLogger.error(
-              "unsupported_media_handling_failed",
-              { wa_id: waId, message_type: event.message.type },
-              err,
-            ),
+            this.adapterLogger.error("unsupported_media_handling_failed", {
+              wa_hash: waIdHash,
+              message_type: event.message.type,
+              ...sanitizeErrorForLog(err),
+            }),
           );
         }
       }
@@ -245,8 +248,9 @@ export class WhatsAppAdapter extends BaseBotAdapter {
     text: string,
     messageId: string,
   ): Promise<void> {
+    const waIdHash = hashLogIdentifier(waId);
     this.adapterLogger.info("incoming_message_started", {
-      wa_id: waId,
+      wa_hash: waIdHash,
       message_id: messageId,
       text_length: text.length,
       is_command: text.startsWith("/"),
@@ -263,11 +267,11 @@ export class WhatsAppAdapter extends BaseBotAdapter {
           typingIndicator: { type: "text" },
         })
         .catch((err: unknown) =>
-          this.adapterLogger.error(
-            "typing_indicator_failed",
-            { wa_id: waId, message_id: messageId },
-            err,
-          ),
+          this.adapterLogger.error("typing_indicator_failed", {
+            wa_hash: waIdHash,
+            message_id: messageId,
+            ...sanitizeErrorForLog(err),
+          }),
         );
 
     showTyping();
@@ -394,18 +398,20 @@ export class WhatsAppAdapter extends BaseBotAdapter {
         this.analytics,
       );
     } catch (err) {
-      this.adapterLogger.error("streaming_failed", { wa_id: waId }, err);
+      this.adapterLogger.error("streaming_failed", {
+        wa_hash: hashLogIdentifier(waId),
+        ...sanitizeErrorForLog(err),
+      });
       try {
         await this.sendWhatsAppText(
           waId,
           "An error occurred. Please try again.",
         );
       } catch (sendErr) {
-        this.adapterLogger.error(
-          "streaming_error_message_send_failed",
-          { wa_id: waId },
-          sendErr,
-        );
+        this.adapterLogger.error("streaming_error_message_send_failed", {
+          wa_hash: hashLogIdentifier(waId),
+          ...sanitizeErrorForLog(sendErr),
+        });
       }
     }
   }

--- a/apps/bots/whatsapp/src/index.ts
+++ b/apps/bots/whatsapp/src/index.ts
@@ -1,17 +1,21 @@
-import { allCommands } from "@gaia/shared";
+import { allCommands, createBotLogger } from "@gaia/shared";
 import { WhatsAppAdapter } from "./adapter";
 
 const adapter = new WhatsAppAdapter();
+const logger = createBotLogger("whatsapp", "main");
 
 async function main() {
+  logger.info("process_boot_start");
   await adapter.boot(allCommands);
+  logger.info("process_boot_complete");
 }
 
 async function shutdown() {
   try {
+    logger.info("process_shutdown_signal");
     await adapter.shutdown();
   } catch (err) {
-    console.error("Shutdown error:", err);
+    logger.error("process_shutdown_failed", undefined, err);
   }
   process.exit(0);
 }
@@ -22,6 +26,6 @@ process.on("SIGTERM", shutdown);
 try {
   await main();
 } catch (err) {
-  console.error("Fatal error:", err);
+  logger.error("process_fatal_error", undefined, err);
   process.exit(1);
 }

--- a/libs/shared/ts/src/bots/adapter/base.ts
+++ b/libs/shared/ts/src/bots/adapter/base.ts
@@ -44,6 +44,7 @@ import type {
   RichMessageTarget,
 } from "../types";
 import { formatBotError } from "../utils/formatters";
+import { type BotLogger, createBotLogger } from "../utils/logger";
 
 /**
  * Abstract base class that all platform bot adapters extend.
@@ -84,6 +85,9 @@ export abstract class BaseBotAdapter {
   /** Server-side PostHog analytics. No-op when POSTHOG_API_KEY is absent. */
   protected analytics: Analytics = new Analytics(undefined);
 
+  /** Shared structured logger for adapter lifecycle and command execution. */
+  protected logger: BotLogger = createBotLogger("shared", "base-adapter");
+
   // ---------------------------------------------------------------------------
   // Lifecycle — template method pattern
   // ---------------------------------------------------------------------------
@@ -102,6 +106,9 @@ export abstract class BaseBotAdapter {
    * @param commands - Array of unified {@link BotCommand} definitions to register.
    */
   async boot(commands: BotCommand[]): Promise<void> {
+    this.logger = createBotLogger(this.platform, "base-adapter");
+    this.logger.info("boot_started", { command_count: commands.length });
+
     this.config = await loadConfig();
     this.gaia = new GaiaClient(
       this.config.gaiaApiUrl,
@@ -117,6 +124,10 @@ export abstract class BaseBotAdapter {
     await this.registerCommands(commands);
     await this.registerEvents();
     await this.start();
+
+    this.logger.info("boot_completed", {
+      gaia_api_url: this.config.gaiaApiUrl,
+    });
   }
 
   /**
@@ -126,9 +137,10 @@ export abstract class BaseBotAdapter {
    * Delegates to the platform-specific {@link stop} implementation.
    */
   async shutdown(): Promise<void> {
-    console.log(`Shutting down ${this.platform} bot...`);
+    this.logger.info("shutdown_started");
     await this.stop();
     await this.analytics.shutdown();
+    this.logger.info("shutdown_completed");
   }
 
   // ---------------------------------------------------------------------------
@@ -231,6 +243,11 @@ export abstract class BaseBotAdapter {
 
     const startMs = Date.now();
     try {
+      this.logger.info("command_dispatch_started", {
+        command: name,
+        user_id: target.userId,
+        channel_id: target.channelId,
+      });
       await command.execute({ gaia: this.gaia, target, ctx, args, rawText });
       this.analytics.capture(distinctId, BOT_EVENTS.COMMAND_EXECUTED, {
         command: name,
@@ -238,10 +255,26 @@ export abstract class BaseBotAdapter {
         success: true,
         channel_id: target.channelId,
       });
+      this.logger.info("command_dispatch_completed", {
+        command: name,
+        user_id: target.userId,
+        channel_id: target.channelId,
+        duration_ms: Date.now() - startMs,
+      });
     } catch (error) {
       const durationMs = Date.now() - startMs;
       const errorType = error instanceof Error ? error.name : "Unknown";
-      console.error(`Error executing command /${name}:`, error);
+      this.logger.error(
+        "command_dispatch_failed",
+        {
+          command: name,
+          user_id: target.userId,
+          channel_id: target.channelId,
+          duration_ms: durationMs,
+          error_type: errorType,
+        },
+        error,
+      );
       // Capture only the error class name. Raw messages can contain file
       // paths, request IDs, or upstream-echoed tokens — never ship them.
       this.analytics.capture(distinctId, BOT_EVENTS.COMMAND_EXECUTED, {

--- a/libs/shared/ts/src/bots/adapter/base.ts
+++ b/libs/shared/ts/src/bots/adapter/base.ts
@@ -44,7 +44,12 @@ import type {
   RichMessageTarget,
 } from "../types";
 import { formatBotError } from "../utils/formatters";
-import { type BotLogger, createBotLogger } from "../utils/logger";
+import {
+  type BotLogger,
+  createBotLogger,
+  hashLogIdentifier,
+  sanitizeErrorForLog,
+} from "../utils/logger";
 
 /**
  * Abstract base class that all platform bot adapters extend.
@@ -125,9 +130,7 @@ export abstract class BaseBotAdapter {
     await this.registerEvents();
     await this.start();
 
-    this.logger.info("boot_completed", {
-      gaia_api_url: this.config.gaiaApiUrl,
-    });
+    this.logger.info("boot_completed", { gaia_api_configured: true });
   }
 
   /**
@@ -245,8 +248,8 @@ export abstract class BaseBotAdapter {
     try {
       this.logger.info("command_dispatch_started", {
         command: name,
-        user_id: target.userId,
-        channel_id: target.channelId,
+        user_hash: hashLogIdentifier(target.userId),
+        channel_hash: hashLogIdentifier(target.channelId),
       });
       await command.execute({ gaia: this.gaia, target, ctx, args, rawText });
       this.analytics.capture(distinctId, BOT_EVENTS.COMMAND_EXECUTED, {
@@ -257,24 +260,21 @@ export abstract class BaseBotAdapter {
       });
       this.logger.info("command_dispatch_completed", {
         command: name,
-        user_id: target.userId,
-        channel_id: target.channelId,
+        user_hash: hashLogIdentifier(target.userId),
+        channel_hash: hashLogIdentifier(target.channelId),
         duration_ms: Date.now() - startMs,
       });
     } catch (error) {
       const durationMs = Date.now() - startMs;
       const errorType = error instanceof Error ? error.name : "Unknown";
-      this.logger.error(
-        "command_dispatch_failed",
-        {
-          command: name,
-          user_id: target.userId,
-          channel_id: target.channelId,
-          duration_ms: durationMs,
-          error_type: errorType,
-        },
-        error,
-      );
+      this.logger.error("command_dispatch_failed", {
+        command: name,
+        user_hash: hashLogIdentifier(target.userId),
+        channel_hash: hashLogIdentifier(target.channelId),
+        duration_ms: durationMs,
+        error_type: errorType,
+        ...sanitizeErrorForLog(error),
+      });
       // Capture only the error class name. Raw messages can contain file
       // paths, request IDs, or upstream-echoed tokens — never ship them.
       this.analytics.capture(distinctId, BOT_EVENTS.COMMAND_EXECUTED, {

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -18,6 +18,7 @@
 
 export * from "./commands";
 export * from "./formatters";
+export * from "./logger";
 export * from "./streaming";
 
 /**

--- a/libs/shared/ts/src/bots/utils/logger.ts
+++ b/libs/shared/ts/src/bots/utils/logger.ts
@@ -1,3 +1,4 @@
+import { createHash, createHmac } from "node:crypto";
 import type { PlatformName } from "../types";
 
 type BotLogLevel = "debug" | "info" | "warn" | "error";
@@ -17,6 +18,48 @@ export interface BotLogger {
   info: (event: string, fields?: BotLogFields) => void;
   warn: (event: string, fields?: BotLogFields) => void;
   error: (event: string, fields?: BotLogFields, error?: unknown) => void;
+}
+
+const RESERVED_LOG_KEYS = new Set([
+  "time",
+  "level",
+  "env",
+  "service",
+  "platform",
+  "component",
+  "event",
+  "error",
+]);
+
+export function hashLogIdentifier(
+  value: string | number | undefined | null,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  const normalized = String(value);
+  const secret =
+    process.env.BOT_LOG_HASH_SECRET ?? process.env.GAIA_BOT_API_KEY;
+
+  const digest = secret
+    ? createHmac("sha256", secret).update(normalized).digest("hex")
+    : createHash("sha256").update(normalized).digest("hex");
+
+  return `h_${digest.slice(0, 16)}`;
+}
+
+export function sanitizeErrorForLog(error: unknown): BotLogFields {
+  if (error instanceof Error) {
+    return {
+      error_name: error.name,
+      error_message: error.message,
+    };
+  }
+
+  return {
+    error_name: "Unknown",
+    error_message:
+      typeof error === "string" ? error : "Unknown non-Error thrown",
+  };
 }
 
 function toJsonValue(value: unknown, depth = 0): JsonValue {
@@ -99,12 +142,13 @@ function buildRecord(
   if (fields) {
     for (const [key, value] of Object.entries(fields)) {
       if (value === undefined) continue;
-      record[key] = toJsonValue(value);
+      const safeKey = RESERVED_LOG_KEYS.has(key) ? `field_${key}` : key;
+      record[safeKey] = toJsonValue(value);
     }
   }
 
   if (error !== undefined) {
-    record.error = toJsonValue(error);
+    record.error = toJsonValue(sanitizeErrorForLog(error));
   }
 
   return record;

--- a/libs/shared/ts/src/bots/utils/logger.ts
+++ b/libs/shared/ts/src/bots/utils/logger.ts
@@ -1,0 +1,140 @@
+import type { PlatformName } from "../types";
+
+type BotLogLevel = "debug" | "info" | "warn" | "error";
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type BotLogFields = Record<string, unknown>;
+
+export interface BotLogger {
+  debug: (event: string, fields?: BotLogFields) => void;
+  info: (event: string, fields?: BotLogFields) => void;
+  warn: (event: string, fields?: BotLogFields) => void;
+  error: (event: string, fields?: BotLogFields, error?: unknown) => void;
+}
+
+function toJsonValue(value: unknown, depth = 0): JsonValue {
+  if (depth > 3) return "[truncated]";
+  if (value === null) return null;
+
+  const valueType = typeof value;
+  if (
+    valueType === "string" ||
+    valueType === "number" ||
+    valueType === "boolean"
+  ) {
+    return value as string | number | boolean;
+  }
+
+  if (valueType === "bigint") return String(value);
+  if (valueType === "undefined") return "[undefined]";
+  if (valueType === "function") return "[function]";
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack ?? "",
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 25).map((entry) => toJsonValue(entry, depth + 1));
+  }
+
+  if (valueType === "object") {
+    const out: Record<string, JsonValue> = {};
+    for (const [key, entry] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      if (entry === undefined) continue;
+      out[key] = toJsonValue(entry, depth + 1);
+    }
+    return out;
+  }
+
+  return String(value);
+}
+
+function write(level: BotLogLevel, line: string): void {
+  if (level === "debug") {
+    console.debug(line);
+    return;
+  }
+  if (level === "info") {
+    console.log(line);
+    return;
+  }
+  if (level === "warn") {
+    console.warn(line);
+    return;
+  }
+  console.error(line);
+}
+
+function buildRecord(
+  level: BotLogLevel,
+  platform: PlatformName | "shared",
+  component: string,
+  event: string,
+  fields?: BotLogFields,
+  error?: unknown,
+): Record<string, JsonValue> {
+  const record: Record<string, JsonValue> = {
+    time: new Date().toISOString(),
+    level: level.toUpperCase(),
+    env: process.env.NODE_ENV ?? "development",
+    service: platform === "shared" ? "gaia-bots" : `gaia-bot-${platform}`,
+    platform,
+    component,
+    event,
+  };
+
+  if (fields) {
+    for (const [key, value] of Object.entries(fields)) {
+      if (value === undefined) continue;
+      record[key] = toJsonValue(value);
+    }
+  }
+
+  if (error !== undefined) {
+    record.error = toJsonValue(error);
+  }
+
+  return record;
+}
+
+export function createBotLogger(
+  platform: PlatformName | "shared",
+  component: string,
+): BotLogger {
+  const emit = (
+    level: BotLogLevel,
+    event: string,
+    fields?: BotLogFields,
+    error?: unknown,
+  ) => {
+    const record = buildRecord(
+      level,
+      platform,
+      component,
+      event,
+      fields,
+      error,
+    );
+    write(level, JSON.stringify(record));
+  };
+
+  return {
+    debug: (event, fields) => emit("debug", event, fields),
+    info: (event, fields) => emit("info", event, fields),
+    warn: (event, fields) => emit("warn", event, fields),
+    error: (event, fields, error) => emit("error", event, fields, error),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared structured JSON logger (`createBotLogger`) for all bot platforms
- wire lifecycle + command-dispatch logging in `BaseBotAdapter`
- add platform-specific event/streaming error logs in Discord, Slack, Telegram, and WhatsApp adapters plus process-level logs in each bot entrypoint

## Notes
- this improves production debugging visibility for message intake, command execution, startup/shutdown, and error paths across all bots
- no runtime behavior changes to command logic; this is observability-focused