### PR TITLE
fix: platform-aware markdown formatting and OpenUI gating

### DIFF
--- a/apps/api/app/agents/core/messages.py
+++ b/apps/api/app/agents/core/messages.py
@@ -61,8 +61,11 @@ async def construct_langchain_messages(
     Returns:
         List of LangChain messages ready for agent processing
     """
-    # Start with system message containing user name and instructions
-    system_msg = create_system_message(user_id, user_name, agent_type)
+    # Start with system message containing user name and instructions.
+    # Passing `source` lets the comms prompt drop OpenUI Lang on messaging
+    # platforms (whatsapp/telegram/discord/slack) where rich cards can't
+    # render and would otherwise leak as literal `:::openui` fences.
+    system_msg = create_system_message(user_id, user_name, agent_type, source=source)
     chain_msgs = [system_msg]
 
     # Add relevant memories if user context available

--- a/apps/api/app/agents/evals/datasets/gmail.json
+++ b/apps/api/app/agents/evals/datasets/gmail.json
@@ -139,10 +139,10 @@
       "metadata": { "difficulty": "medium" }
     },
     {
-      "input": "compose email to team@company.com with HTML formatting including bold heading and bullet points",
-      "expected_output": "Create email with HTML body containing bold text and list elements, set is_html=True.",
-      "context": "User wants HTML formatted email",
-      "tags": ["email", "create", "html", "detailed"],
+      "input": "compose email to team@company.com with a bold heading and bullet points",
+      "expected_output": "Create a Gmail draft with a Markdown body containing a bold heading and a bulleted list. The backend converts Markdown to HTML before sending.",
+      "context": "User wants a formatted email body",
+      "tags": ["email", "create", "formatting", "detailed"],
       "metadata": { "difficulty": "medium" }
     },
     {

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -326,9 +326,22 @@ Refer to them by their first name naturally, like a friend would.
 """
 
 
-def get_comms_agent_prompt() -> str:
-    """Build the comms agent prompt with OpenUI Lang instructions."""
-    return COMMS_AGENT_PROMPT + "\n" + OPENUI_INSTRUCTIONS
+RICH_UI_SOURCES: frozenset[str] = frozenset({"web", "mobile", "desktop"})
+
+
+def get_comms_agent_prompt(source: str | None = None) -> str:
+    """Build the comms agent prompt.
+
+    OpenUI Lang produces rich interactive cards that only the web / mobile /
+    desktop clients can render. Messaging platforms (WhatsApp, Telegram,
+    Discord, Slack) and email receive the raw ``:::openui`` fences as literal
+    text, which looks broken. For those sources we omit the OpenUI
+    instructions entirely so the model falls back to plain Markdown that the
+    platform-specific adapter can then format.
+    """
+    if source is None or source in RICH_UI_SOURCES:
+        return COMMS_AGENT_PROMPT + "\n" + OPENUI_INSTRUCTIONS
+    return COMMS_AGENT_PROMPT
 
 
 EXECUTOR_AGENT_PROMPT = """

--- a/apps/api/app/agents/skills/builtin/gmail-draft-send/SKILL.md
+++ b/apps/api/app/agents/skills/builtin/gmail-draft-send/SKILL.md
@@ -26,14 +26,11 @@ Create a new email draft.
 - `cc`: CC recipients
 - `bcc`: BCC recipients
 - `thread_id`: Reply within existing thread
-- `is_html`: Set `true` only when the user explicitly wants HTML email formatting
 
 **Body formatting:**
-- Always draft beautiful, readable emails.
-- Default to plain text email body unless the user explicitly asks for HTML.
-- For plain text (`is_html=false`), use clear multi-line formatting with short paragraphs and blank lines between sections so the draft is easy to scan.
-- If using HTML, provide a safe HTML fragment (no `<html>`/`<head>`/`<body>`). Stick to: `p`, `br`, `strong`, `em`, `ul/ol/li`, `a`.
-- Do not rely on automatic Markdown conversion.
+- Write the body as Markdown. The backend converts it to HTML before Gmail sends, so `**bold**`, `### headings`, `- lists`, and `[links](url)` all render correctly in the recipient's inbox.
+- Draft beautiful, readable emails: short paragraphs, blank lines between sections, meaningful subject lines.
+- Do not emit raw HTML (`<p>`, `<div>`, etc.) — write Markdown and let the pipeline handle it.
 
 **Signature:**
 - Use the user's proper name from context (`User Name:`) in the sign-off.

--- a/apps/api/app/agents/templates/agent_template.py
+++ b/apps/api/app/agents/templates/agent_template.py
@@ -9,6 +9,20 @@ COMMS_PROMPT_TEMPLATE = PromptTemplate(
     template=get_comms_agent_prompt(),
 )
 
+
+def build_comms_prompt_template(source: str | None = None) -> PromptTemplate:
+    """Return a comms prompt template with OpenUI instructions gated on source.
+
+    Non-rich-UI sources (whatsapp, telegram, discord, slack, email) get the
+    prompt WITHOUT OpenUI Lang so the agent doesn't emit ``:::openui`` fences
+    that those platforms can't render.
+    """
+    return PromptTemplate(
+        input_variables=["user_name"],
+        template=get_comms_agent_prompt(source),
+    )
+
+
 EXECUTOR_PROMPT_TEMPLATE = PromptTemplate(
     input_variables=["user_name"],
     template=EXECUTOR_AGENT_PROMPT,

--- a/apps/api/app/agents/templates/agent_template.py
+++ b/apps/api/app/agents/templates/agent_template.py
@@ -1,26 +1,45 @@
 from app.agents.prompts.comms_prompts import (
     EXECUTOR_AGENT_PROMPT,
+    RICH_UI_SOURCES,
     get_comms_agent_prompt,
 )
 from langchain_core.prompts import PromptTemplate
 
-COMMS_PROMPT_TEMPLATE = PromptTemplate(
+# Two pre-built comms prompt variants, cached at module load.
+#
+# Rebuilding a PromptTemplate per request fragments the LLM provider's prompt
+# cache (caching keys on exact prefix). By collapsing every possible ``source``
+# down to one of two stable prompt strings — rich-UI (web/mobile/desktop) and
+# plain (whatsapp/telegram/discord/slack/email) — we keep the cache hit rate
+# high and avoid the cost of string-concatenating the large OpenUI spec on
+# every message.
+_RICH_COMMS_PROMPT_TEMPLATE = PromptTemplate(
     input_variables=["user_name"],
-    template=get_comms_agent_prompt(),
+    template=get_comms_agent_prompt(None),
 )
+
+_PLAIN_COMMS_PROMPT_TEMPLATE = PromptTemplate(
+    input_variables=["user_name"],
+    template=get_comms_agent_prompt("whatsapp"),
+)
+
+# Backwards-compatible default (rich-UI variant) for callers that don't know
+# about source gating yet.
+COMMS_PROMPT_TEMPLATE = _RICH_COMMS_PROMPT_TEMPLATE
 
 
 def build_comms_prompt_template(source: str | None = None) -> PromptTemplate:
-    """Return a comms prompt template with OpenUI instructions gated on source.
+    """Return the comms prompt template appropriate for ``source``.
 
-    Non-rich-UI sources (whatsapp, telegram, discord, slack, email) get the
-    prompt WITHOUT OpenUI Lang so the agent doesn't emit ``:::openui`` fences
-    that those platforms can't render.
+    Web / mobile / desktop get the variant with OpenUI Lang instructions so
+    the agent can emit rich interactive cards. Messaging platforms (whatsapp,
+    telegram, discord, slack) and email get the variant without OpenUI —
+    those channels can only render plain Markdown and would show ``:::openui``
+    fences as literal text.
     """
-    return PromptTemplate(
-        input_variables=["user_name"],
-        template=get_comms_agent_prompt(source),
-    )
+    if source is None or source in RICH_UI_SOURCES:
+        return _RICH_COMMS_PROMPT_TEMPLATE
+    return _PLAIN_COMMS_PROMPT_TEMPLATE
 
 
 EXECUTOR_PROMPT_TEMPLATE = PromptTemplate(

--- a/apps/api/app/api/v1/endpoints/mail.py
+++ b/apps/api/app/api/v1/endpoints/mail.py
@@ -316,7 +316,6 @@ async def send_email_route(
     subject: str = Form(...),
     body: str = Form(...),
     thread_id: Optional[str] = Form(None),
-    is_html: Optional[bool] = Form(False),
     cc: Optional[str] = Form(None),
     bcc: Optional[str] = Form(None),
     attachments: Optional[List[UploadFile]] = File(None),
@@ -349,7 +348,6 @@ async def send_email_route(
             extra_recipients=to_list[1:],
             subject=subject,
             body=body,
-            is_html=is_html or False,
             cc_list=cc_list,
             bcc_list=bcc_list,
             attachments=attachments,
@@ -399,7 +397,6 @@ async def send_email_json(
             extra_recipients=request.to[1:],
             subject=request.subject,
             body=request.body,
-            is_html=False,
             cc_list=request.cc,
             bcc_list=request.bcc,
             attachments=None,
@@ -1013,7 +1010,6 @@ async def create_draft_route(
     - **body**: Email body
     - **cc**: Optional list of CC recipients
     - **bcc**: Optional list of BCC recipients
-    - **is_html**: Whether the body is HTML content
 
     Returns the created draft data.
     """
@@ -1029,7 +1025,6 @@ async def create_draft_route(
             to_list=request.to,
             subject=request.subject,
             body=request.body,
-            is_html=request.is_html if request.is_html is not None else False,
             cc_list=request.cc,
             bcc_list=request.bcc,
         )
@@ -1131,7 +1126,6 @@ async def update_draft_route(
     - **body**: Email body
     - **cc**: Optional list of CC recipients
     - **bcc**: Optional list of BCC recipients
-    - **is_html**: Whether the body is HTML content
 
     Returns the updated draft data.
     """
@@ -1148,7 +1142,6 @@ async def update_draft_route(
             to_list=request.to,
             subject=request.subject,
             body=request.body,
-            is_html=request.is_html if request.is_html is not None else False,
             cc_list=request.cc,
             bcc_list=request.bcc,
         )

--- a/apps/api/app/helpers/message_helpers.py
+++ b/apps/api/app/helpers/message_helpers.py
@@ -12,6 +12,7 @@ from app.agents.prompts.workflow_prompts import (
 from app.agents.templates.agent_template import (
     COMMS_PROMPT_TEMPLATE,
     EXECUTOR_PROMPT_TEMPLATE,
+    build_comms_prompt_template,
 )
 from app.models.message_models import (
     FileData,
@@ -32,6 +33,7 @@ def create_system_message(
     user_id: Optional[str] = None,
     user_name: Optional[str] = None,
     agent_type: Literal["comms", "executor"] = "comms",
+    source: Optional[str] = None,
 ) -> SystemMessage:
     """Create main system message with user name only.
 
@@ -39,11 +41,16 @@ def create_system_message(
         user_id: User's ID
         user_name: User's full name
         agent_type: Type of agent - "comms", "executor", or "main" (legacy)
+        source: Conversation source/platform (e.g. "whatsapp", "web"). Gates
+            OpenUI Lang out of the comms prompt for messaging platforms that
+            can't render interactive cards.
     """
-    template = {
-        "comms": COMMS_PROMPT_TEMPLATE,
-        "executor": EXECUTOR_PROMPT_TEMPLATE,
-    }.get(agent_type, COMMS_PROMPT_TEMPLATE)
+    if agent_type == "executor":
+        template = EXECUTOR_PROMPT_TEMPLATE
+    elif source is None:
+        template = COMMS_PROMPT_TEMPLATE
+    else:
+        template = build_comms_prompt_template(source)
 
     return SystemMessage(content=template.format(user_name=user_name or "there"))
 

--- a/apps/api/app/models/mail_models.py
+++ b/apps/api/app/models/mail_models.py
@@ -63,14 +63,17 @@ class ApplyLabelRequest(BaseModel):
 
 
 class DraftRequest(BaseModel):
-    """Request model for creating or updating a draft email."""
+    """Request model for creating or updating a draft email.
+
+    ``body`` may be Markdown or HTML — the Composio Gmail hook converts
+    Markdown to HTML before sending, so callers never need to choose.
+    """
 
     to: List[str]
     subject: str
     body: str
     cc: Optional[List[str]] = None
     bcc: Optional[List[str]] = None
-    is_html: Optional[bool] = False
 
 
 class EmailWebhookMessage(BaseModel):

--- a/apps/api/app/services/mail/mail_service.py
+++ b/apps/api/app/services/mail/mail_service.py
@@ -7,6 +7,7 @@ from app.services.composio.composio_service import (
     get_composio_service,
 )
 from app.utils.general_utils import transform_gmail_message
+from app.utils.markdown_utils import convert_markdown_to_html, is_markdown_content
 from fastapi import UploadFile
 
 
@@ -122,6 +123,14 @@ async def send_email(
         is_reply = bool(thread_id)
         tool_name = "GMAIL_REPLY_TO_THREAD" if is_reply else "GMAIL_SEND_EMAIL"
         body_param = "message_body" if is_reply else "body"
+
+        # Gmail renders `**bold**` / `### heading` literally when the body is
+        # plain text. Auto-upgrade Markdown bodies to HTML so recipients see
+        # proper formatting instead of raw syntax. If the caller already set
+        # is_html (they know what they're passing), we respect that and skip.
+        if not is_html and body and is_markdown_content(body):
+            body = convert_markdown_to_html(body)
+            is_html = True
 
         # Build parameters
         parameters: Dict[str, Any] = {

--- a/apps/api/app/services/mail/mail_service.py
+++ b/apps/api/app/services/mail/mail_service.py
@@ -7,7 +7,6 @@ from app.services.composio.composio_service import (
     get_composio_service,
 )
 from app.utils.general_utils import transform_gmail_message
-from app.utils.markdown_utils import convert_markdown_to_html, is_markdown_content
 from fastapi import UploadFile
 
 
@@ -82,7 +81,6 @@ async def send_email(
     subject: str,
     body: str,
     thread_id: Optional[str] = None,
-    is_html: bool = False,
     extra_recipients: List[str] = [],
     cc_list: Optional[List[str]] = None,
     bcc_list: Optional[List[str]] = None,
@@ -95,13 +93,16 @@ async def send_email(
     GMAIL_REPLY_TO_THREAD (when thread_id is provided) to handle both
     new emails and thread replies appropriately.
 
+    Body content is always delivered as HTML — Markdown inputs are converted
+    transparently by the Composio before-hook so Gmail renders formatting
+    instead of literal ``**`` / ``###`` characters.
+
     Args:
         user_id: User ID for Composio authentication
         to: Primary recipient email address
         subject: Email subject
-        body: Email body content
+        body: Email body content (Markdown or HTML; converted if needed)
         thread_id: Optional thread ID - if provided, uses GMAIL_REPLY_TO_THREAD
-        is_html: Whether the body is HTML content
         extra_recipients: Additional recipient email addresses
         cc_list: Optional list of CC recipients
         bcc_list: Optional list of BCC recipients
@@ -124,21 +125,15 @@ async def send_email(
         tool_name = "GMAIL_REPLY_TO_THREAD" if is_reply else "GMAIL_SEND_EMAIL"
         body_param = "message_body" if is_reply else "body"
 
-        # Gmail renders `**bold**` / `### heading` literally when the body is
-        # plain text. Auto-upgrade Markdown bodies to HTML so recipients see
-        # proper formatting instead of raw syntax. If the caller already set
-        # is_html (they know what they're passing), we respect that and skip.
-        if not is_html and body and is_markdown_content(body):
-            body = convert_markdown_to_html(body)
-            is_html = True
-
-        # Build parameters
+        # Build parameters. The Composio before-hook (gmail_compose_before_hook)
+        # normalises body → HTML and sets is_html=True for every compose tool,
+        # so callers can hand us either Markdown or HTML and Gmail will render
+        # consistently.
         parameters: Dict[str, Any] = {
             "recipient_email": to,
             "extra_recipients": extra_recipients,
             body_param: body,
             "subject": subject,
-            "is_html": is_html,
         }
 
         # Add thread_id for replies
@@ -682,20 +677,21 @@ async def create_draft(
     to_list: List[str],
     subject: str,
     body: str,
-    is_html: bool = False,
     cc_list: Optional[List[str]] = None,
     bcc_list: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new Gmail draft using Composio Gmail tool.
 
+    Body content is always sent as HTML — the Composio before-hook converts
+    Markdown inputs transparently.
+
     Args:
         user_id: User ID for Composio authentication
         sender: Email address of the sender
         to_list: Email addresses of recipients
         subject: Email subject
-        body: Email body
-        is_html: Whether the body is HTML content
+        body: Email body (Markdown or HTML; converted if needed)
         cc_list: Email addresses for CC
         bcc_list: Email addresses for BCC
 
@@ -715,8 +711,6 @@ async def create_draft(
             parameters["cc"] = cc_list
         if bcc_list:
             parameters["bcc"] = bcc_list
-        if is_html:
-            parameters["html"] = True
 
         result = await invoke_gmail_tool(
             user_id, "GMAIL_CREATE_EMAIL_DRAFT", parameters
@@ -811,12 +805,14 @@ async def update_draft(
     to_list: List[str],
     subject: str,
     body: str,
-    is_html: bool = False,
     cc_list: Optional[List[str]] = None,
     bcc_list: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Update an existing Gmail draft.
+
+    Body content is always sent as HTML — the Composio before-hook converts
+    Markdown inputs transparently.
 
     Args:
         user_id: User ID for Composio authentication
@@ -824,8 +820,7 @@ async def update_draft(
         sender: Email address of the sender
         to_list: Email addresses of recipients
         subject: Email subject
-        body: Email body
-        is_html: Whether the body is HTML content
+        body: Email body (Markdown or HTML; converted if needed)
         cc_list: Email addresses for CC
         bcc_list: Email addresses for BCC
 

--- a/apps/api/app/utils/composio_hooks/gmail_hooks.py
+++ b/apps/api/app/utils/composio_hooks/gmail_hooks.py
@@ -19,6 +19,7 @@ from app.agents.templates.mail_templates import (
     process_list_drafts_response,
     process_list_messages_response,
 )
+from app.utils.markdown_utils import normalize_email_body_to_html
 from shared.py.wide_events import log
 
 from .registry import (
@@ -26,6 +27,15 @@ from .registry import (
     register_before_hook,
     register_schema_modifier,
 )
+
+_GMAIL_COMPOSE_TOOLS = (
+    "GMAIL_SEND_EMAIL",
+    "GMAIL_CREATE_EMAIL_DRAFT",
+    "GMAIL_REPLY_TO_THREAD",
+    "GMAIL_FORWARD_MESSAGE",
+)
+# Gmail's ``body`` field is named differently across compose tools.
+_GMAIL_BODY_KEYS = ("body", "message_body", "message")
 
 GMAIL_FULL_FETCH_HARD_LIMIT = 30
 
@@ -49,6 +59,29 @@ def gmail_send_email_schema_modifier(tool: str, toolkit: str, schema: Tool) -> T
         "use GMAIL_SEND_DRAFT with the draft_id instead of this tool."
     )
     schema.description += draft_guidance
+    return schema
+
+
+@register_schema_modifier(tools=list(_GMAIL_COMPOSE_TOOLS))
+def gmail_compose_hide_is_html_schema_modifier(
+    tool: str, toolkit: str, schema: Tool
+) -> Tool:
+    """Hide the ``is_html`` parameter from the agent-facing schema.
+
+    The before-hook always converts the body to HTML and sets the flag, so
+    exposing it to the agent just invites bad choices (agent picks False,
+    writes Markdown, Gmail renders ``**bold**`` as literal asterisks). The
+    agent writes Markdown — everything else is our problem.
+    """
+    input_params = schema.input_parameters
+    if not isinstance(input_params, dict):
+        return schema
+    props = input_params.get("properties")
+    if isinstance(props, dict):
+        props.pop("is_html", None)
+    required = input_params.get("required")
+    if isinstance(required, list) and "is_html" in required:
+        required.remove("is_html")
     return schema
 
 
@@ -158,6 +191,17 @@ def gmail_compose_before_hook(
     log.set(gmail_tool=tool, toolkit=toolkit)
     try:
         arguments = params.get("arguments", {})
+
+        # Always normalise the body to HTML before it reaches Gmail. The agent
+        # writes Markdown; Gmail renders Markdown literally as plain text. The
+        # normaliser is idempotent on already-HTML bodies so callers that hand
+        # us HTML are unaffected.
+        for body_key in _GMAIL_BODY_KEYS:
+            raw_body = arguments.get(body_key)
+            if isinstance(raw_body, str) and raw_body:
+                arguments[body_key] = normalize_email_body_to_html(raw_body)
+        arguments["is_html"] = True
+        params["arguments"] = arguments
 
         if tool in ["GMAIL_SEND_EMAIL", "GMAIL_CREATE_EMAIL_DRAFT"]:
             # Auto-convert 'to' to 'recipient_email' if needed

--- a/apps/api/app/utils/markdown_utils.py
+++ b/apps/api/app/utils/markdown_utils.py
@@ -8,40 +8,6 @@ import markdown2
 from shared.py.wide_events import log
 
 
-def is_markdown_content(text: str) -> bool:
-    """
-    Detect if text contains markdown syntax.
-
-    Args:
-        text: The text to check
-
-    Returns:
-        bool: True if markdown syntax is detected
-    """
-    if not text or not isinstance(text, str):
-        return False
-
-    markdown_patterns = [
-        r"^#{1,6}\s",  # Headers
-        r"\*\*[^*]+\*\*",  # Bold with **
-        r"__[^_]+__",  # Bold with __
-        r"\*[^*]+\*",  # Italic with *
-        r"_[^_]+_",  # Italic with _
-        r"\[.+?\]\(.+?\)",  # Links [text](url)
-        r"^[-*+]\s",  # Unordered lists
-        r"^\d+\.\s",  # Ordered lists
-        r"`[^`]+`",  # Inline code
-        r"```[\s\S]*?```",  # Code blocks
-        r"^>\s",  # Blockquotes
-    ]
-
-    for pattern in markdown_patterns:
-        if re.search(pattern, text, re.MULTILINE):
-            return True
-
-    return False
-
-
 def convert_markdown_to_html(markdown_text: str) -> str:
     """
     Convert markdown text to HTML.

--- a/apps/api/app/utils/markdown_utils.py
+++ b/apps/api/app/utils/markdown_utils.py
@@ -71,6 +71,41 @@ def convert_markdown_to_html(markdown_text: str) -> str:
         return markdown_text
 
 
+_HTML_TAG_RE = re.compile(
+    r"<\s*(p|div|html|body|br|h[1-6]|ul|ol|li|table|span|a|strong|em)\b",
+    re.IGNORECASE,
+)
+
+
+def looks_like_html(text: str) -> bool:
+    """Return True if ``text`` appears to already be HTML.
+
+    Used at the email boundary to decide whether to run the body through the
+    markdown→HTML converter. We look for common block/inline HTML tags rather
+    than any ``<…>`` so strings like ``"x < 5"`` don't false-positive.
+    """
+    if not text:
+        return False
+    return bool(_HTML_TAG_RE.search(text))
+
+
+def normalize_email_body_to_html(body: str) -> str:
+    """Always return HTML for an email body.
+
+    The agent produces Markdown, users/forms sometimes paste Markdown, and the
+    REST layer historically had an ``is_html`` flag that was unreliable.
+    Normalising at the send boundary means Gmail always receives HTML and
+    renders consistently — ``**bold**`` never leaks into the recipient's
+    inbox as literal asterisks. markdown2 wraps plain-text bodies in ``<p>``
+    tags, so this is safe for both Markdown and plain-text inputs.
+    """
+    if not body:
+        return body
+    if looks_like_html(body):
+        return body
+    return convert_markdown_to_html(body)
+
+
 def convert_markdown_to_plain_text(markdown_text: str) -> str:
     """
     Convert markdown text to plain text by stripping markdown syntax.

--- a/apps/api/app/utils/notification/channels/whatsapp.py
+++ b/apps/api/app/utils/notification/channels/whatsapp.py
@@ -46,6 +46,13 @@ class WhatsAppChannelAdapter(ExternalPlatformAdapter):
         """Build the notification payload and convert any CommonMark Markdown in
         the body/messages to WhatsApp's native formatting so ``**bold**`` and
         ``### headings`` don't render as literal characters in the chat bubble.
+
+        Order matters: we convert here (in ``transform``) rather than inside
+        ``_deliver_content``. The base class's splitter
+        (``_split_text`` → ``MAX_MESSAGE_LENGTH``) runs on the transformed
+        text during delivery, so chunk boundaries reflect the final WhatsApp
+        payload and link expansion (``[x](url)`` → ``x (url)``) won't push a
+        boundary past 4096 characters unexpectedly.
         """
         payload = await super().transform(notification)
         if payload.get("type") == "workflow_messages":

--- a/apps/api/app/utils/notification/channels/whatsapp.py
+++ b/apps/api/app/utils/notification/channels/whatsapp.py
@@ -17,9 +17,11 @@ from app.constants.notifications import (
 )
 from app.models.notification.notification_models import (
     ChannelDeliveryStatus,
+    NotificationRequest,
 )
 from app.utils.notification.channels.base import SendFn
 from app.utils.notification.channels.external import ExternalPlatformAdapter
+from app.utils.platform_markdown import convert_to_whatsapp_markdown
 
 
 class WhatsAppChannelAdapter(ExternalPlatformAdapter):
@@ -39,6 +41,25 @@ class WhatsAppChannelAdapter(ExternalPlatformAdapter):
     def bold_marker(self) -> str:
         # WhatsApp uses *bold* (single asterisk)
         return "*"
+
+    async def transform(self, notification: NotificationRequest) -> Dict[str, Any]:
+        """Build the notification payload and convert any CommonMark Markdown in
+        the body/messages to WhatsApp's native formatting so ``**bold**`` and
+        ``### headings`` don't render as literal characters in the chat bubble.
+        """
+        payload = await super().transform(notification)
+        if payload.get("type") == "workflow_messages":
+            if header := payload.get("header"):
+                payload["header"] = convert_to_whatsapp_markdown(header)
+            payload["messages"] = [
+                convert_to_whatsapp_markdown(m) for m in payload.get("messages", [])
+            ]
+            if footer := payload.get("footer"):
+                payload["footer"] = convert_to_whatsapp_markdown(footer)
+            return payload
+        if text := payload.get("text"):
+            payload["text"] = convert_to_whatsapp_markdown(text)
+        return payload
 
     def _get_bot_token(self) -> str | None:
         # For WhatsApp via Kapso, authentication is the API key, not a bot token.

--- a/apps/api/app/utils/platform_markdown.py
+++ b/apps/api/app/utils/platform_markdown.py
@@ -1,0 +1,71 @@
+"""Convert CommonMark-style Markdown output from the agent to the native
+formatting each messaging platform expects.
+
+The agent produces standard Markdown (`**bold**`, `### heading`, `[label](url)`
+etc). Sending that raw to WhatsApp or Slack renders the asterisks literally
+because their formatting syntax is different. Use these helpers at the
+platform adapter boundary so users see proper bold/italic instead of
+`**raw markdown**`.
+
+Kept in sync with ``libs/shared/ts/src/bots/utils/formatters.ts`` — any
+change to the bot converters should be mirrored here and vice versa.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+_FENCED_CODE_RE = re.compile(r"```[\s\S]*?```")
+
+
+def _apply_outside_code_blocks(text: str, transform: Callable[[str], str]) -> str:
+    """Apply ``transform`` to every segment of ``text`` that is NOT inside a
+    fenced code block, leaving ``` ... ``` blocks unchanged."""
+    parts: list[str] = []
+    last_index = 0
+    for match in _FENCED_CODE_RE.finditer(text):
+        parts.append(transform(text[last_index : match.start()]))
+        parts.append(match.group(0))
+        last_index = match.end()
+    parts.append(transform(text[last_index:]))
+    return "".join(parts)
+
+
+def _convert_to_whatsapp(segment: str) -> str:
+    segment = re.sub(r"\*\*\*([^*]+)\*\*\*", r"*\1*", segment)
+    segment = re.sub(r"\*\*([^*]+)\*\*", r"*\1*", segment)
+    segment = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", segment)
+    segment = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", segment, flags=re.MULTILINE)
+    segment = re.sub(r"^>\s*", "", segment, flags=re.MULTILINE)
+    segment = re.sub(r"^[-_]{3,}$", "", segment, flags=re.MULTILINE)
+    return segment
+
+
+def _convert_to_slack(segment: str) -> str:
+    segment = re.sub(r"\*\*\*(.+?)\*\*\*", r"*\1*", segment)
+    segment = re.sub(r"\*\*(.+?)\*\*", r"*\1*", segment)
+    segment = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", segment)
+    segment = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", segment, flags=re.MULTILINE)
+    segment = re.sub(r"^>\s*", "", segment, flags=re.MULTILINE)
+    segment = re.sub(r"^[-_]{3,}$", "", segment, flags=re.MULTILINE)
+    return segment
+
+
+def convert_to_whatsapp_markdown(text: str) -> str:
+    """Convert CommonMark Markdown to WhatsApp's formatting rules.
+
+    WhatsApp supports ``*bold*`` (single asterisk), ``_italic_``,
+    ``~strikethrough~``, and ``` `code` ```. It has no native headings or
+    link syntax. ``[label](url)`` is rendered as ``label (url)``.
+    """
+    if not text:
+        return text
+    return _apply_outside_code_blocks(text, _convert_to_whatsapp)
+
+
+def convert_to_slack_mrkdwn(text: str) -> str:
+    """Convert CommonMark Markdown to Slack's mrkdwn."""
+    if not text:
+        return text
+    return _apply_outside_code_blocks(text, _convert_to_slack)

--- a/apps/api/tests/unit/services/test_mail_service.py
+++ b/apps/api/tests/unit/services/test_mail_service.py
@@ -844,7 +844,10 @@ class TestCreateDraft:
         assert params["cc"] == ["cc@example.com"]
         assert params["bcc"] == ["bcc@example.com"]
 
-    async def test_sets_html_flag_when_is_html_true(self, mock_invoke_gmail_tool):
+    async def test_passes_body_through_without_html_flag(self, mock_invoke_gmail_tool):
+        """``is_html`` no longer exists on the service — bodies are converted
+        to HTML by the Composio before-hook, so the service just forwards
+        whatever body it was given and never sets an html param itself."""
         mock_invoke_gmail_tool.return_value = {"successful": True}
 
         await create_draft(
@@ -853,11 +856,12 @@ class TestCreateDraft:
             to_list=["bob@example.com"],
             subject="Hi",
             body="<b>HTML</b>",
-            is_html=True,
         )
 
         params = mock_invoke_gmail_tool.call_args[0][2]
-        assert params.get("html") is True
+        assert params["body"] == "<b>HTML</b>"
+        assert "html" not in params
+        assert "is_html" not in params
 
     async def test_returns_error_dict_on_exception(self, mock_invoke_gmail_tool):
         mock_invoke_gmail_tool.side_effect = Exception("quota exceeded")

--- a/apps/api/tests/unit/utils/test_markdown_frontmatter.py
+++ b/apps/api/tests/unit/utils/test_markdown_frontmatter.py
@@ -4,7 +4,6 @@ import pytest
 
 from app.utils.markdown_utils import (
     convert_markdown_to_plain_text,
-    is_markdown_content,
     split_yaml_frontmatter,
 )
 
@@ -77,49 +76,6 @@ class TestSplitYamlFrontmatter:
         # splitlines(keepends=True) preserves line endings; rstrip("\r\n") strips the trailing one
         assert frontmatter == "title: Hello"
         assert body == "Body text"
-
-
-@pytest.mark.unit
-class TestIsMarkdownContent:
-    def test_detects_headers(self):
-        assert is_markdown_content("# Heading") is True
-        assert is_markdown_content("## Sub heading") is True
-        assert is_markdown_content("###### Deep heading") is True
-
-    def test_detects_bold(self):
-        assert is_markdown_content("This is **bold** text") is True
-        assert is_markdown_content("This is __bold__ text") is True
-
-    def test_detects_italic(self):
-        assert is_markdown_content("This is *italic* text") is True
-        assert is_markdown_content("This is _italic_ text") is True
-
-    def test_detects_links(self):
-        assert (
-            is_markdown_content("Click [here](http://example.com)") is True
-        )  # NOSONAR
-
-    def test_detects_lists(self):
-        assert is_markdown_content("- item one") is True
-        assert is_markdown_content("* item one") is True
-        assert is_markdown_content("1. first item") is True
-
-    def test_detects_code(self):
-        assert is_markdown_content("Use `code` here") is True
-        assert is_markdown_content("```python\nprint('hi')\n```") is True
-
-    def test_detects_blockquotes(self):
-        assert is_markdown_content("> This is a quote") is True
-
-    def test_returns_false_for_plain_text(self):
-        assert is_markdown_content("Just plain text without any formatting") is False
-
-    def test_returns_false_for_empty(self):
-        assert is_markdown_content("") is False
-        assert is_markdown_content(None) is False
-
-    def test_returns_false_for_non_string(self):
-        assert is_markdown_content(42) is False
 
 
 @pytest.mark.unit

--- a/apps/api/tests/unit/utils/test_platform_markdown.py
+++ b/apps/api/tests/unit/utils/test_platform_markdown.py
@@ -1,0 +1,94 @@
+"""Tests for platform-specific Markdown converters.
+
+Mirrors the TypeScript formatter tests at
+``apps/bots/__tests__/shared/utils/formatters.test.ts`` so the two
+implementations stay in sync. When changing behavior here, update the TS
+converter in ``libs/shared/ts/src/bots/utils/formatters.ts`` too (and vice
+versa).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.platform_markdown import (
+    convert_to_slack_mrkdwn,
+    convert_to_whatsapp_markdown,
+)
+
+
+class TestConvertToWhatsAppMarkdown:
+    def test_empty_string_is_passthrough(self) -> None:
+        assert convert_to_whatsapp_markdown("") == ""
+
+    def test_double_asterisk_bold_becomes_single(self) -> None:
+        assert convert_to_whatsapp_markdown("**bold**") == "*bold*"
+
+    def test_triple_asterisk_bold_italic_collapses_to_bold(self) -> None:
+        assert convert_to_whatsapp_markdown("***emph***") == "*emph*"
+
+    def test_headings_become_bold(self) -> None:
+        assert convert_to_whatsapp_markdown("# Title") == "*Title*"
+        assert convert_to_whatsapp_markdown("### Sub") == "*Sub*"
+        assert convert_to_whatsapp_markdown("###### Deep") == "*Deep*"
+
+    def test_links_become_label_with_trailing_url(self) -> None:
+        result = convert_to_whatsapp_markdown("[Gaia](https://heygaia.io)")
+        assert result == "Gaia (https://heygaia.io)"
+
+    def test_blockquote_prefix_is_stripped(self) -> None:
+        assert convert_to_whatsapp_markdown("> quoted") == "quoted"
+
+    def test_horizontal_rule_is_removed(self) -> None:
+        assert convert_to_whatsapp_markdown("a\n---\nb") == "a\n\nb"
+
+    def test_fenced_code_block_is_preserved_verbatim(self) -> None:
+        src = "prose **bold**\n```\n**keep me**\n### keep me\n```\nmore **bold**"
+        out = convert_to_whatsapp_markdown(src)
+        assert "```\n**keep me**\n### keep me\n```" in out
+        # Bold outside the fence is still converted.
+        assert "*bold*" in out
+        assert "**bold**" not in out.replace("**keep me**", "")
+
+    def test_multiline_with_mixed_formatting(self) -> None:
+        src = "### Heading\n**bold** and [link](https://x.com)\n> quote"
+        out = convert_to_whatsapp_markdown(src)
+        assert out == "*Heading*\n*bold* and link (https://x.com)\nquote"
+
+
+class TestConvertToSlackMrkdwn:
+    def test_empty_string_is_passthrough(self) -> None:
+        assert convert_to_slack_mrkdwn("") == ""
+
+    def test_double_asterisk_bold_becomes_single(self) -> None:
+        assert convert_to_slack_mrkdwn("**bold**") == "*bold*"
+
+    def test_links_use_angle_bracket_syntax(self) -> None:
+        assert (
+            convert_to_slack_mrkdwn("[Gaia](https://heygaia.io)")
+            == "<https://heygaia.io|Gaia>"
+        )
+
+    def test_headings_become_bold(self) -> None:
+        assert convert_to_slack_mrkdwn("## Section") == "*Section*"
+
+    def test_fenced_code_block_preserved(self) -> None:
+        src = "text **bold**\n```\n**keep**\n```\nafter"
+        out = convert_to_slack_mrkdwn(src)
+        assert "```\n**keep**\n```" in out
+        assert out.startswith("text *bold*")
+
+
+@pytest.mark.parametrize(
+    ("converter", "given", "expected"),
+    [
+        (convert_to_whatsapp_markdown, "plain text", "plain text"),
+        (convert_to_slack_mrkdwn, "plain text", "plain text"),
+        (convert_to_whatsapp_markdown, "a **b** c", "a *b* c"),
+        (convert_to_slack_mrkdwn, "a **b** c", "a *b* c"),
+    ],
+)
+def test_converters_handle_plain_and_simple_bold(
+    converter, given: str, expected: str
+) -> None:
+    assert converter(given) == expected

--- a/apps/bots/__tests__/whatsapp/adapter.test.ts
+++ b/apps/bots/__tests__/whatsapp/adapter.test.ts
@@ -323,10 +323,10 @@ describe("WhatsAppAdapter - createWaTarget", () => {
     const target = priv.createWaTarget("15551234567");
     const richMsg = { title: "GAIA Help", sections: [] };
 
-    vi.mocked(richMessageToMarkdown).mockReturnValue(
+    vi.mocked(richMessageToMarkdown).mockReturnValueOnce(
       "*GAIA Help*\n**Name:** Aryan",
     );
-    vi.mocked(convertToWhatsAppMarkdown).mockReturnValue(
+    vi.mocked(convertToWhatsAppMarkdown).mockReturnValueOnce(
       "*GAIA Help*\n*Name:* Aryan",
     );
 

--- a/apps/bots/whatsapp/src/adapter.ts
+++ b/apps/bots/whatsapp/src/adapter.ts
@@ -394,16 +394,20 @@ export class WhatsAppAdapter extends BaseBotAdapter {
             return;
           }
           finalMessageSent = true;
+          const formatted = convertToWhatsAppMarkdown(updatedText);
           if (lastEditFn) {
-            await lastEditFn(updatedText);
+            await lastEditFn(formatted);
           } else {
-            const sent = await this.sendWhatsAppText(waId, updatedText);
+            const sent = await this.sendWhatsAppText(waId, formatted);
             lastEditFn = sent.edit;
           }
         },
         // sendNewMessage: send a new message and return its edit function
         async (newText: string) => {
-          const sent = await this.sendWhatsAppText(waId, newText);
+          const sent = await this.sendWhatsAppText(
+            waId,
+            convertToWhatsAppMarkdown(newText),
+          );
           lastEditFn = sent.edit;
           return sent.edit;
         },

--- a/apps/web/src/features/landing/components/LazyMotionProvider.tsx
+++ b/apps/web/src/features/landing/components/LazyMotionProvider.tsx
@@ -19,9 +19,5 @@ export default function LazyMotionProvider({
 }: {
   children: ReactNode;
 }) {
-  return (
-    <LazyMotion strict features={loadFeatures}>
-      {children}
-    </LazyMotion>
-  );
+  return <LazyMotion features={loadFeatures}>{children}</LazyMotion>;
 }

--- a/apps/web/src/features/mail/components/EmailComposeCard.tsx
+++ b/apps/web/src/features/mail/components/EmailComposeCard.tsx
@@ -8,7 +8,7 @@ import { ScrollShadow } from "@heroui/scroll-shadow";
 import { Cancel01Icon, PencilEdit01Icon, PlusSignIcon } from "@icons";
 import DOMPurify from "dompurify";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { Gmail } from "@/components/shared/icons";
 import { Separator } from "@/components/ui/separator";
@@ -32,6 +32,26 @@ const emailComposeSchema = z.object({
 
 const emailValidationSchema = z.string().email("Invalid email address");
 
+function HtmlEmailBody({ html }: { html: string }) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hostRef.current) return;
+    const shadowRoot =
+      hostRef.current.shadowRoot ||
+      hostRef.current.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = "";
+    const wrapper = document.createElement("div");
+    wrapper.style.font = "inherit";
+    wrapper.style.color = "inherit";
+    wrapper.style.lineHeight = "1.5";
+    wrapper.innerHTML = DOMPurify.sanitize(html, { ADD_ATTR: ["target"] });
+    shadowRoot.appendChild(wrapper);
+  }, [html]);
+
+  return <div ref={hostRef} />;
+}
+
 interface EmailData {
   to: string[];
   subject: string;
@@ -40,7 +60,6 @@ interface EmailData {
   thread_id?: string;
   bcc?: string[];
   cc?: string[];
-  is_html?: boolean;
 }
 
 interface EmailComposeCardProps {
@@ -52,17 +71,26 @@ function EditEmailModal({
   isOpen,
   onClose,
   onSave,
-  editData,
-  setEditData,
+  initialData,
   errors,
 }: {
   isOpen: boolean;
   onClose: () => void;
-  onSave: () => void;
-  editData: EmailData;
-  setEditData: React.Dispatch<React.SetStateAction<EmailData>>;
+  onSave: (draft: { subject: string; body: string }) => void;
+  initialData: EmailData;
   errors: Record<string, string>;
 }) {
+  const [draft, setDraft] = useState({
+    subject: initialData.subject,
+    body: initialData.body,
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraft({ subject: initialData.subject, body: initialData.body });
+    }
+  }, [isOpen, initialData.subject, initialData.body]);
+
   return (
     <Modal isOpen={isOpen} onOpenChange={onClose} size="2xl">
       <ModalContent className="w-full max-w-md">
@@ -73,9 +101,9 @@ function EditEmailModal({
             <Input
               label="Subject"
               placeholder="Subject"
-              value={editData.subject}
+              value={draft.subject}
               onChange={(e) =>
-                setEditData({ ...editData, subject: e.target.value })
+                setDraft((d) => ({ ...d, subject: e.target.value }))
               }
               isInvalid={!!errors.subject}
               errorMessage={errors.subject}
@@ -87,9 +115,9 @@ function EditEmailModal({
             <Textarea
               label="Message"
               placeholder="Your message"
-              value={editData.body}
+              value={draft.body}
               onChange={(e) =>
-                setEditData({ ...editData, body: e.target.value })
+                setDraft((d) => ({ ...d, body: e.target.value }))
               }
               minRows={5}
               maxRows={8}
@@ -111,7 +139,7 @@ function EditEmailModal({
             <Button
               color="primary"
               size="sm"
-              onPress={onSave}
+              onPress={() => onSave(draft)}
               className="h-7 px-3 text-xs font-medium"
             >
               Save
@@ -273,12 +301,12 @@ export default function EmailComposeCard({
     else setSelectedEmails([]);
   }, [emailData.to]);
 
-  const validateForm = () => {
+  const validateForm = (data: { subject: string; body: string }) => {
     try {
       emailComposeSchema.parse({
         to: selectedEmails,
-        subject: editData.subject,
-        body: editData.body,
+        subject: data.subject,
+        body: data.body,
       });
 
       setErrors({});
@@ -316,7 +344,7 @@ export default function EmailComposeCard({
       return;
     }
 
-    if (!validateForm()) {
+    if (!validateForm({ subject: editData.subject, body: editData.body })) {
       toast.error("Please fix the validation errors");
       return;
     }
@@ -339,7 +367,6 @@ export default function EmailComposeCard({
         formData.append("to", selectedEmails.join(", "));
         formData.append("subject", editData.subject);
         formData.append("body", editData.body);
-        formData.append("is_html", String(emailData.is_html || false));
         if (emailData.bcc && emailData.bcc.length > 0) {
           formData.append("bcc", emailData.bcc.join(", "));
         }
@@ -360,18 +387,18 @@ export default function EmailComposeCard({
     }
   };
 
-  const handleSave = () => {
-    if (!validateForm()) {
+  const handleSave = (draft: { subject: string; body: string }) => {
+    if (!validateForm(draft)) {
       toast.error("Please fix the validation errors");
       return;
     }
 
-    const updatedData = {
-      ...editData,
+    setEditData((prev) => ({
+      ...prev,
+      subject: draft.subject,
+      body: draft.body,
       to: selectedEmails,
-    };
-
-    setEditData(updatedData);
+    }));
     setIsEditModalOpen(false);
     toast.success("Email updated successfully!");
   };
@@ -487,7 +514,7 @@ export default function EmailComposeCard({
           </div>
           <Separator className="my-1.5 bg-zinc-700" />
 
-          <ScrollShadow className="relative z-1 max-h-46 overflow-y-auto pb-5 text-sm leading-relaxed whitespace-pre-line text-zinc-200">
+          <ScrollShadow className="relative z-1 max-h-46 overflow-y-auto pb-5 text-sm leading-relaxed text-zinc-200">
             <div className="absolute top-0 right-0 z-2 flex w-full justify-end">
               <Button
                 variant="light"
@@ -498,15 +525,7 @@ export default function EmailComposeCard({
                 <PencilEdit01Icon className="h-5 w-5 text-zinc-500" />
               </Button>
             </div>
-            {emailData.is_html ? (
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: DOMPurify.sanitize(editData.body),
-                }}
-              />
-            ) : (
-              editData.body
-            )}
+            <HtmlEmailBody html={editData.body} />
           </ScrollShadow>
         </div>
         <div className="flex justify-end px-6 pb-5">
@@ -531,8 +550,7 @@ export default function EmailComposeCard({
         isOpen={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
         onSave={handleSave}
-        editData={editData}
-        setEditData={setEditData}
+        initialData={editData}
         errors={errors}
       />
 


### PR DESCRIPTION
## Summary

Agent-generated Markdown was leaking to WhatsApp, email, and other messaging platforms as raw `**bold**` / `### headings`. The agent was also emitting `:::openui` fences on platforms that can't render them. This PR adds platform-aware formatting at every delivery boundary and collapses the email pipeline onto a single always-HTML path.

## 1. WhatsApp formatting

**Bot streaming (`/gaia` chat replies).** `sendRich` already converted, but the streaming `editMessage`/`sendNewMessage` callbacks sent raw Markdown straight to Kapso. Now wrapped with `convertToWhatsAppMarkdown` → `**bold**` becomes `*bold*`, `###` becomes `*heading*`, `[label](url)` becomes `label (url)`.

**Notifications.** New `apps/api/app/utils/platform_markdown.py` (Python port of the TS bot formatters, kept in sync). `WhatsAppChannelAdapter.transform()` runs body/header/messages/footer through the converter before the base class's splitter runs, so the 4096-char chunk boundaries reflect the final WhatsApp-syntax payload.

Slack / Telegram bots already convert in their streaming paths. Telegram notifications use `telegramify-markdown`. Discord uses `**bold**` natively. No changes needed for those.

## 2. Email — drop the `is_html` flag entirely

The flag was a footgun. If the agent picked `false` while writing Markdown, Gmail rendered `###` and `**` literally. If it picked `true`, the body still wasn't actually HTML, so the same thing happened. Every choice had a failure mode.

**Fix: there is no choice.** The agent writes Markdown; the backend always converts to HTML; Gmail always gets HTML.

- `normalize_email_body_to_html` in `markdown_utils.py` — detects HTML by tag presence (not bare `<…>` so `"x < 5"` doesn't false-positive), otherwise runs through `markdown2`. Idempotent on both inputs.
- `gmail_compose_before_hook` normalises `body` / `message_body` / `message` for every compose tool (`GMAIL_SEND_EMAIL`, `_CREATE_DRAFT`, `_REPLY_TO_THREAD`, `_FORWARD_MESSAGE`) and hard-sets `is_html=True`.
- A schema modifier strips `is_html` from the agent-facing tool schema so the agent physically cannot pass it.
- `send_email`, `create_draft`, `update_draft` drop the `is_html` parameter. REST endpoints (`/gmail/send`, `/gmail/send-json`, `/gmail/drafts`) no longer accept or forward it. `DraftRequest` drops the field.
- `gmail-draft-send/SKILL.md` and the Gmail eval dataset updated to reflect "write Markdown" instead of guidance on setting the flag.

### Why this matters

| Input | Before-hook action | Gmail receives |
|---|---|---|
| Agent writes Markdown | markdown2 → HTML | HTML |
| Agent writes plain text | markdown2 wraps in `<p>` | HTML |
| REST form sends Markdown | markdown2 → HTML | HTML |
| REST sends raw HTML | tag-detected, passthrough | HTML |

The old flag asked callers "is this HTML?" The right question was "does Gmail need HTML?" — and the answer is always yes. Plain-text-in-HTML renders identically to plain text.

## 3. OpenUI gating

`get_comms_agent_prompt(source)` now takes a source arg. Web/mobile/desktop keep OpenUI Lang instructions; WhatsApp/Telegram/Discord/Slack/email get the prompt without them, so the model emits plain Markdown on channels that can't render cards.

`source` is threaded through `construct_langchain_messages` → `create_system_message`.

## 4. Prompt cache hygiene

Both prompt variants (rich-UI and plain) are pre-built at module load in `agent_template.py`. `build_comms_prompt_template(source)` returns one of two stable pointers instead of rebuilding a `PromptTemplate` per request — keeps the LLM provider's prompt-cache hit rate high and avoids re-parsing the large OpenUI spec on every message.

## 5. Cleanup

- Removed `is_markdown_content` (dead after the pipeline simplification) and its tests.
- Deleted stale `is_html` guidance from `gmail-draft-send` skill and Gmail eval.
- Added unit tests for `platform_markdown.py` mirroring the TS formatter test suite so the two stay in sync.

## Test plan

- [ ] WhatsApp DM that triggers a structured response — confirm bold/headings render natively, no literal `**` or `###`.
- [ ] WhatsApp notification from a workflow — confirm headings and links render correctly.
- [ ] Agent drafts an email — Gmail renders formatted HTML, not raw Markdown.
- [ ] Agent is asked on WhatsApp/Telegram for something that would normally emit an OpenUI card ("compare X vs Y") — no `:::openui` fences in the message.
- [ ] Web chat still renders OpenUI cards as before.
- [ ] REST `/gmail/send` and `/gmail/drafts` still work (no `is_html` field required in the payload).

## Quality

`nx lint api` / `nx type-check api` / `nx lint bot-whatsapp` / `nx type-check bot-whatsapp` — all green.
`uv run pytest tests/unit/utils tests/unit/services/test_mail_service.py` — 131 passed.