### PR TITLE
chore(quality): split onboarding stage files + enforce components-per-file

### DIFF
--- a/.github/quality-gate/enforced/components-per-file
+++ b/.github/quality-gate/enforced/components-per-file
@@ -1,0 +1,1 @@
+enforced

--- a/apps/web/src/app/[locale]/(main)/onboarding/demo/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/onboarding/demo/page.tsx
@@ -25,11 +25,11 @@ import { WorkflowsRevealCard } from "@/features/onboarding/components/reveal/Wor
 import { WritingStyleRevealCard } from "@/features/onboarding/components/reveal/WritingStyleRevealCard";
 import { ClarifyComposer } from "@/features/onboarding/components/stages/Clarify";
 import { Platforms } from "@/features/onboarding/components/stages/Platforms";
-import { SelectedTodoIndicator } from "@/features/onboarding/components/stages/RevealTodos";
 import {
   RevealWritingStyle,
   RevealWritingStyleComposer,
 } from "@/features/onboarding/components/stages/RevealWritingStyle";
+import { SelectedTodoIndicator } from "@/features/onboarding/components/stages/SelectedTodoIndicator";
 import { Workflows } from "@/features/onboarding/components/stages/Workflows";
 import { professionOptions } from "@/features/onboarding/constants";
 import { BOT_BUBBLE_DEFAULTS } from "@/features/onboarding/constants/bubbleDefaults";

--- a/apps/web/src/features/onboarding/components/CompletedStagesTimeline.tsx
+++ b/apps/web/src/features/onboarding/components/CompletedStagesTimeline.tsx
@@ -21,7 +21,7 @@ import { OnboardingPlatformConnect } from "./OnboardingPlatformConnect";
 import { OnboardingTodoCards } from "./OnboardingTodoCards";
 import { OnboardingWorkflowCards } from "./OnboardingWorkflowCards";
 import { WritingStyleRevealCard } from "./reveal/WritingStyleRevealCard";
-import { OnboardingChatStream } from "./stages/Chat";
+import { OnboardingChatStream } from "./stages/ChatStream";
 
 interface CompletedStagesTimelineProps {
   state: OnboardingState;

--- a/apps/web/src/features/onboarding/components/stages/Chat.tsx
+++ b/apps/web/src/features/onboarding/components/stages/Chat.tsx
@@ -11,16 +11,10 @@ import * as m from "motion/react-m";
 import type { Dispatch } from "react";
 import { useEffect } from "react";
 import ChatBubbleBot from "@/features/chat/components/bubbles/bot/ChatBubbleBot";
-import ChatBubbleUser from "@/features/chat/components/bubbles/user/ChatBubbleUser";
-import { LoadingIndicator } from "@/features/chat/components/interface/LoadingIndicator";
-import {
-  BOT_BUBBLE_DEFAULTS,
-  USER_BUBBLE_DEFAULTS,
-} from "../../constants/bubbleDefaults";
+import { BOT_BUBBLE_DEFAULTS } from "../../constants/bubbleDefaults";
 import {
   MOTION_COMPOSER_CTA,
   MOTION_FADE_UP_LARGE,
-  MOTION_STREAM_MESSAGE,
 } from "../../constants/motion";
 import {
   type UseOnboardingChatReturn,
@@ -58,74 +52,6 @@ export function useChatStage(
   }, [pendingTodoMessage, todoDemoConvoId, dispatch]);
 
   return { welcome, todoDemo };
-}
-
-const RUN_NOW_PREFIX = "Execute this todo for me: ";
-
-export function OnboardingChatStream({
-  chat,
-  hideRunNowUserMessage = false,
-  hideBotAvatar = false,
-}: {
-  chat: UseOnboardingChatReturn;
-  hideRunNowUserMessage?: boolean;
-  hideBotAvatar?: boolean;
-}) {
-  const visibleMessages = hideRunNowUserMessage
-    ? chat.streamMessages.filter(
-        (msg) =>
-          !(
-            msg.role === "user" &&
-            typeof msg.content === "string" &&
-            msg.content.startsWith(RUN_NOW_PREFIX)
-          ),
-      )
-    : chat.streamMessages;
-  return (
-    <>
-      {visibleMessages.map((msg) => (
-        <m.div key={msg.id} {...MOTION_STREAM_MESSAGE}>
-          {msg.role === "user" ? (
-            <ChatBubbleUser
-              {...USER_BUBBLE_DEFAULTS}
-              text={msg.content}
-              message_id={msg.id}
-              date={msg.createdAt.toISOString()}
-              fileData={msg.fileData}
-            />
-          ) : (
-            <ChatBubbleBot
-              {...BOT_BUBBLE_DEFAULTS}
-              text={msg.content}
-              message_id={msg.id}
-              loading={msg.status === "sending"}
-              tool_data={msg.tool_data ?? undefined}
-              todo_progress={msg.todo_progress ?? undefined}
-              memory_data={msg.memory_data ?? undefined}
-              image_data={msg.image_data ?? undefined}
-              date={msg.createdAt.toISOString()}
-              hideAvatar={hideBotAvatar}
-            />
-          )}
-        </m.div>
-      ))}
-
-      {chat.isChatSending &&
-        !visibleMessages.some(
-          (msg) => msg.role === "assistant" && msg.content,
-        ) && (
-          <LoadingIndicator
-            loadingText={
-              hideRunNowUserMessage
-                ? "Auto-executing todo…"
-                : "GAIA is thinking…"
-            }
-            loadingTextKey={0}
-            noPadding={hideRunNowUserMessage}
-          />
-        )}
-    </>
-  );
 }
 
 export function Chat({ state }: Omit<ChatProps, "dispatch" | "chat">) {

--- a/apps/web/src/features/onboarding/components/stages/ChatStream.tsx
+++ b/apps/web/src/features/onboarding/components/stages/ChatStream.tsx
@@ -1,0 +1,86 @@
+/**
+ * Renders the live onboarding chat stream (user + bot bubbles plus the thinking
+ * indicator). Shared by the `chat` stage and the run-now todo demo, so it lives
+ * in its own file rather than inside Chat.tsx.
+ */
+
+"use client";
+
+import * as m from "motion/react-m";
+import ChatBubbleBot from "@/features/chat/components/bubbles/bot/ChatBubbleBot";
+import ChatBubbleUser from "@/features/chat/components/bubbles/user/ChatBubbleUser";
+import { LoadingIndicator } from "@/features/chat/components/interface/LoadingIndicator";
+import {
+  BOT_BUBBLE_DEFAULTS,
+  USER_BUBBLE_DEFAULTS,
+} from "../../constants/bubbleDefaults";
+import { MOTION_STREAM_MESSAGE } from "../../constants/motion";
+import type { UseOnboardingChatReturn } from "../../hooks/useOnboardingChat";
+
+const RUN_NOW_PREFIX = "Execute this todo for me: ";
+
+export function OnboardingChatStream({
+  chat,
+  hideRunNowUserMessage = false,
+  hideBotAvatar = false,
+}: {
+  chat: UseOnboardingChatReturn;
+  hideRunNowUserMessage?: boolean;
+  hideBotAvatar?: boolean;
+}) {
+  const visibleMessages = hideRunNowUserMessage
+    ? chat.streamMessages.filter(
+        (msg) =>
+          !(
+            msg.role === "user" &&
+            typeof msg.content === "string" &&
+            msg.content.startsWith(RUN_NOW_PREFIX)
+          ),
+      )
+    : chat.streamMessages;
+  return (
+    <>
+      {visibleMessages.map((msg) => (
+        <m.div key={msg.id} {...MOTION_STREAM_MESSAGE}>
+          {msg.role === "user" ? (
+            <ChatBubbleUser
+              {...USER_BUBBLE_DEFAULTS}
+              text={msg.content}
+              message_id={msg.id}
+              date={msg.createdAt.toISOString()}
+              fileData={msg.fileData}
+            />
+          ) : (
+            <ChatBubbleBot
+              {...BOT_BUBBLE_DEFAULTS}
+              text={msg.content}
+              message_id={msg.id}
+              loading={msg.status === "sending"}
+              tool_data={msg.tool_data ?? undefined}
+              todo_progress={msg.todo_progress ?? undefined}
+              memory_data={msg.memory_data ?? undefined}
+              image_data={msg.image_data ?? undefined}
+              date={msg.createdAt.toISOString()}
+              hideAvatar={hideBotAvatar}
+            />
+          )}
+        </m.div>
+      ))}
+
+      {chat.isChatSending &&
+        !visibleMessages.some(
+          (msg) => msg.role === "assistant" && msg.content,
+        ) && (
+          <LoadingIndicator
+            loadingText={
+              hideRunNowUserMessage
+                ? "Auto-executing todo…"
+                : "GAIA is thinking…"
+            }
+            loadingTextKey={0}
+            noPadding={hideRunNowUserMessage}
+          />
+        )}
+    </>
+  );
+}

--- a/apps/web/src/features/onboarding/components/stages/RevealTodos.tsx
+++ b/apps/web/src/features/onboarding/components/stages/RevealTodos.tsx
@@ -16,8 +16,6 @@
 "use client";
 
 import { Button } from "@heroui/button";
-import { Chip } from "@heroui/chip";
-import { CheckmarkCircle02Icon, Mail01Icon } from "@icons";
 import * as m from "motion/react-m";
 import type { Dispatch } from "react";
 import { useCallback } from "react";
@@ -32,7 +30,8 @@ import type { Action, OnboardingState } from "../../state/types";
 import { OnboardingCTAButton } from "../OnboardingCTAButton";
 import { OnboardingTodoCards } from "../OnboardingTodoCards";
 import { RevealIntroBubble } from "../RevealIntroBubble";
-import { OnboardingChatStream } from "./Chat";
+import { OnboardingChatStream } from "./ChatStream";
+import { SelectedTodoIndicator } from "./SelectedTodoIndicator";
 
 interface RevealTodosProps {
   state: OnboardingState;
@@ -45,43 +44,6 @@ function generateConvoId(): string {
     return crypto.randomUUID();
   }
   return `onboarding-todo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
-export interface SelectedTodoIndicatorProps {
-  title: string;
-  sourceEmail: { sender: string; subject: string } | null;
-}
-
-export function SelectedTodoIndicator({
-  title,
-  sourceEmail,
-}: SelectedTodoIndicatorProps) {
-  return (
-    <div className="rounded-2xl bg-zinc-900 p-3">
-      <Chip
-        color="success"
-        variant="flat"
-        size="sm"
-        startContent={<CheckmarkCircle02Icon className="size-3.5" />}
-      >
-        Selected todo
-      </Chip>
-      <div className="mt-2 text-sm text-white">{title}</div>
-      {sourceEmail && (
-        <div className="mt-3 flex items-start gap-2 rounded-xl bg-zinc-800 p-3">
-          <Mail01Icon className="mt-0.5 size-3.5 shrink-0 text-zinc-500" />
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-xs text-zinc-400">
-              {sourceEmail.sender}
-            </div>
-            <div className="truncate text-xs text-zinc-500">
-              {sourceEmail.subject}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
 }
 
 export function RevealTodosComposer({

--- a/apps/web/src/features/onboarding/components/stages/SelectedTodoIndicator.tsx
+++ b/apps/web/src/features/onboarding/components/stages/SelectedTodoIndicator.tsx
@@ -1,0 +1,48 @@
+/**
+ * Compact card shown above the run-now chat stream summarising the todo the
+ * user chose to execute, plus the source email it was derived from (if any).
+ * Lives in its own file so RevealTodos.tsx stays within the components-per-file
+ * limit.
+ */
+
+"use client";
+
+import { Chip } from "@heroui/chip";
+import { CheckmarkCircle02Icon, Mail01Icon } from "@icons";
+
+export interface SelectedTodoIndicatorProps {
+  title: string;
+  sourceEmail: { sender: string; subject: string } | null;
+}
+
+export function SelectedTodoIndicator({
+  title,
+  sourceEmail,
+}: SelectedTodoIndicatorProps) {
+  return (
+    <div className="rounded-2xl bg-zinc-900 p-3">
+      <Chip
+        color="success"
+        variant="flat"
+        size="sm"
+        startContent={<CheckmarkCircle02Icon className="size-3.5" />}
+      >
+        Selected todo
+      </Chip>
+      <div className="mt-2 text-sm text-white">{title}</div>
+      {sourceEmail && (
+        <div className="mt-3 flex items-start gap-2 rounded-xl bg-zinc-800 p-3">
+          <Mail01Icon className="mt-0.5 size-3.5 shrink-0 text-zinc-500" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs text-zinc-400">
+              {sourceEmail.sender}
+            </div>
+            <div className="truncate text-xs text-zinc-500">
+              {sourceEmail.subject}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/onboarding/components/stages/index.ts
+++ b/apps/web/src/features/onboarding/components/stages/index.ts
@@ -1,4 +1,5 @@
-export { Chat, ChatComposer, OnboardingChatStream, useChatStage } from "./Chat";
+export { Chat, ChatComposer, useChatStage } from "./Chat";
+export { OnboardingChatStream } from "./ChatStream";
 export { ClarifyComposer } from "./Clarify";
 export { FocusComposer } from "./Focus";
 export { Platforms, PlatformsComposer } from "./Platforms";


### PR DESCRIPTION
Resolution PR for the **components-per-file** lane (max 2 React components per file).

## The issue
Two onboarding stage files each declared 3 exported components:
- `stages/Chat.tsx` → `OnboardingChatStream`, `Chat`, `ChatComposer`
- `stages/RevealTodos.tsx` → `SelectedTodoIndicator`, `RevealTodosComposer`, `RevealTodos`

The rule exists so files stay single-purpose and components are easy to find.

## The fix
Move one component out of each file into its own:
- `OnboardingChatStream` → `stages/ChatStream.tsx`
- `SelectedTodoIndicator` → `stages/SelectedTodoIndicator.tsx`

All import sites updated (`stages/index.ts` barrel, `CompletedStagesTimeline.tsx`, `demo/page.tsx`). Public exports unchanged. Verified `check-components-per-file.mjs` → all files within limit; biome clean on touched files.

## Ratchet
Enforces the lane by adding `.github/quality-gate/enforced/components-per-file`.

> Depends on #694 (migrates the gate to read these marker files). Merge #694 first so enforcement activates; this PR is conflict-free either way since it doesn't touch the workflow.