### PR TITLE
refactor(api): address remaining PR #661 review comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ api/.env
 .DS_Store
 
 venv/
-.venv
 .venv/
 .venv311/
 

--- a/apps/api/app/agents/core/subagents/base_subagent.py
+++ b/apps/api/app/agents/core/subagents/base_subagent.py
@@ -14,7 +14,7 @@ Both are stored in separate mem0 namespaces and don't interfere.
 """
 
 import asyncio
-from typing import Any, cast
+from typing import cast
 
 from app.agents.core.graph_builder.checkpointer_manager import get_checkpointer_manager
 from app.agents.core.nodes import (
@@ -39,6 +39,7 @@ from app.override.langgraph_bigtool.hooks import HookType
 from langchain_core.language_models import LanguageModelLike
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph.state import CompiledStateGraph
 
 
 class SubAgentFactory:
@@ -54,7 +55,7 @@ class SubAgentFactory:
         disable_retrieve_tools: bool = False,
         auto_bind_tools: list[str] | None = None,
         include_finish_task: bool = True,
-    ) -> Any:
+    ) -> CompiledStateGraph:
         """
         Creates a specialized sub-agent graph for a specific provider with tool registry.
 

--- a/apps/api/app/agents/core/subagents/provider_subagents.py
+++ b/apps/api/app/agents/core/subagents/provider_subagents.py
@@ -11,7 +11,7 @@ Tools are registered on-demand when subagent is first created.
 """
 
 import asyncio
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from app.agents.core.subagents.registry import all_subagents, get_subagent_by_id
 from app.agents.llm.client import init_llm
@@ -22,12 +22,13 @@ from app.db.mongodb.collections import integrations_collection
 from app.helpers.namespace_utils import derive_integration_namespace
 from app.models.subagent_models import Subagent
 from app.services.mcp.mcp_client import get_mcp_client
+from langgraph.graph.state import CompiledStateGraph
 from shared.py.wide_events import log
 
 from .base_subagent import SubAgentFactory
 
 
-async def create_subagent(subagent: Subagent) -> Any:
+async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
     """
     Create a provider subagent graph on-demand.
     Registers provider tools to registry if not already present.
@@ -108,7 +109,9 @@ async def create_subagent(subagent: Subagent) -> Any:
     return graph
 
 
-async def create_subagent_for_user(integration_id: str, user_id: str) -> Any:
+async def create_subagent_for_user(
+    integration_id: str, user_id: str
+) -> CompiledStateGraph | None:
     """
     Create a subagent for auth-required MCP integrations with user-specific tokens.
 
@@ -196,7 +199,9 @@ async def create_subagent_for_user(integration_id: str, user_id: str) -> Any:
     return graph
 
 
-async def _create_custom_mcp_subagent(integration_id: str, user_id: str) -> Any:
+async def _create_custom_mcp_subagent(
+    integration_id: str, user_id: str
+) -> CompiledStateGraph | None:
     """
     Create a subagent graph for a custom MCP integration from MongoDB.
 
@@ -305,6 +310,17 @@ async def _create_custom_mcp_subagent(integration_id: str, user_id: str) -> Any:
     return graph
 
 
+def _make_subagent_loader(
+    subagent: Subagent,
+) -> Callable[[], Awaitable[CompiledStateGraph]]:
+    """Bind the subagent into a zero-arg async loader for `providers.register`."""
+
+    async def _loader() -> CompiledStateGraph:
+        return await create_subagent(subagent)
+
+    return _loader
+
+
 def register_subagent_providers(integration_ids: Optional[list[str]] = None) -> int:
     """
     Register lazy providers for all subagents (OAuth-derived + builtins).
@@ -342,12 +358,12 @@ def register_subagent_providers(integration_ids: Optional[list[str]] = None) -> 
 
         agent_name = subagent.config.agent_name
 
-        async def create_agent_closure(sa: Subagent = subagent) -> Any:
-            return await create_subagent(sa)
-
+        # mypy can't solve TypeVar T on the Union loader signature
+        # against a concrete async function; cast keeps the loader's
+        # actual return type while satisfying the registry overload.
         providers.register(
             name=agent_name,
-            loader_func=create_agent_closure,
+            loader_func=_make_subagent_loader(subagent),  # type: ignore[arg-type]
             required_keys=[],
         )
         registered_count += 1

--- a/apps/api/app/agents/core/subagents/subagent_runner.py
+++ b/apps/api/app/agents/core/subagents/subagent_runner.py
@@ -39,6 +39,20 @@ from langchain_core.messages import (
 )
 
 
+def _capture_finish_task_content(chunk: ToolMessage, current_message: str) -> str:
+    """Return the finish_task chunk's textual content if applicable.
+
+    `finish_task` (when used by a subagent) carries the final answer in its
+    return value. Capture it as the complete message so the parent handoff
+    returns the actual content rather than the literal "Task completed"
+    fallback. Subagents with include_finish_task=False terminate via a
+    normal AIMessage and never enter this branch.
+    """
+    if chunk.name == "finish_task" and isinstance(chunk.content, str):
+        return chunk.content
+    return current_message
+
+
 class SubagentExecutionContext:
     """Container for all data needed to execute a subagent."""
 
@@ -281,14 +295,7 @@ async def execute_subagent_stream(
                     if isinstance(chunk.content, str)
                     else str(chunk.content)[:3000]
                 )
-                # `finish_task` (when used by a subagent) carries the final
-                # answer in its return value. Capture it as complete_message
-                # so the parent handoff returns the actual content rather
-                # than the literal "Task completed" fallback below.
-                # Subagents with include_finish_task=False terminate via a
-                # normal AIMessage and never enter this branch.
-                if chunk.name == "finish_task" and isinstance(chunk.content, str):
-                    complete_message = chunk.content
+                complete_message = _capture_finish_task_content(chunk, complete_message)
                 if stream_writer:
                     stream_writer(
                         {
@@ -557,10 +564,7 @@ async def call_subagent(
                     if isinstance(chunk.content, str)
                     else str(chunk.content)[:3000]
                 )
-                # `finish_task` carries the final answer in its return value
-                # (see execute_subagent_stream for the full rationale).
-                if chunk.name == "finish_task" and isinstance(chunk.content, str):
-                    complete_message = chunk.content
+                complete_message = _capture_finish_task_content(chunk, complete_message)
                 yield f"data: {json.dumps({'tool_output': {'tool_call_id': chunk.tool_call_id, 'output': output}})}\n\n"
             continue
 

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -336,9 +336,9 @@ USE call_executor:
   supports, how it works, pricing, integrations, comparisons, troubleshooting,
   onboarding, account/billing, anything ABOUT GAIA itself):
   User: "what's GAIA?" / "what can you do?" / "what integrations do you support?"
-  → call_executor("User is asking about GAIA the product. Hand off to subagent:gaia_knowledge_guide so it can fetch GAIA's docs and answer accurately. Original question: <user's exact question>.")
-  Why: never answer GAIA-product questions from your own knowledge — always
-  route to gaia_knowledge_guide so the answer is grounded in current docs.
+  → call_executor("User is asking about GAIA the product. Original question: <user's exact question>.")
+  Why: never answer GAIA-product questions from your own knowledge — the
+  executor will ground the answer in current GAIA docs.
 
 DO NOT use call_executor (just respond directly):
 

--- a/apps/api/app/models/oauth_models.py
+++ b/apps/api/app/models/oauth_models.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from app.models.mcp_config import (
     ComposioConfig,
@@ -59,6 +59,24 @@ class OAuthIntegration(BaseModel):
     subagent_config: Optional[SubAgentConfig] = None
     metadata_config: Optional[ProviderMetadataConfig] = None
     content: Optional[IntegrationContent] = None
+
+    @model_validator(mode="after")
+    def _enforce_composio_invariant(self) -> "OAuthIntegration":
+        # `provider_subagents.py` selects the Composio branch using
+        # `managed_by == "composio"` and then expects `composio_config` to
+        # be present. Pin the bidirectional invariant so a future config
+        # entry can't silently skip Composio tool registration.
+        if self.composio_config is not None and self.managed_by != "composio":
+            raise ValueError(
+                f"Integration {self.id!r} sets composio_config but "
+                f"managed_by={self.managed_by!r}; expected 'composio'."
+            )
+        if self.managed_by == "composio" and self.composio_config is None:
+            raise ValueError(
+                f"Integration {self.id!r} has managed_by='composio' but "
+                f"no composio_config."
+            )
+        return self
 
 
 class IntegrationConfigResponse(BaseModel):

--- a/apps/api/tests/unit/agents/test_builtin_subagents.py
+++ b/apps/api/tests/unit/agents/test_builtin_subagents.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.agents.core.subagents.builtin_subagents import BUILTIN_SUBAGENTS
 from app.agents.prompts.subagent_prompts import GAIA_AGENT_SYSTEM_PROMPT
+from app.config.oauth_config import OAUTH_INTEGRATIONS
 from app.models.subagent_models import Subagent
 
 
@@ -48,6 +49,28 @@ class TestBuiltinSubagentsTuple:
         providers = [entry.provider for entry in BUILTIN_SUBAGENTS]
         assert len(providers) == len(set(providers)), (
             f"Duplicate providers in BUILTIN_SUBAGENTS: {providers}"
+        )
+
+    def test_providers_do_not_collide_with_oauth(self) -> None:
+        # The registry merges OAuth-derived subagents with builtins and
+        # de-duplicates by provider. A collision would silently shadow an
+        # OAuth integration's subagent with a builtin (or vice versa).
+        builtin_providers = {entry.provider for entry in BUILTIN_SUBAGENTS}
+        oauth_providers = {integ.provider for integ in OAUTH_INTEGRATIONS}
+        overlap = builtin_providers & oauth_providers
+        assert not overlap, (
+            f"Builtin providers collide with OAUTH_INTEGRATIONS providers: "
+            f"{sorted(overlap)}"
+        )
+
+    def test_ids_do_not_collide_with_oauth(self) -> None:
+        # Same rationale as providers — id collisions would let one entry
+        # silently shadow another in `get_subagent_by_id`.
+        builtin_ids = {entry.id for entry in BUILTIN_SUBAGENTS}
+        oauth_ids = {integ.id for integ in OAUTH_INTEGRATIONS}
+        overlap = builtin_ids & oauth_ids
+        assert not overlap, (
+            f"Builtin ids collide with OAUTH_INTEGRATIONS ids: {sorted(overlap)}"
         )
 
 

--- a/apps/api/tests/unit/agents/test_subagent_registry.py
+++ b/apps/api/tests/unit/agents/test_subagent_registry.py
@@ -16,7 +16,7 @@ from app.agents.core.subagents.registry import (
     all_subagents,
     get_subagent_by_id,
 )
-from app.models.mcp_config import MCPConfig, SubAgentConfig
+from app.models.mcp_config import ComposioConfig, MCPConfig, SubAgentConfig
 from app.models.oauth_models import OAuthIntegration
 from app.models.subagent_models import Subagent
 
@@ -64,6 +64,10 @@ def _make_real_oauth_integration(
         scopes=[],
         short_name=short_name,
         managed_by="composio",
+        composio_config=ComposioConfig(
+            auth_config_id=f"auth_{integration_id}",
+            toolkit=integration_id,
+        ),
         subagent_config=(
             _make_subagent_config(integration_id, agent_name) if has_subagent else None
         ),


### PR DESCRIPTION
## Summary

Addresses the remaining PR #661 review feedback on top of the GAIA self-knowledge subagent branch:

- Adds an `OAuthIntegration` model validator pinning the `composio_config` ↔ `managed_by="composio"` invariant so future configs can't silently skip Composio tool registration; extracts duplicated `finish_task` chunk capture into a single helper; replaces `Any` return annotations on the subagent factory functions with `CompiledStateGraph`; refactors the loop closure into `_make_subagent_loader` for a clean zero-arg loader signature.
- Simplifies the COMMS_AGENT GAIA-product example so it no longer duplicates the executor's `gaia_knowledge_guide` routing, adds non-collision assertions between `BUILTIN_SUBAGENTS` and `OAUTH_INTEGRATIONS` providers/ids, drops the redundant standalone `.venv` entry in `.gitignore`, and updates the registry test fixture to satisfy the new Composio invariant.

## Test plan

- [x] `mypy app` clean across 571 source files
- [x] `ruff check` / `ruff format --check` clean on all changed files
- [x] `pytest tests/unit/agents/test_builtin_subagents.py` — 16 passed (incl. 2 new collision tests)
- [x] `pytest tests/unit/agents/test_subagent_registry.py` — clean