### PR TITLE
fix(web): alias node: built-ins in Turbopack to fix Windows standalone build

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -32,8 +32,39 @@ const nextConfig = {
   turbopack: {
     root: path.join(__dirname, "../.."),
     // Change the value here to swap the entire icon variant across the app
+    // node:* aliases rewrite Node built-in specifiers to their bare form so
+    // Turbopack does not emit chunks named `[externals]_node:foo_*.js` — the
+    // colon is illegal on NTFS and breaks `next build` on Windows during
+    // standalone output tracing (breaks the Electron Windows installer).
+    // See: https://github.com/vercel/next.js/discussions/86194
+    // and:  https://nextjs-forum.com/post/1471409705514569798
     resolveAlias: {
       "@icons": "@theexperiencecompany/gaia-icons/solid-rounded",
+      "node:inspector": "inspector",
+      "node:fs": "fs",
+      "node:fs/promises": "fs/promises",
+      "node:path": "path",
+      "node:stream": "stream",
+      "node:stream/web": "stream/web",
+      "node:url": "url",
+      "node:util": "util",
+      "node:crypto": "crypto",
+      "node:buffer": "buffer",
+      "node:os": "os",
+      "node:child_process": "child_process",
+      "node:http": "http",
+      "node:https": "https",
+      "node:net": "net",
+      "node:tls": "tls",
+      "node:zlib": "zlib",
+      "node:events": "events",
+      "node:async_hooks": "async_hooks",
+      "node:assert": "assert",
+      "node:querystring": "querystring",
+      "node:worker_threads": "worker_threads",
+      "node:process": "process",
+      "node:perf_hooks": "perf_hooks",
+      "node:diagnostics_channel": "diagnostics_channel",
     },
   },
   serverExternalPackages: ["moment", "moment-timezone"],


### PR DESCRIPTION
## Summary

- Fixes dead Windows `.exe` download link (GAIA-612 / #639).
- Root cause: every Desktop Release CI run since v0.1.1 has failed its `windows-latest` job during `next build`. Turbopack emits external chunks like `[externals]_node:inspector_7a4283c6._.js`. NTFS treats `:` as an alternate-data-stream separator, so Next's standalone output tracing hits `EINVAL: invalid argument, copyfile` and the build aborts before `electron-builder` runs. The release never gets any Windows assets.
- Fix: add Turbopack `resolveAlias` entries that rewrite `node:<builtin>` specifiers to their bare form in `apps/web/next.config.mjs`, so the chunk names contain no `:`. Node resolves both forms to the same built-in module — runtime behavior is unchanged on every platform.

Upstream context: https://github.com/vercel/next.js/discussions/86194, https://nextjs-forum.com/post/1471409705514569798. PR [vercel/next.js#88273](https://github.com/vercel/next.js/pull/88273) attempted a fix but the problem still reproduces on 16.1.6.

## Test plan

- [x] `nx build web --skip-nx-cache` completes locally; `find apps/web/.next/server apps/web/.next/standalone -name "*:*"` returns zero results (was 4 before the fix).
- [ ] Next `desktop-v*` release CI run produces `GAIA-x64.exe`, `GAIA-x64.nsis.exe`, `GAIA-arm64.nsis.exe`, `latest.yml` and attaches them to the GitHub release.
- [ ] `curl -sI -L https://github.com/theexperiencecompany/gaia/releases/latest/download/GAIA-x64.exe` returns `200`.