### PR TITLE
feat(api): add ToolkitManifest dependency graph for subagent tool awareness

### DIFF
--- a/apps/api/app/agents/core/subagents/subagent_helpers.py
+++ b/apps/api/app/agents/core/subagents/subagent_helpers.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from app.agents.prompts.custom_mcp_prompts import CUSTOM_MCP_SUBAGENT_PROMPT
 from app.agents.skills.discovery import get_available_skills_text
+from app.agents.tools.core.toolkit_manifest import toolkit_manifest_registry
 from shared.py.wide_events import log
 from app.config.oauth_config import get_integration_by_id
 from app.services.memory_service import memory_service
@@ -86,6 +87,10 @@ async def build_subagent_system_prompt(
                     )
         except Exception as e:
             log.warning(f"Failed to inject provider metadata: {e}")
+
+    manifest_text = toolkit_manifest_registry.format_by_integration_id(integration_id)
+    if manifest_text:
+        system_prompt = system_prompt + "\n\n" + manifest_text
 
     return system_prompt
 

--- a/apps/api/app/agents/tools/core/toolkit_manifest.py
+++ b/apps/api/app/agents/tools/core/toolkit_manifest.py
@@ -128,12 +128,13 @@ def _format_manifest(manifest: ToolkitManifest) -> str:
         lines.append("")
 
     if manifest.workflows:
-        lines.append("**Dependency chains:**")
-        for i, wf in enumerate(manifest.workflows, 1):
-            chain = " → ".join(wf.steps)
-            lines.append(f"  {i}. {wf.goal}: {chain}")
+        lines.append("**Workflows:**")
+        for wf in manifest.workflows:
+            lines.append(f"  {wf.goal}:")
+            for step in wf.steps:
+                lines.append(f"    {step}")
             if wf.note:
-                lines.append(f"     ({wf.note})")
-        lines.append("")
+                lines.append(f"    Note: {wf.note}")
+            lines.append("")
 
     return "\n".join(lines)

--- a/apps/api/app/agents/tools/core/toolkit_manifest.py
+++ b/apps/api/app/agents/tools/core/toolkit_manifest.py
@@ -1,0 +1,139 @@
+"""
+Toolkit manifests for Composio integration tools.
+
+Each manifest captures the full dependency graph for a toolkit's custom tools:
+  - Output fields: what keys the tool returns (undocumented in the tool itself)
+  - Dependencies: which tools must run first to supply required inputs
+  - Workflows: recommended call sequences for common tasks
+
+Manifests are registered by CustomToolsRegistry.initialize() and consumed by
+build_subagent_system_prompt() to inject structured tool context into each
+subagent's system prompt — replacing fuzzy ChromaDB guessing with an explicit
+dependency graph the agent can follow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ToolOutputField:
+    """A single key in a tool's return dict."""
+
+    name: str
+    type: str
+    description: str
+
+
+@dataclass
+class ToolManifestEntry:
+    """Complete dependency metadata for one custom tool in a toolkit."""
+
+    description: str
+    outputs: list[ToolOutputField]
+    depends_on: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ToolWorkflow:
+    """A recommended call sequence for a common user-facing goal."""
+
+    goal: str
+    steps: list[str]
+    note: str = ""
+
+
+@dataclass
+class ToolkitManifest:
+    """
+    Dependency graph for all custom tools in one integration toolkit.
+
+    The toolkit name must match the key used in CustomToolsRegistry
+    (e.g., 'linear', 'googlecalendar', 'gmail', 'microsoft_teams').
+    """
+
+    toolkit: str
+    tools: dict[str, ToolManifestEntry]
+    workflows: list[ToolWorkflow] = field(default_factory=list)
+
+
+# Maps integration_id (used in subagent routing / oauth_config) to the
+# toolkit name stored in this registry.  Only entries that differ are listed.
+_INTEGRATION_TO_TOOLKIT: dict[str, str] = {
+    "calendar": "googlecalendar",
+    "google_tasks": "googletasks",
+    "google_docs": "googledocs",
+    "google_sheets": "googlesheets",
+    "google_maps": "google_maps",
+    "google_meet": "googlemeet",
+    "teams": "microsoft_teams",
+}
+
+
+class ToolkitManifestRegistry:
+    """Registry mapping toolkit names → ToolkitManifest instances."""
+
+    def __init__(self) -> None:
+        self._manifests: dict[str, ToolkitManifest] = {}
+
+    def register(self, manifest: ToolkitManifest) -> None:
+        self._manifests[manifest.toolkit.lower()] = manifest
+
+    def get(self, toolkit: str) -> ToolkitManifest | None:
+        return self._manifests.get(toolkit.lower())
+
+    def get_by_integration_id(self, integration_id: str) -> ToolkitManifest | None:
+        """Look up manifest by subagent integration_id, handling name mismatches."""
+        toolkit = _INTEGRATION_TO_TOOLKIT.get(
+            integration_id.lower(), integration_id.lower()
+        )
+        return self._manifests.get(toolkit)
+
+    def format_for_prompt(self, toolkit: str) -> str:
+        """Formatted dependency graph for injection into a system prompt."""
+        manifest = self.get(toolkit)
+        if not manifest:
+            return ""
+        return _format_manifest(manifest)
+
+    def format_by_integration_id(self, integration_id: str) -> str:
+        """format_for_prompt variant that accepts a subagent integration_id."""
+        manifest = self.get_by_integration_id(integration_id)
+        if not manifest:
+            return ""
+        return _format_manifest(manifest)
+
+
+toolkit_manifest_registry = ToolkitManifestRegistry()
+
+
+def _format_manifest(manifest: ToolkitManifest) -> str:
+    lines: list[str] = [
+        f"## {manifest.toolkit.upper()} — CUSTOM TOOL REFERENCE\n",
+        "Call these tools directly in dependency order."
+        " Do not rely on ChromaDB retrieval for this toolkit.\n",
+    ]
+
+    for tool_name, entry in manifest.tools.items():
+        tag_str = f"  [{', '.join(entry.tags)}]" if entry.tags else ""
+        lines.append(f"**{tool_name}**{tag_str}")
+        lines.append(f"  {entry.description}")
+        if entry.depends_on:
+            lines.append(f"  ⚠ Requires first: {', '.join(entry.depends_on)}")
+        if entry.outputs:
+            out_str = ", ".join(f"{o.name} ({o.type})" for o in entry.outputs)
+            lines.append(f"  Returns: {out_str}")
+        lines.append("")
+
+    if manifest.workflows:
+        lines.append("**Dependency chains:**")
+        for i, wf in enumerate(manifest.workflows, 1):
+            chain = " → ".join(wf.steps)
+            lines.append(f"  {i}. {wf.goal}: {chain}")
+            if wf.note:
+                lines.append(f"     ({wf.note})")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/apps/api/app/agents/tools/integrations/airtable_tool.py
+++ b/apps/api/app/agents/tools/integrations/airtable_tool.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List
 from composio import Composio
 
 from shared.py.wide_events import log
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -57,3 +62,17 @@ def register_airtable_custom_tools(composio: Composio) -> List[str]:
         return {"bases": bases, "base_count": len(bases_raw)}
 
     return ["AIRTABLE_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="airtable",
+    tools={
+        "AIRTABLE_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Airtable bases (workspaces) and their tables.",
+            outputs=[
+                ToolOutputField("bases", "list[dict]", "Up to 3 bases, each with id, name, and tables list (id, name per table)"),
+                ToolOutputField("base_count", "int", "Total number of bases in the account"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/asana_tool.py
+++ b/apps/api/app/agents/tools/integrations/asana_tool.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List
 
 from composio import Composio
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -37,3 +42,17 @@ def register_asana_custom_tools(composio: Composio) -> List[str]:
         return {"tasks": tasks, "overdue_tasks": overdue}
 
     return ["ASANA_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="asana",
+    tools={
+        "ASANA_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of assigned open Asana tasks across workspaces.",
+            outputs=[
+                ToolOutputField("tasks", "list[dict]", "Assigned open tasks with gid, name, due_on, completed fields"),
+                ToolOutputField("overdue_tasks", "list[dict]", "Subset of tasks where due_on is earlier than today"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/calendar_tool.py
+++ b/apps/api/app/agents/tools/integrations/calendar_tool.py
@@ -13,6 +13,13 @@ import zoneinfo
 from datetime import date, datetime, timedelta, timezone, tzinfo
 from typing import Any, Dict, List
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
+
 import httpx
 from shared.py.wide_events import log
 from app.decorators import with_doc
@@ -791,3 +798,110 @@ def register_calendar_custom_tools(composio: Composio) -> List[str]:
         "GOOGLECALENDAR_CUSTOM_ADD_RECURRENCE",
         "GOOGLECALENDAR_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="googlecalendar",
+    tools={
+        "GOOGLECALENDAR_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Get today's event summary — date, timezone, events, next_event, busy_hours. Call at conversation start.",
+            outputs=[
+                ToolOutputField("date", "str", "Today's date in YYYY-MM-DD"),
+                ToolOutputField("timezone", "str", "User's timezone string"),
+                ToolOutputField("events", "list[dict]", "Today's events with id, summary, start, end, location, attendees"),
+                ToolOutputField("next_event", "dict | None", "Nearest upcoming event"),
+                ToolOutputField("busy_hours", "list", "Busy time ranges for today"),
+            ],
+            tags=["context"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_LIST_CALENDARS": ToolManifestEntry(
+            description="List all calendars the user has access to. Use calendar_id values for FETCH_EVENTS.",
+            outputs=[
+                ToolOutputField("calendars", "list[dict]", "id, summary, primary, accessRole for each calendar"),
+            ],
+            tags=["read"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_GET_DAY_SUMMARY": ToolManifestEntry(
+            description="Get events for a specific date (defaults to today).",
+            outputs=[
+                ToolOutputField("date", "str", "Requested date"),
+                ToolOutputField("timezone", "str", "User's timezone"),
+                ToolOutputField("events", "list[dict]", "Events with id, summary, start, end"),
+                ToolOutputField("next_event", "dict | None", "Next upcoming event on that date"),
+                ToolOutputField("busy_hours", "list", "Busy time ranges"),
+            ],
+            tags=["read"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_FETCH_EVENTS": ToolManifestEntry(
+            description="Fetch events across one or more calendars within a date range.",
+            outputs=[
+                ToolOutputField("calendar_fetch_data", "list[dict]", "Per-calendar results, each containing events[]"),
+                ToolOutputField("has_more", "bool", "True if more events exist beyond max_results"),
+            ],
+            tags=["read"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_FIND_EVENT": ToolManifestEntry(
+            description="Search events by keyword. Returns event_id values needed by GET, PATCH, DELETE, ADD_RECURRENCE.",
+            outputs=[
+                ToolOutputField("events", "list[dict]", "Matches with event_id, calendar_id, summary, start, end"),
+                ToolOutputField("calendar_search_data", "dict", "Raw search metadata"),
+            ],
+            tags=["read"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_GET_EVENT": ToolManifestEntry(
+            description="Fetch full details for one or more events by event_id.",
+            outputs=[
+                ToolOutputField("events", "list[dict]", "Full event objects: event_id, calendar_id, event (all fields)"),
+            ],
+            depends_on=["GOOGLECALENDAR_CUSTOM_FIND_EVENT"],
+            tags=["read"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_CREATE_EVENT": ToolManifestEntry(
+            description="Create one or more calendar events. Returns calendar_options for user confirmation if confirm_immediately=False.",
+            outputs=[
+                ToolOutputField("created", "bool", "True if events were created immediately"),
+                ToolOutputField("created_events", "list[dict] | None", "Created event objects (if confirmed)"),
+                ToolOutputField("calendar_options", "list[dict] | None", "Options presented to user for confirmation"),
+                ToolOutputField("message", "str | None", "Status message"),
+            ],
+            tags=["create"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_PATCH_EVENT": ToolManifestEntry(
+            description="Modify an existing event's fields. Requires event_id from FIND_EVENT.",
+            outputs=[
+                ToolOutputField("event", "dict", "Updated event object with all fields"),
+            ],
+            depends_on=["GOOGLECALENDAR_CUSTOM_FIND_EVENT"],
+            tags=["update"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_DELETE_EVENT": ToolManifestEntry(
+            description="Delete one or more events by event_id. Requires event_id from FIND_EVENT.",
+            outputs=[
+                ToolOutputField("deleted", "list[dict]", "Deleted event_id and calendar_id pairs"),
+            ],
+            depends_on=["GOOGLECALENDAR_CUSTOM_FIND_EVENT"],
+            tags=["delete"],
+        ),
+        "GOOGLECALENDAR_CUSTOM_ADD_RECURRENCE": ToolManifestEntry(
+            description="Add a recurrence rule (RRULE) to an existing event. Requires event_id from FIND_EVENT.",
+            outputs=[
+                ToolOutputField("event", "dict", "Updated event object with recurrence"),
+                ToolOutputField("recurrence_rule", "str", "RRULE string applied"),
+            ],
+            depends_on=["GOOGLECALENDAR_CUSTOM_FIND_EVENT"],
+            tags=["update"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Edit, delete, or make an event recurring",
+            steps=["GOOGLECALENDAR_CUSTOM_FIND_EVENT", "GOOGLECALENDAR_CUSTOM_PATCH_EVENT"],
+            note="event_id from FIND_EVENT.events[].event_id is required for GET/PATCH/DELETE/ADD_RECURRENCE",
+        ),
+        ToolWorkflow(
+            goal="Show today's schedule",
+            steps=["GOOGLECALENDAR_CUSTOM_GATHER_CONTEXT"],
+            note="Single call — no dependencies needed",
+        ),
+    ],
+)

--- a/apps/api/app/agents/tools/integrations/clickup_tool.py
+++ b/apps/api/app/agents/tools/integrations/clickup_tool.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List
 
 from composio import Composio
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -43,3 +48,17 @@ def register_clickup_custom_tools(composio: Composio) -> List[str]:
         return {"tasks": tasks, "overdue_tasks": overdue}
 
     return ["CLICKUP_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="clickup",
+    tools={
+        "CLICKUP_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of assigned open ClickUp tasks across all teams.",
+            outputs=[
+                ToolOutputField("tasks", "list[dict]", "Assigned open tasks with id, name, due_date (ms timestamp), status fields"),
+                ToolOutputField("overdue_tasks", "list[dict]", "Subset of tasks where due_date ms timestamp is earlier than now"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/github_tool.py
+++ b/apps/api/app/agents/tools/integrations/github_tool.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List
 from composio import Composio
 
 from shared.py.wide_events import log
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -67,3 +72,19 @@ def register_github_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["GITHUB_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="github",
+    tools={
+        "GITHUB_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of GitHub assigned issues, PRs, review requests, and unread notifications.",
+            outputs=[
+                ToolOutputField("assigned_issues", "list[dict]", "Open issues assigned to the authenticated user"),
+                ToolOutputField("assigned_prs", "list[dict]", "Open PRs assigned to the authenticated user"),
+                ToolOutputField("review_requests", "list[dict]", "Open PRs requesting review from the authenticated user"),
+                ToolOutputField("notifications", "list[dict]", "Up to 10 unread GitHub notifications"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/google_docs_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_docs_tool.py
@@ -14,6 +14,12 @@ import httpx
 from composio import Composio
 from composio.core.models.tools import ToolExecutionResponse
 from shared.py.wide_events import log
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
 from app.decorators import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.google_docs_models import CreateTOCInput, DeleteDocInput, ShareDocInput
@@ -271,3 +277,63 @@ def register_google_docs_custom_tools(composio: Composio) -> List[str]:
         "GOOGLEDOCS_CUSTOM_DELETE_DOC",
         "GOOGLEDOCS_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="googledocs",
+    tools={
+        "GOOGLEDOCS_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of recently viewed/modified Google Docs — use to discover document IDs.",
+            outputs=[
+                ToolOutputField("recent_docs", "list[dict]", "Up to 20 recent docs with id, name, modified, url"),
+                ToolOutputField("doc_count", "int", "Number of docs returned"),
+            ],
+        ),
+        "GOOGLEDOCS_CUSTOM_SHARE_DOC": ToolManifestEntry(
+            description="Share a Google Doc with one or more recipients by granting Drive permissions.",
+            outputs=[
+                ToolOutputField("document_id", "str", "The document ID that was shared"),
+                ToolOutputField("url", "str", "Direct edit URL for the document"),
+                ToolOutputField("shared", "list[dict]", "Successfully shared recipients with email, role, permission_id"),
+            ],
+            depends_on=["GOOGLEDOCS_CUSTOM_GATHER_CONTEXT"],
+            tags=["write", "sharing"],
+        ),
+        "GOOGLEDOCS_CUSTOM_CREATE_TOC": ToolManifestEntry(
+            description="Generate and insert a table of contents into a Google Doc based on its heading structure.",
+            outputs=[
+                ToolOutputField("document_id", "str", "The document ID"),
+                ToolOutputField("url", "str", "Direct edit URL"),
+                ToolOutputField("headings_found", "int", "Number of headings detected in the document"),
+                ToolOutputField("toc_content", "str", "The generated TOC text that was inserted"),
+            ],
+            depends_on=["GOOGLEDOCS_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "GOOGLEDOCS_CUSTOM_DELETE_DOC": ToolManifestEntry(
+            description="Permanently delete a Google Doc via Drive API. DESTRUCTIVE — confirm with user first.",
+            outputs=[
+                ToolOutputField("successful", "bool", "True if the document was deleted"),
+                ToolOutputField("document_id", "str", "The deleted document ID"),
+            ],
+            depends_on=["GOOGLEDOCS_CUSTOM_GATHER_CONTEXT"],
+            tags=["write", "destructive"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Share a document with collaborators",
+            steps=[
+                "1. Call GOOGLEDOCS_CUSTOM_GATHER_CONTEXT to find the document_id",
+                "2. Call GOOGLEDOCS_CUSTOM_SHARE_DOC with document_id and recipients list",
+            ],
+        ),
+        ToolWorkflow(
+            goal="Insert a table of contents into a document",
+            steps=[
+                "1. Call GOOGLEDOCS_CUSTOM_GATHER_CONTEXT to find the document_id",
+                "2. Call GOOGLEDOCS_CUSTOM_CREATE_TOC with document_id and desired insertion_index",
+            ],
+        ),
+    ],
+)

--- a/apps/api/app/agents/tools/integrations/google_maps_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_maps_tool.py
@@ -3,6 +3,11 @@
 from typing import Any, Dict, List
 
 import httpx
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from composio import Composio
 
@@ -64,3 +69,18 @@ def register_google_maps_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["GOOGLE_MAPS_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="google_maps",
+    tools={
+        "GOOGLE_MAPS_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Confirms Google Maps API connectivity and returns available service list.",
+            outputs=[
+                ToolOutputField("api_connected", "bool", "True if the API key or token is valid and geocoding responds with OK"),
+                ToolOutputField("status", "str", "Google Maps API status string (OK, REQUEST_DENIED, ZERO_RESULTS, etc.)"),
+                ToolOutputField("available_services", "list[str]", "Services enabled: geocoding, places, directions, distance_matrix, elevation, timezone"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/google_meet_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_meet_tool.py
@@ -4,6 +4,11 @@ import datetime
 from typing import Any, Dict, List
 
 import httpx
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from composio import Composio
 
@@ -88,3 +93,18 @@ def register_google_meet_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["GOOGLEMEET_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="googlemeet",
+    tools={
+        "GOOGLEMEET_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Google Meet: user profile and upcoming calendar events that have Meet links.",
+            outputs=[
+                ToolOutputField("user", "dict", "Authenticated user with email, name, picture"),
+                ToolOutputField("upcoming_meets", "list[dict]", "Up to 5 upcoming events with id, summary, start, meet_link"),
+                ToolOutputField("upcoming_meet_count", "int", "Number of upcoming Meet events returned"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/google_sheets_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_sheets_tool.py
@@ -8,6 +8,12 @@ Note: Errors are raised as exceptions - Composio wraps responses automatically.
 
 from typing import Any, Dict, List
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
+
 import httpx
 from shared.py.wide_events import log
 from app.models.common_models import GatherContextInput
@@ -767,3 +773,69 @@ def register_google_sheets_custom_tools(composio: Composio) -> List[str]:
         "GOOGLESHEETS_CUSTOM_CREATE_CHART",
         "GOOGLESHEETS_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="googlesheets",
+    tools={
+        "GOOGLESHEETS_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="List recently modified spreadsheets with their IDs and URLs.",
+            outputs=[
+                ToolOutputField("recent_spreadsheets", "list[dict]", "id, name, modified, url"),
+                ToolOutputField("spreadsheet_count", "int", "Number of spreadsheets returned"),
+            ],
+            tags=["context"],
+        ),
+        "GOOGLESHEETS_CUSTOM_SHARE_SPREADSHEET": ToolManifestEntry(
+            description="Share a spreadsheet with one or more email recipients.",
+            outputs=[
+                ToolOutputField("spreadsheet_id", "str", "Spreadsheet id"),
+                ToolOutputField("url", "str", "Spreadsheet URL"),
+                ToolOutputField("shared", "list[dict]", "email, role, permission_id, notification_sent per recipient"),
+                ToolOutputField("total_shared", "int", "Successfully shared count"),
+                ToolOutputField("total_failed", "int", "Failed share count"),
+            ],
+            tags=["update"],
+        ),
+        "GOOGLESHEETS_CUSTOM_CREATE_PIVOT_TABLE": ToolManifestEntry(
+            description="Create a pivot table in the spreadsheet from a source data range.",
+            outputs=[
+                ToolOutputField("spreadsheet_id", "str", "Spreadsheet id"),
+                ToolOutputField("url", "str", "Spreadsheet URL"),
+                ToolOutputField("pivot_sheet", "str", "Name of the sheet where the pivot was created"),
+                ToolOutputField("source_range", "str", "Source data range used"),
+            ],
+            tags=["create"],
+        ),
+        "GOOGLESHEETS_CUSTOM_SET_DATA_VALIDATION": ToolManifestEntry(
+            description="Apply a data validation rule (dropdown, number, date, or formula) to a cell range.",
+            outputs=[
+                ToolOutputField("spreadsheet_id", "str", "Spreadsheet id"),
+                ToolOutputField("url", "str", "Spreadsheet URL"),
+                ToolOutputField("range_applied", "str", "Range the validation was applied to"),
+                ToolOutputField("validation_type", "str", "Type of validation applied"),
+            ],
+            tags=["update"],
+        ),
+        "GOOGLESHEETS_CUSTOM_ADD_CONDITIONAL_FORMAT": ToolManifestEntry(
+            description="Apply a conditional formatting rule (value-based, color scale, or formula) to a cell range.",
+            outputs=[
+                ToolOutputField("spreadsheet_id", "str", "Spreadsheet id"),
+                ToolOutputField("url", "str", "Spreadsheet URL"),
+                ToolOutputField("range_applied", "str", "Range the format was applied to"),
+                ToolOutputField("format_type", "str", "Format type applied"),
+            ],
+            tags=["update"],
+        ),
+        "GOOGLESHEETS_CUSTOM_CREATE_CHART": ToolManifestEntry(
+            description="Create a chart (BAR, LINE, PIE, COLUMN, AREA, SCATTER, COMBO) from a data range.",
+            outputs=[
+                ToolOutputField("spreadsheet_id", "str", "Spreadsheet id"),
+                ToolOutputField("url", "str", "Spreadsheet URL"),
+                ToolOutputField("chart_id", "str | None", "ID of the created chart"),
+                ToolOutputField("chart_type", "str", "Chart type created"),
+            ],
+            tags=["create"],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/google_tasks_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_tasks_tool.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List
 
 from composio import Composio
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -37,3 +42,17 @@ def register_google_tasks_custom_tools(composio: Composio) -> List[str]:
         return {"tasks": tasks, "overdue_tasks": overdue}
 
     return ["GOOGLETASKS_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="googletasks",
+    tools={
+        "GOOGLETASKS_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Google Tasks: active tasks and overdue items.",
+            outputs=[
+                ToolOutputField("tasks", "list[dict]", "Active tasks with title, due, status, notes fields"),
+                ToolOutputField("overdue_tasks", "list[dict]", "Subset of tasks where due date is past today"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/hubspot_tool.py
+++ b/apps/api/app/agents/tools/integrations/hubspot_tool.py
@@ -6,6 +6,11 @@ import httpx
 from composio import Composio
 
 from shared.py.wide_events import log
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 
 
@@ -94,3 +99,19 @@ def register_hubspot_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["HUBSPOT_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="hubspot",
+    tools={
+        "HUBSPOT_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of recent HubSpot CRM contacts and deals.",
+            outputs=[
+                ToolOutputField("recent_contacts", "list[dict]", "Up to 10 contacts with id, firstname, lastname, email, lead_status"),
+                ToolOutputField("recent_deals", "list[dict]", "Up to 10 deals with id, dealname, amount, dealstage, closedate"),
+                ToolOutputField("contact_count", "int", "Number of contacts returned"),
+                ToolOutputField("deal_count", "int", "Number of deals returned"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/instagram_tool.py
+++ b/apps/api/app/agents/tools/integrations/instagram_tool.py
@@ -3,6 +3,11 @@
 from typing import Any, Dict, List
 
 import httpx
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from composio import Composio
 
@@ -78,3 +83,17 @@ def register_instagram_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["INSTAGRAM_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="instagram",
+    tools={
+        "INSTAGRAM_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Instagram profile info and last 5 media posts.",
+            outputs=[
+                ToolOutputField("user", "dict", "Profile with id, name, username, account_type, media_count, followers, following, biography"),
+                ToolOutputField("recent_media", "list[dict]", "Last 5 posts with id, caption, media_type, timestamp, likes, comments, permalink"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/linear_tool.py
+++ b/apps/api/app/agents/tools/integrations/linear_tool.py
@@ -9,6 +9,12 @@ Note: Errors are raised as exceptions - Composio wraps responses automatically.
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
 from app.decorators import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.linear_models import (
@@ -1024,3 +1030,159 @@ def register_linear_custom_tools(composio: Composio) -> List[str]:
         "LINEAR_CUSTOM_GET_WORKSPACE_CONTEXT",
         "LINEAR_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="linear",
+    tools={
+        "LINEAR_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Lightweight workspace snapshot: current user, teams, and urgent item counts. Call at conversation start.",
+            outputs=[
+                ToolOutputField("user", "dict", "id, name, email"),
+                ToolOutputField("teams", "list[dict]", "id, name, key"),
+                ToolOutputField("urgent_items", "dict", "overdue and high_priority counts"),
+            ],
+            tags=["context"],
+        ),
+        "LINEAR_CUSTOM_GET_WORKSPACE_CONTEXT": ToolManifestEntry(
+            description="Full workspace overview: user, all teams with active sprint progress, and urgent items.",
+            outputs=[
+                ToolOutputField("user", "dict", "id, name, email, assigned_issue_count"),
+                ToolOutputField("teams", "list[dict]", "id, name, key, active_cycle, cycle_progress"),
+                ToolOutputField("urgent_items", "dict", "overdue, high_priority, sla_at_risk counts"),
+            ],
+            tags=["context"],
+        ),
+        "LINEAR_CUSTOM_RESOLVE_CONTEXT": ToolManifestEntry(
+            description="Resolve fuzzy team/user/project/label/state names to Linear UUIDs. Call first when any ID is unknown.",
+            outputs=[
+                ToolOutputField("data.teams", "list[dict]", "id, name, key, states[], projects[], labels[]"),
+                ToolOutputField("data.users", "list[dict]", "id, name for workspace members"),
+                ToolOutputField("data.labels", "list[dict]", "id, name for issue labels"),
+                ToolOutputField("data.projects", "list[dict]", "id, name for projects"),
+                ToolOutputField("data.states", "list[dict]", "id, name, type for workflow states"),
+                ToolOutputField("data.current_user", "dict", "id, name of authenticated user"),
+            ],
+            tags=["context"],
+        ),
+        "LINEAR_CUSTOM_GET_MY_TASKS": ToolManifestEntry(
+            description="Get issues assigned to the current user, filterable by time window or priority.",
+            outputs=[
+                ToolOutputField("issues", "list[dict]", "id, identifier, title, state, priority, dueDate"),
+                ToolOutputField("filter", "str", "Filter applied: all/today/this_week/overdue/high_priority"),
+                ToolOutputField("count", "int", "Number of issues returned"),
+            ],
+            tags=["read"],
+        ),
+        "LINEAR_CUSTOM_SEARCH_ISSUES": ToolManifestEntry(
+            description="Search issues by keyword, team, state, priority, or assignee.",
+            outputs=[
+                ToolOutputField("issues", "list[dict]", "id, identifier, title, state, priority"),
+                ToolOutputField("query", "str", "Search query used"),
+                ToolOutputField("count", "int", "Number of results"),
+            ],
+            tags=["read"],
+        ),
+        "LINEAR_CUSTOM_GET_ISSUE_FULL_CONTEXT": ToolManifestEntry(
+            description="Get complete details for a single issue including comments, activity, sub-issues, and relations.",
+            outputs=[
+                ToolOutputField(
+                    "issue",
+                    "dict",
+                    "id, identifier, title, description, priority, state, dueDate, estimate, "
+                    "team, project, cycle, assignee, creator, parent, sub_issues[], relations[], "
+                    "comments[], activity[], attachments[]",
+                ),
+            ],
+            tags=["read"],
+        ),
+        "LINEAR_CUSTOM_GET_NOTIFICATIONS": ToolManifestEntry(
+            description="Fetch the user's Linear notifications (unread by default).",
+            outputs=[
+                ToolOutputField("notifications", "list[dict]", "id, type, created_at, read, issue, actor"),
+                ToolOutputField("count", "int", "Number of notifications"),
+            ],
+            tags=["read"],
+        ),
+        "LINEAR_CUSTOM_GET_ACTIVE_SPRINT": ToolManifestEntry(
+            description="Get active sprint (cycle) data for one or all teams.",
+            outputs=[
+                ToolOutputField(
+                    "sprints",
+                    "list[dict]",
+                    "id, name, number, team, team_key, starts_at, ends_at, progress, "
+                    "total_issues, issues_by_state, in_progress[], todo[]",
+                ),
+                ToolOutputField("sprint_count", "int", "Number of active sprints"),
+            ],
+            tags=["read"],
+        ),
+        "LINEAR_CUSTOM_GET_ISSUE_ACTIVITY": ToolManifestEntry(
+            description="Get the change history and activity log for a specific issue.",
+            outputs=[
+                ToolOutputField("issue", "dict", "id, identifier, title"),
+                ToolOutputField("activities", "list[dict]", "timestamp, actor, change_type, from, to, labels"),
+                ToolOutputField("activity_count", "int", "Number of activity entries"),
+            ],
+            tags=["read"],
+        ),
+        "LINEAR_CUSTOM_CREATE_ISSUE": ToolManifestEntry(
+            description="Create a new Linear issue. team_id is required — get it from LINEAR_CUSTOM_RESOLVE_CONTEXT.",
+            outputs=[
+                ToolOutputField("issue", "dict", "id, identifier, title, url"),
+                ToolOutputField("sub_issues", "list[dict]", "id, identifier, title (if sub_issues input provided)"),
+                ToolOutputField("sub_issue_errors", "list[str]", "Errors for any sub-issues that failed (optional)"),
+            ],
+            depends_on=["LINEAR_CUSTOM_RESOLVE_CONTEXT"],
+            tags=["create"],
+        ),
+        "LINEAR_CUSTOM_CREATE_SUB_ISSUES": ToolManifestEntry(
+            description="Create one or more sub-issues under an existing parent issue.",
+            outputs=[
+                ToolOutputField("parent", "dict", "Parent issue id and identifier"),
+                ToolOutputField("sub_issues", "list[dict]", "Newly created sub-issues: id, identifier, title"),
+                ToolOutputField("created_count", "int", "Number of sub-issues created"),
+            ],
+            depends_on=["LINEAR_CUSTOM_SEARCH_ISSUES"],
+            tags=["create"],
+        ),
+        "LINEAR_CUSTOM_CREATE_ISSUE_RELATION": ToolManifestEntry(
+            description="Create a relation between two issues (blocks, is_blocked_by, relates_to, duplicates).",
+            outputs=[
+                ToolOutputField("relation", "dict", "id, type, from_issue, to_issue"),
+            ],
+            tags=["create"],
+        ),
+        "LINEAR_CUSTOM_BULK_UPDATE_ISSUES": ToolManifestEntry(
+            description="Update state, priority, assignee, cycle, project, or labels on multiple issues at once.",
+            outputs=[
+                ToolOutputField("updated_issues", "list[dict]", "id, identifier for each updated issue"),
+                ToolOutputField("updated_count", "int", "Number of issues updated"),
+            ],
+            depends_on=["LINEAR_CUSTOM_SEARCH_ISSUES"],
+            tags=["update"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Create a new issue",
+            steps=["LINEAR_CUSTOM_RESOLVE_CONTEXT", "LINEAR_CUSTOM_CREATE_ISSUE"],
+            note="team_id from RESOLVE_CONTEXT.data.teams[].id is required for CREATE_ISSUE",
+        ),
+        ToolWorkflow(
+            goal="Bulk update issues (e.g., close all overdue)",
+            steps=["LINEAR_CUSTOM_SEARCH_ISSUES", "LINEAR_CUSTOM_BULK_UPDATE_ISSUES"],
+            note="issue_ids from SEARCH_ISSUES.issues[].id go into BULK_UPDATE_ISSUES.issue_ids",
+        ),
+        ToolWorkflow(
+            goal="Create sub-issues under a parent",
+            steps=["LINEAR_CUSTOM_SEARCH_ISSUES", "LINEAR_CUSTOM_CREATE_SUB_ISSUES"],
+            note="parent_issue_id from SEARCH_ISSUES.issues[].id is required for CREATE_SUB_ISSUES",
+        ),
+        ToolWorkflow(
+            goal="Get full details on a specific issue",
+            steps=["LINEAR_CUSTOM_SEARCH_ISSUES", "LINEAR_CUSTOM_GET_ISSUE_FULL_CONTEXT"],
+            note="Use issue_identifier from SEARCH_ISSUES (e.g., ENG-123) for GET_ISSUE_FULL_CONTEXT",
+        ),
+    ],
+)

--- a/apps/api/app/agents/tools/integrations/linkedin_tool.py
+++ b/apps/api/app/agents/tools/integrations/linkedin_tool.py
@@ -9,6 +9,12 @@ Note: Errors are raised as exceptions - Composio wraps responses automatically.
 from typing import Any, Dict, List
 
 import httpx
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
 from app.decorators.documentation import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.linkedin_models import (
@@ -438,3 +444,90 @@ def register_linkedin_custom_tools(composio: Composio) -> List[str]:
         "LINKEDIN_CUSTOM_GET_POST_REACTIONS",
         "LINKEDIN_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="linkedin",
+    tools={
+        "LINKEDIN_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of LinkedIn profile and recent posts authored by the authenticated user.",
+            outputs=[
+                ToolOutputField("user", "dict", "Profile with id, name, given_name, family_name, email, profile_picture"),
+                ToolOutputField("recent_posts", "list[dict]", "Up to 5 recent posts with id, text, created, visibility"),
+            ],
+        ),
+        "LINKEDIN_CUSTOM_CREATE_POST": ToolManifestEntry(
+            description="Create a LinkedIn post (text, image, carousel, document, or article link).",
+            outputs=[
+                ToolOutputField("post_id", "str", "LinkedIn URN of the created post — use as post_urn in comment/reaction tools"),
+                ToolOutputField("url", "str", "URL to view the post on LinkedIn"),
+                ToolOutputField("author", "str", "Author URN used to create the post"),
+                ToolOutputField("media_type", "str", "Post type: text, image, carousel, document, or article"),
+            ],
+            tags=["write"],
+        ),
+        "LINKEDIN_CUSTOM_ADD_COMMENT": ToolManifestEntry(
+            description="Add a comment to a LinkedIn post.",
+            outputs=[
+                ToolOutputField("comment_id", "str", "ID of the created comment"),
+                ToolOutputField("post_urn", "str", "URN of the post that was commented on"),
+                ToolOutputField("author", "str", "Author URN"),
+            ],
+            depends_on=["LINKEDIN_CUSTOM_CREATE_POST", "LINKEDIN_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "LINKEDIN_CUSTOM_GET_POST_COMMENTS": ToolManifestEntry(
+            description="Retrieve comments on a LinkedIn post.",
+            outputs=[
+                ToolOutputField("comments", "list[dict]", "Comments with id, author, text, created_at, parent_comment"),
+                ToolOutputField("total_count", "int", "Total comment count on the post"),
+                ToolOutputField("post_urn", "str", "URN of the queried post"),
+            ],
+            depends_on=["LINKEDIN_CUSTOM_CREATE_POST", "LINKEDIN_CUSTOM_GATHER_CONTEXT"],
+        ),
+        "LINKEDIN_CUSTOM_REACT_TO_POST": ToolManifestEntry(
+            description="React to a LinkedIn post (LIKE, CELEBRATE, SUPPORT, FUNNY, LOVE, INSIGHTFUL, CURIOUS).",
+            outputs=[
+                ToolOutputField("post_urn", "str", "URN of the post reacted to"),
+                ToolOutputField("reaction_type", "str", "The reaction type applied"),
+                ToolOutputField("author", "str", "Author URN"),
+            ],
+            depends_on=["LINKEDIN_CUSTOM_CREATE_POST", "LINKEDIN_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "LINKEDIN_CUSTOM_DELETE_REACTION": ToolManifestEntry(
+            description="Remove the authenticated user's reaction from a LinkedIn post.",
+            outputs=[
+                ToolOutputField("post_urn", "str", "URN of the post"),
+                ToolOutputField("message", "str", "Confirmation message"),
+            ],
+            depends_on=["LINKEDIN_CUSTOM_REACT_TO_POST"],
+            tags=["write", "destructive"],
+        ),
+        "LINKEDIN_CUSTOM_GET_POST_REACTIONS": ToolManifestEntry(
+            description="Retrieve all reactions on a LinkedIn post.",
+            outputs=[
+                ToolOutputField("reactions", "list[dict]", "Reactions with actor, reaction_type, created_at"),
+                ToolOutputField("total_count", "int", "Total reaction count on the post"),
+                ToolOutputField("post_urn", "str", "URN of the queried post"),
+            ],
+            depends_on=["LINKEDIN_CUSTOM_CREATE_POST", "LINKEDIN_CUSTOM_GATHER_CONTEXT"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Create a post and then engage with it (comment, react)",
+            steps=[
+                "1. Call LINKEDIN_CUSTOM_CREATE_POST — save the returned post_id as post_urn",
+                "2. Use that post_urn in LINKEDIN_CUSTOM_ADD_COMMENT or LINKEDIN_CUSTOM_REACT_TO_POST",
+            ],
+        ),
+        ToolWorkflow(
+            goal="Engage with an existing post",
+            steps=[
+                "1. Call LINKEDIN_CUSTOM_GATHER_CONTEXT to find recent_posts with their IDs",
+                "2. Use the post id as post_urn in comment/reaction tools",
+            ],
+        ),
+    ],
+)

--- a/apps/api/app/agents/tools/integrations/microsoft_teams_tool.py
+++ b/apps/api/app/agents/tools/integrations/microsoft_teams_tool.py
@@ -6,6 +6,11 @@ import httpx
 from composio import Composio
 
 from shared.py.wide_events import log
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 
 
@@ -115,3 +120,21 @@ def register_microsoft_teams_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["MICROSOFT_TEAMS_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="microsoft_teams",
+    tools={
+        "MICROSOFT_TEAMS_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Microsoft Teams user info, joined teams, and recent chats with unread count.",
+            outputs=[
+                ToolOutputField("user", "dict", "Current user with id, display_name, email"),
+                ToolOutputField("teams", "list[dict]", "Joined teams with id, name, description"),
+                ToolOutputField("recent_chats", "list[dict]", "Last 10 chats with id, topic, chat_type, last_message_preview, is_read"),
+                ToolOutputField("team_count", "int", "Number of joined teams"),
+                ToolOutputField("chat_count", "int", "Number of chats returned"),
+                ToolOutputField("unread_chat_count", "int", "Number of chats with an unread last message"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/notion_tool.py
+++ b/apps/api/app/agents/tools/integrations/notion_tool.py
@@ -8,6 +8,13 @@ These tools wrap existing Composio Notion tools and add markdown conversion:
 Note: Errors are raised as exceptions - Composio wraps responses automatically.
 """
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
+
 from typing import Any, Dict, List
 
 import httpx
@@ -393,3 +400,83 @@ def register_notion_custom_tools(composio: Composio) -> List[str]:
         "NOTION_CUSTOM_CREATE_TEST_PAGE",
         "NOTION_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="notion",
+    tools={
+        "NOTION_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Fetch recent Notion pages relevant to the current context. Call at conversation start.",
+            outputs=[
+                ToolOutputField("relevant_pages", "list[dict]", "Recent pages with id, title, url"),
+            ],
+            tags=["context"],
+        ),
+        "NOTION_FETCH_DATA": ToolManifestEntry(
+            description="Search or list Notion pages, databases, or blocks. Use to find page_ids for other tools.",
+            outputs=[
+                ToolOutputField("values", "list[dict]", "id, title, type for each result"),
+                ToolOutputField("count", "int", "Number of results"),
+                ToolOutputField("has_more", "bool", "Whether more results exist"),
+            ],
+            tags=["read"],
+        ),
+        "NOTION_FETCH_PAGE_AS_MARKDOWN": ToolManifestEntry(
+            description="Read a Notion page and return its full content as markdown. Requires page_id from FETCH_DATA.",
+            outputs=[
+                ToolOutputField("page_id", "str", "The page id"),
+                ToolOutputField("title", "str", "Page title"),
+                ToolOutputField("markdown", "str", "Full page content as markdown"),
+                ToolOutputField("block_count", "int", "Number of blocks in the page"),
+            ],
+            depends_on=["NOTION_FETCH_DATA"],
+            tags=["read"],
+        ),
+        "NOTION_INSERT_MARKDOWN": ToolManifestEntry(
+            description="Append or insert markdown content into a Notion page. Requires parent_block_id from FETCH_DATA.",
+            outputs=[
+                ToolOutputField("parent_block_id", "str", "Block id content was inserted into"),
+                ToolOutputField("blocks_added", "int", "Number of blocks added"),
+                ToolOutputField("tables_added", "int", "Number of tables added"),
+                ToolOutputField("after", "str | None", "Block id after which content was inserted"),
+            ],
+            depends_on=["NOTION_FETCH_DATA"],
+            tags=["create", "update"],
+        ),
+        "NOTION_MOVE_PAGE": ToolManifestEntry(
+            description="Move a page under a new parent. Requires both page_id and parent_id from FETCH_DATA.",
+            outputs=[
+                ToolOutputField("page_id", "str", "Moved page id"),
+                ToolOutputField("new_parent", "dict", "New parent block/page info"),
+                ToolOutputField("url", "str", "Page URL after the move"),
+            ],
+            depends_on=["NOTION_FETCH_DATA"],
+            tags=["update"],
+        ),
+        "NOTION_CUSTOM_CREATE_TEST_PAGE": ToolManifestEntry(
+            description="Create a blank test page, optionally under a parent page.",
+            outputs=[
+                ToolOutputField("page_id", "str", "Created page id"),
+                ToolOutputField("url", "str", "Created page URL"),
+            ],
+            tags=["create"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Read page content",
+            steps=["NOTION_FETCH_DATA", "NOTION_FETCH_PAGE_AS_MARKDOWN"],
+            note="page_id from FETCH_DATA.values[].id is required for FETCH_PAGE_AS_MARKDOWN",
+        ),
+        ToolWorkflow(
+            goal="Append content to a page",
+            steps=["NOTION_FETCH_DATA", "NOTION_INSERT_MARKDOWN"],
+            note="parent_block_id from FETCH_DATA.values[].id goes into INSERT_MARKDOWN",
+        ),
+        ToolWorkflow(
+            goal="Move a page to a new parent",
+            steps=["NOTION_FETCH_DATA", "NOTION_MOVE_PAGE"],
+            note="Two FETCH_DATA calls may be needed: one for the page to move, one for the destination parent",
+        ),
+    ],
+)

--- a/apps/api/app/agents/tools/integrations/reddit_tool.py
+++ b/apps/api/app/agents/tools/integrations/reddit_tool.py
@@ -3,6 +3,11 @@
 from typing import Any, Dict, List
 
 import httpx
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from composio import Composio
 
@@ -90,3 +95,19 @@ def register_reddit_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["REDDIT_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="reddit",
+    tools={
+        "REDDIT_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Reddit user profile, top subscribed subreddits, and unread messages.",
+            outputs=[
+                ToolOutputField("user", "dict", "Profile with name, id, link_karma, comment_karma, total_karma, is_gold"),
+                ToolOutputField("subscribed_subreddits", "list[dict]", "Top 5 subscribed subreddits with name, title, subscribers"),
+                ToolOutputField("unread_messages", "list[dict]", "Up to 5 unread messages with id, subject, author, created_utc"),
+                ToolOutputField("unread_message_count", "int", "Number of unread messages returned"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/slack_tool.py
+++ b/apps/api/app/agents/tools/integrations/slack_tool.py
@@ -6,6 +6,11 @@ from typing import Any, Dict, List
 from composio import Composio
 
 from shared.py.wide_events import log
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -59,3 +64,18 @@ def register_slack_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["SLACK_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="slack",
+    tools={
+        "SLACK_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of today's Slack messages, @mentions, and unread count.",
+            outputs=[
+                ToolOutputField("messages", "list[dict]", "Today's messages (excluding @mentions) with ts, text, channel, username"),
+                ToolOutputField("mentions", "list[dict]", "Today's @mentions of the authenticated user"),
+                ToolOutputField("unread_count", "int", "Total messages seen today (mentions + others combined)"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/todoist_tool.py
+++ b/apps/api/app/agents/tools/integrations/todoist_tool.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List
 
 from composio import Composio
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -43,3 +48,17 @@ def register_todoist_custom_tools(composio: Composio) -> List[str]:
         return {"tasks": tasks, "overdue_tasks": overdue}
 
     return ["TODOIST_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="todoist",
+    tools={
+        "TODOIST_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Todoist tasks and overdue items.",
+            outputs=[
+                ToolOutputField("tasks", "list[dict]", "Active tasks with content, due (dict with date), priority, project_id"),
+                ToolOutputField("overdue_tasks", "list[dict]", "Subset of tasks where due.date is earlier than today"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/trello_tool.py
+++ b/apps/api/app/agents/tools/integrations/trello_tool.py
@@ -4,6 +4,11 @@ from typing import Any, Dict, List
 
 from composio import Composio
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+)
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 
@@ -34,3 +39,16 @@ def register_trello_custom_tools(composio: Composio) -> List[str]:
         return {"cards": cards}
 
     return ["TRELLO_CUSTOM_GATHER_CONTEXT"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="trello",
+    tools={
+        "TRELLO_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Trello cards currently assigned to the authenticated user.",
+            outputs=[
+                ToolOutputField("cards", "list[dict]", "Cards assigned to user with id, name, due, idBoard, idList fields"),
+            ],
+        ),
+    },
+)

--- a/apps/api/app/agents/tools/integrations/twitter_tool.py
+++ b/apps/api/app/agents/tools/integrations/twitter_tool.py
@@ -15,6 +15,12 @@ Note: Errors are raised as exceptions - Composio wraps responses automatically.
 
 from typing import Any, Dict, List, Optional
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
 from app.decorators.documentation import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.twitter_models import (
@@ -475,3 +481,78 @@ def register_twitter_custom_tools(composio: Composio) -> List[str]:
         "TWITTER_CUSTOM_SCHEDULE_TWEET",
         "TWITTER_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="twitter",
+    tools={
+        "TWITTER_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Twitter/X profile and last 5 tweets.",
+            outputs=[
+                ToolOutputField("user", "dict", "Profile with id, username, name, description, followers, following, tweet_count"),
+                ToolOutputField("recent_tweets", "list[dict]", "Last 5 tweets with id, text, created_at, likes, retweets"),
+            ],
+        ),
+        "TWITTER_CUSTOM_BATCH_FOLLOW": ToolManifestEntry(
+            description="Follow multiple Twitter users at once by username or user_id.",
+            outputs=[
+                ToolOutputField("results", "list[dict]", "Per-user result with user_id, username, success, error"),
+                ToolOutputField("followed_count", "int", "Number of users successfully followed"),
+                ToolOutputField("failed_count", "int", "Number of users that failed"),
+            ],
+            tags=["write"],
+        ),
+        "TWITTER_CUSTOM_BATCH_UNFOLLOW": ToolManifestEntry(
+            description="Unfollow multiple Twitter users at once. DESTRUCTIVE — confirm with user before calling.",
+            outputs=[
+                ToolOutputField("results", "list[dict]", "Per-user result with user_id, username, success, error"),
+                ToolOutputField("unfollowed_count", "int", "Number successfully unfollowed"),
+                ToolOutputField("failed_count", "int", "Number that failed"),
+            ],
+            tags=["write", "destructive"],
+        ),
+        "TWITTER_CUSTOM_CREATE_THREAD": ToolManifestEntry(
+            description="Post a Twitter thread (chain of connected tweets) in a single call.",
+            outputs=[
+                ToolOutputField("thread_id", "str", "ID of the first tweet in the thread"),
+                ToolOutputField("tweet_ids", "list[str]", "IDs of all tweets in posting order"),
+                ToolOutputField("tweet_count", "int", "Number of tweets posted"),
+                ToolOutputField("thread_url", "str", "URL to the first tweet"),
+            ],
+            tags=["write"],
+        ),
+        "TWITTER_CUSTOM_SEARCH_USERS": ToolManifestEntry(
+            description="Find Twitter users by name, bio, or keyword when their exact username is unknown.",
+            outputs=[
+                ToolOutputField("users", "list[dict]", "Matched users with id, username, name, description, followers, verified"),
+                ToolOutputField("count", "int", "Number of users returned"),
+            ],
+        ),
+        "TWITTER_CUSTOM_SCHEDULE_TWEET": ToolManifestEntry(
+            description="Create a scheduled tweet draft for later posting.",
+            outputs=[
+                ToolOutputField("draft", "dict", "Draft with text, scheduled_time, media_urls, reply_to_tweet_id"),
+                ToolOutputField("message", "str", "Confirmation message about scheduling"),
+            ],
+            tags=["write"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Follow users when only their name or topic is known",
+            steps=[
+                "1. Call TWITTER_CUSTOM_SEARCH_USERS with a descriptive query",
+                "2. Pick target users from the results",
+                "3. Call TWITTER_CUSTOM_BATCH_FOLLOW with their usernames",
+            ],
+        ),
+        ToolWorkflow(
+            goal="Create and post a tweet thread",
+            steps=[
+                "1. Prepare list of tweet texts (each ≤280 chars)",
+                "2. Call TWITTER_CUSTOM_CREATE_THREAD with the tweets list",
+                "3. Return thread_url to user",
+            ],
+        ),
+    ],
+)

--- a/apps/api/app/agents/tools/integrations/urgency_tool.py
+++ b/apps/api/app/agents/tools/integrations/urgency_tool.py
@@ -9,6 +9,13 @@ from typing import Any, Dict, List
 from composio import Composio
 from pydantic import BaseModel, Field
 
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
+
 
 class UrgencyAggregatorInput(BaseModel):
     """Input for the urgency aggregator — a dict of integration snapshots."""
@@ -229,3 +236,42 @@ def register_urgency_custom_tools(composio: Composio) -> List[str]:
         }
 
     return ["GAIA_CUSTOM_URGENCY_AGGREGATOR"]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="gaia",
+    tools={
+        "GAIA_CUSTOM_URGENCY_AGGREGATOR": ToolManifestEntry(
+            description=(
+                "Aggregates urgency signals from multiple CUSTOM_GATHER_CONTEXT outputs "
+                "into a single prioritized list of items needing attention."
+            ),
+            outputs=[
+                ToolOutputField("urgent_items", "list[dict]", "Items sorted by priority (high/medium/low) with integration, type, count, description, details"),
+                ToolOutputField("total_urgent", "int", "Total number of urgent items across all integrations"),
+                ToolOutputField("summary", "dict", "Priority breakdown: high_priority, medium_priority, low_priority counts"),
+            ],
+            depends_on=[
+                "SLACK_CUSTOM_GATHER_CONTEXT",
+                "GITHUB_CUSTOM_GATHER_CONTEXT",
+                "ASANA_CUSTOM_GATHER_CONTEXT",
+                "CLICKUP_CUSTOM_GATHER_CONTEXT",
+                "TODOIST_CUSTOM_GATHER_CONTEXT",
+                "MICROSOFT_TEAMS_CUSTOM_GATHER_CONTEXT",
+                "REDDIT_CUSTOM_GATHER_CONTEXT",
+            ],
+            tags=["aggregator", "cross-integration"],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Get a unified urgency overview across all active integrations",
+            steps=[
+                "1. Call CUSTOM_GATHER_CONTEXT for each integration the user has connected",
+                "2. Collect all results into a snapshots dict keyed by integration name",
+                "3. Call GAIA_CUSTOM_URGENCY_AGGREGATOR with the snapshots dict",
+                "4. Present urgent_items to the user sorted by priority",
+            ],
+        ),
+    ],
+)

--- a/apps/api/app/services/composio/custom_tools/gmail_tools.py
+++ b/apps/api/app/services/composio/custom_tools/gmail_tools.py
@@ -7,6 +7,12 @@ import datetime
 from typing import Any, Dict, List, Optional
 
 import httpx
+from app.agents.tools.core.toolkit_manifest import (
+    ToolManifestEntry,
+    ToolkitManifest,
+    ToolOutputField,
+    ToolWorkflow,
+)
 from app.models.common_models import GatherContextInput
 from app.services.contact_service import get_gmail_contacts
 from composio import Composio
@@ -488,3 +494,74 @@ def register_gmail_custom_tools(composio: Composio):
         "GMAIL_GET_CONTACT_LIST",
         "GMAIL_CUSTOM_GATHER_CONTEXT",
     ]
+
+
+MANIFEST = ToolkitManifest(
+    toolkit="gmail",
+    tools={
+        "GMAIL_CUSTOM_GATHER_CONTEXT": ToolManifestEntry(
+            description="Snapshot of Gmail: user profile, inbox unread count, and recent message IDs.",
+            outputs=[
+                ToolOutputField("user", "dict", "Profile with email, messages_total, threads_total"),
+                ToolOutputField("inbox", "dict", "Inbox stats with unread_count and message_count"),
+                ToolOutputField("recent_message_ids", "list[str]", "IDs of up to 5 recent inbox messages — pass directly to MARK_AS_READ, ARCHIVE, STAR tools"),
+            ],
+        ),
+        "GMAIL_MARK_AS_READ": ToolManifestEntry(
+            description="Remove the UNREAD label from specified messages, marking them as read.",
+            outputs=[],
+            depends_on=["GMAIL_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "GMAIL_MARK_AS_UNREAD": ToolManifestEntry(
+            description="Add the UNREAD label to specified messages, marking them as unread.",
+            outputs=[],
+            depends_on=["GMAIL_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "GMAIL_ARCHIVE_EMAIL": ToolManifestEntry(
+            description="Remove messages from INBOX (archive them to All Mail).",
+            outputs=[],
+            depends_on=["GMAIL_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "GMAIL_STAR_EMAIL": ToolManifestEntry(
+            description="Star or unstar Gmail messages by adding/removing the STARRED label.",
+            outputs=[
+                ToolOutputField("action", "str", "Either 'starred' or 'unstarred'"),
+            ],
+            depends_on=["GMAIL_CUSTOM_GATHER_CONTEXT"],
+            tags=["write"],
+        ),
+        "GMAIL_GET_UNREAD_COUNT": ToolManifestEntry(
+            description="Get unread and total message counts by label or search query.",
+            outputs=[
+                ToolOutputField("unreadCount", "int", "Number of unread messages matching the criteria"),
+                ToolOutputField("totalCount", "int", "Total messages matching the criteria"),
+                ToolOutputField("counts", "dict", "Per-label breakdown when multiple labels requested"),
+            ],
+        ),
+        "GMAIL_GET_CONTACT_LIST": ToolManifestEntry(
+            description="Extract unique email contacts from Gmail history matching a search query.",
+            outputs=[
+                ToolOutputField("contacts", "list[dict]", "Unique contacts with name and email fields"),
+            ],
+        ),
+    },
+    workflows=[
+        ToolWorkflow(
+            goal="Process recent inbox messages (read, archive, or star)",
+            steps=[
+                "1. Call GMAIL_CUSTOM_GATHER_CONTEXT to get recent_message_ids",
+                "2. Pass those IDs to GMAIL_MARK_AS_READ, GMAIL_ARCHIVE_EMAIL, or GMAIL_STAR_EMAIL",
+            ],
+        ),
+        ToolWorkflow(
+            goal="Check how many unread emails are in the inbox",
+            steps=[
+                "1. Call GMAIL_GET_UNREAD_COUNT with label_ids=['INBOX']",
+                "2. Report the unreadCount to the user",
+            ],
+        ),
+    ],
+)

--- a/apps/api/app/services/composio/custom_tools/registry.py
+++ b/apps/api/app/services/composio/custom_tools/registry.py
@@ -72,6 +72,31 @@ from app.services.composio.custom_tools.gmail_tools import (
 )
 from composio import Composio
 
+from app.agents.tools.core.toolkit_manifest import toolkit_manifest_registry
+from app.agents.tools.integrations.calendar_tool import MANIFEST as CALENDAR_MANIFEST
+from app.agents.tools.integrations.notion_tool import MANIFEST as NOTION_MANIFEST
+from app.agents.tools.integrations.google_sheets_tool import MANIFEST as GOOGLE_SHEETS_MANIFEST
+from app.agents.tools.integrations.linear_tool import MANIFEST as LINEAR_MANIFEST
+from app.agents.tools.integrations.slack_tool import MANIFEST as SLACK_MANIFEST
+from app.agents.tools.integrations.github_tool import MANIFEST as GITHUB_MANIFEST
+from app.agents.tools.integrations.google_tasks_tool import MANIFEST as GOOGLE_TASKS_MANIFEST
+from app.agents.tools.integrations.google_maps_tool import MANIFEST as GOOGLE_MAPS_MANIFEST
+from app.agents.tools.integrations.google_meet_tool import MANIFEST as GOOGLE_MEET_MANIFEST
+from app.agents.tools.integrations.asana_tool import MANIFEST as ASANA_MANIFEST
+from app.agents.tools.integrations.airtable_tool import MANIFEST as AIRTABLE_MANIFEST
+from app.agents.tools.integrations.hubspot_tool import MANIFEST as HUBSPOT_MANIFEST
+from app.agents.tools.integrations.reddit_tool import MANIFEST as REDDIT_MANIFEST
+from app.agents.tools.integrations.instagram_tool import MANIFEST as INSTAGRAM_MANIFEST
+from app.agents.tools.integrations.clickup_tool import MANIFEST as CLICKUP_MANIFEST
+from app.agents.tools.integrations.trello_tool import MANIFEST as TRELLO_MANIFEST
+from app.agents.tools.integrations.todoist_tool import MANIFEST as TODOIST_MANIFEST
+from app.agents.tools.integrations.microsoft_teams_tool import MANIFEST as MICROSOFT_TEAMS_MANIFEST
+from app.agents.tools.integrations.urgency_tool import MANIFEST as URGENCY_MANIFEST
+from app.agents.tools.integrations.google_docs_tool import MANIFEST as GOOGLE_DOCS_MANIFEST
+from app.agents.tools.integrations.twitter_tool import MANIFEST as TWITTER_MANIFEST
+from app.agents.tools.integrations.linkedin_tool import MANIFEST as LINKEDIN_MANIFEST
+from app.services.composio.custom_tools.gmail_tools import MANIFEST as GMAIL_MANIFEST
+
 
 class CustomToolsRegistry:
     """
@@ -141,6 +166,7 @@ class CustomToolsRegistry:
 
         try:
             self._register_all_tools()
+            self._register_all_manifests()
         except Exception:
             self._composio = None
             self._tools_by_toolkit.clear()
@@ -154,6 +180,36 @@ class CustomToolsRegistry:
 
         for toolkit, register_func in self._toolkit_registrations():
             self._register_toolkit(toolkit, register_func)
+
+    def _register_all_manifests(self) -> None:
+        """Register all toolkit manifests with the global manifest registry."""
+        manifests = [
+            CALENDAR_MANIFEST,
+            NOTION_MANIFEST,
+            GOOGLE_SHEETS_MANIFEST,
+            LINEAR_MANIFEST,
+            SLACK_MANIFEST,
+            GITHUB_MANIFEST,
+            GOOGLE_TASKS_MANIFEST,
+            GOOGLE_MAPS_MANIFEST,
+            GOOGLE_MEET_MANIFEST,
+            ASANA_MANIFEST,
+            AIRTABLE_MANIFEST,
+            HUBSPOT_MANIFEST,
+            REDDIT_MANIFEST,
+            INSTAGRAM_MANIFEST,
+            CLICKUP_MANIFEST,
+            TRELLO_MANIFEST,
+            TODOIST_MANIFEST,
+            MICROSOFT_TEAMS_MANIFEST,
+            URGENCY_MANIFEST,
+            GOOGLE_DOCS_MANIFEST,
+            TWITTER_MANIFEST,
+            LINKEDIN_MANIFEST,
+            GMAIL_MANIFEST,
+        ]
+        for manifest in manifests:
+            toolkit_manifest_registry.register(manifest)
 
     def _register_toolkit(
         self,

--- a/apps/api/app/services/composio/custom_tools/registry.py
+++ b/apps/api/app/services/composio/custom_tools/registry.py
@@ -68,34 +68,34 @@ from app.agents.tools.integrations.urgency_tool import (
 )
 from shared.py.wide_events import log
 from app.services.composio.custom_tools.gmail_tools import (
+    MANIFEST as GMAIL_MANIFEST,
     register_gmail_custom_tools,
 )
 from composio import Composio
 
 from app.agents.tools.core.toolkit_manifest import toolkit_manifest_registry
-from app.agents.tools.integrations.calendar_tool import MANIFEST as CALENDAR_MANIFEST
-from app.agents.tools.integrations.notion_tool import MANIFEST as NOTION_MANIFEST
-from app.agents.tools.integrations.google_sheets_tool import MANIFEST as GOOGLE_SHEETS_MANIFEST
-from app.agents.tools.integrations.linear_tool import MANIFEST as LINEAR_MANIFEST
-from app.agents.tools.integrations.slack_tool import MANIFEST as SLACK_MANIFEST
-from app.agents.tools.integrations.github_tool import MANIFEST as GITHUB_MANIFEST
-from app.agents.tools.integrations.google_tasks_tool import MANIFEST as GOOGLE_TASKS_MANIFEST
-from app.agents.tools.integrations.google_maps_tool import MANIFEST as GOOGLE_MAPS_MANIFEST
-from app.agents.tools.integrations.google_meet_tool import MANIFEST as GOOGLE_MEET_MANIFEST
 from app.agents.tools.integrations.asana_tool import MANIFEST as ASANA_MANIFEST
 from app.agents.tools.integrations.airtable_tool import MANIFEST as AIRTABLE_MANIFEST
-from app.agents.tools.integrations.hubspot_tool import MANIFEST as HUBSPOT_MANIFEST
-from app.agents.tools.integrations.reddit_tool import MANIFEST as REDDIT_MANIFEST
-from app.agents.tools.integrations.instagram_tool import MANIFEST as INSTAGRAM_MANIFEST
+from app.agents.tools.integrations.calendar_tool import MANIFEST as CALENDAR_MANIFEST
 from app.agents.tools.integrations.clickup_tool import MANIFEST as CLICKUP_MANIFEST
-from app.agents.tools.integrations.trello_tool import MANIFEST as TRELLO_MANIFEST
-from app.agents.tools.integrations.todoist_tool import MANIFEST as TODOIST_MANIFEST
-from app.agents.tools.integrations.microsoft_teams_tool import MANIFEST as MICROSOFT_TEAMS_MANIFEST
-from app.agents.tools.integrations.urgency_tool import MANIFEST as URGENCY_MANIFEST
+from app.agents.tools.integrations.github_tool import MANIFEST as GITHUB_MANIFEST
 from app.agents.tools.integrations.google_docs_tool import MANIFEST as GOOGLE_DOCS_MANIFEST
-from app.agents.tools.integrations.twitter_tool import MANIFEST as TWITTER_MANIFEST
+from app.agents.tools.integrations.google_maps_tool import MANIFEST as GOOGLE_MAPS_MANIFEST
+from app.agents.tools.integrations.google_meet_tool import MANIFEST as GOOGLE_MEET_MANIFEST
+from app.agents.tools.integrations.google_sheets_tool import MANIFEST as GOOGLE_SHEETS_MANIFEST
+from app.agents.tools.integrations.google_tasks_tool import MANIFEST as GOOGLE_TASKS_MANIFEST
+from app.agents.tools.integrations.hubspot_tool import MANIFEST as HUBSPOT_MANIFEST
+from app.agents.tools.integrations.instagram_tool import MANIFEST as INSTAGRAM_MANIFEST
+from app.agents.tools.integrations.linear_tool import MANIFEST as LINEAR_MANIFEST
 from app.agents.tools.integrations.linkedin_tool import MANIFEST as LINKEDIN_MANIFEST
-from app.services.composio.custom_tools.gmail_tools import MANIFEST as GMAIL_MANIFEST
+from app.agents.tools.integrations.microsoft_teams_tool import MANIFEST as MICROSOFT_TEAMS_MANIFEST
+from app.agents.tools.integrations.notion_tool import MANIFEST as NOTION_MANIFEST
+from app.agents.tools.integrations.reddit_tool import MANIFEST as REDDIT_MANIFEST
+from app.agents.tools.integrations.slack_tool import MANIFEST as SLACK_MANIFEST
+from app.agents.tools.integrations.todoist_tool import MANIFEST as TODOIST_MANIFEST
+from app.agents.tools.integrations.trello_tool import MANIFEST as TRELLO_MANIFEST
+from app.agents.tools.integrations.twitter_tool import MANIFEST as TWITTER_MANIFEST
+from app.agents.tools.integrations.urgency_tool import MANIFEST as URGENCY_MANIFEST
 
 
 class CustomToolsRegistry:


### PR DESCRIPTION
**Problem**

The executor/subagents discover tools via semantic ChromaDB search, which only gives them tool names and descriptions.

They had no knowledge of:
* Which tools must be called before another can work (for example, you need a `document_id` before calling share/delete)
* What workflow sequences to follow for multi-step operations

Because of this, agents would:
* Call tools in the wrong order
* Fail silently

## Why this helps? 
Suppose we have a tool `A` which needs a parameter `x` and `x` is produced by tool `B` then agent now has the idea i need to call this tool  `B` before i call tool `A`

**What this change does**
`app/agents/tools/core/toolkit_manifest.py` introduces new core infrastructure:

* `ToolOutputField`
  Documents a single output field (name, type, description)

* `ToolManifestEntry`
  Defines each tool with description, output fields, `depends_on` list (tools that must run first), and tags

* `ToolWorkflow`
  Represents a named multi-step sequence (goal + ordered steps)

* `ToolkitManifest`
  Groups all tools and workflows for one integration

* `ToolkitManifestRegistry`
  Global singleton. `format_by_integration_id(id)` renders a structured text block ready to inject into a system prompt



