### PR TITLE
fix(web): show user timezone in workflow card schedule chips

### DIFF
--- a/apps/web/src/config/openui/components/document.tsx
+++ b/apps/web/src/config/openui/components/document.tsx
@@ -65,17 +65,15 @@ function htmlToMarkdown(html: string): string {
         return `${inner}\n`;
       case "ol": {
         let index = 0;
-        return (
-          Array.from(el.children)
-            .map((child) => {
-              if (child.tagName.toLowerCase() === "li") {
-                index += 1;
-                return `${index}. ${Array.from(child.childNodes).map(nodeToMd).join("")}\n`;
-              }
-              return nodeToMd(child);
-            })
-            .join("") + "\n"
-        );
+        return `${Array.from(el.children)
+          .map((child) => {
+            if (child.tagName.toLowerCase() === "li") {
+              index += 1;
+              return `${index}. ${Array.from(child.childNodes).map(nodeToMd).join("")}\n`;
+            }
+            return nodeToMd(child);
+          })
+          .join("")}\n`;
       }
       case "li":
         return `- ${inner}\n`;

--- a/apps/web/src/features/use-cases/components/UseCaseSection.tsx
+++ b/apps/web/src/features/use-cases/components/UseCaseSection.tsx
@@ -21,6 +21,7 @@ export default function UseCaseSection({
   showDescriptionAsTooltip,
   useBlurEffect,
   disableCentering = false,
+  noMaxWidth = false,
   slicePerTab,
   hideAllCategory = false,
   rows,
@@ -35,6 +36,7 @@ export default function UseCaseSection({
   showDescriptionAsTooltip?: boolean;
   useBlurEffect?: boolean;
   disableCentering?: boolean;
+  noMaxWidth?: boolean;
   slicePerTab?: number;
   hideAllCategory?: boolean;
   rows?: number;
@@ -275,7 +277,7 @@ export default function UseCaseSection({
           selectedCategory !== "workflows" && (
             <m.div
               key={selectedCategory}
-              className={`${disableCentering ? "" : "mx-auto"} grid ${setShowUseCases ? "max-w-5xl" : "max-w-7xl"} grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-${columns} xl:grid-cols-${columns}`}
+              className={`${disableCentering ? "" : "mx-auto"} grid ${noMaxWidth ? "" : setShowUseCases ? "max-w-5xl" : "max-w-7xl"} grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-${columns} xl:grid-cols-${columns}`}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
@@ -327,7 +329,7 @@ export default function UseCaseSection({
           workflows.length > 0 && (
             <m.div
               key="workflows"
-              className={`${disableCentering ? "" : "mx-auto"} grid ${setShowUseCases ? "max-w-5xl" : "max-w-7xl"}  grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-${columns} xl:grid-cols-${columns}`}
+              className={`${disableCentering ? "" : "mx-auto"} grid ${noMaxWidth ? "" : setShowUseCases ? "max-w-5xl" : "max-w-7xl"} grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-${columns} xl:grid-cols-${columns}`}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}

--- a/apps/web/src/features/workflows/components/WorkflowPage.tsx
+++ b/apps/web/src/features/workflows/components/WorkflowPage.tsx
@@ -283,6 +283,7 @@ export default function WorkflowPage() {
             hideUserWorkflows={true}
             exploreWorkflows={exploreWorkflows}
             disableCentering={true}
+            noMaxWidth={true}
           />
         ) : null,
         undefined,

--- a/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
@@ -10,8 +10,8 @@ import {
   UserCircle02Icon,
 } from "@icons";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
+import { cn } from "@/lib/utils";
 import { formatRunCount } from "@/utils/formatters";
 
 import type { Workflow } from "../../api/workflowApi";
@@ -128,7 +128,9 @@ export function TriggerDisplay({
   }
 
   return (
-    <div className={cn("flex items-center gap-1 text-xs text-zinc-500", className)}>
+    <div
+      className={cn("flex items-center gap-1 text-xs text-zinc-500", className)}
+    >
       <div className="w-4">
         <TriggerIcon
           triggerType={triggerType}
@@ -159,7 +161,10 @@ export function RunCountDisplay({
   if (runCount !== "Never run")
     return (
       <div
-        className={cn("flex items-center gap-1 text-xs text-zinc-500", className)}
+        className={cn(
+          "flex items-center gap-1 text-xs text-zinc-500",
+          className,
+        )}
       >
         <PlayIcon size={16} className="w-4 text-zinc-500" />
         <span className="text-nowrap">{formatRunCount(totalExecutions)}</span>

--- a/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
@@ -10,6 +10,7 @@ import {
   UserCircle02Icon,
 } from "@icons";
 import Image from "next/image";
+import { cn } from "@/lib/utils";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import { formatRunCount } from "@/utils/formatters";
 
@@ -118,22 +119,29 @@ export function TriggerDisplay({
   nextRunText,
   className = "",
 }: TriggerDisplayProps) {
-  if (triggerLabel !== "Manual Trigger")
+  if (triggerLabel === "Manual Trigger" || !triggerLabel) {
     return (
-      <div className={`flex items-center gap-1 text-xs text-zinc-500 ${className}`}>
-        <div className="w-4">
-          <TriggerIcon
-            triggerType={triggerType}
-            integrationId={integrationId}
-            size={17}
-          />
-        </div>
-        <span>
-          {triggerLabel}
-          {nextRunText ? ` (${nextRunText})` : ""}
-        </span>
-      </div>
+      <Chip size="sm" variant="flat" radius="sm" className="text-xs">
+        Manual
+      </Chip>
     );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-1 text-xs text-zinc-500", className)}>
+      <div className="w-4">
+        <TriggerIcon
+          triggerType={triggerType}
+          integrationId={integrationId}
+          size={16}
+        />
+      </div>
+      <span>
+        {triggerLabel}
+        {nextRunText ? ` (${nextRunText})` : ""}
+      </span>
+    </div>
+  );
 }
 
 // Reusable Run Count Component
@@ -151,9 +159,9 @@ export function RunCountDisplay({
   if (runCount !== "Never run")
     return (
       <div
-        className={`flex items-center gap-1 text-xs text-zinc-500 ${className}`}
+        className={cn("flex items-center gap-1 text-xs text-zinc-500", className)}
       >
-        <PlayIcon width={15} height={15} className="w-4 text-zinc-500" />
+        <PlayIcon size={16} className="w-4 text-zinc-500" />
         <span className="text-nowrap">{formatRunCount(totalExecutions)}</span>
       </div>
     );

--- a/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
@@ -7,7 +7,6 @@ import {
   DateTimeIcon,
   Mail01Icon,
   PlayIcon,
-  TimeScheduleIcon,
   UserCircle02Icon,
 } from "@icons";
 import Image from "next/image";
@@ -15,58 +14,6 @@ import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import { formatRunCount } from "@/utils/formatters";
 
 import type { Workflow } from "../../api/workflowApi";
-import { getBrowserTimezone } from "../../utils/browserTimezone";
-
-/**
- * Format a UTC date to a localized time string in the specified timezone.
- *
- * @param utcDate - Date object in UTC
- * @param timezone - IANA timezone name (e.g., "America/New_York") or offset string (e.g., "+05:30")
- * @returns Formatted time string like "9:00 AM" or "9:00 AM IST"
- */
-function formatTimeInTimezone(utcDate: Date, timezone: string): string {
-  try {
-    // Check if timezone is an offset string like "+05:30" or "-08:00"
-    const offsetMatch = timezone.match(/^([+-])(\d{2}):(\d{2})$/);
-
-    if (offsetMatch) {
-      // For offset strings, we can't use Intl directly with the offset
-      // We need to manually calculate the time
-      const sign = offsetMatch[1] === "+" ? 1 : -1;
-      const hours = parseInt(offsetMatch[2], 10);
-      const minutes = parseInt(offsetMatch[3], 10);
-      const offsetMs = sign * (hours * 60 + minutes) * 60 * 1000;
-
-      // Create a new date adjusted by the offset
-      const localDate = new Date(utcDate.getTime() + offsetMs);
-
-      // Format without timezone name since we only have an offset
-      return localDate.toLocaleTimeString("en-US", {
-        hour: "numeric",
-        minute: "2-digit",
-        hour12: true,
-        timeZone: "UTC", // Use UTC since we already applied the offset
-      });
-    }
-
-    // For IANA timezone names, use Intl.DateTimeFormat
-    return utcDate.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-      timeZone: timezone,
-      timeZoneName: "short",
-    });
-  } catch {
-    // Fallback to browser timezone if the timezone is invalid
-    return utcDate.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-      timeZoneName: "short",
-    });
-  }
-}
 
 /**
  * Get relative time display (e.g., "in 2h", "in 3d")
@@ -88,7 +35,7 @@ function getRelativeTime(nextRun: Date, now: Date): string {
   }
 }
 
-// Utility function for calculating next run display
+// Utility function for calculating next run relative time display
 export function getNextRunDisplay(workflow: Workflow): string | null {
   const { trigger_config } = workflow;
 
@@ -99,15 +46,10 @@ export function getNextRunDisplay(workflow: Workflow): string | null {
 
     // Check if next run is in the future
     if (nextRun > now) {
-      // Get the workflow's stored timezone, fallback to browser timezone
-      const workflowTimezone =
-        (trigger_config.timezone as string) || getBrowserTimezone();
-
-      // Format: "9:00 AM IST (in 2h)"
-      const formattedTime = formatTimeInTimezone(nextRun, workflowTimezone);
-      const relativeTime = getRelativeTime(nextRun, now);
-
-      return `${formattedTime} (${relativeTime})`;
+      // Return only the relative time — the trigger label already shows
+      // the scheduled time in the user's local timezone, so we avoid
+      // displaying the same time twice.
+      return getRelativeTime(nextRun, now);
     }
   }
 
@@ -178,24 +120,18 @@ export function TriggerDisplay({
 }: TriggerDisplayProps) {
   if (triggerLabel !== "Manual Trigger")
     return (
-      <div className={`flex flex-wrap items-center gap-2 ${className}`}>
-        <div className="flex items-center gap-1 text-xs text-zinc-500">
-          <div className="w-4">
-            <TriggerIcon
-              triggerType={triggerType}
-              integrationId={integrationId}
-              size={17}
-            />
-          </div>
-          {triggerLabel}
+      <div className={`flex items-center gap-1 text-xs text-zinc-500 ${className}`}>
+        <div className="w-4">
+          <TriggerIcon
+            triggerType={triggerType}
+            integrationId={integrationId}
+            size={17}
+          />
         </div>
-
-        {nextRunText && (
-          <div className="flex items-center gap-1 text-xs text-zinc-500">
-            <TimeScheduleIcon width={15} height={15} />
-            {nextRunText}
-          </div>
-        )}
+        <span>
+          {triggerLabel}
+          {nextRunText ? ` (${nextRunText})` : ""}
+        </span>
       </div>
     );
 }

--- a/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
@@ -21,16 +21,21 @@ import type { Workflow } from "../../api/workflowApi";
  */
 function getRelativeTime(nextRun: Date, now: Date): string {
   const diffMs = nextRun.getTime() - now.getTime();
-  const diffMinutes = Math.floor(diffMs / (1000 * 60));
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffDays = Math.floor(diffHours / 24);
+  const totalMinutes = Math.floor(diffMs / (1000 * 60));
+  const totalHours = Math.floor(totalMinutes / 60);
+  const totalDays = Math.floor(totalHours / 24);
 
-  if (diffDays > 0) {
-    return `in ${diffDays}d`;
-  } else if (diffHours > 0) {
-    return `in ${diffHours}h`;
-  } else if (diffMinutes > 0) {
-    return `in ${diffMinutes}m`;
+  const remHours = totalHours % 24;
+  const remMinutes = totalMinutes % 60;
+
+  if (totalDays > 0) {
+    return remHours > 0 ? `in ${totalDays}d ${remHours}h` : `in ${totalDays}d`;
+  } else if (totalHours > 0) {
+    return remMinutes > 0
+      ? `in ${totalHours}h ${remMinutes}m`
+      : `in ${totalHours}h`;
+  } else if (totalMinutes > 0) {
+    return `in ${totalMinutes}m`;
   } else {
     return "soon";
   }

--- a/apps/web/src/features/workflows/triggers/utils.ts
+++ b/apps/web/src/features/workflows/triggers/utils.ts
@@ -80,11 +80,7 @@ export function getTriggerDisplayInfo(
   ) {
     const cronExpression = trigger_config.cron_expression;
     if (typeof cronExpression === "string") {
-      const storedTimezone =
-        typeof trigger_config.timezone === "string"
-          ? trigger_config.timezone
-          : undefined;
-      const cronDesc = getScheduleDescription(cronExpression, storedTimezone);
+      const cronDesc = getScheduleDescription(cronExpression);
       if (cronDesc) {
         displayInfo.label = cronDesc;
       }

--- a/apps/web/src/features/workflows/triggers/utils.ts
+++ b/apps/web/src/features/workflows/triggers/utils.ts
@@ -80,7 +80,11 @@ export function getTriggerDisplayInfo(
   ) {
     const cronExpression = trigger_config.cron_expression;
     if (typeof cronExpression === "string") {
-      const cronDesc = getScheduleDescription(cronExpression);
+      const storedTimezone =
+        typeof trigger_config.timezone === "string"
+          ? trigger_config.timezone
+          : undefined;
+      const cronDesc = getScheduleDescription(cronExpression, storedTimezone);
       if (cronDesc) {
         displayInfo.label = cronDesc;
       }

--- a/apps/web/src/features/workflows/utils/cronUtils.ts
+++ b/apps/web/src/features/workflows/utils/cronUtils.ts
@@ -1,5 +1,7 @@
 // Comprehensive cron expression builder and parser
 
+import { getBrowserTimezone } from "./browserTimezone";
+
 export interface CronSchedule {
   type: "daily" | "weekly" | "monthly" | "yearly" | "custom";
   minute?: number;
@@ -160,15 +162,49 @@ export const parseCronExpression = (cron: string): CronSchedule => {
   return { type: "custom", customExpression: cron };
 };
 
-export const getScheduleDescription = (cron: string): string => {
+/**
+ * Convert a UTC hour/minute to the user's local timezone and return a
+ * formatted time string with the short timezone name (e.g., "9:00 AM IST").
+ *
+ * Cron expressions are stored in UTC on the backend, so we create a Date
+ * object at the given UTC hour/minute and format it in the target timezone.
+ */
+function convertUtcTimeToLocalString(
+  utcHour: number,
+  utcMinute: number,
+  timezone: string,
+): string {
+  try {
+    // Build a Date in UTC at the given hour/minute (day is irrelevant)
+    const utcDate = new Date(
+      Date.UTC(2000, 0, 1, utcHour, utcMinute, 0),
+    );
+    return utcDate.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+      timeZone: timezone,
+      timeZoneName: "short",
+    });
+  } catch {
+    // Fallback: format without timezone conversion
+    const ampm = utcHour >= 12 ? "PM" : "AM";
+    const displayHour =
+      utcHour > 12 ? utcHour - 12 : utcHour === 0 ? 12 : utcHour;
+    const displayMinute = utcMinute.toString().padStart(2, "0");
+    return `${displayHour}:${displayMinute} ${ampm}`;
+  }
+}
+
+export const getScheduleDescription = (
+  cron: string,
+  timezone?: string,
+): string => {
+  const tz = timezone ?? getBrowserTimezone();
   const schedule = parseCronExpression(cron);
 
-  const formatTime = (hour: number, minute: number) => {
-    const ampm = hour >= 12 ? "PM" : "AM";
-    const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
-    const displayMinute = minute.toString().padStart(2, "0");
-    return `${displayHour}:${displayMinute} ${ampm}`;
-  };
+  const formatTime = (hour: number, minute: number) =>
+    convertUtcTimeToLocalString(hour, minute, tz);
 
   const dayNames = [
     "Sunday",
@@ -217,13 +253,6 @@ export const getScheduleDescription = (cron: string): string => {
       return `Yearly on ${monthNames[schedule.month! - 1]} ${schedule.dayOfMonth} at ${formatTime(schedule.hour!, schedule.minute!)}`;
 
     case "custom":
-      // Try to match common patterns
-      if (schedule.customExpression === "0 9,18 * * *") {
-        return "Twice daily at 9:00 AM and 6:00 PM";
-      }
-      if (schedule.customExpression === "0 9 * * 1-5") {
-        return "Weekdays at 9:00 AM";
-      }
       return `Custom: ${schedule.customExpression}`;
 
     default:

--- a/apps/web/src/features/workflows/utils/cronUtils.ts
+++ b/apps/web/src/features/workflows/utils/cronUtils.ts
@@ -1,7 +1,5 @@
 // Comprehensive cron expression builder and parser
 
-import { getBrowserTimezone } from "./browserTimezone";
-
 export interface CronSchedule {
   type: "daily" | "weekly" | "monthly" | "yearly" | "custom";
   minute?: number;
@@ -162,53 +160,15 @@ export const parseCronExpression = (cron: string): CronSchedule => {
   return { type: "custom", customExpression: cron };
 };
 
-/**
- * Convert a UTC hour/minute to the user's local timezone and return a
- * formatted time string with the short timezone name (e.g., "9:00 AM IST").
- *
- * Cron expressions are stored in UTC on the backend, so we create a Date
- * object at the given UTC hour/minute and format it in the target timezone.
- */
-function convertUtcTimeToLocalString(
-  utcHour: number,
-  utcMinute: number,
-  timezone: string,
-): string {
-  try {
-    // Build a Date in UTC at the given hour/minute (day is irrelevant)
-    const utcDate = new Date(Date.UTC(2000, 0, 1, utcHour, utcMinute, 0));
-    return utcDate.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-      timeZone: timezone,
-      timeZoneName: "short",
-    });
-  } catch {
-    // Fallback: format without timezone conversion
-    const ampm = utcHour >= 12 ? "PM" : "AM";
-    let displayHour: number;
-    if (utcHour === 0) {
-      displayHour = 12;
-    } else if (utcHour > 12) {
-      displayHour = utcHour - 12;
-    } else {
-      displayHour = utcHour;
-    }
-    const displayMinute = utcMinute.toString().padStart(2, "0");
-    return `${displayHour}:${displayMinute} ${ampm}`;
-  }
-}
-
-export const getScheduleDescription = (
-  cron: string,
-  timezone?: string,
-): string => {
-  const tz = timezone ?? getBrowserTimezone();
+export const getScheduleDescription = (cron: string): string => {
   const schedule = parseCronExpression(cron);
 
-  const formatTime = (hour: number, minute: number) =>
-    convertUtcTimeToLocalString(hour, minute, tz);
+  const formatTime = (hour: number, minute: number): string => {
+    const ampm = hour >= 12 ? "PM" : "AM";
+    const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
+    const displayMinute = minute.toString().padStart(2, "0");
+    return `${displayHour}:${displayMinute} ${ampm}`;
+  };
 
   const dayNames = [
     "Sunday",

--- a/apps/web/src/features/workflows/utils/cronUtils.ts
+++ b/apps/web/src/features/workflows/utils/cronUtils.ts
@@ -187,8 +187,14 @@ function convertUtcTimeToLocalString(
   } catch {
     // Fallback: format without timezone conversion
     const ampm = utcHour >= 12 ? "PM" : "AM";
-    const displayHour =
-      utcHour > 12 ? utcHour - 12 : utcHour === 0 ? 12 : utcHour;
+    let displayHour: number;
+    if (utcHour === 0) {
+      displayHour = 12;
+    } else if (utcHour > 12) {
+      displayHour = utcHour - 12;
+    } else {
+      displayHour = utcHour;
+    }
     const displayMinute = utcMinute.toString().padStart(2, "0");
     return `${displayHour}:${displayMinute} ${ampm}`;
   }

--- a/apps/web/src/features/workflows/utils/cronUtils.ts
+++ b/apps/web/src/features/workflows/utils/cronUtils.ts
@@ -176,9 +176,7 @@ function convertUtcTimeToLocalString(
 ): string {
   try {
     // Build a Date in UTC at the given hour/minute (day is irrelevant)
-    const utcDate = new Date(
-      Date.UTC(2000, 0, 1, utcHour, utcMinute, 0),
-    );
+    const utcDate = new Date(Date.UTC(2000, 0, 1, utcHour, utcMinute, 0));
     return utcDate.toLocaleTimeString("en-US", {
       hour: "numeric",
       minute: "2-digit",


### PR DESCRIPTION
## Summary
- Show schedule times in user's local timezone instead of UTC
- Merge redundant chips (e.g. 'Daily' + '9:00 AM UTC') into a single chip like 'Daily at 9:00 AM IST'
- Uses `Intl.DateTimeFormat().resolvedOptions().timeZone` for the user's local timezone

Closes GAIA-619

## Test plan
- [x] Create a workflow with a daily schedule
- [x] Verify the card shows correct local timezone time
- [x] Verify no redundant chips appear

Before: 
<img width="572" height="528" alt="image" src="https://github.com/user-attachments/assets/be08c8b1-a90b-41de-ada4-9bacca71c899" />


After:

<img width="604" height="352" alt="CleanShot 2026-05-03 at 02 04 48@2x" src="https://github.com/user-attachments/assets/887dd908-3663-481a-b25e-a5b1976fdf5b" />
