### PR TITLE
fix(shared): reference window via globalThis in getUserTimezone

### DIFF
--- a/libs/shared/ts/src/api/timezone.ts
+++ b/libs/shared/ts/src/api/timezone.ts
@@ -1,5 +1,9 @@
 export function getUserTimezone(): string {
-  if (typeof window !== "undefined") {
+  // `window` only exists in the browser. Reference it through globalThis so
+  // this isomorphic util type-checks against the ES2022 lib without pulling
+  // the DOM lib into the shared package, which is also consumed by Node code.
+  const inBrowser = typeof globalThis !== "undefined" && "window" in globalThis;
+  if (inBrowser) {
     try {
       return Intl.DateTimeFormat().resolvedOptions().timeZone;
     } catch (error) {


### PR DESCRIPTION
## Summary

`libs/shared/ts/src/api/timezone.ts` referenced the bare browser global `window`, but the `shared-typescript` build (`pnpm tsc`) targets **ES2022 with no DOM lib**. A *cold* build therefore fails with:

```
src/api/timezone.ts(2,14): error TS2304: Cannot find name 'window'.
```

This is a pre-existing latent bug on `develop`. It only ever passed because nx restored a cached `shared-typescript:build` result. On a cache miss the build runs `tsc` for real and fails, which breaks **any** PR that cold-builds `shared-typescript` (it's a dependency of `cli:build`). It surfaced on #691's CI.

## Fix

Detect the browser via `globalThis` instead of the bare `window` identifier:

```ts
const inBrowser = typeof globalThis !== "undefined" && "window" in globalThis;
```

- **Behavior-preserving** — same isomorphic logic (detect the user's timezone in the browser, default to `UTC` on the server).
- **Zero blast radius** — `globalThis` is part of the ES2022 lib, so no tsconfig change is needed. `timezone.ts` is the only file in the shared lib that touched a browser global, so adding `"DOM"` to the lib would have pulled the entire DOM type surface into a package that Node code (CLI, bots) also consumes — letting `document.querySelector(...)` and friends type-check in server code. The `globalThis` guard avoids that.

## Test plan

- [x] `pnpm tsc` (real `shared-typescript` build target) passes
- [x] DOM-excluded `tsc` (`--lib ES2022 --types node`, replicating the CI cold-build environment) passes on the fix
- [x] The same DOM-excluded `tsc` reproduces `TS2304: Cannot find name 'window'` on the original, confirming the fix addresses the actual failure
- [x] Biome clean