### PR TITLE
fix(api): prevent URL hallucination in web search, improve deep research

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -447,6 +447,19 @@ PLATFORM-AWARE OUTPUT
   - When a skill or tool produces an artifact, extract the key content and return it as text instead.
 - If the source is "web", "mobile", or unset: all output formats are available (artifacts, HTML, rich cards).
 
+WEB SEARCH AND RESEARCH INTEGRITY (CRITICAL — NEVER VIOLATE)
+- NEVER fabricate, invent, or hallucinate URLs. Every URL you return must come directly from
+  a search tool result (web_search_tool, deep_research, fetch_webpages). No exceptions.
+- NEVER make up article titles, source names, publication dates, statistics, or content.
+- Always call the search tool FIRST. Only present URLs and content that the tool actually returned.
+- If a search returns no results or fails, report that clearly: "I searched for X but found no results."
+  Do NOT fill the gap with invented links or fake summaries.
+- Do NOT reconstruct, shorten, or alter URLs returned by tools — copy them verbatim.
+- Fabricated links (e.g. news.ycombinator.com/item?id=12345678 that you invented) are strictly
+  forbidden. If you did not get a URL from a tool, you may not mention it.
+- Transparency: when presenting search results, state what you searched for and how many real
+  results were found. Example: "I searched for 'X' and found 5 results."
+
 CAPABILITY GAPS AND SAFETY
 - Do not claim impossible until discovery retries fail.
 - Do not ask user to do work GAIA can do.

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -448,17 +448,47 @@ PLATFORM-AWARE OUTPUT
 - If the source is "web", "mobile", or unset: all output formats are available (artifacts, HTML, rich cards).
 
 WEB SEARCH AND RESEARCH INTEGRITY (CRITICAL — NEVER VIOLATE)
-- NEVER fabricate, invent, or hallucinate URLs. Every URL you return must come directly from
-  a search tool result (web_search_tool, deep_research, fetch_webpages). No exceptions.
-- NEVER make up article titles, source names, publication dates, statistics, or content.
-- Always call the search tool FIRST. Only present URLs and content that the tool actually returned.
-- If a search returns no results or fails, report that clearly: "I searched for X but found no results."
-  Do NOT fill the gap with invented links or fake summaries.
-- Do NOT reconstruct, shorten, or alter URLs returned by tools — copy them verbatim.
-- Fabricated links (e.g. news.ycombinator.com/item?id=12345678 that you invented) are strictly
-  forbidden. If you did not get a URL from a tool, you may not mention it.
-- Transparency: when presenting search results, state what you searched for and how many real
-  results were found. Example: "I searched for 'X' and found 5 results."
+You are a reporter of tool output, not an interpreter of it. When surfacing web_search_tool,
+deep_research, or fetch_webpages results, you do NOT get to infer, paraphrase, rename, or
+"clean up" anything that came from the tool. Repeat it as-is.
+
+VERBATIM-ONLY FIELDS (never rewrite, never infer, never guess):
+- Article / page / post titles — copy exactly as the tool returned them, including punctuation,
+  capitalization, quotes, brackets, and any " — Site Name" suffix. Do not shorten. Do not
+  translate. Do not "fix" typos. If the title is "How I built X (in 3 days)", you write
+  "How I built X (in 3 days)" — not "Building X in three days".
+- Source / publication / site names (e.g. "Hacker News", "TechCrunch", "arXiv") — only use the
+  name if it appears in the tool output. Never derive a "source name" from a domain you guessed.
+- Author / byline names — only if explicitly returned. Do not infer authorship from URL slugs.
+- Publication dates, timestamps, version numbers, prices, statistics, counts — only if returned.
+  Never round, normalize, or "estimate" them.
+- URLs — copy verbatim. Do not reconstruct, shorten, canonicalize, strip query params, or fix.
+- Direct quotes — only quote text that appears verbatim in the tool's snippet/content. Never
+  paraphrase inside quote marks.
+
+WHAT YOU MAY DO:
+- Summarize the OVERALL theme of results in your own words (e.g. "most discuss pricing strategy").
+- Group or order results.
+- Decide which results to surface and which to skip.
+- Add your own commentary clearly outside of any title/quote/citation.
+
+WHAT YOU MAY NOT DO:
+- Invent a title that "sounds like" what the article is probably about.
+- Replace a long/awkward title with a tidier one of your own.
+- Attribute a result to a source ("from Hacker News", "via TechCrunch") unless that source name
+  is in the tool output. A domain is not a source name unless the tool said so.
+- Fill missing fields with plausible guesses. Missing = say it's missing or omit the field.
+- Translate, localize, or rephrase any tool-returned string before showing it.
+
+WHEN TOOL OUTPUT IS EMPTY OR FAILS:
+- Say so plainly: "I searched for X but found no results" or "the fetch failed for that URL".
+- Never substitute invented results to fill the gap.
+
+TRANSPARENCY:
+- State what you actually searched for and how many real results came back.
+- If a result was only a snippet (no full page), say so — do not fabricate the rest of the body.
+- If a source's domain doesn't match what the user asked for (e.g. user asked for Hacker News
+  threads but results are blog posts about HN), call that out instead of pretending it matches.
 
 CAPABILITY GAPS AND SAFETY
 - Do not claim impossible until discovery retries fail.

--- a/apps/api/app/agents/tools/research_tool.py
+++ b/apps/api/app/agents/tools/research_tool.py
@@ -93,7 +93,6 @@ async def deep_research(
 
         # ── Phase 2: Parallel searches ────────────────────────────────────────
         writer({"progress": f"Running {len(sub_queries)} parallel searches..."})
-        writer({"research_queries": sub_queries})
 
         async def _resilient_search(q: str) -> dict:
             return await search_with_duckduckgo(q, count=5)

--- a/apps/api/app/agents/tools/research_tool.py
+++ b/apps/api/app/agents/tools/research_tool.py
@@ -93,6 +93,7 @@ async def deep_research(
 
         # ── Phase 2: Parallel searches ────────────────────────────────────────
         writer({"progress": f"Running {len(sub_queries)} parallel searches..."})
+        writer({"research_queries": sub_queries})
 
         async def _resilient_search(q: str) -> dict:
             return await search_with_duckduckgo(q, count=5)
@@ -105,24 +106,40 @@ async def deep_research(
         successful_searches = sum(
             1 for r in search_results if isinstance(r, dict) and r.get("results")
         )
+        total_raw_urls = sum(
+            len(r.get("results", []))
+            for r in search_results
+            if isinstance(r, dict) and r.get("results")
+        )
         writer(
             {
-                "progress": f"{successful_searches}/{len(sub_queries)} searches returned results"
+                "progress": (
+                    f"{successful_searches}/{len(sub_queries)} searches returned results "
+                    f"({total_raw_urls} total URLs before deduplication)"
+                )
             }
         )
 
         # ── Phase 3: Deduplicate + rank URLs ────────────────────────────────
         ranked_urls = rank_and_deduplicate_urls(search_results, max_urls=max_sources)
+        found_urls = [u["url"] for u in ranked_urls]
         writer(
             {
-                "progress": f"Found {len(ranked_urls)} unique sources — fetching full content..."
+                "progress": f"Found {len(ranked_urls)} unique sources — fetching full content...",
+                "found_urls": found_urls,
             }
         )
 
         if not ranked_urls:
             return {
-                "error": "No sources found for the given query. Try broadening your search.",
+                "error": (
+                    "Search returned no results for the given query. "
+                    "No URLs were found — do not fabricate links. "
+                    "Try broadening the search or inform the user that no sources were found."
+                ),
                 "query": query,
+                "searched_queries": sub_queries,
+                "source_count": 0,
                 "data": None,
             }
 
@@ -205,6 +222,8 @@ async def deep_research(
         )
 
         # ── Build result ─────────────────────────────────────────────────────
+        # Include the authoritative list of real URLs so the LLM cannot fabricate others
+        authoritative_urls = [s["url"] for s in valid_sources]
         result: Dict[str, Any] = {
             "query": query,
             "scope": scope,
@@ -212,9 +231,15 @@ async def deep_research(
             "sub_queries": sub_queries,
             "sources": valid_sources,
             "source_count": len(valid_sources),
+            "authoritative_urls": authoritative_urls,
             "depth": depth,
             "elapsed_seconds": elapsed,
+            "failed_sources": failed_count,
             "error": None,
+            "integrity_note": (
+                "All URLs in `sources` and `authoritative_urls` were returned by real search "
+                "queries. Only cite URLs from this list — never invent or guess URLs."
+            ),
         }
 
         # Only cache when we have content — avoid masking transient fetch failures

--- a/apps/api/app/agents/tools/webpage_tool.py
+++ b/apps/api/app/agents/tools/webpage_tool.py
@@ -15,6 +15,10 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
+_NO_URLS_RETRIEVED_MSG = (
+    "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results."
+)
+
 
 @tool
 @with_rate_limiting("webpage_fetch")
@@ -155,7 +159,7 @@ async def web_search_tool(
             "formatted_text": "\n\nConnection timed out during web search. Please try again later.",
             "error": str(e),
             "real_urls_from_search": [],
-            "integrity_note": "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results.",
+            "integrity_note": _NO_URLS_RETRIEVED_MSG,
         }
     except ValueError as e:
         log.error(f"Value error in web search: {e}", exc_info=True)
@@ -163,7 +167,7 @@ async def web_search_tool(
             "formatted_text": "\n\nInvalid search parameters. Please try a different query.",
             "error": str(e),
             "real_urls_from_search": [],
-            "integrity_note": "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results.",
+            "integrity_note": _NO_URLS_RETRIEVED_MSG,
         }
     except Exception as e:
         log.error(f"Unexpected error in web search: {e}", exc_info=True)
@@ -171,7 +175,7 @@ async def web_search_tool(
             "formatted_text": "\n\nError performing web search. Please try again later.",
             "error": str(e),
             "real_urls_from_search": [],
-            "integrity_note": "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results.",
+            "integrity_note": _NO_URLS_RETRIEVED_MSG,
         }
 
 

--- a/apps/api/app/agents/tools/webpage_tool.py
+++ b/apps/api/app/agents/tools/webpage_tool.py
@@ -130,9 +130,23 @@ async def web_search_tool(
         )
 
         # Return the raw search results for the LLM to use
+        # Include explicit URL list so the LLM has a ground-truth set and cannot hallucinate
+        real_urls = [r.get("url", "") for r in web_results if r.get("url")]
         return {
             **search_results,
-            "instructions": "Don't repeat the search results, just summarise them, don't show the images in markdown either. These results will be shown on the frontend in an appropriate manner",
+            "real_urls_from_search": real_urls,
+            "integrity_note": (
+                f"Search query: '{query_text}'. "
+                f"Found {len(web_results)} real results. "
+                "Only reference URLs listed in `real_urls_from_search` or in the `web` results. "
+                "NEVER invent or fabricate URLs. If no results were found, say so clearly."
+            ),
+            "instructions": (
+                "Summarise the search results — do not repeat them verbatim. "
+                "Do not show images in markdown. "
+                "Only mention URLs that appear in the search results. "
+                "These results will be shown on the frontend in an appropriate manner."
+            ),
         }
 
     except (asyncio.TimeoutError, ConnectionError) as e:
@@ -140,18 +154,24 @@ async def web_search_tool(
         return {
             "formatted_text": "\n\nConnection timed out during web search. Please try again later.",
             "error": str(e),
+            "real_urls_from_search": [],
+            "integrity_note": "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results.",
         }
     except ValueError as e:
         log.error(f"Value error in web search: {e}", exc_info=True)
         return {
             "formatted_text": "\n\nInvalid search parameters. Please try a different query.",
             "error": str(e),
+            "real_urls_from_search": [],
+            "integrity_note": "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results.",
         }
     except Exception as e:
         log.error(f"Unexpected error in web search: {e}", exc_info=True)
         return {
             "formatted_text": "\n\nError performing web search. Please try again later.",
             "error": str(e),
+            "real_urls_from_search": [],
+            "integrity_note": "Search failed — no URLs were retrieved. Do NOT fabricate any URLs or results.",
         }
 
 

--- a/apps/api/app/templates/docstrings/research_tool_docs.py
+++ b/apps/api/app/templates/docstrings/research_tool_docs.py
@@ -14,6 +14,23 @@ Pipeline:
   4. Fetch full page content for top sources (crawl4ai → httpx fallback chain)
   5. Return structured result with sources, content, and citations metadata
 
+⚠️ ANTI-HALLUCINATION RULES (CRITICAL — NEVER VIOLATE):
+  - NEVER invent, fabricate, or guess URLs. Every URL in your response MUST come from the
+    `sources` list returned by this tool. No exceptions.
+  - NEVER make up article titles, author names, publication dates, or statistics.
+  - If a source has `fetch_error` or only a snippet, note this and do not fabricate full content.
+  - If no sources were found (`source_count` is 0), say clearly: "I couldn't find sources on
+    this topic" — do NOT invent fake links or results.
+  - Only cite URLs that appear in the `sources` list. Copy them verbatim — do not alter, shorten,
+    or reconstruct them.
+  - When content is only a snippet (prefixed with "[Snippet only — full page unavailable]"),
+    clearly indicate the source was not fully accessible.
+
+⚠️ TRANSPARENCY REQUIREMENTS:
+  - Report the sub-queries that were used to search (from `sub_queries` field).
+  - Show which URLs were found and successfully fetched vs. those that failed.
+  - If search returned fewer results than expected, say so.
+
 ⚠️ ASK BEFORE CALLING (if not already clear from context):
   - Scope: What angle matters most? (e.g. "technical", "market trends", "historical")
   - Depth: How thorough? 1=quick, 2=standard, 3=exhaustive
@@ -55,11 +72,19 @@ Args:
 
 Returns:
     Structured research data with full source content, sub-queries used, source rankings,
-    elapsed time, and synthesis-ready findings.
+    elapsed time, and synthesis-ready findings. All URLs in `sources` were returned by actual
+    search queries — they are real and were not fabricated.
 """
 
 RESEARCH_INSTRUCTIONS = (
     "You have full page content from multiple research sources. "
+    "CRITICAL — ANTI-HALLUCINATION: Only cite and reference URLs that appear in the `sources` list "
+    "returned by this tool. NEVER invent, guess, or fabricate URLs, titles, authors, or statistics. "
+    "If a source failed to fetch (has fetch_error) or contains only a snippet, note this limitation "
+    "clearly rather than making up the missing content. "
+    "If source_count is 0 or no results were found, state that clearly — do not hallucinate results. "
+    "TRANSPARENCY: Mention what searches were run (sub_queries) and how many sources were found and "
+    "fetched successfully. "
     "Match response depth to the requested research depth (quick, standard, deep). "
     "The user explicitly requested deep research, so they expect depth and completeness, not a short overview. "
     "Cover every important aspect thoroughly: explain concepts in detail, include specific data points, "
@@ -68,6 +93,7 @@ RESEARCH_INSTRUCTIONS = (
     "multiple paragraphs, not a single sentence. "
     "Reproduce key data, numbers, and specific findings directly from the sources rather than vaguely referencing them. "
     "Highlight agreements and contradictions across sources. "
-    "Always cite with [1], [2] notation inline and include a full numbered reference list at the end. "
+    "Always cite with [1], [2] notation inline and include a full numbered reference list at the end "
+    "using only the URLs from the `sources` list. "
     "Use length appropriate to the selected depth and topic complexity."
 )

--- a/apps/api/app/templates/docstrings/search_tool_docs.py
+++ b/apps/api/app/templates/docstrings/search_tool_docs.py
@@ -6,6 +6,14 @@ Perform a quick, high-level web search to gather brief and relevant information 
 This tool is designed for fast, general-purpose lookups — returning summarized snippets and titles
 from various web and news sources. It prioritizes speed and topical variety over detail.
 
+⚠️ ANTI-HALLUCINATION RULES (CRITICAL — NEVER VIOLATE):
+- NEVER make up, invent, or guess URLs. Only use URLs that appear in the tool's returned results.
+- NEVER fabricate article titles, source names, or publication dates.
+- If the search returns no results or fails, say so clearly — do NOT invent fake results.
+- Only report URLs, titles, and snippets that the tool actually returned.
+- When presenting results, always attribute them as "found via search" and show only what the tool returned.
+- If you cannot find information, say "I couldn't find results for that" — never fill the gap with made-up links.
+
 ✅ USE THIS TOOL WHEN:
 - The user asks a general question requiring current or public knowledge.
 - You need a quick overview, definition, or summary from external sources.
@@ -31,6 +39,7 @@ Args:
 
 Returns:
     A JSON string with summarized search data, formatted text, and raw result structure.
+    All URLs in the result came directly from the search API — they are real and verified.
 """
 
 DEEP_RESEARCH_TOOL = """


### PR DESCRIPTION
## Summary
- Add system prompt rule: never fabricate URLs, only cite URLs from search tool results
- Research tool returns authoritative_urls list and integrity_note to constrain LLM output
- Deep research improved: tiered fetching (crawl4ai -> httpx -> snippet fallback), clearer error when no results found
- Webpage and search tool docstrings updated with anti-hallucination guidance

Closes GAIA-627

## Test plan
- [x] Could you web search for different hackernews articles in getting sales for startups or about marketing?
- [x] Verify no fabricated item IDs in URLs
- [x] Deep research error when search fails is clear, not hallucinated