### PR TITLE
fix(api): harden workflow timezone resolution + lifecycle wide events

### DIFF
--- a/apps/api/app/api/v1/dependencies/oauth_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/oauth_dependencies.py
@@ -1,8 +1,44 @@
-from datetime import datetime
-from zoneinfo import ZoneInfo
+import asyncio
+from datetime import datetime, timezone as dt_timezone
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from bson import ObjectId
 from fastapi import Depends, Header, HTTPException, Request, WebSocket, status
 from shared.py.wide_events import log
+
+from app.db.mongodb.collections import users_collection
+
+_TIMEZONE_BACKFILL_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _is_valid_iana_or_offset(tz: str) -> bool:
+    """Cheap validation: accept IANA names or ±HH:MM offsets; reject garbage."""
+    if not tz:
+        return False
+    if tz.startswith(("+", "-")) and len(tz) == 6 and tz[3] == ":":
+        return True
+    try:
+        ZoneInfo(tz)
+        return True
+    except (ZoneInfoNotFoundError, ValueError):
+        return False
+
+
+async def _backfill_user_timezone(user_id: str, tz: str) -> None:
+    """Fire-and-forget write-through of the browser-reported timezone."""
+    try:
+        await users_collection.update_one(
+            {"_id": ObjectId(user_id)},
+            {"$set": {"timezone": tz, "updated_at": datetime.now(dt_timezone.utc)}},
+        )
+        log.info(
+            "Backfilled user.timezone from x-timezone header",
+            user_id=user_id,
+            timezone=tz,
+        )
+    except Exception as e:
+        log.warning(f"Failed to backfill user.timezone for {user_id}: {e}")
 
 
 async def get_current_user(request: Request):
@@ -123,30 +159,56 @@ def get_user_timezone(
 
 async def get_user_timezone_from_preferences(
     user: dict = Depends(get_current_user),
+    x_timezone: str = Header(
+        default="", alias="x-timezone", description="Browser timezone fallback"
+    ),
 ) -> str:
     """
-    Get the user's timezone from their stored preferences.
-    Falls back to UTC if no timezone is set.
+    Resolve the user's timezone with three-tier priority:
 
-    Args:
-        user: User data from get_current_user dependency
+      1. `user.timezone` stored in Mongo (set during onboarding)
+      2. `x-timezone` request header (browser-reported IANA zone)
+      3. UTC (last resort)
 
-    Returns:
-        User's timezone string (e.g., 'America/New_York', 'UTC')
+    Emits the wide-event field `timezone_source` so every request makes
+    it visible which branch was used. When we fall through to the header,
+    fire-and-forget a backfill so the Mongo doc is populated for next time.
     """
+    user_id = user.get("user_id")
+
     try:
-        # Only check the root level timezone field
-        timezone = user.get("timezone")
-        log.debug(f"User timezone from user.timezone: {timezone}")
+        stored_tz = (user.get("timezone") or "").strip()
+        if stored_tz:
+            log.set(timezone_source="user_profile", user_timezone=stored_tz)
+            return stored_tz
 
-        if timezone and timezone.strip():
-            log.debug(f"Using user's stored timezone: {timezone}")
-            return timezone.strip()
+        header_tz = (x_timezone or "").strip()
+        if (
+            header_tz
+            and header_tz.upper() != "UTC"
+            and _is_valid_iana_or_offset(header_tz)
+        ):
+            log.set(timezone_source="x_timezone_header", user_timezone=header_tz)
+            log.warning(
+                "user.timezone missing; using x-timezone header fallback",
+                user_id=user_id,
+                header_timezone=header_tz,
+            )
+            if user_id:
+                task = asyncio.create_task(_backfill_user_timezone(user_id, header_tz))
+                _TIMEZONE_BACKFILL_TASKS.add(task)
+                task.add_done_callback(_TIMEZONE_BACKFILL_TASKS.discard)
+            return header_tz
 
-        # Fallback to UTC
-        log.debug("No user timezone found, falling back to UTC")
+        log.set(timezone_source="fallback_utc", user_timezone="UTC")
+        log.warning(
+            "user.timezone missing and no valid x-timezone header; falling back to UTC",
+            user_id=user_id,
+            header_value=header_tz or None,
+        )
         return "UTC"
 
     except Exception as e:
-        log.warning(f"Error getting user timezone from preferences: {e}")
+        log.warning(f"Error resolving user timezone: {e}", user_id=user_id)
+        log.set(timezone_source="fallback_utc", user_timezone="UTC")
         return "UTC"

--- a/apps/api/app/services/scheduler_service.py
+++ b/apps/api/app/services/scheduler_service.py
@@ -302,19 +302,30 @@ class BaseSchedulerService(ABC):
             log.error("ARQ pool not initialized")
             return False
 
-        # Ensure scheduled_at is timezone-aware
-        if scheduled_at.tzinfo is None:
+        tz_was_naive = scheduled_at.tzinfo is None
+        if tz_was_naive:
             scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+            log.warning(
+                f"Task {task_id} scheduled_at was naive; assumed UTC — this is a "
+                f"common source of timezone drift, check the caller",
+            )
 
-        # Check if scheduled time is in the past - if so, schedule for now + small buffer
-        # This prevents Redis PSETEX errors from negative expire times
         now = datetime.now(timezone.utc)
-        if scheduled_at <= now:
+        past_due = scheduled_at <= now
+        if past_due:
             log.warning(
                 f"Task {task_id} scheduled_at ({scheduled_at}) is in the past, "
                 f"rescheduling to execute in 120 seconds"
             )
             scheduled_at = now + timedelta(seconds=120)
+
+        defer_seconds = int((scheduled_at - now).total_seconds())
+        log.set(
+            scheduled_at_utc=scheduled_at.isoformat(),
+            defer_seconds=defer_seconds,
+            scheduled_at_was_naive=tz_was_naive,
+            scheduled_at_past_due=past_due,
+        )
 
         job_name = self.get_job_name()
         job = await self.arq_pool.enqueue_job(
@@ -325,6 +336,7 @@ class BaseSchedulerService(ABC):
             log.error(f"Failed to enqueue task {task_id}")
             return False
 
+        log.set(arq_job_id=job.job_id, arq_job_name=job_name)
         log.debug(f"Enqueued task {task_id} with job ID {job.job_id}")
         return True
 

--- a/apps/api/app/services/triggers/base.py
+++ b/apps/api/app/services/triggers/base.py
@@ -6,6 +6,7 @@ All provider-specific trigger handlers must extend this class.
 
 import asyncio
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Set
 
 from shared.py.wide_events import log
@@ -14,6 +15,25 @@ from app.models.workflow_models import TriggerConfig, Workflow
 from app.services.composio.composio_service import get_composio_service
 from app.services.workflow.queue_service import WorkflowQueueService
 from app.utils.exceptions import TriggerRegistrationError
+
+
+def _parse_event_start_utc(data: Dict[str, Any]) -> Optional[datetime]:
+    """Best-effort extraction of an event's start time as a UTC datetime.
+
+    Handles Composio/Google payloads that may ship `start_time` as an ISO-8601
+    string with or without offset. Returns None when the field is absent or
+    unparseable — callers should skip lag instrumentation in that case.
+    """
+    raw = data.get("start_time") or data.get("startTime")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 class TriggerHandler(ABC):
@@ -278,13 +298,38 @@ class TriggerHandler(ABC):
         Returns:
             Dict with 'status' and 'message' keys
         """
+        now_utc = datetime.now(timezone.utc)
         log.set(
             service="trigger_handler",
             operation="process_event",
             event_type=event_type,
             trigger_id=trigger_id,
             user_id=user_id,
+            now_utc=now_utc.isoformat(),
         )
+
+        event_start_utc = _parse_event_start_utc(data)
+        if event_start_utc is not None:
+            seconds_until_event = int((event_start_utc - now_utc).total_seconds())
+            log.set(
+                event_start_time_utc=event_start_utc.isoformat(),
+                event_start_time_raw=data.get("start_time") or data.get("startTime"),
+                seconds_until_event=seconds_until_event,
+            )
+            countdown = data.get("countdown_window_minutes")
+            if isinstance(countdown, int):
+                expected_fire = event_start_utc.timestamp() - countdown * 60
+                webhook_lag = int(now_utc.timestamp() - expected_fire)
+                log.set(
+                    countdown_window_minutes=countdown,
+                    webhook_lag_seconds=webhook_lag,
+                )
+                if abs(webhook_lag) > 300:
+                    log.warning(
+                        "webhook fired far from expected time — "
+                        f"lag={webhook_lag}s (positive = late, negative = early)",
+                    )
+
         # Find matching workflows using handler's find_workflows method
         # Each handler decides what identifiers it needs (trigger_id, user_id, etc.)
         workflows = await self.find_workflows(event_type, trigger_id or "", data)

--- a/apps/api/app/services/triggers/handlers/calendar.py
+++ b/apps/api/app/services/triggers/handlers/calendar.py
@@ -122,13 +122,26 @@ class CalendarTriggerHandler(TriggerHandler):
                     config["include_all_day"] = starting_soon_data.include_all_day
             configs.append(config)
 
+        log.set(
+            trigger_name=trigger_name,
+            composio_slug=composio_slug,
+            calendar_count=len(calendar_ids),
+            minutes_before_start=(
+                trigger_data.minutes_before_start
+                if isinstance(trigger_data, CalendarEventStartingSoonConfig)
+                else None
+            ),
+        )
+
         # Use the base class helper for parallel registration with rollback
-        return await self._register_triggers_parallel(
+        trigger_ids = await self._register_triggers_parallel(
             user_id=user_id,
             trigger_name=trigger_name,
             configs=configs,
             composio_slug=composio_slug,
         )
+        log.set(composio_trigger_ids=trigger_ids, trigger_ids_count=len(trigger_ids))
+        return trigger_ids
 
     async def find_workflows(
         self, event_type: str, trigger_id: str, data: Dict[str, Any]

--- a/apps/api/app/services/workflow/queue_service.py
+++ b/apps/api/app/services/workflow/queue_service.py
@@ -47,7 +47,12 @@ class WorkflowQueueService:
             )
 
             if job:
-                log.set(workflow={"id": workflow_id, "status": "execution_queued"})
+                log.set(
+                    workflow={"id": workflow_id, "status": "execution_queued"},
+                    arq_job_id=job.job_id,
+                    queue_mode="immediate",
+                    defer_seconds=0,
+                )
                 log.info(
                     f"Queued workflow execution for {workflow_id} with job ID {job.job_id}"
                 )
@@ -66,7 +71,19 @@ class WorkflowQueueService:
     ) -> bool:
         """Queue a scheduled workflow execution with defer_until."""
         try:
+            from datetime import timezone as _tz
+
             pool = await RedisPoolManager.get_pool()
+
+            tz_was_naive = scheduled_at.tzinfo is None
+            if tz_was_naive:
+                log.warning(
+                    f"queue_scheduled_workflow_execution: naive scheduled_at for "
+                    f"{workflow_id}, assuming UTC — check caller",
+                )
+                scheduled_at = scheduled_at.replace(tzinfo=_tz.utc)
+            now = datetime.now(_tz.utc)
+            defer_seconds = int((scheduled_at - now).total_seconds())
 
             job = await pool.enqueue_job(
                 "execute_workflow_by_id",
@@ -76,7 +93,14 @@ class WorkflowQueueService:
             )
 
             if job:
-                log.set(workflow={"id": workflow_id, "status": "scheduled_queued"})
+                log.set(
+                    workflow={"id": workflow_id, "status": "scheduled_queued"},
+                    arq_job_id=job.job_id,
+                    queue_mode="scheduled",
+                    scheduled_at_utc=scheduled_at.isoformat(),
+                    scheduled_at_was_naive=tz_was_naive,
+                    defer_seconds=defer_seconds,
+                )
                 log.info(
                     f"Queued scheduled workflow execution for {workflow_id} at {scheduled_at} with job ID {job.job_id}"
                 )

--- a/apps/api/app/services/workflow/service.py
+++ b/apps/api/app/services/workflow/service.py
@@ -134,6 +134,20 @@ class WorkflowService:
                 trigger_config.timezone = timezone_to_use
                 if trigger_config.cron_expression:
                     trigger_config.update_next_run(user_timezone=timezone_to_use)
+                log.set(
+                    trigger_type=str(trigger_config.type),
+                    trigger_name=trigger_config.trigger_name,
+                    cron_expression=trigger_config.cron_expression,
+                    trigger_timezone=trigger_config.timezone,
+                    next_run_utc=trigger_config.next_run.isoformat()
+                    if trigger_config.next_run
+                    else None,
+                )
+            else:
+                log.set(
+                    trigger_type=str(trigger_config.type),
+                    trigger_name=trigger_config.trigger_name,
+                )
 
             # Use provided steps or initialize empty list for generation
             workflow_steps = request.steps if request.steps else []

--- a/apps/api/app/utils/workflow_utils.py
+++ b/apps/api/app/utils/workflow_utils.py
@@ -152,8 +152,20 @@ def get_user_time(config: RunnableConfig) -> datetime:
 
 
 def get_user_timezone(config: RunnableConfig) -> str:
-    """Extract user_timezone from config. Falls back to +00:00 (UTC)."""
-    return config.get("configurable", {}).get("user_timezone", "+00:00")
+    """Extract user_timezone from config. Falls back to +00:00 (UTC).
+
+    Emits `timezone_source` on the wide event so timezone resolution is
+    always traceable. When the config carries no user_timezone we warn
+    loudly — this is the exact silent-UTC drift that causes scheduled
+    workflows to fire at the user's offset hours late.
+    """
+    tz = config.get("configurable", {}).get("user_timezone")
+    if tz:
+        log.set(timezone_source="agent_config", user_timezone=tz)
+        return tz
+    log.set(timezone_source="fallback_utc", user_timezone="+00:00")
+    log.warning("get_user_timezone: no user_timezone in config, falling back to +00:00")
+    return "+00:00"
 
 
 def can_create_directly(draft: FinalizedOutput) -> bool:

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -204,6 +204,8 @@ async def execute_workflow_by_id(
     Execute a workflow by ID with proper execution count tracking.
     """
     async with wide_task("execute_workflow_by_id", workflow_id=workflow_id):
+        actual_fire_utc = datetime.now(timezone.utc)
+        log.set(actual_fire_utc=actual_fire_utc.isoformat())
         log.info(f"Processing workflow execution: {workflow_id}")
 
         scheduler = WorkflowScheduler()
@@ -235,6 +237,21 @@ async def execute_workflow_by_id(
                     steps_count=len(workflow.steps),
                 )
             )
+
+            scheduled_at = getattr(workflow, "scheduled_at", None)
+            if isinstance(scheduled_at, datetime):
+                if scheduled_at.tzinfo is None:
+                    scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+                drift = int((actual_fire_utc - scheduled_at).total_seconds())
+                log.set(
+                    scheduled_at_utc=scheduled_at.isoformat(),
+                    drift_from_scheduled_seconds=drift,
+                )
+                if abs(drift) > 300:
+                    log.warning(
+                        f"Workflow {workflow_id} fired {drift}s off schedule "
+                        f"(positive = late, negative = early)",
+                    )
 
             # Create execution record at start
             execution = await create_execution(


### PR DESCRIPTION
## Summary
- Three-tier timezone fallback (`user.timezone` → `x-timezone` header → UTC) in `get_user_timezone_from_preferences`, with fire-and-forget Mongo backfill so users who skipped onboarding get populated on next request.
- Emits `timezone_source` on every resolution — the silent-UTC drift that caused scheduled workflows to fire hours off for non-UTC users is now visible in wide events instead of invisible.
- Instruments the full workflow lifecycle (create → register → webhook → enqueue → execute) with structured wide-event fields so a single trace explains timing end-to-end.
- Warns when webhook lag or execution drift exceeds 5 minutes — future timing reports point at the faulty hop immediately.

## Wide-event fields added

| Stage | File | Fields |
|---|---|---|
| Create | `workflow/service.py` | `trigger_type`, `trigger_name`, `cron_expression`, `trigger_timezone`, `next_run_utc` |
| Register | `triggers/handlers/calendar.py` | `composio_slug`, `calendar_count`, `minutes_before_start`, `composio_trigger_ids` |
| Webhook | `triggers/base.py` | `event_start_time_utc`, `seconds_until_event`, `countdown_window_minutes`, `webhook_lag_seconds` |
| Enqueue | `queue_service.py`, `scheduler_service.py` | `scheduled_at_utc`, `defer_seconds`, `scheduled_at_was_naive`, `arq_job_id` |
| Execute | `workers/tasks/workflow_tasks.py` | `actual_fire_utc`, `drift_from_scheduled_seconds` |

## Test plan
- [ ] Sign in as a user whose Mongo doc has no `timezone` field and a valid `x-timezone` header — confirm the header value is persisted to Mongo on next request and wide event shows `timezone_source=x_timezone_header`.
- [ ] Confirm existing users with `user.timezone` set continue to see `timezone_source=user_profile`.
- [ ] Create a scheduled workflow with a cron in a non-UTC zone and verify `next_run_utc` matches the expected local time converted to UTC.
- [ ] Trigger a `calendar_event_starting_soon` webhook and verify `webhook_lag_seconds` is close to 0; delayed webhooks should log the drift warning.
- [ ] Run `nx type-check api` and `nx lint api` locally.
