### PR TITLE
fix(bots): chunk long messages into multiple bubbles; gate OpenUI from plain comms prompt

### DIFF
--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -345,15 +345,30 @@ def _strip_openui_section(prompt: str) -> str:
     """Remove the embedded OpenUI component-instructions block from ``prompt``.
 
     The block is delimited by ``_OPENUI_SECTION_START_MARKER`` and
-    ``_OPENUI_SECTION_END_MARKER``. Returns ``prompt`` unchanged if either
-    marker is missing (defensive — keeps the build safe if the prompt is
-    edited and the markers move).
+    ``_OPENUI_SECTION_END_MARKER``. If either marker is missing we log a
+    loud warning and return ``prompt`` unchanged — silently re-introducing
+    the bug (plain prompt still telling the model to emit ``:::openui``)
+    would be far worse than logging a noisy startup warning that someone
+    edited the prompt and forgot to keep the markers in sync.
     """
+    from shared.py.wide_events import log
+
     start = prompt.find(_OPENUI_SECTION_START_MARKER)
     if start == -1:
+        log.warning(
+            "comms_prompts: OpenUI section start marker not found in "
+            "COMMS_AGENT_PROMPT — plain (whatsapp/telegram/discord/slack) "
+            "variant will still contain OpenUI instructions. Update "
+            "_OPENUI_SECTION_START_MARKER to match the prompt."
+        )
         return prompt
     end_marker_idx = prompt.find(_OPENUI_SECTION_END_MARKER, start)
     if end_marker_idx == -1:
+        log.warning(
+            "comms_prompts: OpenUI section end marker not found after the "
+            "start marker — plain variant strip aborted. Update "
+            "_OPENUI_SECTION_END_MARKER to match the prompt."
+        )
         return prompt
     end_of_line = prompt.find("\n", end_marker_idx + len(_OPENUI_SECTION_END_MARKER))
     end = end_of_line + 1 if end_of_line != -1 else len(prompt)

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -329,6 +329,40 @@ and a other username in the connected apps.
 
 RICH_UI_SOURCES: frozenset[str] = frozenset({"web", "mobile", "desktop"})
 
+# Markers that bracket the embedded OpenUI component-instructions section
+# inside ``COMMS_AGENT_PROMPT``. Used to strip the section for messaging
+# platforms (WhatsApp, Telegram, Discord, Slack) where ``:::openui`` fences
+# render as literal text and contradict the platform context message that
+# tells the model to use plain text only.
+_OPENUI_SECTION_START_MARKER = "—Rich UI Components (OpenUI) — CRITICAL—"
+_OPENUI_SECTION_END_MARKER = (
+    "See the full OpenUI Lang reference with all components and "
+    "syntax rules at the end of this prompt."
+)
+
+
+def _strip_openui_section(prompt: str) -> str:
+    """Remove the embedded OpenUI component-instructions block from ``prompt``.
+
+    The block is delimited by ``_OPENUI_SECTION_START_MARKER`` and
+    ``_OPENUI_SECTION_END_MARKER``. Returns ``prompt`` unchanged if either
+    marker is missing (defensive — keeps the build safe if the prompt is
+    edited and the markers move).
+    """
+    start = prompt.find(_OPENUI_SECTION_START_MARKER)
+    if start == -1:
+        return prompt
+    end_marker_idx = prompt.find(_OPENUI_SECTION_END_MARKER, start)
+    if end_marker_idx == -1:
+        return prompt
+    end_of_line = prompt.find("\n", end_marker_idx + len(_OPENUI_SECTION_END_MARKER))
+    end = end_of_line + 1 if end_of_line != -1 else len(prompt)
+    # Collapse the surrounding blank lines so the result still reads cleanly.
+    return prompt[:start].rstrip() + "\n\n" + prompt[end:].lstrip()
+
+
+_COMMS_AGENT_PROMPT_PLAIN = _strip_openui_section(COMMS_AGENT_PROMPT)
+
 
 def get_comms_agent_prompt(source: str | None = None) -> str:
     """Build the comms agent prompt.
@@ -336,13 +370,17 @@ def get_comms_agent_prompt(source: str | None = None) -> str:
     OpenUI Lang produces rich interactive cards that only the web / mobile /
     desktop clients can render. Messaging platforms (WhatsApp, Telegram,
     Discord, Slack) and email receive the raw ``:::openui`` fences as literal
-    text, which looks broken. For those sources we omit the OpenUI
-    instructions entirely so the model falls back to plain Markdown that the
-    platform-specific adapter can then format.
+    text, which looks broken. For those sources we omit BOTH the embedded
+    OpenUI component-instructions section and the appended OpenUI Lang
+    reference so the model falls back to plain Markdown that the
+    platform-specific adapter can then format. Leaving the embedded section
+    in (the previous behavior) caused the model to emit ``:::openui`` fences
+    on WhatsApp anyway, drowning out the comms voice and contradicting the
+    per-platform context message.
     """
     if source is None or source in RICH_UI_SOURCES:
         return COMMS_AGENT_PROMPT + "\n" + OPENUI_INSTRUCTIONS
-    return COMMS_AGENT_PROMPT
+    return _COMMS_AGENT_PROMPT_PLAIN
 
 
 EXECUTOR_AGENT_PROMPT = """

--- a/apps/api/app/helpers/message_helpers.py
+++ b/apps/api/app/helpers/message_helpers.py
@@ -169,7 +169,9 @@ async def get_memory_message(
 
         # Combine all sections
         content = "\n".join(context_parts) + memories_section + gaia_knowledge_section
-        return SystemMessage(content=content, memory_message=True)
+        return SystemMessage(
+            content=content, additional_kwargs={"memory_message": True}
+        )
 
     except Exception as e:
         log.error(f"Error creating memory message: {e}")
@@ -178,7 +180,8 @@ async def get_memory_message(
             "%A, %B %d, %Y, %H:%M:%S UTC"
         )
         return SystemMessage(
-            content=f"Current UTC Time: {utc_time_str}", memory_message=True
+            content=f"Current UTC Time: {utc_time_str}",
+            additional_kwargs={"memory_message": True},
         )
 
 
@@ -242,7 +245,12 @@ WHAT TO DO INSTEAD:
 - For content that would be an artifact, include it directly in your message as text
 - Keep messages concise — messaging platforms work best with shorter, focused messages"""
 
-    return SystemMessage(content=content)
+    # Mark as memory-style so manage_system_prompts_node preserves it alongside
+    # the COMMS_AGENT_PROMPT instead of treating this auxiliary platform context
+    # as the "latest non-memory system prompt" and silently dropping the real
+    # agent prompt. Platform context is persistent contextual metadata, not the
+    # agent's voice prompt — it should always travel with the conversation.
+    return SystemMessage(content=content, additional_kwargs={"memory_message": True})
 
 
 def format_tool_selection_message(

--- a/libs/shared/ts/src/bots/utils/formatters.ts
+++ b/libs/shared/ts/src/bots/utils/formatters.ts
@@ -175,11 +175,24 @@ export function convertToWhatsAppMarkdown(text: string): string {
     text,
     (segment) =>
       segment
-        .replaceAll(/\*\*\*([^*]+)\*\*\*/g, "*$1*") // ***bold italic*** → *bold*
-        .replaceAll(/\*\*([^*]+)\*\*/g, "*$1*") // **bold** → *bold*
-        .replaceAll(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)") // [label](url) → label (url)
+        // Headings FIRST so the content gets wrapped in ``*`` before the
+        // bold rule sees it. Otherwise the model's ``### **Heading**`` would
+        // become ``### *Heading*`` (after bold) and then ``**Heading**`` once
+        // the heading rule wraps the already-emphasised content in ``*`` —
+        // re-introducing the double asterisks we tried to remove.
         .replaceAll(/^#{1,6}\s+(.+)$/gm, "*$1*") // # Heading → *Heading*
-        .replaceAll(/^[-_]{3,}$/gm, "") // --- / ___ → remove (BEFORE bullets)
+        // Horizontal-rule remover MUST run before the bold rule. Otherwise
+        // ``***`` on its own line followed by ``**Heading**`` lets the bold
+        // regex's ``[^*]`` greedy-match the inter-line newlines and pair
+        // chars across the ``***`` boundary into ``**X**``, splitting the
+        // ``**Heading**`` and leaving stray ``**`` glyphs in the output.
+        .replaceAll(/^[-_*]{3,}$/gm, "") // --- / ___ / *** → remove
+        // Bold rules: keep ``[^*\n]`` (no newlines) so a single ``**`` opener
+        // cannot reach across blank lines and accidentally pair with the
+        // opener of a SEPARATE bold span.
+        .replaceAll(/\*\*\*([^*\n]+)\*\*\*/g, "*$1*") // ***bold italic*** → *bold*
+        .replaceAll(/\*\*([^*\n]+)\*\*/g, "*$1*") // **bold** → *bold*
+        .replaceAll(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)") // [label](url) → label (url)
         .replaceAll(/^(\s*)[*\-+]\s+/gm, "$1• ") // - / * / + bullet → •
         .replaceAll(/^>\s*/gm, ""), // > quote → strip prefix
   );

--- a/libs/shared/ts/src/bots/utils/formatters.ts
+++ b/libs/shared/ts/src/bots/utils/formatters.ts
@@ -179,8 +179,9 @@ export function convertToWhatsAppMarkdown(text: string): string {
         .replaceAll(/\*\*([^*]+)\*\*/g, "*$1*") // **bold** → *bold*
         .replaceAll(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)") // [label](url) → label (url)
         .replaceAll(/^#{1,6}\s+(.+)$/gm, "*$1*") // # Heading → *Heading*
-        .replaceAll(/^>\s*/gm, "") // > quote → strip prefix
-        .replaceAll(/^[-_]{3,}$/gm, ""), // --- / ___ → remove
+        .replaceAll(/^[-_]{3,}$/gm, "") // --- / ___ → remove (BEFORE bullets)
+        .replaceAll(/^(\s*)[*\-+]\s+/gm, "$1• ") // - / * / + bullet → •
+        .replaceAll(/^>\s*/gm, ""), // > quote → strip prefix
   );
 }
 

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -120,46 +120,68 @@ function cutsInsideMarkdownLink(text: string, idx: number): boolean {
 }
 
 /**
+ * Strips fenced code blocks (``` ... ```) so the parity checks only see
+ * narrative text. Code can legitimately contain ``**`` (Python ``**kwargs``),
+ * lone ``*`` (shell globs ``*.txt``), or stray backticks, and those bytes
+ * must not poison emphasis parity for prose.
+ */
+function stripFencedBlocks(s: string): string {
+  let out = "";
+  let inFence = false;
+  let i = 0;
+  while (i < s.length) {
+    if (s.startsWith("```", i)) {
+      inFence = !inFence;
+      i += 3;
+      continue;
+    }
+    if (!inFence) out += s[i];
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Counts single ``*`` markers in ``text``, excluding any ``*`` that is part
+ * of a ``**`` (markdown bold). Used to detect WhatsApp-native ``*bold*``
+ * pairs that the model emits when the platform context tells it to use
+ * single-asterisk bold. Markdown bullets at line start (``^* ``) are also
+ * excluded — they are not paired emphasis markers.
+ */
+function countSingleAsterisks(text: string): number {
+  // Drop ``**`` first so the bold pairs don't double-count toward single-`*`.
+  const noDouble = text.replaceAll("**", "");
+  // Drop bullet-list ``*`` followed by a space at line start.
+  const noBullets = noDouble.replace(/^\*\s/gm, "");
+  return (noBullets.match(/\*/g) ?? []).length;
+}
+
+/**
  * Returns true if cutting ``text`` at index ``idx`` would land inside an
- * unclosed markdown emphasis span. We only check the two markers that bite us
- * in practice: ``**bold**`` (model emits markdown bold even when output goes
- * to WhatsApp) and `` `inline code` ``. Single ``*``, ``_``, ``~`` are skipped
- * because they appear in code identifiers, URLs, and plain prose — the false
- * positive rate is too high to be worth the rare valid catch.
+ * unclosed markdown emphasis span. We check the markers that actually bite us
+ * in WhatsApp output: ``**bold**``, single-asterisk ``*bold*`` (the
+ * WhatsApp-native bold the platform context steers the model toward), and
+ * `` `inline code` ``. ``_`` and ``~`` are skipped because they appear in
+ * identifiers/URLs and the false-positive rate would shrink chunks
+ * pointlessly.
  *
- * The check is symmetric: an odd number of ``**`` in the prefix AND a closing
- * ``**`` somewhere in the suffix means the cut would orphan one half of the
- * pair. Same logic for backticks (excluding triple-backticks, which are
- * handled separately by the fence-balancing step in {@link chunkResponse}).
+ * The check is symmetric: an odd number of a marker in the prefix AND a
+ * closing marker somewhere in the suffix means the cut would orphan one
+ * half of the pair.
  */
 function cutsInsideEmphasisSpan(text: string, idx: number): boolean {
-  const prefix = text.slice(0, idx);
-  const suffix = text.slice(idx);
-
-  // Strip fenced code blocks (``` ... ```) before counting markers — code can
-  // legitimately contain ``**`` (e.g. Python ``**kwargs``) and stray
-  // backticks (e.g. shell quoting), and those bytes must not poison the
-  // emphasis parity check that's deciding cut positions in narrative text.
-  const stripFences = (s: string): string => {
-    let out = "";
-    let inFence = false;
-    let i = 0;
-    while (i < s.length) {
-      if (s.startsWith("```", i)) {
-        inFence = !inFence;
-        i += 3;
-        continue;
-      }
-      if (!inFence) out += s[i];
-      i++;
-    }
-    return out;
-  };
-  const prefixNarrative = stripFences(prefix);
-  const suffixNarrative = stripFences(suffix);
+  const prefixNarrative = stripFencedBlocks(text.slice(0, idx));
+  const suffixNarrative = stripFencedBlocks(text.slice(idx));
 
   const doubleAsteriskOpens = (prefixNarrative.match(/\*\*/g) ?? []).length;
   if (doubleAsteriskOpens % 2 === 1 && suffixNarrative.includes("**"))
+    return true;
+
+  const singleAsteriskOpens = countSingleAsterisks(prefixNarrative);
+  if (
+    singleAsteriskOpens % 2 === 1 &&
+    countSingleAsterisks(suffixNarrative) > 0
+  )
     return true;
 
   const inlineTickOpens = (prefixNarrative.match(/`/g) ?? []).length;
@@ -174,6 +196,39 @@ function cutsInsideEmphasisSpan(text: string, idx: number): boolean {
  */
 function cutsInsideMarkdown(text: string, idx: number): boolean {
   return cutsInsideMarkdownLink(text, idx) || cutsInsideEmphasisSpan(text, idx);
+}
+
+/**
+ * Find the orphan single ``*`` to strip. Skips ``**`` (double-asterisk bold,
+ * already handled separately) and ``* `` at line start (markdown bullet,
+ * not an emphasis marker).
+ *
+ * @param scan - ``"tail"`` walks from the end (last orphan in chunk),
+ *               ``"head"`` walks from the start (first orphan in next chunk).
+ * @returns Index of the orphan ``*`` or -1 if none found.
+ */
+function findOrphanSingleAsterisk(text: string, scan: "tail" | "head"): number {
+  const isBulletStart = (i: number): boolean => {
+    const lineStart = text.lastIndexOf("\n", i - 1) + 1;
+    // Ignore leading whitespace before checking ``*``
+    let j = lineStart;
+    while (j < i && (text[j] === " " || text[j] === "\t")) j++;
+    return j === i && text[i + 1] === " ";
+  };
+
+  const indices: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "*") continue;
+    if (text[i + 1] === "*") {
+      i++; // skip second `*` of `**`
+      continue;
+    }
+    if (text[i - 1] === "*") continue; // tail half of `**` (defensive)
+    if (isBulletStart(i)) continue;
+    indices.push(i);
+  }
+  if (indices.length === 0) return -1;
+  return scan === "tail" ? indices[indices.length - 1] : indices[0];
 }
 
 /**
@@ -259,31 +314,16 @@ export function chunkResponse(
     let chunk = remaining.slice(0, cutAt);
     let next = remaining.slice(cutAt);
 
-    // Belt-and-suspenders: balance unbalanced ``**`` markers across the cut
-    // in narrative text. We ignore ``**`` that appears inside fenced code
-    // blocks (Python ``**kwargs`` etc.) so legitimate code doesn't flip the
-    // parity and mask a real orphan in prose.
-    const stripFences = (s: string): string => {
-      let out = "";
-      let inFence = false;
-      let i = 0;
-      while (i < s.length) {
-        if (s.startsWith("```", i)) {
-          inFence = !inFence;
-          i += 3;
-          continue;
-        }
-        if (!inFence) out += s[i];
-        i++;
-      }
-      return out;
-    };
-    const chunkOpens = (stripFences(chunk).match(/\*\*/g) ?? []).length;
-    if (chunkOpens % 2 === 1) {
-      // Strip the orphan ``**`` from the chunk's narrative tail and the
-      // matching opener from the next chunk's narrative head so
-      // convertToWhatsAppMarkdown's pair regex does not greedily merge them
-      // with unrelated ``**`` pairs and emit stray asterisks.
+    // Belt-and-suspenders: balance unbalanced emphasis markers across the
+    // cut in narrative text. We ignore markers inside fenced code blocks
+    // (Python ``**kwargs``, shell globs ``*.txt``, backtick-quoted strings)
+    // so legitimate code doesn't flip parity and mask a real prose orphan.
+    const chunkNarrative = stripFencedBlocks(chunk);
+    const nextNarrative = stripFencedBlocks(next);
+
+    // 1. Double-asterisk markdown bold (``**X**``).
+    const doubleOpens = (chunkNarrative.match(/\*\*/g) ?? []).length;
+    if (doubleOpens % 2 === 1) {
       const lastIdx = chunk.lastIndexOf("**");
       if (lastIdx !== -1) {
         chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 2);
@@ -291,6 +331,23 @@ export function chunkResponse(
       const firstIdx = next.indexOf("**");
       if (firstIdx !== -1) {
         next = next.slice(0, firstIdx) + next.slice(firstIdx + 2);
+      }
+    }
+
+    // 2. Single-asterisk WhatsApp-native bold (``*X*``). The platform context
+    //    steers the model toward this style on WhatsApp, so without this
+    //    branch a cut inside ``*Bold Heading*`` leaves stray ``*`` glyphs in
+    //    the rendered bubbles.
+    if (countSingleAsterisks(chunkNarrative) % 2 === 1) {
+      // Strip the orphan single ``*`` from chunk's tail (skipping any ``**``
+      // and bullet-list ``*`` markers) and the matching opener from next.
+      const lastIdx = findOrphanSingleAsterisk(chunk, "tail");
+      if (lastIdx !== -1) {
+        chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 1);
+      }
+      const firstIdx = findOrphanSingleAsterisk(next, "head");
+      if (firstIdx !== -1) {
+        next = next.slice(0, firstIdx) + next.slice(firstIdx + 1);
       }
     }
 

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -120,6 +120,63 @@ function cutsInsideMarkdownLink(text: string, idx: number): boolean {
 }
 
 /**
+ * Returns true if cutting ``text`` at index ``idx`` would land inside an
+ * unclosed markdown emphasis span. We only check the two markers that bite us
+ * in practice: ``**bold**`` (model emits markdown bold even when output goes
+ * to WhatsApp) and `` `inline code` ``. Single ``*``, ``_``, ``~`` are skipped
+ * because they appear in code identifiers, URLs, and plain prose — the false
+ * positive rate is too high to be worth the rare valid catch.
+ *
+ * The check is symmetric: an odd number of ``**`` in the prefix AND a closing
+ * ``**`` somewhere in the suffix means the cut would orphan one half of the
+ * pair. Same logic for backticks (excluding triple-backticks, which are
+ * handled separately by the fence-balancing step in {@link chunkResponse}).
+ */
+function cutsInsideEmphasisSpan(text: string, idx: number): boolean {
+  const prefix = text.slice(0, idx);
+  const suffix = text.slice(idx);
+
+  // Strip fenced code blocks (``` ... ```) before counting markers — code can
+  // legitimately contain ``**`` (e.g. Python ``**kwargs``) and stray
+  // backticks (e.g. shell quoting), and those bytes must not poison the
+  // emphasis parity check that's deciding cut positions in narrative text.
+  const stripFences = (s: string): string => {
+    let out = "";
+    let inFence = false;
+    let i = 0;
+    while (i < s.length) {
+      if (s.startsWith("```", i)) {
+        inFence = !inFence;
+        i += 3;
+        continue;
+      }
+      if (!inFence) out += s[i];
+      i++;
+    }
+    return out;
+  };
+  const prefixNarrative = stripFences(prefix);
+  const suffixNarrative = stripFences(suffix);
+
+  const doubleAsteriskOpens = (prefixNarrative.match(/\*\*/g) ?? []).length;
+  if (doubleAsteriskOpens % 2 === 1 && suffixNarrative.includes("**"))
+    return true;
+
+  const inlineTickOpens = (prefixNarrative.match(/`/g) ?? []).length;
+  if (inlineTickOpens % 2 === 1 && suffixNarrative.includes("`")) return true;
+
+  return false;
+}
+
+/**
+ * Aggregate predicate — true when the cut at ``idx`` would split any markdown
+ * span (link or emphasis). Keeps {@link pickCutBoundary} short.
+ */
+function cutsInsideMarkdown(text: string, idx: number): boolean {
+  return cutsInsideMarkdownLink(text, idx) || cutsInsideEmphasisSpan(text, idx);
+}
+
+/**
  * Picks the best cut index ≤ ``limit`` for a chunk of ``text``. Prefers
  * paragraph (`\n\n`), then sentence enders, then word boundary, then a hard
  * cut at ``limit`` as a last resort. Boundaries that would split a markdown
@@ -135,7 +192,7 @@ function pickCutBoundary(text: string, limit: number): number {
 
   // 1. Paragraph break
   const paragraph = window.lastIndexOf("\n\n");
-  if (paragraph >= floor && !cutsInsideMarkdownLink(text, paragraph)) {
+  if (paragraph >= floor && !cutsInsideMarkdown(text, paragraph)) {
     return paragraph;
   }
 
@@ -145,7 +202,7 @@ function pickCutBoundary(text: string, limit: number): number {
     const idx = window.lastIndexOf(sep);
     if (idx < floor) continue;
     const cut = idx + sep.length;
-    if (cut > bestSentence && !cutsInsideMarkdownLink(text, cut)) {
+    if (cut > bestSentence && !cutsInsideMarkdown(text, cut)) {
       bestSentence = cut;
     }
   }
@@ -154,7 +211,7 @@ function pickCutBoundary(text: string, limit: number): number {
   // 3. Word boundary
   let space = window.lastIndexOf(" ");
   while (space >= floor) {
-    if (!cutsInsideMarkdownLink(text, space + 1)) return space + 1;
+    if (!cutsInsideMarkdown(text, space + 1)) return space + 1;
     space = window.lastIndexOf(" ", space - 1);
   }
 
@@ -201,6 +258,41 @@ export function chunkResponse(
     const cutAt = pickCutBoundary(remaining, cutLimit);
     let chunk = remaining.slice(0, cutAt).trimEnd();
     let next = remaining.slice(cutAt).trimStart();
+
+    // Belt-and-suspenders: balance unbalanced ``**`` markers across the cut
+    // in narrative text. We ignore ``**`` that appears inside fenced code
+    // blocks (Python ``**kwargs`` etc.) so legitimate code doesn't flip the
+    // parity and mask a real orphan in prose.
+    const stripFences = (s: string): string => {
+      let out = "";
+      let inFence = false;
+      let i = 0;
+      while (i < s.length) {
+        if (s.startsWith("```", i)) {
+          inFence = !inFence;
+          i += 3;
+          continue;
+        }
+        if (!inFence) out += s[i];
+        i++;
+      }
+      return out;
+    };
+    const chunkOpens = (stripFences(chunk).match(/\*\*/g) ?? []).length;
+    if (chunkOpens % 2 === 1) {
+      // Strip the orphan ``**`` from the chunk's narrative tail and the
+      // matching opener from the next chunk's narrative head so
+      // convertToWhatsAppMarkdown's pair regex does not greedily merge them
+      // with unrelated ``**`` pairs and emit stray asterisks.
+      const lastIdx = chunk.lastIndexOf("**");
+      if (lastIdx !== -1) {
+        chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 2);
+      }
+      const firstIdx = next.indexOf("**");
+      if (firstIdx !== -1) {
+        next = next.slice(0, firstIdx) + next.slice(firstIdx + 2);
+      }
+    }
 
     // Balance code fences across the cut: if the chunk has an odd number of
     // ``` it ends inside an open fence — close it here and reopen on the next

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -256,8 +256,8 @@ export function chunkResponse(
 
   while (remaining.length > limit) {
     const cutAt = pickCutBoundary(remaining, cutLimit);
-    let chunk = remaining.slice(0, cutAt).trimEnd();
-    let next = remaining.slice(cutAt).trimStart();
+    let chunk = remaining.slice(0, cutAt);
+    let next = remaining.slice(cutAt);
 
     // Belt-and-suspenders: balance unbalanced ``**`` markers across the cut
     // in narrative text. We ignore ``**`` that appears inside fenced code
@@ -298,9 +298,17 @@ export function chunkResponse(
     // ``` it ends inside an open fence — close it here and reopen on the next
     // chunk so each bubble renders as valid markdown.
     const fenceCount = chunk.match(/```/g)?.length ?? 0;
-    if (fenceCount % 2 === 1) {
+    const insideFence = fenceCount % 2 === 1;
+    if (insideFence) {
       chunk = `${chunk}\n\`\`\``;
       next = `\`\`\`\n${next}`;
+    } else {
+      // Cosmetic whitespace trim for narrative cuts only. We never trim when
+      // the cut lands inside a fenced block, because leading whitespace there
+      // is significant code indentation (Python, YAML) and trimming it would
+      // produce broken code in the next bubble.
+      chunk = chunk.trimEnd();
+      next = next.trimStart();
     }
 
     chunks.push(chunk);

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -92,3 +92,61 @@ export function truncateResponse(
 
   return truncated + suffix;
 }
+
+/**
+ * Splits a long response into platform-sized chunks for delivery as multiple
+ * messages instead of a single truncated bubble. Used by non-streaming bot
+ * adapters (WhatsApp, Discord) so the user receives the full content.
+ *
+ * Splits prefer paragraph (`\n\n`) boundaries, then sentence enders
+ * (`. `, `! `, `? `, `\n`), then the last word boundary, then a hard cut as a
+ * last resort. Each returned chunk is guaranteed to be ≤ the platform limit.
+ *
+ * @param text - The full message text.
+ * @param platform - The target platform (discord, slack, telegram, whatsapp).
+ * @returns An array of chunks, in order, each ≤ the platform character limit.
+ *   Returns ``[text]`` when ``text`` already fits.
+ */
+export function chunkResponse(
+  text: string,
+  platform: "discord" | "slack" | "telegram" | "whatsapp",
+): string[] {
+  const limit = PLATFORM_LIMITS[platform];
+  if (text.length <= limit) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > limit) {
+    let cutAt = -1;
+    const window = remaining.slice(0, limit);
+
+    // Prefer paragraph break
+    cutAt = window.lastIndexOf("\n\n");
+    if (cutAt < limit * 0.5) cutAt = -1;
+
+    // Fall back to sentence end
+    if (cutAt === -1) {
+      const candidates = [". ", "! ", "? ", "\n"];
+      for (const sep of candidates) {
+        const idx = window.lastIndexOf(sep);
+        if (idx > limit * 0.5 && idx > cutAt) cutAt = idx + sep.length;
+      }
+    }
+
+    // Fall back to last word boundary
+    if (cutAt === -1) {
+      const space = window.lastIndexOf(" ");
+      if (space > limit * 0.5) cutAt = space + 1;
+    }
+
+    // Hard cut as last resort
+    if (cutAt === -1) cutAt = limit;
+
+    chunks.push(remaining.slice(0, cutAt).trimEnd());
+    remaining = remaining.slice(cutAt).trimStart();
+  }
+
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks.filter((c) => c.length > 0);
+}

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -152,7 +152,7 @@ function countSingleAsterisks(text: string): number {
   // Drop ``**`` first so the bold pairs don't double-count toward single-`*`.
   const noDouble = text.replaceAll("**", "");
   // Drop bullet-list ``*`` followed by a space at line start.
-  const noBullets = noDouble.replace(/^\*\s/gm, "");
+  const noBullets = noDouble.replaceAll(/^\*\s/gm, "");
   return (noBullets.match(/\*/g) ?? []).length;
 }
 
@@ -228,7 +228,7 @@ function findOrphanSingleAsterisk(text: string, scan: "tail" | "head"): number {
     indices.push(i);
   }
   if (indices.length === 0) return -1;
-  return scan === "tail" ? indices[indices.length - 1] : indices[0];
+  return scan === "tail" ? (indices.at(-1) ?? -1) : indices[0];
 }
 
 /**
@@ -274,6 +274,41 @@ function pickCutBoundary(text: string, limit: number): number {
   return limit;
 }
 
+function balanceDoubleAsterisks(
+  chunk: string,
+  next: string,
+  chunkNarrative: string,
+): [string, string] {
+  const doubleOpens = (chunkNarrative.match(/\*\*/g) ?? []).length;
+  if (doubleOpens % 2 !== 1) return [chunk, next];
+  const lastIdx = chunk.lastIndexOf("**");
+  if (lastIdx !== -1) {
+    chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 2);
+  }
+  const firstIdx = next.indexOf("**");
+  if (firstIdx !== -1) {
+    next = next.slice(0, firstIdx) + next.slice(firstIdx + 2);
+  }
+  return [chunk, next];
+}
+
+function balanceSingleAsterisks(
+  chunk: string,
+  next: string,
+  chunkNarrative: string,
+): [string, string] {
+  if (countSingleAsterisks(chunkNarrative) % 2 !== 1) return [chunk, next];
+  const lastIdx = findOrphanSingleAsterisk(chunk, "tail");
+  if (lastIdx !== -1) {
+    chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 1);
+  }
+  const firstIdx = findOrphanSingleAsterisk(next, "head");
+  if (firstIdx !== -1) {
+    next = next.slice(0, firstIdx) + next.slice(firstIdx + 1);
+  }
+  return [chunk, next];
+}
+
 /**
  * Splits a long response into platform-sized chunks for delivery as multiple
  * messages instead of a single truncated bubble. Used by bot adapters so the
@@ -314,42 +349,9 @@ export function chunkResponse(
     let chunk = remaining.slice(0, cutAt);
     let next = remaining.slice(cutAt);
 
-    // Belt-and-suspenders: balance unbalanced emphasis markers across the
-    // cut in narrative text. We ignore markers inside fenced code blocks
-    // (Python ``**kwargs``, shell globs ``*.txt``, backtick-quoted strings)
-    // so legitimate code doesn't flip parity and mask a real prose orphan.
     const chunkNarrative = stripFencedBlocks(chunk);
-    const nextNarrative = stripFencedBlocks(next);
-
-    // 1. Double-asterisk markdown bold (``**X**``).
-    const doubleOpens = (chunkNarrative.match(/\*\*/g) ?? []).length;
-    if (doubleOpens % 2 === 1) {
-      const lastIdx = chunk.lastIndexOf("**");
-      if (lastIdx !== -1) {
-        chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 2);
-      }
-      const firstIdx = next.indexOf("**");
-      if (firstIdx !== -1) {
-        next = next.slice(0, firstIdx) + next.slice(firstIdx + 2);
-      }
-    }
-
-    // 2. Single-asterisk WhatsApp-native bold (``*X*``). The platform context
-    //    steers the model toward this style on WhatsApp, so without this
-    //    branch a cut inside ``*Bold Heading*`` leaves stray ``*`` glyphs in
-    //    the rendered bubbles.
-    if (countSingleAsterisks(chunkNarrative) % 2 === 1) {
-      // Strip the orphan single ``*`` from chunk's tail (skipping any ``**``
-      // and bullet-list ``*`` markers) and the matching opener from next.
-      const lastIdx = findOrphanSingleAsterisk(chunk, "tail");
-      if (lastIdx !== -1) {
-        chunk = chunk.slice(0, lastIdx) + chunk.slice(lastIdx + 1);
-      }
-      const firstIdx = findOrphanSingleAsterisk(next, "head");
-      if (firstIdx !== -1) {
-        next = next.slice(0, firstIdx) + next.slice(firstIdx + 1);
-      }
-    }
+    [chunk, next] = balanceDoubleAsterisks(chunk, next, chunkNarrative);
+    [chunk, next] = balanceSingleAsterisks(chunk, next, chunkNarrative);
 
     // Balance code fences across the cut: if the chunk has an odd number of
     // ``` it ends inside an open fence — close it here and reopen on the next

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -94,13 +94,88 @@ export function truncateResponse(
 }
 
 /**
- * Splits a long response into platform-sized chunks for delivery as multiple
- * messages instead of a single truncated bubble. Used by non-streaming bot
- * adapters (WhatsApp, Discord) so the user receives the full content.
+ * Returns true if cutting ``text`` at index ``idx`` would land inside an
+ * incomplete markdown link of the form ``[label](url)``. Used by
+ * {@link chunkResponse} to walk the cut boundary back to before the link so
+ * we never deliver a half-rendered link to the user.
+ */
+function cutsInsideMarkdownLink(text: string, idx: number): boolean {
+  const lastOpenBracket = text.lastIndexOf("[", idx - 1);
+  if (lastOpenBracket === -1) return false;
+  // If a `]` appears between `[` and idx the bracket is already closed.
+  if (text.lastIndexOf("]", idx - 1) > lastOpenBracket) {
+    // Bracket closed — but if `(` follows immediately, the URL portion may
+    // still be open at idx. Check for an unclosed `(` to the left of idx.
+    const lastOpenParen = text.lastIndexOf("(", idx - 1);
+    const lastCloseParen = text.lastIndexOf(")", idx - 1);
+    if (lastOpenParen > lastCloseParen) {
+      const closeAfter = text.indexOf(")", idx);
+      return closeAfter !== -1;
+    }
+    return false;
+  }
+  // Bracket is still open at idx — definitely inside a link.
+  const closeParen = text.indexOf(")", lastOpenBracket);
+  return closeParen !== -1;
+}
+
+/**
+ * Picks the best cut index ≤ ``limit`` for a chunk of ``text``. Prefers
+ * paragraph (`\n\n`), then sentence enders, then word boundary, then a hard
+ * cut at ``limit`` as a last resort. Boundaries that would split a markdown
+ * link are skipped.
  *
- * Splits prefer paragraph (`\n\n`) boundaries, then sentence enders
- * (`. `, `! `, `? `, `\n`), then the last word boundary, then a hard cut as a
- * last resort. Each returned chunk is guaranteed to be ≤ the platform limit.
+ * The 50 %-of-limit floor avoids producing tiny fragments — if no decent
+ * boundary exists in the second half of the window, we accept the hard cut
+ * rather than emit a 200-char chunk on a 4000-char limit.
+ */
+function pickCutBoundary(text: string, limit: number): number {
+  const window = text.slice(0, limit);
+  const floor = limit * 0.5;
+
+  // 1. Paragraph break
+  const paragraph = window.lastIndexOf("\n\n");
+  if (paragraph >= floor && !cutsInsideMarkdownLink(text, paragraph)) {
+    return paragraph;
+  }
+
+  // 2. Sentence end (in priority order: ". ", "! ", "? ", "\n")
+  let bestSentence = -1;
+  for (const sep of [". ", "! ", "? ", "\n"]) {
+    const idx = window.lastIndexOf(sep);
+    if (idx < floor) continue;
+    const cut = idx + sep.length;
+    if (cut > bestSentence && !cutsInsideMarkdownLink(text, cut)) {
+      bestSentence = cut;
+    }
+  }
+  if (bestSentence > 0) return bestSentence;
+
+  // 3. Word boundary
+  let space = window.lastIndexOf(" ");
+  while (space >= floor) {
+    if (!cutsInsideMarkdownLink(text, space + 1)) return space + 1;
+    space = window.lastIndexOf(" ", space - 1);
+  }
+
+  // 4. Hard cut as last resort
+  return limit;
+}
+
+/**
+ * Splits a long response into platform-sized chunks for delivery as multiple
+ * messages instead of a single truncated bubble. Used by bot adapters so the
+ * user receives the full content across as many bubbles as needed.
+ *
+ * The boundary search prefers paragraph breaks, then sentence enders, then
+ * word boundaries, then a hard cut. Boundaries that would land inside a
+ * markdown link `[text](url)` are skipped. If a chunk would end with an
+ * unclosed code fence (```), the chunk is closed and the next chunk reopens
+ * with the same fence so the markdown stays valid across bubbles.
+ *
+ * Each returned chunk is guaranteed to be ≤ the platform character limit
+ * (after fence-balancing, the closing/reopening adds a small fixed overhead;
+ * we leave headroom by reserving 8 chars for the fence pair).
  *
  * @param text - The full message text.
  * @param platform - The target platform (discord, slack, telegram, whatsapp).
@@ -114,37 +189,30 @@ export function chunkResponse(
   const limit = PLATFORM_LIMITS[platform];
   if (text.length <= limit) return [text];
 
+  // Reserve space for code-fence balancing markers ("\n```" + "```\n") so a
+  // chunk that closes/reopens a fence still fits inside the platform limit.
+  const FENCE_HEADROOM = 8;
+  const cutLimit = limit - FENCE_HEADROOM;
+
   const chunks: string[] = [];
   let remaining = text;
 
   while (remaining.length > limit) {
-    let cutAt = -1;
-    const window = remaining.slice(0, limit);
+    const cutAt = pickCutBoundary(remaining, cutLimit);
+    let chunk = remaining.slice(0, cutAt).trimEnd();
+    let next = remaining.slice(cutAt).trimStart();
 
-    // Prefer paragraph break
-    cutAt = window.lastIndexOf("\n\n");
-    if (cutAt < limit * 0.5) cutAt = -1;
-
-    // Fall back to sentence end
-    if (cutAt === -1) {
-      const candidates = [". ", "! ", "? ", "\n"];
-      for (const sep of candidates) {
-        const idx = window.lastIndexOf(sep);
-        if (idx > limit * 0.5 && idx > cutAt) cutAt = idx + sep.length;
-      }
+    // Balance code fences across the cut: if the chunk has an odd number of
+    // ``` it ends inside an open fence — close it here and reopen on the next
+    // chunk so each bubble renders as valid markdown.
+    const fenceCount = chunk.match(/```/g)?.length ?? 0;
+    if (fenceCount % 2 === 1) {
+      chunk = `${chunk}\n\`\`\``;
+      next = `\`\`\`\n${next}`;
     }
 
-    // Fall back to last word boundary
-    if (cutAt === -1) {
-      const space = window.lastIndexOf(" ");
-      if (space > limit * 0.5) cutAt = space + 1;
-    }
-
-    // Hard cut as last resort
-    if (cutAt === -1) cutAt = limit;
-
-    chunks.push(remaining.slice(0, cutAt).trimEnd());
-    remaining = remaining.slice(cutAt).trimStart();
+    chunks.push(chunk);
+    remaining = next;
   }
 
   if (remaining.length > 0) chunks.push(remaining);

--- a/libs/shared/ts/src/bots/utils/streaming.ts
+++ b/libs/shared/ts/src/bots/utils/streaming.ts
@@ -142,6 +142,23 @@ async function _handleStream(
     }
   };
 
+  const deliverOverflowChunk = async (chunk: string): Promise<void> => {
+    if (sendNewMessage) {
+      currentEditor = await sendNewMessage(chunk);
+      sentText = chunk;
+    } else {
+      // Adapter cannot post additional bubbles — best-effort fallback that
+      // keeps the legacy truncation behaviour for this single bubble.
+      const overflow = truncateResponse(chunk, platform);
+      try {
+        await currentEditor(overflow);
+        sentText = overflow;
+      } catch {
+        // ignore
+      }
+    }
+  };
+
   /**
    * Final delivery: split ``text`` on any unprocessed ``<NEW_MESSAGE_BREAK>``
    * markers, chunk each segment to the platform character limit, and deliver
@@ -160,37 +177,21 @@ async function _handleStream(
       .filter(Boolean);
     if (segments.length === 0) return;
 
-    let isFirstOutput = true;
-    for (const segment of segments) {
-      const chunks = chunkResponse(segment, platform);
-      for (const chunk of chunks) {
-        if (isFirstOutput) {
-          isFirstOutput = false;
-          if (chunk === sentText) continue;
-          try {
-            await currentEditor(chunk);
-            sentText = chunk;
-          } catch {
-            // current bubble may have been deleted or expired
-          }
-          continue;
-        }
+    const allChunks = segments.flatMap((s) => chunkResponse(s, platform));
+    if (allChunks.length === 0) return;
 
-        if (sendNewMessage) {
-          currentEditor = await sendNewMessage(chunk);
-          sentText = chunk;
-        } else {
-          // Adapter cannot post additional bubbles — best-effort fallback that
-          // keeps the legacy truncation behaviour for this single bubble.
-          const overflow = truncateResponse(chunk, platform);
-          try {
-            await currentEditor(overflow);
-            sentText = overflow;
-          } catch {
-            // ignore
-          }
-        }
+    const [firstChunk, ...remainingChunks] = allChunks;
+    if (firstChunk !== sentText) {
+      try {
+        await currentEditor(firstChunk);
+        sentText = firstChunk;
+      } catch {
+        // current bubble may have been deleted or expired
       }
+    }
+
+    for (const chunk of remainingChunks) {
+      await deliverOverflowChunk(chunk);
     }
   };
 

--- a/libs/shared/ts/src/bots/utils/streaming.ts
+++ b/libs/shared/ts/src/bots/utils/streaming.ts
@@ -20,6 +20,10 @@
  */
 import type { Analytics } from "../../analytics";
 import { BOT_EVENTS } from "../../analytics/events/bots";
+import {
+  NEW_MESSAGE_BREAK_TOKEN,
+  NEW_MESSAGE_BREAK_TOKEN_LENGTH,
+} from "../../utils/messageBreakUtils";
 import type { GaiaClient } from "../api";
 import type { ChatRequest } from "../types";
 import { formatBotError } from "./formatters";
@@ -96,7 +100,7 @@ async function _handleStream(
 
   const updateDisplay = async (text: string) => {
     // Strip any unprocessed break tags before displaying
-    const cleaned = text.replaceAll("<NEW_MESSAGE_BREAK>", "").trim();
+    const cleaned = text.replaceAll(NEW_MESSAGE_BREAK_TOKEN, "").trim();
     if (!cleaned) return;
     const truncated = truncateResponse(cleaned, platform);
     if (truncated === sentText) return;
@@ -111,10 +115,12 @@ async function _handleStream(
   const handleNewMessageBreak = async () => {
     if (!sendNewMessage) return;
 
-    while (fullText.includes("<NEW_MESSAGE_BREAK>")) {
-      const breakIndex = fullText.indexOf("<NEW_MESSAGE_BREAK>");
+    while (fullText.includes(NEW_MESSAGE_BREAK_TOKEN)) {
+      const breakIndex = fullText.indexOf(NEW_MESSAGE_BREAK_TOKEN);
       const beforeBreak = fullText.slice(0, breakIndex).trim();
-      const afterBreak = fullText.slice(breakIndex + 19);
+      const afterBreak = fullText.slice(
+        breakIndex + NEW_MESSAGE_BREAK_TOKEN_LENGTH,
+      );
 
       if (beforeBreak && beforeBreak !== sentText) {
         await updateDisplay(beforeBreak);
@@ -128,11 +134,11 @@ async function _handleStream(
       }
 
       currentEditor = await sendNewMessage(
-        afterTrimmed.replaceAll("<NEW_MESSAGE_BREAK>", "").trim() || "...",
+        afterTrimmed.replaceAll(NEW_MESSAGE_BREAK_TOKEN, "").trim() || "...",
       );
       fullText = afterTrimmed;
       sentText =
-        afterTrimmed.replaceAll("<NEW_MESSAGE_BREAK>", "").trim() || "...";
+        afterTrimmed.replaceAll(NEW_MESSAGE_BREAK_TOKEN, "").trim() || "...";
     }
   };
 
@@ -149,7 +155,7 @@ async function _handleStream(
    */
   const finalizeDelivery = async (text: string): Promise<void> => {
     const segments = text
-      .split("<NEW_MESSAGE_BREAK>")
+      .split(NEW_MESSAGE_BREAK_TOKEN)
       .map((s) => s.trim())
       .filter(Boolean);
     if (segments.length === 0) return;
@@ -196,7 +202,7 @@ async function _handleStream(
 
         const now = Date.now();
         if (
-          fullText.includes("<NEW_MESSAGE_BREAK>") ||
+          fullText.includes(NEW_MESSAGE_BREAK_TOKEN) ||
           now - lastEditTime >= editIntervalMs
         ) {
           lastEditTime = now;

--- a/libs/shared/ts/src/bots/utils/streaming.ts
+++ b/libs/shared/ts/src/bots/utils/streaming.ts
@@ -23,7 +23,7 @@ import { BOT_EVENTS } from "../../analytics/events/bots";
 import type { GaiaClient } from "../api";
 import type { ChatRequest } from "../types";
 import { formatBotError } from "./formatters";
-import { truncateResponse } from "./index";
+import { chunkResponse, truncateResponse } from "./index";
 
 export interface StreamingOptions {
   editIntervalMs: number;
@@ -85,7 +85,6 @@ async function _handleStream(
   let streamDone = false;
   let currentEditor = editMessage;
   let sentText = "";
-  let breakHandledDuringStreaming = false;
 
   // Serialization queue to prevent concurrent Telegram API calls
   // which cause out-of-order message updates
@@ -125,7 +124,6 @@ async function _handleStream(
       if (!afterTrimmed) {
         // Break at end of text with nothing after — just update current segment
         fullText = "";
-        breakHandledDuringStreaming = true;
         return;
       }
 
@@ -135,7 +133,58 @@ async function _handleStream(
       fullText = afterTrimmed;
       sentText =
         afterTrimmed.replaceAll("<NEW_MESSAGE_BREAK>", "").trim() || "...";
-      breakHandledDuringStreaming = true;
+    }
+  };
+
+  /**
+   * Final delivery: split ``text`` on any unprocessed ``<NEW_MESSAGE_BREAK>``
+   * markers, chunk each segment to the platform character limit, and deliver
+   * the chunks in order — first chunk edits the current bubble, every
+   * subsequent chunk is posted via ``sendNewMessage`` as a new bubble. Falls
+   * back to truncation only when the adapter cannot send additional bubbles.
+   *
+   * Used at the end of the stream so the user always receives the full
+   * response across as many bubbles as it takes, instead of a single bubble
+   * with a ``... (truncated)`` suffix.
+   */
+  const finalizeDelivery = async (text: string): Promise<void> => {
+    const segments = text
+      .split("<NEW_MESSAGE_BREAK>")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (segments.length === 0) return;
+
+    let isFirstOutput = true;
+    for (const segment of segments) {
+      const chunks = chunkResponse(segment, platform);
+      for (const chunk of chunks) {
+        if (isFirstOutput) {
+          isFirstOutput = false;
+          if (chunk === sentText) continue;
+          try {
+            await currentEditor(chunk);
+            sentText = chunk;
+          } catch {
+            // current bubble may have been deleted or expired
+          }
+          continue;
+        }
+
+        if (sendNewMessage) {
+          currentEditor = await sendNewMessage(chunk);
+          sentText = chunk;
+        } else {
+          // Adapter cannot post additional bubbles — best-effort fallback that
+          // keeps the legacy truncation behaviour for this single bubble.
+          const overflow = truncateResponse(chunk, platform);
+          try {
+            await currentEditor(overflow);
+            sentText = overflow;
+          } catch {
+            // ignore
+          }
+        }
+      }
     }
   };
 
@@ -182,35 +231,17 @@ async function _handleStream(
         // Wait for any in-flight operations to finish before final update
         await opQueue;
 
-        if (streaming && breakHandledDuringStreaming) {
-          // Breaks were already processed during streaming — just do final update
-          // of the current (last) segment without re-splitting
-          await updateDisplay(fullText);
-        } else if (
-          sendNewMessage &&
-          finalText.includes("<NEW_MESSAGE_BREAK>")
-        ) {
-          // Handle NEW_MESSAGE_BREAK for non-streaming platforms (e.g. Discord)
+        // Non-streaming platforms (Discord, WhatsApp) haven't shown anything
+        // yet — adopt the full ``finalText``. Streaming platforms have been
+        // live-editing one bubble (and potentially split off prior bubbles
+        // via handleNewMessageBreak); ``fullText`` already holds the current
+        // segment, no reset needed.
+        if (!streaming) {
           fullText = finalText;
           sentText = "";
-          const parts = fullText
-            .split("<NEW_MESSAGE_BREAK>")
-            .map((p) => p.trim())
-            .filter(Boolean);
-          if (parts.length > 0) {
-            await updateDisplay(parts[0]);
-            for (let i = 1; i < parts.length; i++) {
-              currentEditor = await sendNewMessage(parts[i]);
-            }
-          }
-        } else {
-          // For streaming, don't reset sentText — avoid re-sending already displayed content
-          if (!streaming) {
-            fullText = finalText;
-            sentText = "";
-          }
-          await updateDisplay(fullText);
         }
+
+        await finalizeDelivery(fullText);
       },
       async (error) => {
         streamDone = true;

--- a/libs/shared/ts/src/utils/messageBreakUtils.ts
+++ b/libs/shared/ts/src/utils/messageBreakUtils.ts
@@ -3,18 +3,28 @@
  * Enables WhatsApp-style multiple bubble responses from a single message
  */
 
+/**
+ * The literal sentinel the LLM emits to signal "split into a new bubble here".
+ * Single source of truth — every consumer (bot streaming, frontend rendering,
+ * message persistence) should reference this constant rather than duplicating
+ * the string. Length is exposed separately as a small convenience for
+ * substring math.
+ */
+export const NEW_MESSAGE_BREAK_TOKEN = "<NEW_MESSAGE_BREAK>";
+export const NEW_MESSAGE_BREAK_TOKEN_LENGTH = NEW_MESSAGE_BREAK_TOKEN.length;
+
 export function splitMessageByBreaks(content: string): string[] {
   // Return empty array for empty/whitespace content
   if (!content?.trim()) {
     return [];
   }
 
-  if (!content.includes("<NEW_MESSAGE_BREAK>")) {
+  if (!content.includes(NEW_MESSAGE_BREAK_TOKEN)) {
     return [content];
   }
 
   return content
-    .split("<NEW_MESSAGE_BREAK>")
+    .split(NEW_MESSAGE_BREAK_TOKEN)
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
 }


### PR DESCRIPTION
GAIA-633

## Summary

Two bugs in the bot/comms path got fixed together because they manifest as the same symptom on WhatsApp ("ugly truncated reply that doesn't sound like GAIA").

### 1. `... (truncated)` on long messages
`truncateResponse` was clamping every reply to the platform limit and appending `... (truncated)`. WhatsApp users never saw the rest of long answers (markdown drafts, summaries, etc.).

Replaced with proper end-of-stream chunking:
- New `chunkResponse(text, platform)` helper splits long text into platform-sized chunks at paragraph → sentence → word boundaries (with a 50%-of-limit floor to avoid tiny fragments).
- Markdown-aware: cuts that would split `[label](url)` are rejected; chunks that would end with an unclosed ` ``` ` fence are auto-closed and the next chunk reopens the fence so each bubble is valid markdown.
- New `finalizeDelivery` collapses the previous three branchy onDone paths into one pipeline that splits on `<NEW_MESSAGE_BREAK>`, chunks each segment, and delivers via `currentEditor` (first chunk) + `sendNewMessage` (overflow). `truncateResponse` is now only used for in-flight edits during streaming and as a fallback when the adapter has no `sendNewMessage`.
- Dead `breakHandledDuringStreaming` flag removed.

### 2. Comms prompt's plain variant still pushed OpenUI
`get_comms_agent_prompt(source)` was only gating the appended OpenUI Lang reference. The embedded **"Rich UI Components (OpenUI) — CRITICAL"** section inside `COMMS_AGENT_PROMPT` was still telling the model to emit `:::openui` blocks for any structured data — even on WhatsApp/Telegram/Discord/Slack/email, where they render as broken text and contradict the per-platform context message.

Strip the embedded OpenUI block via marker-bracketing for plain platforms. GAIA's casual messaging voice now comes through cleanly on WhatsApp.

### 3. Cleanup
- Extracted `NEW_MESSAGE_BREAK_TOKEN` / `NEW_MESSAGE_BREAK_TOKEN_LENGTH` in `messageBreakUtils` and threaded them through `streaming.ts` — no more magic strings or the hardcoded `19` length offset.

## Test plan

- [ ] Send a >4096-char markdown answer to GAIA on WhatsApp → arrives across multiple bubbles, no `... (truncated)` suffix.
- [ ] Send a long answer that contains a fenced code block crossing the cut → both bubbles render as valid markdown (fence closed/reopened).
- [ ] Send a long answer with a markdown link near the cut boundary → link is intact in one bubble (cut walked back).
- [ ] Conversational WhatsApp reply ("hey what's up") → comes back in casual GAIA voice with no `:::openui` fences leaking.
- [ ] Discord/Slack/Telegram regression sanity: long replies still deliver in full; `<NEW_MESSAGE_BREAK>` still splits live during streaming on Slack/Telegram.
- [ ] Web/desktop/mobile: rich `:::openui` cards still render (no behavior change).