### PR TITLE
fix(cli): self-host & non-TTY fixes from end-to-end VM testing

### DIFF
--- a/infra/docker/docker-compose.selfhost.yml
+++ b/infra/docker/docker-compose.selfhost.yml
@@ -163,7 +163,11 @@ services:
     environment:
       WORKER_TYPE: arq_worker
       PYTHONPATH: /app/apps/api
-    command: ["uv", "run", "python", "-m", "arq", "app.worker.WorkerSettings"]
+    # Python deps are installed system-wide via UV_PROJECT_ENVIRONMENT=/usr/local
+    # in the API Dockerfile, so call python directly. `uv run` would try to
+    # rewrite /app/uv.lock and fail (Permission denied) under the non-root
+    # appuser the runtime image switches to.
+    command: ["python", "-m", "arq", "app.worker.WorkerSettings"]
     restart: always
     depends_on:
       redis:
@@ -182,7 +186,9 @@ services:
       - ../../apps/api/.env
     environment:
       PYTHONPATH: /app/apps/api
-    command: ["uv", "run", "python", "scripts/seed_models.py", "--force"]
+    # Same reason as arq_worker: drop the `uv run` wrapper so we don't hit
+    # the Permission denied on /app/uv.lock as appuser.
+    command: ["python", "scripts/seed_models.py", "--force"]
     depends_on:
       mongo:
         condition: service_healthy

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -1,51 +1,17 @@
 /**
- * Handler for the 'init' command.
- * Sets up the React/Ink rendering and orchestrates the init flow.
+ * Handler for the 'init' command — clones the GAIA repo.
  * @module commands/init/handler
  */
 
-import { render } from "ink";
-import React from "react";
-import { requireInteractive } from "../../lib/non-tty.js";
-import { App } from "../../ui/app.js";
-import { createStore } from "../../ui/store.js";
+import { runCommandUI } from "../../lib/command-runner.js";
 import { runInitFlow } from "./flow.js";
 
-/**
- * Executes the init command.
- * Creates the store, renders the UI, and runs the initialization flow.
- * Handles errors by displaying them in the UI before exiting.
- */
 export async function runInit(
   options: { branch?: string } = {},
 ): Promise<void> {
-  requireInteractive("init");
-  const store = createStore();
-
-  const { unmount } = render(
-    React.createElement(App, { store, command: "init" }),
-  );
-
-  const handleExit = () => {
-    unmount();
-    process.exit(130);
-  };
-  process.once("SIGINT", handleExit);
-  process.once("SIGTERM", handleExit);
-
-  try {
-    await runInitFlow(store, options.branch);
-  } catch (error) {
-    store.setError(error as Error);
-  } finally {
-    process.off("SIGINT", handleExit);
-    process.off("SIGTERM", handleExit);
-  }
-
-  if (store.currentState.error) {
-    await store.waitForInput("exit");
-  }
-
-  unmount();
-  process.exit(store.currentState.error ? 1 : 0);
+  await runCommandUI({
+    command: "init",
+    whenNonInteractive: "fail",
+    runFlow: (store) => runInitFlow(store, options.branch),
+  });
 }

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -6,6 +6,7 @@
 
 import { render } from "ink";
 import React from "react";
+import { requireInteractive } from "../../lib/non-tty.js";
 import { App } from "../../ui/app.js";
 import { createStore } from "../../ui/store.js";
 import { runInitFlow } from "./flow.js";
@@ -18,6 +19,7 @@ import { runInitFlow } from "./flow.js";
 export async function runInit(
   options: { branch?: string } = {},
 ): Promise<void> {
+  requireInteractive("init");
   const store = createStore();
 
   const { unmount } = render(

--- a/packages/cli/src/commands/setup/handler.ts
+++ b/packages/cli/src/commands/setup/handler.ts
@@ -1,10 +1,12 @@
 import { render } from "ink";
 import React from "react";
+import { requireInteractive } from "../../lib/non-tty.js";
 import { App } from "../../ui/app.js";
 import { createStore } from "../../ui/store.js";
 import { runSetupFlow } from "./flow.js";
 
 export async function runSetup(): Promise<void> {
+  requireInteractive("setup");
   const store = createStore();
 
   const { unmount } = render(

--- a/packages/cli/src/commands/setup/handler.ts
+++ b/packages/cli/src/commands/setup/handler.ts
@@ -1,38 +1,15 @@
-import { render } from "ink";
-import React from "react";
-import { requireInteractive } from "../../lib/non-tty.js";
-import { App } from "../../ui/app.js";
-import { createStore } from "../../ui/store.js";
+/**
+ * Handler for the 'setup' command — interactive env configuration wizard.
+ * @module commands/setup/handler
+ */
+
+import { runCommandUI } from "../../lib/command-runner.js";
 import { runSetupFlow } from "./flow.js";
 
 export async function runSetup(): Promise<void> {
-  requireInteractive("setup");
-  const store = createStore();
-
-  const { unmount } = render(
-    React.createElement(App, { store, command: "setup" }),
-  );
-
-  const handleExit = () => {
-    unmount();
-    process.exit(130);
-  };
-  process.once("SIGINT", handleExit);
-  process.once("SIGTERM", handleExit);
-
-  try {
-    await runSetupFlow(store);
-  } catch (error) {
-    store.setError(error as Error);
-  } finally {
-    process.off("SIGINT", handleExit);
-    process.off("SIGTERM", handleExit);
-  }
-
-  if (store.currentState.error) {
-    await store.waitForInput("exit");
-  }
-
-  unmount();
-  process.exit(store.currentState.error ? 1 : 0);
+  await runCommandUI({
+    command: "setup",
+    whenNonInteractive: "fail",
+    runFlow: runSetupFlow,
+  });
 }

--- a/packages/cli/src/commands/start/handler.ts
+++ b/packages/cli/src/commands/start/handler.ts
@@ -1,54 +1,17 @@
-import { render } from "ink";
-import React from "react";
-import { attachPlainReporter, isInteractive } from "../../lib/non-tty.js";
+/**
+ * Handler for the 'start' command — starts services via Docker Compose.
+ * @module commands/start/handler
+ */
+
+import { runCommandUI } from "../../lib/command-runner.js";
 import type { StartServicesOptions } from "../../lib/service-starter.js";
-import { App } from "../../ui/app.js";
-import { createStore } from "../../ui/store.js";
 import { runStartFlow } from "./flow.js";
 
 export async function runStart(options?: StartServicesOptions): Promise<void> {
-  const store = createStore();
-
-  if (!isInteractive()) {
-    // Non-TTY: skip Ink (it can't render without raw mode) and stream the
-    // store's state changes as plain text. Auto-resolve the trailing
-    // "press Enter to exit" prompt so the process terminates cleanly.
-    attachPlainReporter(store);
-    store.setAutoResolve("exit");
-    try {
-      await runStartFlow(store, options);
-    } catch (error) {
-      store.setError(error as Error);
-    }
-    process.exit(store.currentState.error ? 1 : 0);
-  }
-
-  const { unmount } = render(
-    React.createElement(App, { store, command: "start" }),
-  );
-
-  const handleExit = () => {
-    unmount();
-    process.exit(130);
-  };
-  process.once("SIGINT", handleExit);
-  process.once("SIGTERM", handleExit);
-
-  await new Promise((resolve) => setTimeout(resolve, 50));
-
-  try {
-    await runStartFlow(store, options);
-  } catch (error) {
-    store.setError(error as Error);
-  } finally {
-    process.off("SIGINT", handleExit);
-    process.off("SIGTERM", handleExit);
-  }
-
-  if (store.currentState.error) {
-    await store.waitForInput("exit");
-  }
-
-  unmount();
-  process.exit(store.currentState.error ? 1 : 0);
+  await runCommandUI({
+    command: "start",
+    whenNonInteractive: "plain",
+    autoResolve: [["exit"]],
+    runFlow: (store) => runStartFlow(store, options),
+  });
 }

--- a/packages/cli/src/commands/start/handler.ts
+++ b/packages/cli/src/commands/start/handler.ts
@@ -1,5 +1,6 @@
 import { render } from "ink";
 import React from "react";
+import { attachPlainReporter, isInteractive } from "../../lib/non-tty.js";
 import type { StartServicesOptions } from "../../lib/service-starter.js";
 import { App } from "../../ui/app.js";
 import { createStore } from "../../ui/store.js";
@@ -7,6 +8,20 @@ import { runStartFlow } from "./flow.js";
 
 export async function runStart(options?: StartServicesOptions): Promise<void> {
   const store = createStore();
+
+  if (!isInteractive()) {
+    // Non-TTY: skip Ink (it can't render without raw mode) and stream the
+    // store's state changes as plain text. Auto-resolve the trailing
+    // "press Enter to exit" prompt so the process terminates cleanly.
+    attachPlainReporter(store);
+    store.setAutoResolve("exit");
+    try {
+      await runStartFlow(store, options);
+    } catch (error) {
+      store.setError(error as Error);
+    }
+    process.exit(store.currentState.error ? 1 : 0);
+  }
 
   const { unmount } = render(
     React.createElement(App, { store, command: "start" }),

--- a/packages/cli/src/commands/status/handler.ts
+++ b/packages/cli/src/commands/status/handler.ts
@@ -1,11 +1,26 @@
 import { render } from "ink";
 import React from "react";
+import { attachPlainReporter, isInteractive } from "../../lib/non-tty.js";
 import { App } from "../../ui/app.js";
 import { createStore } from "../../ui/store.js";
 import { runStatusFlow } from "./flow.js";
 
 export async function runStatus(): Promise<void> {
   const store = createStore();
+
+  if (!isInteractive()) {
+    // Non-TTY: render results as plain text and exit instead of looping on
+    // an interactive refresh prompt.
+    attachPlainReporter(store);
+    store.setAutoResolve("exit_or_refresh", "exit");
+    try {
+      await runStatusFlow(store);
+      printStatusSnapshot(store);
+    } catch (error) {
+      store.setError(error as Error);
+    }
+    process.exit(store.currentState.error ? 1 : 0);
+  }
 
   const { unmount } = render(
     React.createElement(App, { store, command: "status" }),
@@ -27,4 +42,45 @@ export async function runStatus(): Promise<void> {
 
   unmount();
   process.exit(store.currentState.error ? 1 : 0);
+}
+
+interface PlainService {
+  name: string;
+  port: number;
+  status: "up" | "down" | "unknown";
+  latency?: number;
+}
+
+interface PlainContainer {
+  name: string;
+  status: "running" | "stopped" | "not_found";
+  health?: string;
+}
+
+function printStatusSnapshot(store: ReturnType<typeof createStore>): void {
+  const services = (store.currentState.data.services ?? []) as PlainService[];
+  const docker = store.currentState.data.docker as
+    | { running: boolean; containers: PlainContainer[] }
+    | undefined;
+
+  if (services.length > 0) {
+    // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+    console.log("\nServices:");
+    for (const s of services) {
+      const tag = s.status === "up" ? "UP" : "DOWN";
+      const latency = s.latency ? `${s.latency}ms` : "--";
+      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+      console.log(`  ${s.name.padEnd(12)} :${s.port}  ${tag}  ${latency}`);
+    }
+  }
+
+  if (docker) {
+    // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+    console.log(`\nDocker: ${docker.running ? "running" : "not running"}`);
+    for (const c of docker.containers ?? []) {
+      const health = c.health ? ` (${c.health})` : "";
+      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+      console.log(`  ${c.name.padEnd(14)} ${c.status}${health}`);
+    }
+  }
 }

--- a/packages/cli/src/commands/status/handler.ts
+++ b/packages/cli/src/commands/status/handler.ts
@@ -1,47 +1,23 @@
-import { render } from "ink";
-import React from "react";
-import { attachPlainReporter, isInteractive } from "../../lib/non-tty.js";
-import { App } from "../../ui/app.js";
-import { createStore } from "../../ui/store.js";
+/**
+ * Handler for the 'status' command — shows service health.
+ * @module commands/status/handler
+ */
+
+import { runCommandUI } from "../../lib/command-runner.js";
+import type { CLIStore } from "../../ui/store.js";
 import { runStatusFlow } from "./flow.js";
 
 export async function runStatus(): Promise<void> {
-  const store = createStore();
-
-  if (!isInteractive()) {
-    // Non-TTY: render results as plain text and exit instead of looping on
-    // an interactive refresh prompt.
-    attachPlainReporter(store);
-    store.setAutoResolve("exit_or_refresh", "exit");
-    try {
-      await runStatusFlow(store);
-      printStatusSnapshot(store);
-    } catch (error) {
-      store.setError(error as Error);
-    }
-    process.exit(store.currentState.error ? 1 : 0);
-  }
-
-  const { unmount } = render(
-    React.createElement(App, { store, command: "status" }),
-  );
-
-  // Wait a tick for ink to fully initialize and measure terminal dimensions
-  // before running the flow, otherwise ink-big-text may fall back to plain text
-  await new Promise((resolve) => setTimeout(resolve, 50));
-
-  try {
-    await runStatusFlow(store);
-  } catch (error) {
-    store.setError(error as Error);
-  }
-
-  if (store.currentState.error) {
-    await store.waitForInput("exit");
-  }
-
-  unmount();
-  process.exit(store.currentState.error ? 1 : 0);
+  await runCommandUI({
+    command: "status",
+    whenNonInteractive: "plain",
+    // The interactive screen loops on an "exit_or_refresh" prompt; in plain
+    // mode resolve it to "exit" so the snapshot prints once and the process
+    // terminates instead of hanging.
+    autoResolve: [["exit_or_refresh", "exit"]],
+    runFlow: runStatusFlow,
+    onPlainComplete: printStatusSnapshot,
+  });
 }
 
 interface PlainService {
@@ -57,30 +33,36 @@ interface PlainContainer {
   health?: string;
 }
 
-function printStatusSnapshot(store: ReturnType<typeof createStore>): void {
+interface PlainDocker {
+  running: boolean;
+  containers: PlainContainer[];
+}
+
+/** Renders the collected status as plain text for non-TTY environments. */
+function printStatusSnapshot(store: CLIStore): void {
   const services = (store.currentState.data.services ?? []) as PlainService[];
-  const docker = store.currentState.data.docker as
-    | { running: boolean; containers: PlainContainer[] }
-    | undefined;
+  const docker = store.currentState.data.docker as PlainDocker | undefined;
+  printServices(services);
+  printDocker(docker);
+}
 
-  if (services.length > 0) {
-    // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
-    console.log("\nServices:");
-    for (const s of services) {
-      const tag = s.status === "up" ? "UP" : "DOWN";
-      const latency = s.latency ? `${s.latency}ms` : "--";
-      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
-      console.log(`  ${s.name.padEnd(12)} :${s.port}  ${tag}  ${latency}`);
-    }
+function printServices(services: PlainService[]): void {
+  if (services.length === 0) return;
+  console.log("\nServices:");
+  for (const service of services) {
+    const tag = service.status === "up" ? "UP" : "DOWN";
+    const latency = service.latency ? `${service.latency}ms` : "--";
+    const name = service.name.padEnd(12);
+    console.log(`  ${name} :${service.port}  ${tag}  ${latency}`);
   }
+}
 
-  if (docker) {
-    // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
-    console.log(`\nDocker: ${docker.running ? "running" : "not running"}`);
-    for (const c of docker.containers ?? []) {
-      const health = c.health ? ` (${c.health})` : "";
-      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
-      console.log(`  ${c.name.padEnd(14)} ${c.status}${health}`);
-    }
+function printDocker(docker: PlainDocker | undefined): void {
+  if (!docker) return;
+  console.log(`\nDocker: ${docker.running ? "running" : "not running"}`);
+  for (const container of docker.containers ?? []) {
+    const health = container.health ? ` (${container.health})` : "";
+    const name = container.name.padEnd(14);
+    console.log(`  ${name} ${container.status}${health}`);
   }
 }

--- a/packages/cli/src/commands/status/handler.ts
+++ b/packages/cli/src/commands/status/handler.ts
@@ -46,12 +46,19 @@ function printStatusSnapshot(store: CLIStore): void {
   printDocker(docker);
 }
 
+function statusTag(status: PlainService["status"]): string {
+  if (status === "up") return "UP";
+  if (status === "down") return "DOWN";
+  return "UNKNOWN";
+}
+
 function printServices(services: PlainService[]): void {
   if (services.length === 0) return;
   console.log("\nServices:");
   for (const service of services) {
-    const tag = service.status === "up" ? "UP" : "DOWN";
-    const latency = service.latency ? `${service.latency}ms` : "--";
+    const tag = statusTag(service.status);
+    const latency =
+      service.latency === undefined ? "--" : `${service.latency}ms`;
     const name = service.name.padEnd(12);
     console.log(`  ${name} :${service.port}  ${tag}  ${latency}`);
   }

--- a/packages/cli/src/commands/stop/handler.ts
+++ b/packages/cli/src/commands/stop/handler.ts
@@ -1,51 +1,17 @@
-import { render } from "ink";
-import React from "react";
-import { attachPlainReporter, isInteractive } from "../../lib/non-tty.js";
+/**
+ * Handler for the 'stop' command — stops running services.
+ * @module commands/stop/handler
+ */
+
+import { runCommandUI } from "../../lib/command-runner.js";
 import type { StopServicesOptions } from "../../lib/service-starter.js";
-import { App } from "../../ui/app.js";
-import { createStore } from "../../ui/store.js";
 import { runStopFlow } from "./flow.js";
 
 export async function runStop(options?: StopServicesOptions): Promise<void> {
-  const store = createStore();
-
-  if (!isInteractive()) {
-    attachPlainReporter(store);
-    store.setAutoResolve("exit");
-    try {
-      await runStopFlow(store, options);
-    } catch (error) {
-      store.setError(error as Error);
-    }
-    process.exit(store.currentState.error ? 1 : 0);
-  }
-
-  const { unmount } = render(
-    React.createElement(App, { store, command: "stop" }),
-  );
-
-  const handleExit = () => {
-    unmount();
-    process.exit(130);
-  };
-  process.once("SIGINT", handleExit);
-  process.once("SIGTERM", handleExit);
-
-  await new Promise((resolve) => setTimeout(resolve, 50));
-
-  try {
-    await runStopFlow(store, options);
-  } catch (error) {
-    store.setError(error as Error);
-  } finally {
-    process.off("SIGINT", handleExit);
-    process.off("SIGTERM", handleExit);
-  }
-
-  if (store.currentState.error) {
-    await store.waitForInput("exit");
-  }
-
-  unmount();
-  process.exit(store.currentState.error ? 1 : 0);
+  await runCommandUI({
+    command: "stop",
+    whenNonInteractive: "plain",
+    autoResolve: [["exit"]],
+    runFlow: (store) => runStopFlow(store, options),
+  });
 }

--- a/packages/cli/src/commands/stop/handler.ts
+++ b/packages/cli/src/commands/stop/handler.ts
@@ -1,5 +1,6 @@
 import { render } from "ink";
 import React from "react";
+import { attachPlainReporter, isInteractive } from "../../lib/non-tty.js";
 import type { StopServicesOptions } from "../../lib/service-starter.js";
 import { App } from "../../ui/app.js";
 import { createStore } from "../../ui/store.js";
@@ -7,6 +8,17 @@ import { runStopFlow } from "./flow.js";
 
 export async function runStop(options?: StopServicesOptions): Promise<void> {
   const store = createStore();
+
+  if (!isInteractive()) {
+    attachPlainReporter(store);
+    store.setAutoResolve("exit");
+    try {
+      await runStopFlow(store, options);
+    } catch (error) {
+      store.setError(error as Error);
+    }
+    process.exit(store.currentState.error ? 1 : 0);
+  }
 
   const { unmount } = render(
     React.createElement(App, { store, command: "stop" }),

--- a/packages/cli/src/lib/command-runner.ts
+++ b/packages/cli/src/lib/command-runner.ts
@@ -118,6 +118,29 @@ async function runInk(store: CLIStore, runtime: CommandRuntime): Promise<void> {
   exitForStore(store);
 }
 
-function exitForStore(store: CLIStore): never {
-  process.exit(store.currentState.error ? 1 : 0);
+/**
+ * Exit with status 1 when the store ended in an error, else 0 — but let any
+ * buffered stdout/stderr drain first. process.exit() can terminate mid-write
+ * and truncate piped (non-TTY) output, so we only force-exit once the streams
+ * are flushed. (Setting process.exitCode and returning instead would let the
+ * undici keep-alive sockets from the health checks delay exit by several
+ * seconds, so we force-exit after the drain.)
+ */
+function exitForStore(store: CLIStore): void {
+  const code = store.currentState.error ? 1 : 0;
+  const pending = [process.stdout, process.stderr].filter(
+    (stream) => stream.writableLength > 0,
+  );
+
+  if (pending.length === 0) {
+    process.exit(code);
+  }
+
+  let remaining = pending.length;
+  for (const stream of pending) {
+    stream.once("drain", () => {
+      remaining -= 1;
+      if (remaining === 0) process.exit(code);
+    });
+  }
 }

--- a/packages/cli/src/lib/command-runner.ts
+++ b/packages/cli/src/lib/command-runner.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared lifecycle for the Ink-based commands (init/setup/status/start/stop).
+ *
+ * Every one of those handlers used to repeat the same dance: create the store,
+ * branch on TTY availability, render Ink (or stream plain text), install
+ * SIGINT/SIGTERM handlers, run the flow, wait on the trailing error prompt,
+ * and exit with the right code. This module centralises that so each handler
+ * only has to declare *what* flow to run and *how* it behaves without a TTY.
+ *
+ * @module lib/command-runner
+ */
+
+import { render } from "ink";
+import React from "react";
+import { App, type CLICommand } from "../ui/app.js";
+import { type CLIStore, createStore } from "../ui/store.js";
+import {
+  attachPlainReporter,
+  isInteractive,
+  requireInteractive,
+} from "./non-tty.js";
+
+/**
+ * Give Ink a tick to initialize and measure the terminal before the flow runs.
+ * Without it, ink-big-text occasionally falls back to plain rendering because
+ * dimensions aren't available yet.
+ */
+const INK_INIT_DELAY_MS = 50;
+
+/** Exit code POSIX shells report for a process terminated by SIGINT. */
+const SIGINT_EXIT_CODE = 130;
+
+/** An input id to resolve automatically in plain mode, with an optional value. */
+type AutoResolve = readonly [id: string, value?: unknown];
+
+interface CommandRuntime {
+  /** Selects the Ink screen to render and labels non-TTY error output. */
+  command: CLICommand;
+  /** Imperative flow that drives the store. */
+  runFlow: (store: CLIStore) => Promise<void>;
+  /**
+   * Behaviour when stdin/stdout is not a TTY:
+   * - "fail": the flow needs interactive input, so exit early with an error.
+   * - "plain": stream state changes as text instead of rendering Ink.
+   */
+  whenNonInteractive: "fail" | "plain";
+  /** Input ids to auto-resolve in plain mode (e.g. trailing "exit" prompts). */
+  autoResolve?: readonly AutoResolve[];
+  /** Plain-mode hook to print a final snapshot once the flow succeeds. */
+  onPlainComplete?: (store: CLIStore) => void;
+}
+
+/**
+ * Runs a command's flow under either an Ink UI or a plain non-TTY reporter,
+ * then exits the process with status 1 if the store ended in an error state.
+ */
+export async function runCommandUI(runtime: CommandRuntime): Promise<void> {
+  const store = createStore();
+
+  if (runtime.whenNonInteractive === "fail") {
+    requireInteractive(runtime.command); // exits the process when not a TTY
+    await runInk(store, runtime);
+    return;
+  }
+
+  if (isInteractive()) {
+    await runInk(store, runtime);
+  } else {
+    await runPlain(store, runtime);
+  }
+}
+
+async function runPlain(
+  store: CLIStore,
+  runtime: CommandRuntime,
+): Promise<void> {
+  attachPlainReporter(store);
+  for (const [id, value] of runtime.autoResolve ?? []) {
+    store.setAutoResolve(id, value);
+  }
+  try {
+    await runtime.runFlow(store);
+    runtime.onPlainComplete?.(store);
+  } catch (error) {
+    store.setError(error as Error);
+  }
+  exitForStore(store);
+}
+
+async function runInk(store: CLIStore, runtime: CommandRuntime): Promise<void> {
+  const { unmount } = render(
+    React.createElement(App, { store, command: runtime.command }),
+  );
+
+  const handleExit = () => {
+    unmount();
+    process.exit(SIGINT_EXIT_CODE);
+  };
+  process.once("SIGINT", handleExit);
+  process.once("SIGTERM", handleExit);
+
+  await new Promise((resolve) => setTimeout(resolve, INK_INIT_DELAY_MS));
+
+  try {
+    await runtime.runFlow(store);
+  } catch (error) {
+    store.setError(error as Error);
+  } finally {
+    process.off("SIGINT", handleExit);
+    process.off("SIGTERM", handleExit);
+  }
+
+  if (store.currentState.error) {
+    await store.waitForInput("exit");
+  }
+
+  unmount();
+  exitForStore(store);
+}
+
+function exitForStore(store: CLIStore): never {
+  process.exit(store.currentState.error ? 1 : 0);
+}

--- a/packages/cli/src/lib/interactive.ts
+++ b/packages/cli/src/lib/interactive.ts
@@ -109,10 +109,21 @@ export async function runConcurrentInteractiveCommands(
         reject(error);
       });
 
-      proc.on("close", (code) => {
+      proc.on("close", (code, signal) => {
         closedCount += 1;
 
-        const exitedCleanly = code === null || code === 0;
+        // Treat SIGINT / SIGTERM as a clean exit: foreground commands like
+        // `gaia logs` and `gaia dev` are *expected* to be terminated by
+        // Ctrl-C, and a child terminated by signal reports code 128+N (130
+        // for SIGINT, 143 for SIGTERM) which would otherwise look like an
+        // error to the parent.
+        const sigExit =
+          signal === "SIGINT" ||
+          signal === "SIGTERM" ||
+          code === 130 ||
+          code === 143 ||
+          stopping;
+        const exitedCleanly = code === null || code === 0 || sigExit;
         if (!exitedCleanly && !settled) {
           settled = true;
           cleanupSignalHandlers();

--- a/packages/cli/src/lib/interactive.ts
+++ b/packages/cli/src/lib/interactive.ts
@@ -123,7 +123,10 @@ export async function runConcurrentInteractiveCommands(
           code === 130 ||
           code === 143 ||
           stopping;
-        const exitedCleanly = code === null || code === 0 || sigExit;
+        // A signal-terminated child reports code === null, so only treat that
+        // as clean when it's an expected shutdown (sigExit). An unexpected
+        // SIGKILL/SIGSEGV must still surface as an error.
+        const exitedCleanly = code === 0 || sigExit;
         if (!exitedCleanly && !settled) {
           settled = true;
           cleanupSignalHandlers();

--- a/packages/cli/src/lib/non-tty.ts
+++ b/packages/cli/src/lib/non-tty.ts
@@ -16,11 +16,9 @@ export function isInteractive(): boolean {
 export function requireInteractive(commandName: string): void {
   if (isInteractive()) return;
   const what = commandName ? `'gaia ${commandName}'` : "this command";
-  // biome-ignore lint/suspicious/noConsole: error reporting before the UI layer
   console.error(
     `Error: ${what} needs an interactive terminal (TTY) to prompt for input.`,
   );
-  // biome-ignore lint/suspicious/noConsole: error reporting before the UI layer
   console.error(
     `Re-run it from a regular shell session — not a pipe, redirect, or non-TTY environment.`,
   );
@@ -40,17 +38,14 @@ export function attachPlainReporter(store: CLIStore): void {
   store.on("change", (state) => {
     if (state.step && state.step !== lastStep) {
       lastStep = state.step;
-      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
       console.log(`\n[${state.step}]`);
     }
     if (state.status && state.status !== lastStatus) {
       lastStatus = state.status;
-      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
       console.log(`  ${state.status}`);
     }
     if (state.error && state.error.message !== lastErrorMsg) {
       lastErrorMsg = state.error.message;
-      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
       console.error(`  Error: ${state.error.message}`);
     }
   });

--- a/packages/cli/src/lib/non-tty.ts
+++ b/packages/cli/src/lib/non-tty.ts
@@ -1,0 +1,57 @@
+import type { CLIStore } from "../ui/store.js";
+
+/**
+ * True only when both stdin and stdout are connected to a real TTY.
+ * Ink's raw-mode rendering requires this; without it the React components
+ * that call useInput throw "Raw mode is not supported".
+ */
+export function isInteractive(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+/**
+ * Exit early with a clear error when a command that cannot proceed without
+ * user input is invoked outside a TTY (CI, pipes, redirected stdin, etc.).
+ */
+export function requireInteractive(commandName: string): void {
+  if (isInteractive()) return;
+  const what = commandName ? `'gaia ${commandName}'` : "this command";
+  // biome-ignore lint/suspicious/noConsole: error reporting before the UI layer
+  console.error(
+    `Error: ${what} needs an interactive terminal (TTY) to prompt for input.`,
+  );
+  // biome-ignore lint/suspicious/noConsole: error reporting before the UI layer
+  console.error(
+    `Re-run it from a regular shell session — not a pipe, redirect, or non-TTY environment.`,
+  );
+  process.exit(1);
+}
+
+/**
+ * Subscribe to a CLIStore and stream its state changes as plain text. Used
+ * when the command is running outside a TTY: Ink cannot render, but we still
+ * want to surface progress (steps, status messages, errors) on stdout/stderr.
+ */
+export function attachPlainReporter(store: CLIStore): void {
+  let lastStep = "";
+  let lastStatus = "";
+  let lastErrorMsg = "";
+
+  store.on("change", (state) => {
+    if (state.step && state.step !== lastStep) {
+      lastStep = state.step;
+      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+      console.log(`\n[${state.step}]`);
+    }
+    if (state.status && state.status !== lastStatus) {
+      lastStatus = state.status;
+      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+      console.log(`  ${state.status}`);
+    }
+    if (state.error && state.error.message !== lastErrorMsg) {
+      lastErrorMsg = state.error.message;
+      // biome-ignore lint/suspicious/noConsole: this IS the UI layer in non-TTY mode
+      console.error(`  Error: ${state.error.message}`);
+    }
+  });
+}

--- a/packages/cli/src/lib/service-starter.ts
+++ b/packages/cli/src/lib/service-starter.ts
@@ -87,12 +87,18 @@ export async function startServices(
     if (isPull) upArgs.push("--pull", "always");
 
     // docker-compose.selfhost.yml has services with only `build:` defined
-    // (gaia-backend, arq_worker, seed-models). On the first start, docker
-    // compose builds those images implicitly even without --build, and
-    // building can easily take 10+ minutes on a slow link. Use the longer
-    // ceiling unconditionally — once images are cached, subsequent starts
-    // finish in seconds, so no real downside.
-    const timeoutMs = 30 * 60 * 1000;
+    // (gaia-backend, arq_worker, seed-models). On the first start docker
+    // compose has to build them implicitly even without --build, and on a
+    // resource-constrained VM (e.g. a 4 GB self-hosted box) the full Web
+    // production build alone can sit at 30+ minutes.
+    //
+    // Default ceiling: 60 minutes — long enough for the slow path, short
+    // enough to flag a stuck build. Override with GAIA_START_TIMEOUT_MIN
+    // when you genuinely need more (or 0 to disable).
+    const overrideMin = Number(process.env.GAIA_START_TIMEOUT_MIN);
+    const timeoutMin =
+      Number.isFinite(overrideMin) && overrideMin >= 0 ? overrideMin : 60;
+    const timeoutMs = timeoutMin === 0 ? undefined : timeoutMin * 60 * 1000;
 
     await runCommand(
       "docker",

--- a/packages/cli/src/lib/service-starter.ts
+++ b/packages/cli/src/lib/service-starter.ts
@@ -27,6 +27,50 @@ export interface StartServicesOptions {
   pull?: boolean;
 }
 
+/** Default ceiling for `gaia start`, in minutes. */
+const DEFAULT_START_TIMEOUT_MIN = 60;
+
+/**
+ * Resolve the `docker compose up` timeout in milliseconds.
+ *
+ * docker-compose.selfhost.yml has services with only `build:` defined
+ * (gaia-backend, arq_worker, seed-models). On the first start docker compose
+ * has to build them implicitly even without --build, and on a
+ * resource-constrained VM (e.g. a 4 GB self-hosted box) the full Web
+ * production build alone can sit at 30+ minutes.
+ *
+ * The default ceiling is long enough for that slow path but short enough to
+ * flag a genuinely stuck build. Override with GAIA_START_TIMEOUT_MIN when you
+ * need more (or set it to 0 to disable the timeout entirely).
+ */
+function resolveStartTimeoutMs(): number | undefined {
+  const overrideMin = Number(process.env.GAIA_START_TIMEOUT_MIN);
+  const timeoutMin =
+    Number.isFinite(overrideMin) && overrideMin >= 0
+      ? overrideMin
+      : DEFAULT_START_TIMEOUT_MIN;
+  return timeoutMin === 0 ? undefined : timeoutMin * 60 * 1000;
+}
+
+/** Build the `docker compose ... up` argument list for self-host mode. */
+function buildSelfhostUpArgs(
+  envArgs: string[],
+  options?: StartServicesOptions,
+): string[] {
+  const upArgs = [
+    "compose",
+    "-f",
+    "docker-compose.selfhost.yml",
+    ...envArgs,
+    "up",
+    "-d",
+    "--remove-orphans",
+  ];
+  if (options?.build) upArgs.push("--build");
+  if (options?.pull) upArgs.push("--pull", "always");
+  return upArgs;
+}
+
 export function readStoredDevPid(repoPath: string): number | null {
   const pidPath = path.join(repoPath, DEV_PID_FILE);
   if (!fs.existsSync(pidPath)) return null;
@@ -56,66 +100,35 @@ export async function startServices(
   onLog?: (chunk: string) => void,
   options?: StartServicesOptions,
 ): Promise<void> {
-  if (setupMode === "selfhost") {
-    const isBuild = options?.build ?? false;
-    const isPull = options?.pull ?? false;
-
-    if (isBuild) {
-      onStatus?.("Building and starting all services in Docker...");
-    } else {
-      onStatus?.("Starting all services in Docker (selfhost mode)...");
-    }
-
-    const dockerComposePath = path.join(repoPath, "infra/docker");
-    const envArgs = getEnvFileArgs(dockerComposePath);
-    const dockerEnv =
-      portOverrides && Object.keys(portOverrides).length > 0
-        ? portOverridesToDockerEnv(portOverrides)
-        : undefined;
-
-    const upArgs = [
-      "compose",
-      "-f",
-      "docker-compose.selfhost.yml",
-      ...envArgs,
-      "up",
-      "-d",
-      "--remove-orphans",
-    ];
-
-    if (isBuild) upArgs.push("--build");
-    if (isPull) upArgs.push("--pull", "always");
-
-    // docker-compose.selfhost.yml has services with only `build:` defined
-    // (gaia-backend, arq_worker, seed-models). On the first start docker
-    // compose has to build them implicitly even without --build, and on a
-    // resource-constrained VM (e.g. a 4 GB self-hosted box) the full Web
-    // production build alone can sit at 30+ minutes.
-    //
-    // Default ceiling: 60 minutes — long enough for the slow path, short
-    // enough to flag a stuck build. Override with GAIA_START_TIMEOUT_MIN
-    // when you genuinely need more (or 0 to disable).
-    const overrideMin = Number(process.env.GAIA_START_TIMEOUT_MIN);
-    const timeoutMin =
-      Number.isFinite(overrideMin) && overrideMin >= 0 ? overrideMin : 60;
-    const timeoutMs = timeoutMin === 0 ? undefined : timeoutMin * 60 * 1000;
-
-    await runCommand(
-      "docker",
-      upArgs,
-      dockerComposePath,
-      undefined,
-      onLog,
-      dockerEnv,
-      timeoutMs,
-    );
-    onStatus?.("All services started in Docker!");
-  } else {
+  if (setupMode !== "selfhost") {
     onStatus?.("Developer mode must run in foreground.");
     throw new Error(
       "Developer mode runs in foreground. Use 'gaia dev' or 'gaia dev full' instead of 'gaia start'.",
     );
   }
+
+  onStatus?.(
+    options?.build
+      ? "Building and starting all services in Docker..."
+      : "Starting all services in Docker (selfhost mode)...",
+  );
+
+  const dockerComposePath = path.join(repoPath, "infra/docker");
+  const dockerEnv =
+    portOverrides && Object.keys(portOverrides).length > 0
+      ? portOverridesToDockerEnv(portOverrides)
+      : undefined;
+
+  await runCommand(
+    "docker",
+    buildSelfhostUpArgs(getEnvFileArgs(dockerComposePath), options),
+    dockerComposePath,
+    undefined,
+    onLog,
+    dockerEnv,
+    resolveStartTimeoutMs(),
+  );
+  onStatus?.("All services started in Docker!");
 }
 
 export async function stopServices(

--- a/packages/cli/src/lib/service-starter.ts
+++ b/packages/cli/src/lib/service-starter.ts
@@ -44,7 +44,10 @@ const DEFAULT_START_TIMEOUT_MIN = 60;
  * need more (or set it to 0 to disable the timeout entirely).
  */
 function resolveStartTimeoutMs(): number | undefined {
-  const overrideMin = Number(process.env.GAIA_START_TIMEOUT_MIN);
+  // Number("") and Number("  ") are 0, which would silently disable the
+  // timeout. Treat a blank value as unset and fall back to the default.
+  const raw = process.env.GAIA_START_TIMEOUT_MIN?.trim();
+  const overrideMin = raw ? Number(raw) : Number.NaN;
   const timeoutMin =
     Number.isFinite(overrideMin) && overrideMin >= 0
       ? overrideMin

--- a/packages/cli/src/lib/service-starter.ts
+++ b/packages/cli/src/lib/service-starter.ts
@@ -86,7 +86,13 @@ export async function startServices(
     if (isBuild) upArgs.push("--build");
     if (isPull) upArgs.push("--pull", "always");
 
-    const timeoutMs = isBuild ? 15 * 60 * 1000 : 5 * 60 * 1000;
+    // docker-compose.selfhost.yml has services with only `build:` defined
+    // (gaia-backend, arq_worker, seed-models). On the first start, docker
+    // compose builds those images implicitly even without --build, and
+    // building can easily take 10+ minutes on a slow link. Use the longer
+    // ceiling unconditionally — once images are cached, subsequent starts
+    // finish in seconds, so no real downside.
+    const timeoutMs = 30 * 60 * 1000;
 
     await runCommand(
       "docker",

--- a/packages/cli/src/ui/components/shared-steps.tsx
+++ b/packages/cli/src/ui/components/shared-steps.tsx
@@ -5,7 +5,7 @@ import type { PortCheckResult } from "../../lib/prerequisites.js";
 import { THEME_COLOR } from "../constants.js";
 
 export const SystemChecksStep: React.FC<{
-  checks: { git: string; docker: string; mise: string };
+  checks: { git: string; docker: string; mise?: string };
 }> = ({ checks }) => (
   <Box
     flexDirection="column"
@@ -23,10 +23,12 @@ export const SystemChecksStep: React.FC<{
         label="Docker"
         status={checks.docker as "pending" | "success" | "error" | "missing"}
       />
-      <CheckItem
-        label="Mise"
-        status={checks.mise as "pending" | "success" | "error" | "missing"}
-      />
+      {checks.mise && (
+        <CheckItem
+          label="Mise"
+          status={checks.mise as "pending" | "success" | "error" | "missing"}
+        />
+      )}
     </Box>
   </Box>
 );

--- a/packages/cli/src/ui/store.ts
+++ b/packages/cli/src/ui/store.ts
@@ -50,16 +50,14 @@ export class CLIStore extends EventEmitter {
   private inputResolver: ((value: any) => void) | null = null;
   private emitTimer: ReturnType<typeof setTimeout> | null = null;
   private emitPending = false;
-  // biome-ignore lint: Allow any for flexible auto-resolve values
-  private readonly autoResolveInputs: Map<string, any> = new Map();
+  private readonly autoResolveInputs: Map<string, unknown> = new Map();
 
   /**
    * Mark an input request id as auto-resolved instead of blocking on a UI
    * prompt. Used by non-TTY (plain text) handlers so flows that wait for a
    * final "exit" confirmation don't hang the process.
    */
-  // biome-ignore lint: Allow any for flexible auto-resolve values
-  setAutoResolve(id: string, value: any = "exit"): void {
+  setAutoResolve(id: string, value: unknown = "exit"): void {
     this.autoResolveInputs.set(id, value);
   }
 

--- a/packages/cli/src/ui/store.ts
+++ b/packages/cli/src/ui/store.ts
@@ -51,7 +51,7 @@ export class CLIStore extends EventEmitter {
   private emitTimer: ReturnType<typeof setTimeout> | null = null;
   private emitPending = false;
   // biome-ignore lint: Allow any for flexible auto-resolve values
-  private autoResolveInputs: Map<string, any> = new Map();
+  private readonly autoResolveInputs: Map<string, any> = new Map();
 
   /**
    * Mark an input request id as auto-resolved instead of blocking on a UI

--- a/packages/cli/src/ui/store.ts
+++ b/packages/cli/src/ui/store.ts
@@ -50,6 +50,18 @@ export class CLIStore extends EventEmitter {
   private inputResolver: ((value: any) => void) | null = null;
   private emitTimer: ReturnType<typeof setTimeout> | null = null;
   private emitPending = false;
+  // biome-ignore lint: Allow any for flexible auto-resolve values
+  private autoResolveInputs: Map<string, any> = new Map();
+
+  /**
+   * Mark an input request id as auto-resolved instead of blocking on a UI
+   * prompt. Used by non-TTY (plain text) handlers so flows that wait for a
+   * final "exit" confirmation don't hang the process.
+   */
+  // biome-ignore lint: Allow any for flexible auto-resolve values
+  setAutoResolve(id: string, value: any = "exit"): void {
+    this.autoResolveInputs.set(id, value);
+  }
 
   /**
    * Gets the current state snapshot.
@@ -143,6 +155,11 @@ export class CLIStore extends EventEmitter {
    */
   // biome-ignore lint: Allow any for flexible meta and return types
   waitForInput(id: string, meta?: any, timeoutMs?: number): Promise<any> {
+    if (this.autoResolveInputs.has(id)) {
+      this.state.inputRequest = null;
+      this.emitNow();
+      return Promise.resolve(this.autoResolveInputs.get(id));
+    }
     this.state.inputRequest = { id, meta };
     this.emitNow();
     return new Promise((resolve) => {


### PR DESCRIPTION
## Summary

A batch of CLI and self-host fixes surfaced while running the GAIA CLI end-to-end against fresh VMs (Ubuntu / Debian / Multipass, including resource-constrained 4 GB arm64 Apple Silicon hosts). These are the rough edges that broke a clean first-time self-host install.

## Changes

- **fix(selfhost): drop `uv run` wrapper from arq_worker / seed-models** — `arq_worker` was stuck in a restart loop with `failed to write to file /app/uv.lock: Permission denied`. The API runtime image runs as non-root `appuser`, but `uv run` tries to refresh the root-owned `uv.lock` even on a frozen install. Deps are already installed system-wide (`UV_PROJECT_ENVIRONMENT=/usr/local`), so we call `python` directly — matching gaia-backend's working default CMD.

- **fix(cli): non-TTY support** — Every Ink-based command crashed in non-TTY contexts (CI, pipes, Dockerfiles, cron) with *"Raw mode is not supported on the current process.stdin"*. New `src/lib/non-tty.ts` adds `isInteractive()`, `requireInteractive()`, and `attachPlainReporter()`. `init`/`setup` exit early with a clear error when not interactive; `start`/`stop`/`status` skip Ink and stream plain-text state changes, with `CLIStore.setAutoResolve` letting trailing "press Enter to exit" prompts resolve immediately.

- **fix(cli): make `gaia start` timeout configurable, default 60 min** — First-time self-host builds (notably the gaia-web Next.js production build) can exceed 30 min on slow/low-RAM hosts, and the old ceiling killed them. Default bumped to 60 min, overridable via `GAIA_START_TIMEOUT_MIN` (`0` disables). Cached subsequent starts finish in seconds, so no happy-path cost.

- **fix(cli): treat Ctrl-C / SIGTERM as clean exit in interactive commands** — `gaia logs` / `gaia dev` shell out to long-running processes; Ctrl-C produced a scary `Command failed with code 130` stack trace. Signal-terminated children (signal set, or exit 130/143) and self-requested stops now resolve quietly.

- **fix(cli): hide Mise prereq row in self-host system checks** — Mise is only relevant in developer mode; the status screen was rendering an irrelevant yellow "missing" warning in self-host mode. Made optional in the type and conditionally rendered.

## Test plan

- [x] End-to-end self-host install verified on fresh Ubuntu / Debian / Multipass VMs
- [x] Verified arq_worker / seed-models start without the `uv.lock` permission error
- [x] Verified `status` / `start` / `stop` run in non-TTY (piped) contexts without the raw-mode crash
- [x] Verified Ctrl-C on `gaia logs` / `gaia dev` exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)