### PR TITLE
feat(web): add llms.txt via next-llms-txt

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -163,6 +163,7 @@
     "motion": "^12.23.12",
     "next": "16.1.6",
     "next-intl": "^4.8.3",
+    "next-llms-txt": "^1.0.2",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.6",
     "posthog-js": "^1.260.2",

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,71 @@
+import fs from "fs";
+import type { PageInfo } from "next-llms-txt";
+import { createLLmsTxt } from "next-llms-txt";
+
+import { siteConfig } from "@/lib/seo";
+
+const BASE_URL = siteConfig.url;
+
+function extractMetadata(
+  filePath: string,
+): { title: string; description?: string } | null {
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const titleMatch = content.match(/\btitle:\s*["']([^"'\n]+)["']/);
+    if (!titleMatch) return null;
+    const descriptionMatch = content.match(
+      /\bdescription:\s*["']([^"'\n]+)["']/,
+    );
+    return {
+      title: titleMatch[1],
+      description: descriptionMatch?.[1],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function generateContent(
+  _config: unknown,
+  pages: PageInfo[] | undefined,
+): string {
+  const enriched = (pages ?? [])
+    .filter((p) => !p.route.includes("["))
+    .map((page) => {
+      if (page.config?.title) return page;
+      const meta = extractMetadata(page.filePath);
+      if (!meta) return null;
+      return { ...page, config: { ...meta } };
+    })
+    .filter((p): p is PageInfo => p !== null && !!p.config?.title);
+
+  const lines: string[] = [
+    `# ${siteConfig.short_name}`,
+    "",
+    `> ${siteConfig.description}`,
+    "",
+    "## Pages",
+  ];
+
+  for (const page of enriched) {
+    const desc = page.config?.description ? `: ${page.config.description}` : "";
+    lines.push(`- [${page.config?.title}](${BASE_URL}${page.route})${desc}`);
+  }
+
+  return lines.join("\n");
+}
+
+export const { GET } = createLLmsTxt({
+  baseUrl: BASE_URL,
+  defaultConfig: {
+    title: siteConfig.short_name,
+    description: siteConfig.description,
+  },
+  autoDiscovery: {
+    appDir: "src/app/[locale]/(landing)",
+    rootDir: process.cwd(),
+  },
+  generator: generateContent,
+});
+
+export const revalidate = 3600;

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -37,7 +37,10 @@ function generateContent(
       if (!meta) return null;
       return { ...page, config: { ...meta } };
     })
-    .filter((p): p is PageInfo => p !== null && !!p.config?.title);
+    .filter((p): p is PageInfo => p !== null && !!p.config?.title)
+    .sort((a, b) =>
+      (a.config?.title ?? "").localeCompare(b.config?.title ?? ""),
+    );
 
   const lines: string[] = [
     `# ${siteConfig.short_name}`,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,7 +1,15 @@
 import type { NextRequest } from "next/server";
 import createMiddleware from "next-intl/middleware";
+import { createLLmsTxt, isLLMsTxtPath } from "next-llms-txt";
 
 import { routing } from "./i18n/routing";
+
+const { GET: handleLLmsTxt } = createLLmsTxt({
+  autoDiscovery: {
+    appDir: "src/app/[locale]/(landing)",
+    rootDir: process.cwd(),
+  },
+});
 
 // Routes that have actual translations — only these get locale-prefixed URLs
 const translatedPrefixes = [
@@ -28,7 +36,10 @@ const intlMiddlewareDefaultOnly = createMiddleware({
   localeDetection: false,
 });
 
-export default function proxy(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
+  if (isLLMsTxtPath(request.nextUrl.pathname)) {
+    return await handleLLmsTxt(request);
+  }
   if (isTranslatedRoute(request.nextUrl.pathname)) {
     return intlMiddleware(request);
   }
@@ -38,5 +49,9 @@ export default function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|sitemap|ingest|.*\\..*).*)", "/"],
+  matcher: [
+    "/((?!api|_next|_vercel|sitemap|ingest|.*\\..*).*)",
+    "/(.*\\.html\\.md)",
+    "/",
+  ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,6 +818,9 @@ importers:
       next-intl:
         specifier: ^4.8.3
         version: 4.9.0(@swc/helpers@0.5.21)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.99.0))(react@19.1.0)(typescript@5.9.3)
+      next-llms-txt:
+        specifier: ^1.0.2
+        version: 1.0.2(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.99.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -9717,6 +9720,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -14713,6 +14717,15 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  next-llms-txt@1.0.2:
+    resolution: {integrity: sha512-v5YtAJiT0JC4C4kQ2Z5QCgc2NwOVy6wYRrLga8SBtSsOffp8L66HGaNMnTQySpgCfhB+Z3I3OdxuAeHDktFHGA==}
+    engines: {node: ^22.0.0 || ^24.0.0}
+    peerDependencies:
+      next: ^16.0.0
+      react: 19.1.0
+      react-dom: 19.1.0
+      typescript: ^5.9.3
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -36246,6 +36259,20 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@swc/helpers'
+
+  next-llms-txt@1.0.2(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.99.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.99.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `/llms.txt` endpoint to `heygaia.io` using the [`next-llms-txt`](https://github.com/bke-daniel/next-llms-txt) library
- Fully dynamic — no hardcoded URLs or sections; scans `src/app/[locale]/(landing)` at runtime and extracts `title`/`description` from every page's metadata export (handles both plain objects and `generatePageMetadata({...})` calls via regex)
- New pages in `(landing)` automatically appear in `/llms.txt` without any extra work
- Also wires up `*.html.md` per-page markdown endpoints via the middleware (`proxy.ts`)
- Response is cached with `revalidate = 3600` (ISR)

## How it works

`createLLmsTxt` from the library handles the HTTP layer. A custom `generator` callback overrides content generation: it walks `src/app/[locale]/(landing)`, enriches pages the library's Babel parser couldn't extract (those using `generatePageMetadata`), and formats the standard llms.txt spec output.

## Output snippet (`/llms.txt`)

```
# GAIA

> GAIA is your open-source personal AI assistant to proactively manage your email, calendar, todos, workflows and all your digital tools to boost productivity.

## Pages

- [About GAIA](https://heygaia.io/about): Learn about GAIA — the open-source personal AI assistant built to proactively manage your digital life.
- [GAIA for Agency Owners](https://heygaia.io/agency-owners): Use GAIA to manage client communications, automate reporting, and keep projects on track.
- [GAIA — Your AI Chief of Staff](https://heygaia.io/ai-chief-of-staff): Let GAIA act as your AI Chief of Staff — managing priorities, communications, and daily operations.
- [Blog](https://heygaia.io/blog): Read the GAIA blog for insights on AI productivity, personal automation, and open-source tools.
- [Bots](https://heygaia.io/bots): Use GAIA through Discord, Slack, and WhatsApp bots for seamless AI assistance anywhere.
- [CLI](https://heygaia.io/cli): Use GAIA from your terminal with the CLI — automate tasks and manage your digital life from the command line.
...
```

## Test plan

- [ ] Visit `https://heygaia.io/llms.txt` after deploy — confirm the file is served with correct content-type and lists all landing pages
- [ ] Add a new page to `(landing)` and confirm it appears in `/llms.txt` without any config changes
- [ ] Visit `https://heygaia.io/about.html.md` — confirm markdown content is served

Closes GAIA-590

🤖 Generated with [Claude Code](https://claude.com/claude-code)