### PR TITLE
feat: show related workflows on integration pages

### DIFF
--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -350,12 +350,7 @@ async def get_related_workflows(
         total = await workflows_collection.count_documents(match_stage)
 
         formatted_workflows = []
-        seen_ids: set[str] = set()
         for workflow in workflows:
-            wf_id = workflow["_id"]
-            if wf_id in seen_ids:
-                continue
-            seen_ids.add(wf_id)
             raw_steps = workflow.get("steps", [])
             normalized_steps = []
             for step in raw_steps:
@@ -371,7 +366,7 @@ async def get_related_workflows(
 
             formatted_workflows.append(
                 {
-                    "id": wf_id,
+                    "id": workflow["_id"],
                     "title": workflow["title"],
                     "description": workflow.get("description"),
                     "slug": workflow.get("slug"),

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -321,23 +321,15 @@ async def get_related_workflows(
                         {
                             "$match": {
                                 "$expr": {
-                                    "$and": [
-                                        # Only attempt $toObjectId when creator_id
-                                        # is a 24-hex-character string to avoid a
-                                        # ConversionError for UUIDs or other IDs.
+                                    "$eq": [
+                                        "$_id",
                                         {
-                                            "$regexMatch": {
-                                                "input": {
-                                                    "$ifNull": ["$$creator_id", ""]
-                                                },
-                                                "regex": "^[0-9a-fA-F]{24}$",
+                                            "$convert": {
+                                                "input": "$$creator_id",
+                                                "to": "objectId",
+                                                "onError": None,
+                                                "onNull": None,
                                             }
-                                        },
-                                        {
-                                            "$eq": [
-                                                "$_id",
-                                                {"$toObjectId": "$$creator_id"},
-                                            ]
                                         },
                                     ]
                                 }

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -297,20 +297,23 @@ async def get_related_workflows(
         # MongoDB regex, preventing ReDoS and regex-injection attacks.
         escaped_identifier = re.escape(identifier)
 
-        pipeline: list = [
-            {
-                "$match": {
-                    "is_public": True,
-                    "steps": {
-                        "$elemMatch": {
-                            "category": {
-                                "$regex": escaped_identifier,
-                                "$options": "i",
-                            }
-                        }
-                    },
+        # Mix featured (is_explore) and community (is_public) workflows that
+        # use this integration, sorted by total runs so the most popular ones
+        # surface first regardless of source.
+        match_stage: dict[str, object] = {
+            "$or": [{"is_public": True}, {"is_explore": True}],
+            "steps": {
+                "$elemMatch": {
+                    "category": {
+                        "$regex": escaped_identifier,
+                        "$options": "i",
+                    }
                 }
             },
+        }
+
+        pipeline: list = [
+            {"$match": match_stage},
             {"$sort": {"total_executions": -1, "created_at": -1}},
             {"$skip": offset},
             {"$limit": limit},
@@ -344,18 +347,15 @@ async def get_related_workflows(
 
         workflows = await workflows_collection.aggregate(pipeline).to_list(length=limit)
 
-        count_query: dict[str, object] = {
-            "is_public": True,
-            "steps": {
-                "$elemMatch": {
-                    "category": {"$regex": escaped_identifier, "$options": "i"}
-                }
-            },
-        }
-        total = await workflows_collection.count_documents(count_query)
+        total = await workflows_collection.count_documents(match_stage)
 
         formatted_workflows = []
+        seen_ids: set[str] = set()
         for workflow in workflows:
+            wf_id = workflow["_id"]
+            if wf_id in seen_ids:
+                continue
+            seen_ids.add(wf_id)
             raw_steps = workflow.get("steps", [])
             normalized_steps = []
             for step in raw_steps:
@@ -371,7 +371,7 @@ async def get_related_workflows(
 
             formatted_workflows.append(
                 {
-                    "id": workflow["_id"],
+                    "id": wf_id,
                     "title": workflow["title"],
                     "description": workflow.get("description"),
                     "slug": workflow.get("slug"),

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -275,7 +275,9 @@ async def search_integrations(q: str) -> SearchIntegrationsResponse:
 
 @router.get(
     "/public/{identifier}/workflows",
-    response_model=PublicWorkflowsResponse,
+    responses={
+        500: {"description": "Failed to fetch related workflows"},
+    },
 )
 async def get_related_workflows(
     identifier: str,

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -24,6 +24,7 @@ from app.services.integrations.integration_connection_service import (
 )
 from app.services.integrations.user_integrations import add_user_integration
 from app.services.mcp.mcp_tools_store import get_mcp_tools_store
+from app.utils.creator import creator_lookup_stage, format_creator
 from app.config.oauth_config import OAUTH_INTEGRATIONS
 from app.helpers.integration_helpers import (
     build_public_integration_pipeline,
@@ -313,33 +314,7 @@ async def get_related_workflows(
             {"$sort": {"total_executions": -1, "created_at": -1}},
             {"$skip": offset},
             {"$limit": limit},
-            {
-                "$lookup": {
-                    "from": "users",
-                    "let": {"creator_id": "$created_by"},
-                    "pipeline": [
-                        {
-                            "$match": {
-                                "$expr": {
-                                    "$eq": [
-                                        "$_id",
-                                        {
-                                            "$convert": {
-                                                "input": "$$creator_id",
-                                                "to": "objectId",
-                                                "onError": None,
-                                                "onNull": None,
-                                            }
-                                        },
-                                    ]
-                                }
-                            }
-                        },
-                        {"$project": {"name": 1, "picture": 1, "_id": 0}},
-                    ],
-                    "as": "creator_info",
-                }
-            },
+            creator_lookup_stage(),
             {
                 "$project": {
                     "_id": 1,
@@ -381,12 +356,6 @@ async def get_related_workflows(
 
         formatted_workflows = []
         for workflow in workflows:
-            creator_info = (
-                workflow.get("creator_info", [{}])[0]
-                if workflow.get("creator_info")
-                else {}
-            )
-
             raw_steps = workflow.get("steps", [])
             normalized_steps = []
             for step in raw_steps:
@@ -410,11 +379,7 @@ async def get_related_workflows(
                     "steps": normalized_steps,
                     "total_executions": workflow.get("total_executions", 0),
                     "created_at": workflow["created_at"],
-                    "creator": {
-                        "id": workflow.get("created_by"),
-                        "name": creator_info.get("name", "Unknown"),
-                        "avatar": creator_info.get("picture"),
-                    },
+                    "creator": format_creator(workflow),
                 }
             )
 

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -6,7 +6,9 @@ from app.db.chroma.public_integrations_store import search_public_integrations
 from app.db.mongodb.collections import (
     integrations_collection,
     user_integrations_collection,
+    workflows_collection,
 )
+from app.models.workflow_models import PublicWorkflowsResponse
 from app.schemas.integrations.requests import ConnectIntegrationRequest
 from app.schemas.integrations.responses import (
     AddIntegrationResponse,
@@ -267,3 +269,142 @@ async def search_integrations(q: str) -> SearchIntegrationsResponse:
     except Exception as e:
         log.error(f"Error searching integrations: {e}")
         raise HTTPException(status_code=500, detail="Failed to search integrations")
+
+
+@router.get(
+    "/public/{identifier}/workflows",
+    response_model=PublicWorkflowsResponse,
+)
+async def get_related_workflows(
+    identifier: str,
+    limit: int = 10,
+    offset: int = 0,
+) -> PublicWorkflowsResponse:
+    """Get public community workflows related to an integration by identifier (slug or native ID)."""
+    try:
+        log.set(operation="get_related_workflows", integration_id=identifier)
+
+        # Normalize limit/offset
+        limit = max(1, min(limit, 50))
+        offset = max(0, offset)
+
+        pipeline: list = [
+            {
+                "$match": {
+                    "is_public": True,
+                    "steps": {
+                        "$elemMatch": {
+                            "category": {
+                                "$regex": identifier,
+                                "$options": "i",
+                            }
+                        }
+                    },
+                }
+            },
+            {"$sort": {"total_executions": -1, "created_at": -1}},
+            {"$skip": offset},
+            {"$limit": limit},
+            {
+                "$lookup": {
+                    "from": "users",
+                    "let": {"creator_id": "$created_by"},
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "$expr": {
+                                    "$eq": [
+                                        "$_id",
+                                        {"$toObjectId": "$$creator_id"},
+                                    ]
+                                }
+                            }
+                        },
+                        {"$project": {"name": 1, "picture": 1, "_id": 0}},
+                    ],
+                    "as": "creator_info",
+                }
+            },
+            {
+                "$project": {
+                    "_id": 1,
+                    "title": 1,
+                    "description": 1,
+                    "slug": 1,
+                    "prompt": 1,
+                    "steps": {
+                        "$map": {
+                            "input": "$steps",
+                            "as": "step",
+                            "in": {
+                                "id": "$$step.id",
+                                "title": "$$step.title",
+                                "category": "$$step.category",
+                                "description": "$$step.description",
+                            },
+                        }
+                    },
+                    "total_executions": 1,
+                    "created_at": 1,
+                    "created_by": 1,
+                    "creator_info": 1,
+                }
+            },
+        ]
+
+        workflows = await workflows_collection.aggregate(pipeline).to_list(length=limit)
+
+        count_query: dict[str, object] = {
+            "is_public": True,
+            "steps": {
+                "$elemMatch": {"category": {"$regex": identifier, "$options": "i"}}
+            },
+        }
+        total = await workflows_collection.count_documents(count_query)
+
+        formatted_workflows = []
+        for workflow in workflows:
+            creator_info = (
+                workflow.get("creator_info", [{}])[0]
+                if workflow.get("creator_info")
+                else {}
+            )
+
+            raw_steps = workflow.get("steps", [])
+            normalized_steps = []
+            for step in raw_steps:
+                normalized_steps.append(
+                    {
+                        "id": step.get("id", ""),
+                        "title": step.get("title", ""),
+                        "description": step.get("description", ""),
+                        "category": step.get("category")
+                        or step.get("tool_category", "general"),
+                    }
+                )
+
+            formatted_workflows.append(
+                {
+                    "id": workflow["_id"],
+                    "title": workflow["title"],
+                    "description": workflow.get("description"),
+                    "slug": workflow.get("slug"),
+                    "prompt": workflow.get("prompt"),
+                    "steps": normalized_steps,
+                    "total_executions": workflow.get("total_executions", 0),
+                    "created_at": workflow["created_at"],
+                    "creator": {
+                        "id": workflow.get("created_by"),
+                        "name": creator_info.get("name", "Unknown"),
+                        "avatar": creator_info.get("picture"),
+                    },
+                }
+            )
+
+        log.set(result_count=len(formatted_workflows))
+        log.set(outcome="success")
+        return PublicWorkflowsResponse(workflows=formatted_workflows, total=total)
+
+    except Exception as e:
+        log.error(f"Error fetching related workflows for {identifier}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch related workflows")

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -1,5 +1,7 @@
 """Public integration routes (no auth required for SEO/sharing)."""
 
+import re
+
 from app.api.v1.dependencies.oauth_dependencies import get_user_id
 from shared.py.wide_events import log
 from app.db.chroma.public_integrations_store import search_public_integrations
@@ -288,6 +290,10 @@ async def get_related_workflows(
         limit = max(1, min(limit, 50))
         offset = max(0, offset)
 
+        # Escape the identifier so it is treated as a literal string in the
+        # MongoDB regex, preventing ReDoS and regex-injection attacks.
+        escaped_identifier = re.escape(identifier)
+
         pipeline: list = [
             {
                 "$match": {
@@ -295,7 +301,7 @@ async def get_related_workflows(
                     "steps": {
                         "$elemMatch": {
                             "category": {
-                                "$regex": identifier,
+                                "$regex": escaped_identifier,
                                 "$options": "i",
                             }
                         }
@@ -313,9 +319,24 @@ async def get_related_workflows(
                         {
                             "$match": {
                                 "$expr": {
-                                    "$eq": [
-                                        "$_id",
-                                        {"$toObjectId": "$$creator_id"},
+                                    "$and": [
+                                        # Only attempt $toObjectId when creator_id
+                                        # is a 24-hex-character string to avoid a
+                                        # ConversionError for UUIDs or other IDs.
+                                        {
+                                            "$regexMatch": {
+                                                "input": {
+                                                    "$ifNull": ["$$creator_id", ""]
+                                                },
+                                                "regex": "^[0-9a-fA-F]{24}$",
+                                            }
+                                        },
+                                        {
+                                            "$eq": [
+                                                "$_id",
+                                                {"$toObjectId": "$$creator_id"},
+                                            ]
+                                        },
                                     ]
                                 }
                             }
@@ -357,7 +378,9 @@ async def get_related_workflows(
         count_query: dict[str, object] = {
             "is_public": True,
             "steps": {
-                "$elemMatch": {"category": {"$regex": identifier, "$options": "i"}}
+                "$elemMatch": {
+                    "category": {"$regex": escaped_identifier, "$options": "i"}
+                }
             },
         }
         total = await workflows_collection.count_documents(count_query)

--- a/apps/api/app/services/workflow/service.py
+++ b/apps/api/app/services/workflow/service.py
@@ -24,6 +24,11 @@ from app.models.workflow_models import (
     WorkflowStatusResponse,
 )
 from app.services.workflow.trigger_service import TriggerService
+from app.utils.creator import (
+    SYSTEM_CREATOR_NAME,
+    creator_lookup_stage,
+    format_creator,
+)
 from app.utils.exceptions import TriggerRegistrationError
 from app.utils.workflow_utils import (
     ensure_trigger_config_object,
@@ -918,40 +923,7 @@ class WorkflowService:
                 {"$sort": {"created_at": -1}},
                 {"$skip": offset},
                 {"$limit": limit},
-                {
-                    "$lookup": {
-                        "from": "users",
-                        "let": {"creator_id": "$created_by"},
-                        "pipeline": [
-                            {
-                                "$match": {
-                                    "$expr": {
-                                        "$eq": [
-                                            "$_id",
-                                            {
-                                                "$convert": {
-                                                    "input": "$$creator_id",
-                                                    "to": "objectId",
-                                                    "onError": None,
-                                                    "onNull": None,
-                                                }
-                                            },
-                                        ]
-                                    }
-                                }
-                            },
-                            {
-                                "$project": {
-                                    "name": 1,
-                                    "email": 1,
-                                    "picture": 1,
-                                    "_id": 0,
-                                }
-                            },
-                        ],
-                        "as": "creator_info",
-                    }
-                },
+                creator_lookup_stage(),
                 {
                     "$project": {
                         "_id": 1,
@@ -990,12 +962,6 @@ class WorkflowService:
 
             formatted_workflows = []
             for workflow in workflows:
-                creator_info = (
-                    workflow.get("creator_info", [{}])[0]
-                    if workflow.get("creator_info")
-                    else {}
-                )
-
                 # Normalize steps to use 'category' field (handle legacy 'tool_category')
                 raw_steps = workflow.get("steps", [])
                 normalized_steps = []
@@ -1019,11 +985,7 @@ class WorkflowService:
                     "prompt": workflow.get("prompt"),
                     "steps": normalized_steps,
                     "created_at": workflow["created_at"],
-                    "creator": {
-                        "id": workflow.get("created_by"),
-                        "name": creator_info.get("name", "Unknown"),
-                        "avatar": creator_info.get("picture"),
-                    },
+                    "creator": format_creator(workflow),
                 }
                 formatted_workflows.append(formatted_workflow)
 
@@ -1068,12 +1030,6 @@ class WorkflowService:
             # Format workflows with creator information
             formatted_workflows = []
             for workflow in workflows:
-                creator_info = (
-                    workflow.get("creator_info", [{}])[0]
-                    if workflow.get("creator_info")
-                    else {}
-                )
-
                 # Normalize steps to use 'category' field (handle legacy 'tool_category')
                 raw_steps = workflow.get("steps", [])
                 normalized_steps = []
@@ -1099,11 +1055,9 @@ class WorkflowService:
                     "created_at": workflow["created_at"],
                     "categories": workflow.get("use_case_categories", ["featured"]),
                     "total_executions": workflow.get("total_executions", 0),
-                    "creator": {
-                        "id": workflow.get("created_by"),
-                        "name": creator_info.get("name", "GAIA Team"),
-                        "avatar": creator_info.get("picture"),
-                    },
+                    "creator": format_creator(
+                        workflow, default_name=SYSTEM_CREATOR_NAME
+                    ),
                 }
                 formatted_workflows.append(formatted_workflow)
 

--- a/apps/api/app/services/workflow/service.py
+++ b/apps/api/app/services/workflow/service.py
@@ -926,7 +926,17 @@ class WorkflowService:
                             {
                                 "$match": {
                                     "$expr": {
-                                        "$eq": ["$_id", {"$toObjectId": "$$creator_id"}]
+                                        "$eq": [
+                                            "$_id",
+                                            {
+                                                "$convert": {
+                                                    "input": "$$creator_id",
+                                                    "to": "objectId",
+                                                    "onError": None,
+                                                    "onNull": None,
+                                                }
+                                            },
+                                        ]
                                     }
                                 }
                             },

--- a/apps/api/app/utils/creator.py
+++ b/apps/api/app/utils/creator.py
@@ -1,0 +1,80 @@
+"""Shared helpers for hydrating workflow creator information from MongoDB.
+
+Centralizes the `$lookup` pipeline stage that joins workflows.created_by to
+users._id, plus the post-aggregation creator-dict shape (with the system →
+"GAIA Team" convention). Keep this in sync with the frontend helper at
+apps/web/src/features/workflows/utils/creator.ts.
+"""
+
+from typing import Any
+
+SYSTEM_CREATOR_ID = "system"
+SYSTEM_CREATOR_NAME = "GAIA Team"
+UNKNOWN_CREATOR_NAME = "Unknown"
+
+
+def creator_lookup_stage(
+    creator_field: str = "created_by",
+    output_field: str = "creator_info",
+) -> dict[str, Any]:
+    """Return a `$lookup` stage that joins `creator_field` (a user id string)
+    against the `users` collection's ObjectId `_id`. Uses `$convert` with
+    `onError: None` so non-OID values (like the literal "system") don't crash
+    the aggregation — they simply yield no match.
+    """
+    return {
+        "$lookup": {
+            "from": "users",
+            "let": {"creator_id": f"${creator_field}"},
+            "pipeline": [
+                {
+                    "$match": {
+                        "$expr": {
+                            "$eq": [
+                                "$_id",
+                                {
+                                    "$convert": {
+                                        "input": "$$creator_id",
+                                        "to": "objectId",
+                                        "onError": None,
+                                        "onNull": None,
+                                    }
+                                },
+                            ]
+                        }
+                    }
+                },
+                {"$project": {"name": 1, "email": 1, "picture": 1, "_id": 0}},
+            ],
+            "as": output_field,
+        }
+    }
+
+
+def format_creator(
+    workflow: dict[str, Any],
+    creator_field: str = "created_by",
+    info_field: str = "creator_info",
+    default_name: str | None = None,
+) -> dict[str, Any]:
+    """Build the public-facing `creator` dict for a workflow document, given
+    the joined `creator_info` array. Falls back to `SYSTEM_CREATOR_NAME` when
+    the creator id is "system" (or `default_name` is set), else
+    `UNKNOWN_CREATOR_NAME`.
+    """
+    info_array = workflow.get(info_field) or []
+    info = info_array[0] if info_array else {}
+    creator_id = workflow.get(creator_field)
+
+    if default_name is not None:
+        fallback_name = default_name
+    elif creator_id == SYSTEM_CREATOR_ID:
+        fallback_name = SYSTEM_CREATOR_NAME
+    else:
+        fallback_name = UNKNOWN_CREATOR_NAME
+
+    return {
+        "id": creator_id,
+        "name": info.get("name", fallback_name),
+        "avatar": info.get("picture"),
+    }

--- a/apps/web/src/app/[locale]/(landing)/marketplace/[slug]/client.tsx
+++ b/apps/web/src/app/[locale]/(landing)/marketplace/[slug]/client.tsx
@@ -410,6 +410,8 @@ export function IntegrationDetailClient({
           {/* Related community workflows */}
           <IntegrationRelatedWorkflows
             integrationId={integration.integrationId}
+            integrationName={integration.name}
+            variant="section"
           />
 
           {/* Rich content sections for SEO and user education */}

--- a/apps/web/src/app/[locale]/(landing)/marketplace/[slug]/client.tsx
+++ b/apps/web/src/app/[locale]/(landing)/marketplace/[slug]/client.tsx
@@ -23,6 +23,7 @@ import { useAuth } from "@/features/auth/hooks/useAuth";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import { integrationsApi } from "@/features/integrations/api/integrationsApi";
 import { BearerTokenModal } from "@/features/integrations/components/BearerTokenModal";
+import { IntegrationRelatedWorkflows } from "@/features/integrations/components/IntegrationRelatedWorkflows";
 import type { PublicIntegrationResponse } from "@/features/integrations/types";
 import ShareButton from "@/features/use-cases/components/ShareButton";
 import { toast } from "@/lib/toast";
@@ -405,6 +406,11 @@ export function IntegrationDetailClient({
               )}
             </CardBody>
           </Card>
+
+          {/* Related community workflows */}
+          <IntegrationRelatedWorkflows
+            integrationId={integration.integrationId}
+          />
 
           {/* Rich content sections for SEO and user education */}
           <IntegrationRichContent

--- a/apps/web/src/app/[locale]/(landing)/use-cases/[slug]/client.tsx
+++ b/apps/web/src/app/[locale]/(landing)/use-cases/[slug]/client.tsx
@@ -17,6 +17,7 @@ import type { Workflow } from "@/features/workflows/api/workflowApi";
 import WorkflowSteps from "@/features/workflows/components/shared/WorkflowSteps";
 import { useWorkflowCreation } from "@/features/workflows/hooks/useWorkflowCreation";
 import { getTriggerDisplayInfo } from "@/features/workflows/triggers/utils";
+import { resolveCreatorAvatar } from "@/features/workflows/utils/creator";
 import type { UseCase } from "@/types/features/workflowTypes";
 
 interface UseCaseDetailClientProps {
@@ -119,9 +120,12 @@ export default function UseCaseDetailClient({
       : communityWorkflow
         ? "GAIA Team"
         : null;
-  const creatorAvatar = hasCreatorObject
-    ? communityWorkflow.creator?.avatar
-    : undefined;
+  const creatorRecord = hasCreatorObject
+    ? communityWorkflow.creator
+    : communityWorkflow?.created_by
+      ? { id: communityWorkflow.created_by }
+      : null;
+  const creatorAvatar = resolveCreatorAvatar(creatorRecord);
   const showCreator = !!communityWorkflow && !!creatorName;
 
   // Prepare tools - Type-safe extraction from steps, mapped to Tool format for ToolsList

--- a/apps/web/src/components/layout/sidebar/right-variants/IntegrationSidebar.tsx
+++ b/apps/web/src/components/layout/sidebar/right-variants/IntegrationSidebar.tsx
@@ -23,6 +23,7 @@ import { formatToolName } from "@/features/chat/utils/chatUtils";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import { integrationsApi } from "@/features/integrations/api/integrationsApi";
 import { BearerTokenModal } from "@/features/integrations/components/BearerTokenModal";
+import { IntegrationRelatedWorkflows } from "@/features/integrations/components/IntegrationRelatedWorkflows";
 import type { Integration } from "@/features/integrations/types";
 import { toast } from "@/lib/toast";
 import { useUserStore } from "@/stores/userStore";
@@ -505,6 +506,8 @@ export const IntegrationSidebar: React.FC<IntegrationSidebarProps> = ({
               ))}
             </div>
           )}
+
+          <IntegrationRelatedWorkflows integrationId={integration.id} />
         </div>
       </SidebarContent>
 

--- a/apps/web/src/components/layout/sidebar/right-variants/IntegrationSidebar.tsx
+++ b/apps/web/src/components/layout/sidebar/right-variants/IntegrationSidebar.tsx
@@ -479,16 +479,16 @@ export const IntegrationSidebar: React.FC<IntegrationSidebarProps> = ({
           </Button>
         )}
         {integrationTools.length > 0 && (
-          <h2 className="mb-1 mt-3 text-xs font-medium text-zinc-400 -ml-1">
-            Available Tools ({integrationTools.length})
+          <h2 className="mt-3 text-sm font-medium text-zinc-300 relative right-1">
+            Available tools ({integrationTools.length})
           </h2>
         )}
       </SidebarHeader>
 
-      <SidebarContent className="flex-1 overflow-y-auto">
-        <div className="space-y-4 pb-4">
-          {integrationTools.length > 0 && (
-            <div className="flex flex-wrap gap-2">
+      <SidebarContent className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {integrationTools.length > 0 && (
+          <div className="flex-1 min-h-0 overflow-y-auto pb-2">
+            <div className="flex flex-wrap gap-2 content-start">
               {integrationTools.map((tool) => (
                 <Chip
                   key={tool.name}
@@ -505,8 +505,10 @@ export const IntegrationSidebar: React.FC<IntegrationSidebarProps> = ({
                 </Chip>
               ))}
             </div>
-          )}
+          </div>
+        )}
 
+        <div className="shrink-0 pb-4">
           <IntegrationRelatedWorkflows integrationId={integration.id} />
         </div>
       </SidebarContent>

--- a/apps/web/src/config/openui/components/document.tsx
+++ b/apps/web/src/config/openui/components/document.tsx
@@ -65,17 +65,15 @@ function htmlToMarkdown(html: string): string {
         return `${inner}\n`;
       case "ol": {
         let index = 0;
-        return (
-          Array.from(el.children)
-            .map((child) => {
-              if (child.tagName.toLowerCase() === "li") {
-                index += 1;
-                return `${index}. ${Array.from(child.childNodes).map(nodeToMd).join("")}\n`;
-              }
-              return nodeToMd(child);
-            })
-            .join("") + "\n"
-        );
+        return `${Array.from(el.children)
+          .map((child) => {
+            if (child.tagName.toLowerCase() === "li") {
+              index += 1;
+              return `${index}. ${Array.from(child.childNodes).map(nodeToMd).join("")}\n`;
+            }
+            return nodeToMd(child);
+          })
+          .join("")}\n`;
       }
       case "li":
         return `- ${inner}\n`;

--- a/apps/web/src/features/integrations/api/integrationsApi.ts
+++ b/apps/web/src/features/integrations/api/integrationsApi.ts
@@ -1,4 +1,5 @@
 import { apiService } from "@/lib/api/service";
+import type { CommunityWorkflowsResponse } from "@/types/features/workflowTypes";
 
 import type {
   CommunityIntegration,
@@ -443,5 +444,19 @@ export const integrationsApi = {
       integrations: PublicIntegrationResponse[];
       query: string;
     };
+  },
+
+  /**
+   * Get community workflows related to an integration by slug or native ID
+   */
+  getRelatedWorkflows: async (
+    identifier: string,
+    limit: number = 10,
+  ): Promise<CommunityWorkflowsResponse> => {
+    const response = await apiService.get(
+      `/integrations/public/${encodeURIComponent(identifier)}/workflows?limit=${limit}`,
+      { silent: true },
+    );
+    return response as CommunityWorkflowsResponse;
   },
 };

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -8,15 +8,15 @@ import { integrationsApi } from "../api/integrationsApi";
 
 interface IntegrationRelatedWorkflowsProps {
   /** The integration slug or native integration ID */
-  integrationId: string;
+  readonly integrationId: string;
   /** Max number of workflows to fetch */
-  limit?: number;
+  readonly limit?: number;
 }
 
 export function IntegrationRelatedWorkflows({
   integrationId,
   limit = 10,
-}: IntegrationRelatedWorkflowsProps) {
+}: Readonly<IntegrationRelatedWorkflowsProps>) {
   const { data, isLoading } = useQuery({
     queryKey: ["integration-workflows", integrationId, limit],
     queryFn: () => integrationsApi.getRelatedWorkflows(integrationId, limit),
@@ -26,12 +26,21 @@ export function IntegrationRelatedWorkflows({
   const workflows = (data?.workflows ?? []) as CommunityWorkflow[];
 
   if (!isLoading && workflows.length === 0) {
-    return null;
+    return (
+      <div className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-zinc-100">
+          Workflows that use this Integration
+        </h2>
+        <p className="text-sm text-zinc-500">
+          No workflows found for this integration.
+        </p>
+      </div>
+    );
   }
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-sm font-medium text-zinc-300">
+      <h2 className="text-sm font-medium text-zinc-100">
         Workflows that use this Integration
       </h2>
 
@@ -46,9 +55,7 @@ export function IntegrationRelatedWorkflows({
         </div>
       ) : (
         <section
-          aria-label="Related workflows"
-          // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable region needs keyboard focus to scroll
-          tabIndex={0}
+          aria-label="Workflows that use this integration"
           className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ WebkitOverflowScrolling: "touch" }}
         >

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Skeleton } from "@heroui/skeleton";
+import { useQuery } from "@tanstack/react-query";
+import UnifiedWorkflowCard from "@/features/workflows/components/shared/UnifiedWorkflowCard";
+import type { CommunityWorkflow } from "@/types/features/workflowTypes";
+import { integrationsApi } from "../api/integrationsApi";
+
+interface IntegrationRelatedWorkflowsProps {
+  /** The integration slug or native integration ID */
+  integrationId: string;
+  /** Max number of workflows to fetch */
+  limit?: number;
+}
+
+export function IntegrationRelatedWorkflows({
+  integrationId,
+  limit = 10,
+}: IntegrationRelatedWorkflowsProps) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["integration-workflows", integrationId, limit],
+    queryFn: () => integrationsApi.getRelatedWorkflows(integrationId, limit),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const workflows = (data?.workflows ?? []) as CommunityWorkflow[];
+
+  if (!isLoading && workflows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h2 className="text-sm font-medium text-zinc-400">
+        Workflows that use this Integration
+      </h2>
+
+      {isLoading ? (
+        <div className="flex gap-3 overflow-hidden">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              className="h-36 w-60 shrink-0 rounded-3xl bg-zinc-800"
+            />
+          ))}
+        </div>
+      ) : (
+        <div
+          className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          style={{ WebkitOverflowScrolling: "touch" }}
+        >
+          {workflows.map((workflow) => (
+            <div key={workflow.id} className="w-60 shrink-0">
+              <UnifiedWorkflowCard
+                communityWorkflow={workflow}
+                variant="community"
+                showCreator={false}
+                showExecutions={false}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Skeleton } from "@heroui/skeleton";
+import { CircleArrowUpRightIcon } from "@icons";
 import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
 import UnifiedWorkflowCard from "@/features/workflows/components/shared/UnifiedWorkflowCard";
 import type { CommunityWorkflow } from "@/types/features/workflowTypes";
 import { integrationsApi } from "../api/integrationsApi";
@@ -11,11 +12,40 @@ interface IntegrationRelatedWorkflowsProps {
   readonly integrationId: string;
   /** Max number of workflows to fetch */
   readonly limit?: number;
+  /**
+   * Visual variant.
+   * - "sidebar" (default): compact heading, no card wrapper. For use in side panels.
+   * - "section": full marketplace section styling (rounded-3xl card, large heading).
+   */
+  readonly variant?: "sidebar" | "section";
+  /** Optional name of the integration to personalise the section copy. */
+  readonly integrationName?: string;
+}
+
+const VIEW_MORE_HREF = "/use-cases#community-section";
+
+function ViewMoreCard() {
+  return (
+    <Link
+      href={VIEW_MORE_HREF}
+      aria-label="View more workflows"
+      className="group flex w-60 shrink-0 flex-col items-center justify-center gap-2 rounded-3xl border border-dashed border-zinc-700/60 bg-transparent text-zinc-400 transition-colors hover:border-transparent hover:bg-zinc-800 hover:text-zinc-100"
+    >
+      <CircleArrowUpRightIcon
+        width={28}
+        height={28}
+        className="transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+      />
+      <span className="text-sm font-medium">View more</span>
+    </Link>
+  );
 }
 
 export function IntegrationRelatedWorkflows({
   integrationId,
-  limit = 10,
+  limit = 4,
+  variant = "sidebar",
+  integrationName,
 }: Readonly<IntegrationRelatedWorkflowsProps>) {
   const { data, isLoading } = useQuery({
     queryKey: ["integration-workflows", integrationId, limit],
@@ -23,54 +53,58 @@ export function IntegrationRelatedWorkflows({
     staleTime: 5 * 60 * 1000,
   });
 
-  const workflows = (data?.workflows ?? []) as CommunityWorkflow[];
+  // Render nothing until data is resolved AND we have something to show.
+  // This avoids the "skeleton flash → empty collapse" jank for integrations
+  // that have zero matching workflows.
+  if (isLoading) return null;
 
-  if (!isLoading && workflows.length === 0) {
+  const workflows = (data?.workflows ?? []) as CommunityWorkflow[];
+  if (workflows.length === 0) return null;
+
+  const list = (
+    <section
+      aria-label="Workflows that use this integration"
+      className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      style={{ WebkitOverflowScrolling: "touch" }}
+    >
+      {workflows.map((workflow) => (
+        <div key={workflow.id} className="w-60 shrink-0">
+          <UnifiedWorkflowCard
+            communityWorkflow={workflow}
+            variant="community"
+            showCreator={false}
+            showExecutions={false}
+          />
+        </div>
+      ))}
+      <ViewMoreCard />
+    </section>
+  );
+
+  if (variant === "section") {
     return (
-      <div className="flex flex-col gap-3">
-        <h2 className="text-sm font-medium text-zinc-100">
-          Workflows that use this Integration
-        </h2>
-        <p className="text-sm text-zinc-500">
-          No workflows found for this integration.
-        </p>
-      </div>
+      <section className="rounded-3xl bg-zinc-900/50 backdrop-blur-md p-8 space-y-6">
+        <div>
+          <h2 className="text-2xl font-medium text-foreground mb-2">
+            Workflows that use this integration
+          </h2>
+          <p className="text-zinc-400 text-sm leading-relaxed">
+            {integrationName
+              ? `Community-built workflows that automate ${integrationName} with GAIA. Clone any of them in one click.`
+              : "Community-built workflows powered by this integration. Clone any of them in one click."}
+          </p>
+        </div>
+        {list}
+      </section>
     );
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      <h2 className="text-sm font-medium text-zinc-100">
-        Workflows that use this Integration
+    <div className="flex flex-col gap-2 mt-6">
+      <h2 className="text-sm font-medium text-zinc-300">
+        Workflows that use this integration
       </h2>
-
-      {isLoading ? (
-        <div className="flex gap-3 overflow-hidden">
-          {["s1", "s2", "s3"].map((key) => (
-            <Skeleton
-              key={key}
-              className="h-36 w-60 shrink-0 rounded-3xl bg-zinc-800"
-            />
-          ))}
-        </div>
-      ) : (
-        <section
-          aria-label="Workflows that use this integration"
-          className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          style={{ WebkitOverflowScrolling: "touch" }}
-        >
-          {workflows.map((workflow) => (
-            <div key={workflow.id} className="w-60 shrink-0">
-              <UnifiedWorkflowCard
-                communityWorkflow={workflow}
-                variant="community"
-                showCreator={false}
-                showExecutions={false}
-              />
-            </div>
-          ))}
-        </section>
-      )}
+      {list}
     </div>
   );
 }

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -37,17 +37,17 @@ export function IntegrationRelatedWorkflows({
 
       {isLoading ? (
         <div className="flex gap-3 overflow-hidden">
-          {Array.from({ length: 3 }).map((_, i) => (
+          {["s1", "s2", "s3"].map((key) => (
             <Skeleton
-              key={i}
+              key={key}
               className="h-36 w-60 shrink-0 rounded-3xl bg-zinc-800"
             />
           ))}
         </div>
       ) : (
-        <div
-          role="region"
+        <section
           aria-label="Related workflows"
+          // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable region needs keyboard focus to scroll
           tabIndex={0}
           className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ WebkitOverflowScrolling: "touch" }}
@@ -62,7 +62,7 @@ export function IntegrationRelatedWorkflows({
               />
             </div>
           ))}
-        </div>
+        </section>
       )}
     </div>
   );

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -22,14 +22,14 @@ interface IntegrationRelatedWorkflowsProps {
   readonly integrationName?: string;
 }
 
-const VIEW_MORE_HREF = "/use-cases#community-section";
+const VIEW_MORE_HREF = "/use-cases";
 
 function ViewMoreCard({ fullWidth = false }: { readonly fullWidth?: boolean }) {
   return (
     <Link
       href={VIEW_MORE_HREF}
       aria-label="View more workflows"
-      className={`group flex ${fullWidth ? "min-h-[180px] w-full" : "w-72 shrink-0"} flex-col items-center justify-center gap-2 rounded-3xl border border-dashed border-zinc-700/60 bg-transparent text-zinc-400 transition-colors hover:border-transparent hover:bg-zinc-800 hover:text-zinc-100`}
+      className={`group flex ${fullWidth ? "min-h-[180px] w-full" : "w-72 shrink-0"} flex-col items-center justify-center gap-2 rounded-3xl border-3 border-dashed border-zinc-700/60 bg-transparent text-zinc-400 transition-colors hover:border-transparent hover:bg-zinc-800 hover:text-zinc-100`}
     >
       <CircleArrowUpRightIcon
         width={28}

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -24,12 +24,12 @@ interface IntegrationRelatedWorkflowsProps {
 
 const VIEW_MORE_HREF = "/use-cases#community-section";
 
-function ViewMoreCard() {
+function ViewMoreCard({ fullWidth = false }: { readonly fullWidth?: boolean }) {
   return (
     <Link
       href={VIEW_MORE_HREF}
       aria-label="View more workflows"
-      className="group flex w-60 shrink-0 flex-col items-center justify-center gap-2 rounded-3xl border border-dashed border-zinc-700/60 bg-transparent text-zinc-400 transition-colors hover:border-transparent hover:bg-zinc-800 hover:text-zinc-100"
+      className={`group flex ${fullWidth ? "min-h-[180px] w-full" : "w-72 shrink-0"} flex-col items-center justify-center gap-2 rounded-3xl border border-dashed border-zinc-700/60 bg-transparent text-zinc-400 transition-colors hover:border-transparent hover:bg-zinc-800 hover:text-zinc-100`}
     >
       <CircleArrowUpRightIcon
         width={28}
@@ -61,26 +61,6 @@ export function IntegrationRelatedWorkflows({
   const workflows = (data?.workflows ?? []) as CommunityWorkflow[];
   if (workflows.length === 0) return null;
 
-  const list = (
-    <section
-      aria-label="Workflows that use this integration"
-      className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      style={{ WebkitOverflowScrolling: "touch" }}
-    >
-      {workflows.map((workflow) => (
-        <div key={workflow.id} className="w-60 shrink-0">
-          <UnifiedWorkflowCard
-            communityWorkflow={workflow}
-            variant="community"
-            showCreator={false}
-            showExecutions={false}
-          />
-        </div>
-      ))}
-      <ViewMoreCard />
-    </section>
-  );
-
   if (variant === "section") {
     return (
       <section className="rounded-3xl bg-zinc-900/50 backdrop-blur-md p-8 space-y-6">
@@ -90,11 +70,22 @@ export function IntegrationRelatedWorkflows({
           </h2>
           <p className="text-zinc-400 text-sm leading-relaxed">
             {integrationName
-              ? `Community-built workflows that automate ${integrationName} with GAIA. Clone any of them in one click.`
-              : "Community-built workflows powered by this integration. Clone any of them in one click."}
+              ? `Featured and community workflows that automate ${integrationName} with GAIA. Clone any of them in one click.`
+              : "Featured and community workflows powered by this integration. Clone any of them in one click."}
           </p>
         </div>
-        {list}
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {workflows.map((workflow) => (
+            <UnifiedWorkflowCard
+              key={workflow.id}
+              communityWorkflow={workflow}
+              variant="community"
+              showCreator={true}
+              showExecutions={true}
+            />
+          ))}
+          <ViewMoreCard fullWidth />
+        </div>
       </section>
     );
   }
@@ -104,7 +95,23 @@ export function IntegrationRelatedWorkflows({
       <h2 className="text-sm font-medium text-zinc-300">
         Workflows that use this integration
       </h2>
-      {list}
+      <section
+        aria-label="Workflows that use this integration"
+        className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{ WebkitOverflowScrolling: "touch" }}
+      >
+        {workflows.map((workflow) => (
+          <div key={workflow.id} className="w-70 shrink-0">
+            <UnifiedWorkflowCard
+              communityWorkflow={workflow}
+              variant="community"
+              showCreator={true}
+              showExecutions={true}
+            />
+          </div>
+        ))}
+        <ViewMoreCard />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationRelatedWorkflows.tsx
@@ -31,7 +31,7 @@ export function IntegrationRelatedWorkflows({
 
   return (
     <div className="flex flex-col gap-3">
-      <h2 className="text-sm font-medium text-zinc-400">
+      <h2 className="text-sm font-medium text-zinc-300">
         Workflows that use this Integration
       </h2>
 
@@ -46,6 +46,9 @@ export function IntegrationRelatedWorkflows({
         </div>
       ) : (
         <div
+          role="region"
+          aria-label="Related workflows"
+          tabIndex={0}
           className="flex gap-3 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ WebkitOverflowScrolling: "touch" }}
         >

--- a/apps/web/src/features/workflows/components/shared/UnifiedWorkflowCard.tsx
+++ b/apps/web/src/features/workflows/components/shared/UnifiedWorkflowCard.tsx
@@ -204,7 +204,8 @@ export default function UnifiedWorkflowCard({
   };
 
   const handleNavigate = () => {
-    const targetSlug = slug || communityWorkflow?.id || workflow?.id;
+    const targetSlug =
+      slug || communityWorkflow?.slug || workflow?.slug || workflow?.id;
     if (targetSlug) {
       trackEvent(ANALYTICS_EVENTS.WORKFLOW_CARD_NAVIGATE, {
         slug: targetSlug,

--- a/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
@@ -12,6 +12,10 @@ import {
 } from "@icons";
 import Image from "next/image";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
+import {
+  resolveCreatorAvatar,
+  resolveCreatorName,
+} from "@/features/workflows/utils/creator";
 import { formatRunCount } from "@/utils/formatters";
 
 import type { Workflow } from "../../api/workflowApi";
@@ -287,13 +291,16 @@ export function CreatorAvatar({
   size = 27,
   showTooltip = true,
 }: CreatorAvatarProps) {
+  const avatarSrc = resolveCreatorAvatar(creator);
+  const displayName = resolveCreatorName(creator);
+
   const avatar = (
     <div className="flex items-center gap-2">
       <div className="flex h-7 w-7 items-center justify-center rounded-full">
-        {creator.avatar || creator.id === "system" ? (
+        {avatarSrc ? (
           <Image
-            src={creator.avatar || "/images/logos/experience_black_bg.png"}
-            alt={creator.name}
+            src={avatarSrc}
+            alt={displayName}
             width={size}
             height={size}
             className="rounded-full h-7 w-7"
@@ -309,7 +316,7 @@ export function CreatorAvatar({
 
   return (
     <Tooltip
-      content={`Created by ${creator.name}`}
+      content={`Created by ${displayName}`}
       showArrow
       closeDelay={0}
       delay={0}

--- a/apps/web/src/features/workflows/utils/creator.ts
+++ b/apps/web/src/features/workflows/utils/creator.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve avatar + display name for a workflow creator across all surfaces
+ * (cards, detail pages, sidebars). Centralizes the "system" → GAIA Team
+ * convention so card and detail pages stay in sync.
+ */
+
+const SYSTEM_CREATOR_ID = "system";
+const GAIA_LOGO_SRC = "/images/logos/experience_black_bg.png";
+
+export interface ResolvableCreator {
+  id?: string | null;
+  name?: string | null;
+  avatar?: string | null;
+}
+
+export function isSystemCreator(
+  creator: ResolvableCreator | null | undefined,
+): boolean {
+  return creator?.id === SYSTEM_CREATOR_ID;
+}
+
+export function resolveCreatorAvatar(
+  creator: ResolvableCreator | null | undefined,
+): string | undefined {
+  if (isSystemCreator(creator)) return GAIA_LOGO_SRC;
+  return creator?.avatar ?? undefined;
+}
+
+export function resolveCreatorName(
+  creator: ResolvableCreator | null | undefined,
+): string {
+  if (isSystemCreator(creator)) return "GAIA Team";
+  return creator?.name?.trim() || "Unknown";
+}

--- a/apps/web/src/types/features/workflowTypes.ts
+++ b/apps/web/src/types/features/workflowTypes.ts
@@ -74,7 +74,7 @@ export type { ExecutionConfig, WorkflowMetadata };
  */
 export interface CommunityWorkflow {
   id: string;
-  slug?: string; // human-readable URL slug
+  slug: string; // human-readable URL slug — always present for public workflows
   title: string;
   description: string;
   prompt?: string;


### PR DESCRIPTION
## Summary
- Add IntegrationRelatedWorkflows component with horizontal scroll, no visible scrollbar
- Show related workflow cards in /integrations sidebar for selected integration
- Show related workflow cards at bottom of /marketplace/[slug] page
- Backend API endpoint returns community workflows filtered by integration slug
- Heading: 'Workflows that use this Integration'

Closes GAIA-571

## Test plan
- [x] Visit /integrations and select an integration that has workflows
- [x] Verify horizontal scroll works without scrollbar
- [x] Visit /marketplace/[slug] and verify workflows appear at bottom
- [x] Verify UnifiedWorkflowCard renders correctly