### PR TITLE
fix(docker): mount pgdata at /var/lib/postgresql for postgres 18 compatibility

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -368,7 +368,7 @@ services:
     secrets:
       - gaia_postgres_password
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     networks:
       gaia-prod-shared:
         aliases:

--- a/infra/docker/docker-compose.selfhost.yml
+++ b/infra/docker/docker-compose.selfhost.yml
@@ -32,7 +32,7 @@ services:
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
       POSTGRES_DB: langgraph
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     ports:
       - "${POSTGRES_HOST_PORT:-5432}:5432"
     restart: on-failure

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
       POSTGRES_DB: langgraph
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     ports:
       - "${POSTGRES_HOST_PORT:-5432}:5432"
     restart: on-failure


### PR DESCRIPTION
## Summary

The `postgres:18-alpine` image changed its data layout to `/var/lib/postgresql/<major>/docker/` (Debian `pg_ctlcluster` convention). Our compose files mount the named `pgdata` volume at the legacy `/var/lib/postgresql/data` path, which means the actual data directory ends up **outside** the named volume — Docker silently creates an anonymous volume to back the new path on every container start.

**Effect:** every container recreation orphans the previous anonymous volume and spawns a new empty one. The named `pgdata` volume stays empty. Cluster data does not persist across restarts.

Introduced by the pg18 bump in cd47526b1.

## Fix

```diff
volumes:
-  - pgdata:/var/lib/postgresql/data
+  - pgdata:/var/lib/postgresql
```

Applied identically to:
- `infra/docker/docker-compose.yml`
- `infra/docker/docker-compose.prod.yml`
- `infra/docker/docker-compose.selfhost.yml`

With this change, the named `pgdata` volume covers the path postgres 18 actually writes to, so writes persist as intended.

## Test plan

- [ ] Local: `docker compose -f infra/docker/docker-compose.yml down -v && docker compose -f infra/docker/docker-compose.yml up -d` → postgres starts cleanly, named `pgdata` volume contains `18/docker/` subdir after startup
- [ ] Local: restart the container, verify cluster data still present in `pgdata` volume (not orphaned to anonymous volume)

Production data migration is handled separately on the Hetzner VM before this compose change is deployed.