### PR TITLE
fix(api): invalidate tool_namespaces cache on integration status change

### DIFF
--- a/apps/api/app/agents/core/subagents/base_subagent.py
+++ b/apps/api/app/agents/core/subagents/base_subagent.py
@@ -31,6 +31,7 @@ from app.agents.tools.core.tool_runtime_config import (
 )
 from app.agents.tools.memory_tools import search_memory
 from app.agents.tools.finish_task_tool import finish_task
+from app.constants.general import FINISH_TASK_NAME
 from app.agents.tools.todo_tools import create_todo_pre_model_hook, create_todo_tools
 from app.agents.tools.vfs_tools import vfs_cmd, vfs_read
 from shared.py.wide_events import log
@@ -109,8 +110,8 @@ class SubAgentFactory:
         scoped_tool_dict[fetch_webpages.name] = fetch_webpages
         scoped_tool_dict[deep_research.name] = deep_research
 
-        scoped_tool_dict["finish_task"] = finish_task
-        initial_tool_ids.append("finish_task")
+        scoped_tool_dict[FINISH_TASK_NAME] = finish_task
+        initial_tool_ids.append(FINISH_TASK_NAME)
 
         # Get full tool dict so spawned sub-subagents (via spawn_subagent) inherit
         # all parent tools, not just the provider's scoped tools.

--- a/apps/api/app/agents/core/subagents/subagent_runner.py
+++ b/apps/api/app/agents/core/subagents/subagent_runner.py
@@ -25,6 +25,7 @@ from app.agents.core.subagents.subagent_helpers import (
 )
 from shared.py.wide_events import log
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.general import FINISH_TASK_NAME
 from app.core.lazy_loader import providers
 from app.core.stream_manager import stream_manager
 from app.helpers.agent_helpers import build_agent_config
@@ -255,6 +256,7 @@ async def execute_subagent_stream(
     """
     log.set(subagent={"name": ctx.agent_name, "provider": ctx.integration_id})
     complete_message = ""
+    finish_task_result: str | None = None
     emitted_tool_calls: set[str] = set()
 
     async for event in ctx.subagent_graph.astream(
@@ -298,17 +300,23 @@ async def execute_subagent_stream(
 
             # Emit tool_output when ToolMessage arrives
             elif chunk and isinstance(chunk, ToolMessage):
-                output = (
-                    chunk.content[:3000]
+                content_str = (
+                    chunk.content
                     if isinstance(chunk.content, str)
-                    else str(chunk.content)[:3000]
+                    else str(chunk.content)
                 )
+                # finish_task is the explicit "this is my final answer" tool —
+                # its content IS the message returned to the parent. The
+                # AIMessage that issued the call typically has empty content
+                # (tool-call-only response), so we capture the result here.
+                if chunk.name == FINISH_TASK_NAME:
+                    finish_task_result = content_str
                 if stream_writer:
                     stream_writer(
                         {
                             "tool_output": {
                                 "tool_call_id": chunk.tool_call_id,
-                                "output": output,
+                                "output": content_str[:3000],
                             }
                         }
                     )
@@ -318,7 +326,13 @@ async def execute_subagent_stream(
             if stream_writer:
                 stream_writer(payload)
 
-    final_message = complete_message if complete_message else "Task completed"
+    final_message = (
+        finish_task_result
+        if finish_task_result is not None
+        else complete_message
+        if complete_message
+        else "Task completed"
+    )
     log.set(
         subagent={
             "name": ctx.agent_name,
@@ -526,6 +540,7 @@ async def call_subagent(
     )
 
     complete_message = ""
+    finish_task_result: str | None = None
     emitted_tool_calls: set[str] = set()
 
     async for event in ctx.subagent_graph.astream(
@@ -567,19 +582,29 @@ async def call_subagent(
 
             # Emit tool_output when ToolMessage arrives
             elif chunk and isinstance(chunk, ToolMessage):
-                output = (
-                    chunk.content[:3000]
+                content_str = (
+                    chunk.content
                     if isinstance(chunk.content, str)
-                    else str(chunk.content)[:3000]
+                    else str(chunk.content)
                 )
-                yield f"data: {json.dumps({'tool_output': {'tool_call_id': chunk.tool_call_id, 'output': output}})}\n\n"
+                # finish_task content is the subagent's final response —
+                # capture it for the parent and surface it as a streamed
+                # response chunk so the user sees the same text the parent
+                # will receive.
+                if chunk.name == FINISH_TASK_NAME:
+                    finish_task_result = content_str
+                    yield f"data: {json.dumps({'response': content_str})}\n\n"
+                yield f"data: {json.dumps({'tool_output': {'tool_call_id': chunk.tool_call_id, 'output': content_str[:3000]}})}\n\n"
             continue
 
         if stream_mode == "custom":
             yield f"data: {json.dumps(payload)}\n\n"
 
+    final_message = (
+        finish_task_result if finish_task_result is not None else complete_message
+    )
     # Final message for DB storage
-    yield f"nostream: {json.dumps({'complete_message': complete_message})}"
+    yield f"nostream: {json.dumps({'complete_message': final_message})}"
     yield "data: [DONE]\n\n"
 
     log.set(

--- a/apps/api/app/agents/core/subagents/subagent_runner.py
+++ b/apps/api/app/agents/core/subagents/subagent_runner.py
@@ -611,9 +611,9 @@ async def call_subagent(
         subagent={
             "name": ctx.agent_name,
             "provider": ctx.integration_id,
-            "response_length": len(complete_message),
+            "response_length": len(final_message),
         }
     )
     log.info(
-        f"[DIRECT] Subagent '{ctx.agent_name}' completed. Response: {len(complete_message)} chars"
+        f"[DIRECT] Subagent '{ctx.agent_name}' completed. Response: {len(final_message)} chars"
     )

--- a/apps/api/app/agents/middleware/subagent.py
+++ b/apps/api/app/agents/middleware/subagent.py
@@ -17,6 +17,7 @@ from app.agents.prompts.spawn_subagent_prompts import (
 from app.agents.tools.core.retrieval import get_retrieve_tools_function
 from app.agents.tools.core.tool_runtime_config import ToolRuntimeConfig
 from shared.py.wide_events import log
+from app.constants.general import FINISH_TASK_NAME
 from app.constants.llm import SUBAGENT_RECURSION_LIMIT
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -255,7 +256,7 @@ class SubagentMiddleware(AgentMiddleware[SubagentState, Any]):
                 return str(response.content) if response.content else "Task completed."
 
             for tc in response.tool_calls:
-                if tc["name"] == "finish_task":
+                if tc["name"] == FINISH_TASK_NAME:
                     args = tc.get("args", {})
                     result = args.get("result")
                     if result is None:

--- a/apps/api/app/agents/tools/core/retrieval.py
+++ b/apps/api/app/agents/tools/core/retrieval.py
@@ -50,7 +50,8 @@ def _is_platform_tool_space(tool_space: str) -> bool:
     so one user cannot search another user's MCP tools.
     """
     return any(
-        integration.subagent_config is not None
+        integration.available is True
+        and integration.subagent_config is not None
         and integration.subagent_config.tool_space == tool_space
         for integration in OAUTH_INTEGRATIONS
     )
@@ -549,7 +550,12 @@ def get_retrieve_tools_function(
             unknown_tool_names: list[str] = []
             for tool_name in exact_tool_names:
                 if tool_name.startswith("subagent:"):
-                    # Only pass through subagent keys when subagents are enabled
+                    # Subagents are invoked via the `handoff` tool, not bound
+                    # here — the docstring tells the LLM this and select_tools
+                    # filters subagent:* out before binding. We accept the
+                    # key when subagents are enabled so it appears in the
+                    # response (purely informational); membership validation
+                    # happens at handoff time where it actually matters.
                     if include_subagents:
                         validated_tool_names.append(tool_name)
                     else:

--- a/apps/api/app/agents/tools/core/retrieval.py
+++ b/apps/api/app/agents/tools/core/retrieval.py
@@ -26,7 +26,6 @@ from app.agents.tools.research_tool import deep_research
 from app.agents.tools.webpage_tool import fetch_webpages, web_search_tool
 from app.config.oauth_config import OAUTH_INTEGRATIONS, get_integration_by_id
 from app.db.chroma.public_integrations_store import search_public_integrations
-from app.services.composio.composio_service import get_composio_service
 from app.services.integrations.integration_service import (
     get_user_available_tool_namespaces,
 )
@@ -38,86 +37,23 @@ from shared.py.wide_events import log
 WEBPAGE_TOOLS = [web_search_tool.name, fetch_webpages.name, deep_research.name]
 
 
-def _get_integration_for_space(tool_space: str):
-    for integration in OAUTH_INTEGRATIONS:
-        if (
-            integration.subagent_config
-            and integration.subagent_config.tool_space == tool_space
-        ):
-            return integration
-    return None
+def _is_platform_tool_space(tool_space: str) -> bool:
+    """True if `tool_space` belongs to a hardcoded platform integration.
 
+    Platform integrations (github, gmail, slack, ...) are defined in
+    OAUTH_INTEGRATIONS and have a fixed `subagent_config.tool_space`.
+    Their tool descriptions are not user-owned, so it is safe to search
+    them without checking that the caller's `user_namespaces` lists them.
 
-async def _maybe_hydrate_missing_tools(
-    *,
-    tool_registry,
-    tool_space: str,
-    results: list[Any],
-    available_tool_names: set[str],
-) -> tuple[set[str], int]:
-    if tool_space in {"general", "subagents"}:
-        return available_tool_names, 0
-
-    integration = _get_integration_for_space(tool_space)
-    if not integration or not integration.composio_config:
-        return available_tool_names, 0
-
-    missing: set[str] = set()
-    for result in results:
-        if not isinstance(result, list) or not result:
-            continue
-        if isinstance(result[0], dict):
-            continue
-        for item in result:
-            if not hasattr(item, "namespace"):
-                continue
-            if item.namespace != (tool_space,):
-                continue
-            tool_key = str(item.key)
-            if tool_key.startswith("subagent:"):
-                continue
-            if tool_key not in available_tool_names:
-                missing.add(tool_key)
-
-    if not missing:
-        return available_tool_names, 0
-
-    missing_list = list(missing)[:10]
-    try:
-        composio_service = get_composio_service()
-        tools = await composio_service.get_tools_by_name(missing_list)
-    except Exception as e:
-        log.warning(f"Lazy hydration failed for {tool_space}: {e}")
-        return available_tool_names, 0
-
-    if not tools:
-        return available_tool_names, 0
-
-    category_name = None
-    category = None
-    for name, cat in tool_registry._categories.items():
-        if cat.space == tool_space:
-            category_name = name
-            category = cat
-            break
-
-    if category is None:
-        try:
-            await tool_registry.register_provider_tools(
-                toolkit_name=integration.composio_config.toolkit,
-                space_name=tool_space,
-                specific_tools=missing_list,
-            )
-        except Exception as e:
-            log.warning(f"Lazy hydration registry load failed for {tool_space}: {e}")
-            return available_tool_names, 0
-    else:
-        category.add_tools(tools)
-        if category_name:
-            await tool_registry._index_category_tools(category_name)
-
-    refreshed = set(tool_registry.get_tool_names())
-    return refreshed, len(tools)
+    Custom MCPs and user-added integrations have dynamic, user-owned
+    namespaces (e.g. URL-derived). Those MUST stay gated by user_namespaces
+    so one user cannot search another user's MCP tools.
+    """
+    return any(
+        integration.subagent_config is not None
+        and integration.subagent_config.tool_space == tool_space
+        for integration in OAUTH_INTEGRATIONS
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +166,17 @@ async def _get_user_context(
     Returns:
         Tuple of (user_namespaces, connected_integrations, internal_subagents)
     """
-    user_namespaces: Set[str] = {tool_space, "general"}
+    # Seed namespaces:
+    # - "general" is always available (core tools).
+    # - tool_space is seeded ONLY when it belongs to a platform integration
+    #   (hardcoded in OAUTH_INTEGRATIONS). For custom MCPs / user-owned
+    #   integrations the namespace is user-scoped, so it must come from
+    #   user_namespaces and not be implicitly granted by the seed —
+    #   otherwise one user could search another user's MCP tools.
+    user_namespaces: Set[str] = {"general"}
+    if _is_platform_tool_space(tool_space):
+        user_namespaces.add(tool_space)
+
     connected_integrations: Set[str] = set()
     internal_subagents: Set[str] = set()
 
@@ -248,7 +194,10 @@ async def _get_user_context(
         return user_namespaces, connected_integrations, internal_subagents
 
     try:
-        user_namespaces = set(await get_user_available_tool_namespaces(user_id))
+        # Union (not assign) so platform seeds survive cache contents.
+        # Custom MCP namespaces only enter via the cache lookup, which is
+        # the user-scoped source of truth.
+        user_namespaces |= set(await get_user_available_tool_namespaces(user_id))
 
         if include_subagents:
             raw_connected = user_namespaces - {"general", "subagents"}
@@ -286,17 +235,34 @@ def _build_search_tasks(
     include_subagents: bool,
     limit: int,
 ) -> List[Awaitable[Union[List[SearchItem], List[dict[str, Any]]]]]:
-    """Build list of search tasks to execute."""
+    """Build list of search tasks to execute.
+
+    The `tool_space in user_namespaces` gate is the security boundary that
+    keeps a user from searching another user's custom MCP tools. We never
+    bypass it here — _get_user_context is responsible for ensuring
+    user_namespaces contains tool_space whenever the caller is entitled
+    to search it (always for platform integrations, only when the user
+    has the integration connected for custom MCPs).
+    """
     search_tasks: List[Awaitable[Union[List[SearchItem], List[dict[str, Any]]]]] = []
 
     # Search in tool_space
     if tool_space in user_namespaces or tool_space == "general":
         log.info(f"Adding search for tool_space: {tool_space}")
         search_tasks.append(store.asearch((tool_space,), query=query, limit=limit))
+    else:
+        # Caller is in a subagent whose namespace they don't own. This is
+        # unusual — usually it means a stale cache or a misrouted handoff.
+        # We refuse the search rather than leak another user's tool index.
+        log.warning(
+            "retrieve_tools refused search: tool_space not in user_namespaces",
+            tool_space=tool_space,
+            user_namespaces=sorted(user_namespaces),
+        )
 
-    # For subagents, also search 'general' namespace with small limit
-    # to discover core tools like webpage tools
-    if tool_space != "general" and "general" in user_namespaces:
+    # For subagents, also search 'general' namespace with a small limit
+    # so core tools (e.g. webpage tools) are still discoverable.
+    if tool_space != "general":
         log.info("Adding search for general namespace (limited to 5 for core tools)")
         search_tasks.append(store.asearch(("general",), query=query, limit=5))
 
@@ -578,14 +544,31 @@ def get_retrieve_tools_function(
 
         # BINDING MODE: Validate and bind exact tool names
         if exact_tool_names:
-            validated_tool_names = []
+            available_tool_names_set = set(available_tool_names)
+            validated_tool_names: list[str] = []
+            unknown_tool_names: list[str] = []
             for tool_name in exact_tool_names:
                 if tool_name.startswith("subagent:"):
                     # Only pass through subagent keys when subagents are enabled
                     if include_subagents:
                         validated_tool_names.append(tool_name)
-                elif tool_name in available_tool_names:
+                    else:
+                        unknown_tool_names.append(tool_name)
+                elif tool_name in available_tool_names_set:
                     validated_tool_names.append(tool_name)
+                else:
+                    unknown_tool_names.append(tool_name)
+
+            if unknown_tool_names:
+                # Surfacing this is important: silently dropping requested tools
+                # makes registry-population bugs invisible to operators.
+                log.warning(
+                    "retrieve_tools binding dropped unknown tools",
+                    tool_space=tool_space,
+                    unknown=unknown_tool_names,
+                    available_count=len(available_tool_names_set),
+                )
+
             log.set(
                 tool_retrieval=dict(
                     mode="binding",
@@ -615,12 +598,6 @@ def get_retrieve_tools_function(
         results = await asyncio.gather(*search_tasks, return_exceptions=True)
 
         available_tool_names_set = set(available_tool_names)
-        available_tool_names_set, hydrated_count = await _maybe_hydrate_missing_tools(
-            tool_registry=tool_registry,
-            tool_space=tool_space,
-            results=results,
-            available_tool_names=available_tool_names_set,
-        )
 
         chroma_hits = 0
         public_hits = 0

--- a/apps/api/app/agents/tools/core/tool_runtime_config.py
+++ b/apps/api/app/agents/tools/core/tool_runtime_config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from app.agents.tools.core.retrieval import get_retrieve_tools_function
+from app.constants.general import FINISH_TASK_NAME
 
 
 @dataclass(slots=True)
@@ -52,7 +53,7 @@ def build_provider_parent_tool_runtime_config(
         initial = [
             *provider_tool_names,
             *todo_tool_names,
-            "finish_task",
+            FINISH_TASK_NAME,
             "vfs_read",
             "vfs_cmd",
         ]
@@ -61,7 +62,7 @@ def build_provider_parent_tool_runtime_config(
             "search_memory",
             "vfs_read",
             "vfs_cmd",
-            "finish_task",
+            FINISH_TASK_NAME,
             *todo_tool_names,
         ]
         if auto_bind_tool_names and not disable_retrieve_tools:
@@ -88,7 +89,7 @@ def build_child_tool_runtime_config(
             include_subagents_in_retrieve=False,
         )
     return ToolRuntimeConfig(
-        initial_tool_names=["vfs_read", "vfs_cmd", "finish_task"],
+        initial_tool_names=["vfs_read", "vfs_cmd", FINISH_TASK_NAME],
         enable_retrieve_tools=not disable_retrieve_tools,
         include_subagents_in_retrieve=False,
     )
@@ -97,7 +98,7 @@ def build_child_tool_runtime_config(
 def build_executor_child_tool_runtime_config() -> ToolRuntimeConfig:
     """Build child tool runtime config for executor-spawned subagents."""
     return ToolRuntimeConfig(
-        initial_tool_names=["vfs_read", "vfs_cmd", "finish_task"],
+        initial_tool_names=["vfs_read", "vfs_cmd", FINISH_TASK_NAME],
         enable_retrieve_tools=True,
         include_subagents_in_retrieve=False,
     )

--- a/apps/api/app/agents/tools/finish_task_tool.py
+++ b/apps/api/app/agents/tools/finish_task_tool.py
@@ -1,8 +1,24 @@
-"""Finish task tool for subagent completion."""
+"""Finish task tool for subagent completion.
+
+The tool name MUST match `FINISH_TASK_NAME` in `app.constants.general` —
+the bigtool router and subagent runner key off that constant.
+"""
 
 from langchain_core.tools import tool
+
+from app.constants.general import FINISH_TASK_NAME
 
 
 @tool(description="Finish the task and return the final result to the parent.")
 async def finish_task(result: str) -> str:
     return result
+
+
+# Hard guarantee at import time that the decorated tool's name still
+# matches the routing constant. If someone renames the function without
+# updating FINISH_TASK_NAME, this fires immediately instead of silently
+# breaking the finish_task → END short-circuit.
+assert finish_task.name == FINISH_TASK_NAME, (
+    f"finish_task tool name mismatch: tool exposes {finish_task.name!r} but "
+    f"FINISH_TASK_NAME is {FINISH_TASK_NAME!r}"
+)

--- a/apps/api/app/constants/general.py
+++ b/apps/api/app/constants/general.py
@@ -7,6 +7,12 @@ Centralized general-purpose constants.
 ORCHESTRATOR_MAX_ITERATIONS = 10
 NEW_MESSAGE_BREAKER = "<NEW_MESSAGE_BREAK>"
 
+# Name of the explicit "this is my final answer" tool subagents call to
+# return a result to their parent. Routing logic in the bigtool override
+# and the subagent runner both key off this — keep them in sync via this
+# single constant.
+FINISH_TASK_NAME = "finish_task"
+
 MAX_EMAILS_PER_PLATFORM = 20
 DEDUPLICATION_SIMILARITY_THRESHOLD = 0.9
 PROFILE_EXTRACTION_LLM_PROVIDER = "gemini"

--- a/apps/api/app/db/chroma/chroma_tools_store.py
+++ b/apps/api/app/db/chroma/chroma_tools_store.py
@@ -220,7 +220,6 @@ def _build_put_operations(
         else:
             # Subagent tool
             description = tool_data["description"]
-        print("composio tool description", description)
         put_ops.append(
             PutOp(
                 namespace=(tool_data["namespace"],),

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -42,7 +42,7 @@ from langgraph.utils.runnable import RunnableCallable
 from langgraph_bigtool.tools import get_default_retrieval_tool, get_store_arg
 
 from app.agents.middleware.executor import MiddlewareExecutor
-from app.constants.general import NEW_MESSAGE_BREAKER
+from app.constants.general import FINISH_TASK_NAME, NEW_MESSAGE_BREAKER
 from app.override.langgraph_bigtool.dynamic_tool_node import DynamicToolNode
 from app.override.langgraph_bigtool.hooks import (
     HookType,
@@ -59,7 +59,6 @@ from app.override.langgraph_bigtool.utils import (
 from shared.py.wide_events import log
 
 RetrieveToolsResponse = RetrieveToolsResult | list[str]
-_FINISH_TASK_NAME = "finish_task"
 
 
 def create_agent(
@@ -419,10 +418,10 @@ def create_agent(
             finish_calls: list[ToolCall] = [
                 call
                 for call in last_message.tool_calls
-                if call.get("name") == _FINISH_TASK_NAME
+                if call.get("name") == FINISH_TASK_NAME
             ]
             if finish_calls:
-                return Send("finish_task", finish_calls)
+                return Send(FINISH_TASK_NAME, finish_calls)
 
             for call in last_message.tool_calls:
                 if retrieve_tools is not None and call["name"] == retrieve_tools.name:
@@ -460,7 +459,7 @@ def create_agent(
                 ToolMessage(
                     content=content,
                     tool_call_id=call.get("id", ""),
-                    name=_FINISH_TASK_NAME,
+                    name=FINISH_TASK_NAME,
                 )
             )
         return {"messages": messages}  # type: ignore[return-value]
@@ -497,7 +496,7 @@ def create_agent(
         builder.add_node("select_tools", select_tools_node)  # type: ignore[possibly-undefined]
     builder.add_node("tools", tool_node)
     builder.add_node(
-        "finish_task",
+        FINISH_TASK_NAME,
         RunnableCallable(finish_task_node, afinish_task_node),
     )
     builder.add_node(
@@ -505,7 +504,7 @@ def create_agent(
         RunnableCallable(reject_unbound_tools, areject_unbound_tools),
     )
 
-    path_map = ["tools", "finish_task", "reject_unbound_tools", END]
+    path_map = ["tools", FINISH_TASK_NAME, "reject_unbound_tools", END]
     if not disable_retrieve_tools:
         path_map.insert(0, "select_tools")
     if end_graph_hooks:
@@ -526,7 +525,7 @@ def create_agent(
 
     builder.add_edge("tools", "agent")
     builder.add_edge(
-        "finish_task",
+        FINISH_TASK_NAME,
         "end_graph_hooks" if end_graph_hooks else END,
     )
     builder.add_edge("reject_unbound_tools", "agent")

--- a/apps/api/app/services/integrations/user_integration_status.py
+++ b/apps/api/app/services/integrations/user_integration_status.py
@@ -13,7 +13,9 @@ from app.db.mongodb.collections import user_integrations_collection
 from app.decorators.caching import CacheInvalidator
 
 
-@CacheInvalidator(key_patterns=["tools:user:{user_id}:*"])
+@CacheInvalidator(
+    key_patterns=["tools:user:{user_id}:*", "tool_namespaces:{user_id}"]
+)
 async def update_user_integration_status(
     user_id: str,
     integration_id: str,

--- a/apps/api/app/services/oauth/oauth_service.py
+++ b/apps/api/app/services/oauth/oauth_service.py
@@ -362,14 +362,9 @@ async def handle_oauth_connection(
     except Exception as e:
         log.warning(f"Failed to invalidate OAuth status cache: {e}")
 
-    # Invalidate tool namespace cache so retrieval uses fresh integration status
-    try:
-        await delete_cache(f"tool_namespaces:{user_id}")
-        log.info(f"Tool namespaces cache invalidated for user {user_id}")
-    except Exception as e:
-        log.warning(f"Failed to invalidate tool namespaces cache: {e}")
-
     # Update user_integrations status in MongoDB
+    # The @CacheInvalidator on update_user_integration_status invalidates
+    # `tools:user:{user_id}:*` and `tool_namespaces:{user_id}` automatically.
     try:
         await update_user_integration_status(
             user_id, integration_config.id, INTEGRATION_STATUS_CONNECTED


### PR DESCRIPTION
## Summary

PR #646 worked around a stale `tool_namespaces:{user_id}` cache by adding ad-hoc invalidation in `oauth_service.py`, a lazy-hydration band-aid in `retrieve_tools`, and left a debug `print` in `chroma_tools_store.py`. The actual root cause was that `update_user_integration_status` only invalidated `tools:user:*`, not `tool_namespaces:{user_id}` — so any state change going through it (OAuth connect, MCP token refresh, disconnect) left retrieval blind to the user's new integrations for up to 24h.

This PR fixes it at the source by adding `tool_namespaces:{user_id}` to that function's `@CacheInvalidator`, then removes the workarounds. It also hardens `retrieve_tools` without weakening the security boundary that protects user-owned MCPs:

- `_get_user_context` seeds `tool_space` into `user_namespaces` only for hardcoded platform integrations (`OAUTH_INTEGRATIONS`); custom MCP namespaces stay gated by the cache lookup so one user cannot search another user's tool index.
- Cache contents are unioned (not assigned) into `user_namespaces` so a stale cache cannot drop the platform seed.
- Binding mode now logs a warning when it silently drops unknown tool names, and search refusals for non-owned namespaces are logged — both previously silent failures.

## Test plan

- [ ] Wipe `tool_namespaces:<user_id>` in Redis, send a chat message (populates cache without GitHub), connect GitHub, send "list my GitHub repos" — should succeed without restarting or waiting for TTL.
- [ ] Repeat with a poisoned cache (`SET tool_namespaces:<user_id> '["general","subagents"]'`) and confirm the platform seed still routes the GitHub search.
- [ ] Confirm a custom MCP belonging to user A is not searchable from user B (look for `retrieve_tools refused search: tool_space not in user_namespaces`).
- [ ] `nx lint api` and `nx type-check api`.