### PR TITLE
chore(quality): fix biome errors + enforce biome lane

### DIFF
--- a/.github/quality-gate/enforced/biome
+++ b/.github/quality-gate/enforced/biome
@@ -1,0 +1,1 @@
+enforced

--- a/apps/web/src/app/[locale]/(main)/dashboard/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@icons";
 import { getSimpleTimeGreeting } from "@shared/utils";
 import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
 import { useUser } from "@/features/auth/hooks/useUser";
 import { useCalendarsQuery } from "@/features/calendar/hooks/useCalendarsQuery";
 import { useUpcomingEventsQuery } from "@/features/calendar/hooks/useUpcomingEventsQuery";
@@ -112,7 +113,7 @@ export default function HomePage() {
     activeWorkflows > 0;
 
   // Build sections array for display
-  const sections = [];
+  const sections: { icon: ReactNode; count: number; label: string }[] = [];
   if (todaysMeetings > 0) {
     sections.push({
       icon: <Calendar03Icon className="w-7 h-7 text-blue-400" />,

--- a/apps/web/src/app/[locale]/(main)/layout.tsx
+++ b/apps/web/src/app/[locale]/(main)/layout.tsx
@@ -10,7 +10,6 @@ import RightSidebar from "@/components/layout/sidebar/RightSidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useOnboardingGuard } from "@/features/auth/hooks/useOnboardingGuard";
-import { useUser } from "@/features/auth/hooks/useUser";
 import { useIsMobile } from "@/hooks/ui/useMobile";
 import { useBackgroundSync } from "@/hooks/useBackgroundSync";
 import ProvidersLayout from "@/layouts/ProvidersLayout";
@@ -55,7 +54,6 @@ const HeaderSidebarTrigger = () => {
 };
 
 export default function MainLayout({ children }: { children: ReactNode }) {
-  const user = useUser();
   const { isOpen, isMobileOpen, setOpen, setMobileOpen } = useUIStoreSidebar();
   const {
     content: rightSidebarContent,

--- a/apps/web/src/app/[locale]/(main)/onboarding/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/onboarding/page.tsx
@@ -103,10 +103,7 @@ export default function Onboarding() {
     setIntroDone(true);
   };
 
-  const { welcome: welcomeChat, todoDemo: todoDemoChat } = useChatStage(
-    state,
-    dispatch,
-  );
+  const { todoDemo: todoDemoChat } = useChatStage(state, dispatch);
 
   const stageContent = (() => {
     switch (stage) {

--- a/apps/web/src/app/api/og/integration/route.tsx
+++ b/apps/web/src/app/api/og/integration/route.tsx
@@ -21,6 +21,17 @@ import {
 
 export const runtime = "edge";
 
+interface OgIntegration {
+  name?: string;
+  description?: string;
+  category?: string;
+  creator?: { name?: string; picture?: string };
+  cloneCount?: number;
+  toolCount?: number;
+  integrationId?: string;
+  iconUrl?: string;
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -36,7 +47,7 @@ export async function GET(request: Request) {
     const siteBaseUrl = getBaseUrl(request.url);
     const wallpaperUrl = `${siteBaseUrl}${wallpapers.integration.png}`;
 
-    let integration = null;
+    let integration: OgIntegration | null = null;
     try {
       const response = await fetch(
         `${apiBaseUrl}/integrations/public/${identifier}`,
@@ -51,7 +62,7 @@ export async function GET(request: Request) {
       console.error("[OG Image] Fetch failed:", e);
     }
 
-    const name = integration?.name || id;
+    const name = integration?.name || identifier;
     const description = integration?.description || "MCP Integration for GAIA";
     const category = integration?.category || "integration";
     const creatorName = integration?.creator?.name || "Community";
@@ -65,7 +76,7 @@ export async function GET(request: Request) {
     const toolCount = integration?.toolCount || 0;
 
     // Integration ID is used to look up known icons
-    const integrationId = integration?.integrationId || id;
+    const integrationId = integration?.integrationId || identifier;
 
     // First, try to get a known icon from the config (same as PublicIntegrationCard)
     const knownIconPath = getOgIconPath(integrationId);

--- a/apps/web/src/app/api/og/use-case/route.tsx
+++ b/apps/web/src/app/api/og/use-case/route.tsx
@@ -23,6 +23,15 @@ import {
 
 export const runtime = "edge";
 
+interface OgWorkflow {
+  id?: string;
+  title?: string;
+  description?: string;
+  steps?: { category: string }[];
+  total_executions?: number;
+  creator?: { id?: string; name?: string; avatar?: string };
+}
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -35,7 +44,7 @@ export async function GET(request: NextRequest) {
     const apiBaseUrl = getApiBaseUrl();
     const siteBaseUrl = getBaseUrl(request.url);
 
-    let workflow = null;
+    let workflow: OgWorkflow | null = null;
     try {
       const [exploreResponse, communityResponse] = await Promise.all([
         fetch(`${apiBaseUrl}/workflows/explore`, { cache: "no-store" }),

--- a/apps/web/src/features/chat/components/interface/ChatRenderer.tsx
+++ b/apps/web/src/features/chat/components/interface/ChatRenderer.tsx
@@ -24,6 +24,7 @@ import {
 import { getMessageProps } from "@/features/chat/utils/messagePropsUtils";
 import type {
   ChatBubbleBotProps,
+  ChatBubbleUserProps,
   SetImageDataType,
 } from "@/types/features/chatBubbleTypes";
 import type { MessageType } from "@/types/features/convoTypes";
@@ -202,7 +203,8 @@ export default function ChatRenderer({
       {isWelcomeConversation && <WelcomeChat />}
       {messagesWithDeduplicatedToolCalls?.map(
         (message: MessageType, index: number) => {
-          let messageProps = null;
+          let messageProps: ChatBubbleBotProps | ChatBubbleUserProps | null =
+            null;
 
           if (message.type === "bot")
             messageProps = getMessageProps(message, "bot", messagePropsOptions);

--- a/apps/web/src/features/chat/components/tools/MCPAppRenderer.tsx
+++ b/apps/web/src/features/chat/components/tools/MCPAppRenderer.tsx
@@ -94,9 +94,8 @@ export function MCPAppRenderer({ data }: Props) {
         );
         const content = result.content.map((item) => {
           if (item && typeof item === "object") {
-            const c = { ...(item as Record<string, unknown>) };
-            if (c.annotations == null) delete c.annotations;
-            return c;
+            const { annotations, ...rest } = item as Record<string, unknown>;
+            return annotations == null ? rest : { ...rest, annotations };
           }
           return item;
         });

--- a/apps/web/src/features/chat/components/voice-agent/hooks/useChatAndTranscription.ts
+++ b/apps/web/src/features/chat/components/voice-agent/hooks/useChatAndTranscription.ts
@@ -16,7 +16,7 @@ export default function useChatAndTranscription() {
   const room = useRoomContext();
 
   const mergedTranscriptions = useMemo(() => {
-    const merged: Array<ReceivedChatMessage> = [
+    const merged: ReceivedChatMessage[] = [
       ...transcriptions.map((transcription) =>
         transcriptionToChatMessage(transcription, room),
       ),

--- a/apps/web/src/features/download/components/DownloadPage.tsx
+++ b/apps/web/src/features/download/components/DownloadPage.tsx
@@ -272,7 +272,7 @@ function DesktopSection() {
   };
 
   const renderSecondaryButtons = () => {
-    const buttons = [];
+    const buttons: ReactNode[] = [];
 
     if (!isMac) buttons.push(<MacDownloadButton key="mac" />);
 

--- a/apps/web/src/features/mail/components/MailCompose.tsx
+++ b/apps/web/src/features/mail/components/MailCompose.tsx
@@ -75,264 +75,262 @@ export default function MailCompose({ open, onOpenChange }: MailComposeProps) {
   // Remaining original logic that doesn't belong in the hook
 
   return (
-    <>
-      <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
-        <Drawer.Portal>
-          <Drawer.Overlay
-            className={`fixed inset-0 bg-black/40 backdrop-blur-md ${isAiModalOpen ? "pointer-events-auto" : "pointer-events-none"}`}
+    <Drawer.Root open={open} onOpenChange={onOpenChange} direction="right">
+      <Drawer.Portal>
+        <Drawer.Overlay
+          className={`fixed inset-0 bg-black/40 backdrop-blur-md ${isAiModalOpen ? "pointer-events-auto" : "pointer-events-none"}`}
+        />
+        <Drawer.Content
+          className="fixed right-0 bottom-0 z-10 flex min-h-[60vh] w-[50vw] flex-col gap-2 rounded-tl-xl bg-zinc-900 p-4"
+          aria-describedby="Drawer to Compose a new email"
+        >
+          <Drawer.Title className="text-xl">New Message</Drawer.Title>
+
+          {error && (
+            <Alert variant="destructive" className="bg-red-500/10">
+              <AlertCircleIcon className="h-4 w-4" />
+              <AlertTitle>There was an error.</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Input
+            variant="underlined"
+            startContent={
+              <div className="flex w-[50px] justify-center text-sm text-foreground-500">
+                From
+              </div>
+            }
+            disabled
+            value={user.email}
+            className="bg-zinc-800"
           />
-          <Drawer.Content
-            className="fixed right-0 bottom-0 z-10 flex min-h-[60vh] w-[50vw] flex-col gap-2 rounded-tl-xl bg-zinc-900 p-4"
-            aria-describedby="Drawer to Compose a new email"
-          >
-            <Drawer.Title className="text-xl">New Message</Drawer.Title>
 
-            {error && (
-              <Alert variant="destructive" className="bg-red-500/10">
-                <AlertCircleIcon className="h-4 w-4" />
-                <AlertTitle>There was an error.</AlertTitle>
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
+          <div className="relative">
+            <TagInput
+              styleClasses={{
+                inlineTagsContainer:
+                  "bg-zinc-800 border border-t-0 border-x-0 border-b-zinc-600! border-b-2 p-2 rounded-none",
+                tag: { body: "p-0 bg-white/20 pl-3 text-sm border-none" },
+              }}
+              shape="pill"
+              animation="fadeIn"
+              placeholder="To"
+              tags={toEmails}
+              setTags={setToEmails}
+              activeTagIndex={activeTagIndex}
+              setActiveTagIndex={setActiveTagIndex}
+            />
+            <Button
+              isIconOnly
+              className="absolute top-[3px] right-[3px]"
+              size="sm"
+              color="primary"
+              onPress={() => setIsAiModalOpen(true)}
+            >
+              <AiSearch02Icon width={19} />
+            </Button>
+          </div>
+
+          <Input
+            placeholder="Subject"
+            variant="underlined"
+            className="bg-zinc-800"
+            classNames={{ innerWrapper: "px-2" }}
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+          />
+
+          <div className="relative flex h-full w-full flex-col">
+            <div className="z-2 flex w-full justify-end gap-3 pb-2">
+              {/* Writing Style Dropdown */}
+              <div className="relative">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <ShadcnButton
+                      className="border-none bg-[#00bbff40] text-sm font-normal text-[#00bbff] ring-0 outline-hidden hover:bg-[#00bbff20]"
+                      size="sm"
+                    >
+                      <div className="flex flex-row gap-1">
+                        <BrushIcon width={20} height={20} />
+                        <span className="font-medium">Writing Style:</span>{" "}
+                        <span>
+                          {
+                            writingStyles.find((s) => s.id === writingStyle)
+                              ?.label
+                          }
+                        </span>
+                        <ArrowDown01Icon width={20} />
+                      </div>
+                    </ShadcnButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="border-none bg-zinc-900 text-white dark">
+                    {writingStyles.map((style) => (
+                      <DropdownMenuItem
+                        key={style.id}
+                        onClick={() => {
+                          setWritingStyle(style.id);
+                          handleAskGaia(style.id);
+                        }}
+                        className="cursor-pointer focus:bg-zinc-600 focus:text-white"
+                      >
+                        <div className="flex w-full items-center justify-between">
+                          {style.label}
+                          {writingStyles.find((s) => s.id === writingStyle)
+                            ?.label === style.label && (
+                            <Tick02Icon width={20} height={20} />
+                          )}
+                        </div>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              {/* Content Length Dropdown */}
+              <div className="relative">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <ShadcnButton
+                      className="border-none bg-[#00bbff40] text-sm font-normal text-[#00bbff] ring-0 outline-hidden hover:bg-[#00bbff20]"
+                      size="sm"
+                    >
+                      <div className="flex flex-row gap-1">
+                        <BrushIcon width={20} height={20} />
+                        <span className="font-medium">Content Length:</span>{" "}
+                        <span>
+                          {contentLengthOptions.find(
+                            (opt) => opt.id === contentLength,
+                          )?.label || "None"}
+                        </span>
+                        <ArrowDown01Icon width={20} />
+                      </div>
+                    </ShadcnButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="border-none bg-zinc-900 text-white dark">
+                    {contentLengthOptions.map((option) => (
+                      <DropdownMenuItem
+                        key={option.id}
+                        onClick={() => {
+                          setContentLength(option.id);
+                          handleAskGaia();
+                        }}
+                        className="cursor-pointer focus:bg-zinc-600 focus:text-white"
+                      >
+                        <div className="flex w-full items-center justify-between">
+                          {option.label}
+                          {contentLength === option.id && (
+                            <Tick02Icon width={20} />
+                          )}
+                        </div>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              {/* Clarity Dropdown */}
+              <div className="relative">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <ShadcnButton
+                      className="border-none bg-[#00bbff40] text-sm font-normal text-[#00bbff] ring-0 outline-hidden hover:bg-[#00bbff20]"
+                      size="sm"
+                    >
+                      <div className="flex flex-row gap-1">
+                        <BrushIcon width={20} height={20} />
+                        <span className="font-medium">Clarity:</span>{" "}
+                        <span>
+                          {clarityOptions.find(
+                            (opt) => opt.id === clarityOption,
+                          )?.label || "None"}
+                        </span>
+                        <ArrowDown01Icon width={20} />
+                      </div>
+                    </ShadcnButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="border-none bg-zinc-900 text-white dark">
+                    {clarityOptions.map((option) => (
+                      <DropdownMenuItem
+                        key={option.id}
+                        onClick={() => {
+                          setClarityOption(option.id);
+                          handleAskGaia();
+                        }}
+                        className="cursor-pointer focus:bg-zinc-600 focus:text-white"
+                      >
+                        <div className="flex w-full items-center justify-between">
+                          {option.label}
+                          {clarityOption === option.id && (
+                            <Tick02Icon width={20} />
+                          )}
+                        </div>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            {editor && (
+              <>
+                {/* <MenuBar editor={editor} textLength={false} isEmail={true} /> */}
+                <EditorContent className="bg-zinc-800 p-2" editor={editor} />
+              </>
             )}
+          </div>
 
+          <footer className="flex w-full justify-end gap-5">
             <Input
-              variant="underlined"
+              placeholder="What is the email about?"
+              radius="full"
+              classNames={{ inputWrapper: "pr-1 pl-0" }}
+              className="pr-1"
+              variant="faded"
+              size="lg"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={handleAskGaiaKeyPress}
               startContent={
-                <div className="flex w-[50px] justify-center text-sm text-foreground-500">
-                  From
-                </div>
+                <Image
+                  alt="GAIA Logo"
+                  src={"/images/logos/logo.webp"}
+                  width={25}
+                  height={25}
+                  className={`ml-2`}
+                />
               }
-              disabled
-              value={user.email}
-              className="bg-zinc-800"
+              endContent={
+                <Button
+                  isIconOnly={loading}
+                  color="primary"
+                  radius="full"
+                  onPress={() => handleAskGaia()}
+                  isLoading={loading}
+                >
+                  <div className="flex w-fit items-center gap-2 px-3 text-medium">
+                    {!loading && (
+                      <>
+                        AI Draft
+                        <SentIcon width={25} className="min-w-[25px]" />
+                      </>
+                    )}
+                  </div>
+                </Button>
+              }
             />
 
-            <div className="relative">
-              <TagInput
-                styleClasses={{
-                  inlineTagsContainer:
-                    "bg-zinc-800 border border-t-0 border-x-0 border-b-zinc-600! border-b-2 p-2 rounded-none",
-                  tag: { body: "p-0 bg-white/20 pl-3 text-sm border-none" },
-                }}
-                shape="pill"
-                animation="fadeIn"
-                placeholder="To"
-                tags={toEmails}
-                setTags={setToEmails}
-                activeTagIndex={activeTagIndex}
-                setActiveTagIndex={setActiveTagIndex}
-              />
-              <Button
-                isIconOnly
-                className="absolute top-[3px] right-[3px]"
-                size="sm"
-                color="primary"
-                onPress={() => setIsAiModalOpen(true)}
-              >
-                <AiSearch02Icon width={19} />
-              </Button>
+            <div className="flex items-center gap-2">
+              <ButtonGroup color="primary">
+                <Button className="text-medium">
+                  Send
+                  <Sent02Icon width={23} height={23} />
+                </Button>
+              </ButtonGroup>
             </div>
-
-            <Input
-              placeholder="Subject"
-              variant="underlined"
-              className="bg-zinc-800"
-              classNames={{ innerWrapper: "px-2" }}
-              value={subject}
-              onChange={(e) => setSubject(e.target.value)}
-            />
-
-            <div className="relative flex h-full w-full flex-col">
-              <div className="z-2 flex w-full justify-end gap-3 pb-2">
-                {/* Writing Style Dropdown */}
-                <div className="relative">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <ShadcnButton
-                        className="border-none bg-[#00bbff40] text-sm font-normal text-[#00bbff] ring-0 outline-hidden hover:bg-[#00bbff20]"
-                        size="sm"
-                      >
-                        <div className="flex flex-row gap-1">
-                          <BrushIcon width={20} height={20} />
-                          <span className="font-medium">Writing Style:</span>{" "}
-                          <span>
-                            {
-                              writingStyles.find((s) => s.id === writingStyle)
-                                ?.label
-                            }
-                          </span>
-                          <ArrowDown01Icon width={20} />
-                        </div>
-                      </ShadcnButton>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="border-none bg-zinc-900 text-white dark">
-                      {writingStyles.map((style) => (
-                        <DropdownMenuItem
-                          key={style.id}
-                          onClick={() => {
-                            setWritingStyle(style.id);
-                            handleAskGaia(style.id);
-                          }}
-                          className="cursor-pointer focus:bg-zinc-600 focus:text-white"
-                        >
-                          <div className="flex w-full items-center justify-between">
-                            {style.label}
-                            {writingStyles.find((s) => s.id === writingStyle)
-                              ?.label === style.label && (
-                              <Tick02Icon width={20} height={20} />
-                            )}
-                          </div>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-
-                {/* Content Length Dropdown */}
-                <div className="relative">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <ShadcnButton
-                        className="border-none bg-[#00bbff40] text-sm font-normal text-[#00bbff] ring-0 outline-hidden hover:bg-[#00bbff20]"
-                        size="sm"
-                      >
-                        <div className="flex flex-row gap-1">
-                          <BrushIcon width={20} height={20} />
-                          <span className="font-medium">Content Length:</span>{" "}
-                          <span>
-                            {contentLengthOptions.find(
-                              (opt) => opt.id === contentLength,
-                            )?.label || "None"}
-                          </span>
-                          <ArrowDown01Icon width={20} />
-                        </div>
-                      </ShadcnButton>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="border-none bg-zinc-900 text-white dark">
-                      {contentLengthOptions.map((option) => (
-                        <DropdownMenuItem
-                          key={option.id}
-                          onClick={() => {
-                            setContentLength(option.id);
-                            handleAskGaia();
-                          }}
-                          className="cursor-pointer focus:bg-zinc-600 focus:text-white"
-                        >
-                          <div className="flex w-full items-center justify-between">
-                            {option.label}
-                            {contentLength === option.id && (
-                              <Tick02Icon width={20} />
-                            )}
-                          </div>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-
-                {/* Clarity Dropdown */}
-                <div className="relative">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <ShadcnButton
-                        className="border-none bg-[#00bbff40] text-sm font-normal text-[#00bbff] ring-0 outline-hidden hover:bg-[#00bbff20]"
-                        size="sm"
-                      >
-                        <div className="flex flex-row gap-1">
-                          <BrushIcon width={20} height={20} />
-                          <span className="font-medium">Clarity:</span>{" "}
-                          <span>
-                            {clarityOptions.find(
-                              (opt) => opt.id === clarityOption,
-                            )?.label || "None"}
-                          </span>
-                          <ArrowDown01Icon width={20} />
-                        </div>
-                      </ShadcnButton>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="border-none bg-zinc-900 text-white dark">
-                      {clarityOptions.map((option) => (
-                        <DropdownMenuItem
-                          key={option.id}
-                          onClick={() => {
-                            setClarityOption(option.id);
-                            handleAskGaia();
-                          }}
-                          className="cursor-pointer focus:bg-zinc-600 focus:text-white"
-                        >
-                          <div className="flex w-full items-center justify-between">
-                            {option.label}
-                            {clarityOption === option.id && (
-                              <Tick02Icon width={20} />
-                            )}
-                          </div>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              </div>
-
-              {editor && (
-                <>
-                  {/* <MenuBar editor={editor} textLength={false} isEmail={true} /> */}
-                  <EditorContent className="bg-zinc-800 p-2" editor={editor} />
-                </>
-              )}
-            </div>
-
-            <footer className="flex w-full justify-end gap-5">
-              <Input
-                placeholder="What is the email about?"
-                radius="full"
-                classNames={{ inputWrapper: "pr-1 pl-0" }}
-                className="pr-1"
-                variant="faded"
-                size="lg"
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                onKeyDown={handleAskGaiaKeyPress}
-                startContent={
-                  <Image
-                    alt="GAIA Logo"
-                    src={"/images/logos/logo.webp"}
-                    width={25}
-                    height={25}
-                    className={`ml-2`}
-                  />
-                }
-                endContent={
-                  <Button
-                    isIconOnly={loading}
-                    color="primary"
-                    radius="full"
-                    onPress={() => handleAskGaia()}
-                    isLoading={loading}
-                  >
-                    <div className="flex w-fit items-center gap-2 px-3 text-medium">
-                      {!loading && (
-                        <>
-                          AI Draft
-                          <SentIcon width={25} className="min-w-[25px]" />
-                        </>
-                      )}
-                    </div>
-                  </Button>
-                }
-              />
-
-              <div className="flex items-center gap-2">
-                <ButtonGroup color="primary">
-                  <Button className="text-medium">
-                    Send
-                    <Sent02Icon width={23} height={23} />
-                  </Button>
-                </ButtonGroup>
-              </div>
-            </footer>
-          </Drawer.Content>
-        </Drawer.Portal>
-      </Drawer.Root>
-    </>
+          </footer>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   );
 }

--- a/apps/web/src/lib/sitemapData.ts
+++ b/apps/web/src/lib/sitemapData.ts
@@ -73,7 +73,7 @@ const BUILD_DATE = new Date().toISOString();
 type ChangeFreq = "daily" | "weekly" | "monthly" | "yearly";
 type StaticPage = { path: string; freq: ChangeFreq; priority: number };
 
-const TRANSLATED_STATIC_PAGES: Array<StaticPage> = [
+const TRANSLATED_STATIC_PAGES: StaticPage[] = [
   { path: "/compare", freq: "weekly", priority: 0.9 },
   { path: "/alternative-to", freq: "weekly", priority: 0.9 },
   { path: "/automate", freq: "weekly", priority: 0.8 },
@@ -81,7 +81,7 @@ const TRANSLATED_STATIC_PAGES: Array<StaticPage> = [
   { path: "/learn", freq: "weekly", priority: 0.8 },
 ];
 
-const UNTRANSLATED_STATIC_PAGES: Array<StaticPage> = [
+const UNTRANSLATED_STATIC_PAGES: StaticPage[] = [
   { path: "", freq: "daily", priority: 1.0 },
   { path: "/pricing", freq: "weekly", priority: 0.9 },
   { path: "/marketplace", freq: "weekly", priority: 0.9 },

--- a/apps/web/src/stores/calendarEventSelectionStore.ts
+++ b/apps/web/src/stores/calendarEventSelectionStore.ts
@@ -23,7 +23,7 @@ export interface SelectedCalendarEventData {
   isAllDay?: boolean;
 }
 
-export type CalendarEventSelectionOptions = {};
+export type CalendarEventSelectionOptions = Record<string, never>;
 
 interface CalendarEventSelectionState {
   selectedCalendarEvent: SelectedCalendarEventData | null;

--- a/libs/shared/ts/src/utils/openui-parser.ts
+++ b/libs/shared/ts/src/utils/openui-parser.ts
@@ -120,7 +120,7 @@ export function splitByBreaksPreservingFences(content: string): string[] {
       .filter((p) => p.length > 0);
   }
 
-  const fenceRanges: Array<[number, number]> = [];
+  const fenceRanges: [number, number][] = [];
   let search = 0;
   while (search < content.length) {
     const openIdx = content.indexOf(OPENUI_OPEN, search);


### PR DESCRIPTION
## Summary

Clears all **14 Biome errors** so the `quality:lint` (`biome check`) CI lane passes, then enforces the lane via a marker file. Part of the ratcheted code-quality rollout (one lane per PR).

Depends on PR #694.

## The 14 errors (all manual fixes, none were auto-fixable)

`pnpm run quality:lint:fix` (`biome check --write`) applied **0 fixes** for these — every error required a manual, behavior-preserving fix:

| Count | Rule | Fix |
|------:|------|-----|
| 5 | `suspicious/noEvolvingTypes` | Gave explicit types to `let x = null` / `const x = []` that were silently evolving to `any`. Added local interfaces (`OgIntegration`, `OgWorkflow`) for the two OG-image edge routes, typed `messageProps` as `ChatBubbleBotProps \| ChatBubbleUserProps \| null` in `ChatRenderer`, and typed the `sections` / `buttons` arrays in `dashboard/page.tsx` and `DownloadPage.tsx`. |
| 4 | `style/useConsistentArrayType` | Rewrote `Array<T>` to shorthand `T[]` (config enforces `shorthand`) in `useChatAndTranscription.ts`, `sitemapData.ts` (x2), `openui-parser.ts`. |
| 2 | `correctness/noUnusedVariables` | Removed dead `const user = useUser()` (+ its now-unused import) in `(main)/layout.tsx`, and dropped the unused `welcome: welcomeChat` from a destructure in `onboarding/page.tsx`. |
| 1 | `performance/noDelete` | Replaced `delete c.annotations` with destructure-and-rebuild in `MCPAppRenderer.tsx`. |
| 1 | `complexity/noUselessFragments` | Removed a redundant `<>...</>` wrapping a single `<Drawer.Root>` in `MailCompose.tsx` (the large line count in that file is pure re-indentation from the biome formatter, `git diff -w` shows no logic change). |
| 1 | `complexity/noBannedTypes` | Replaced the banned empty `{}` type with `Record<string, never>` for `CalendarEventSelectionOptions`. |

No `any` introduced, no `biome-ignore` comments added — all real fixes. Also verified `tsc --noEmit` on the touched files reports no new type errors (the typed OG routes now correctly fall back to the guaranteed-non-null `identifier` rather than the nullable `id`).

## Verification

```
$ pnpm run quality:lint
Checked 1890 files in 7s. No fixes applied.
Found 334 warnings.
```

Exit code **0**, **0 errors**. The 334 warnings are non-blocking (the lane only fails on errors).

## Enforcement

Adds the marker file `.github/quality-gate/enforced/biome` (content: `enforced`). Does **not** touch `.github/workflows/code-quality.yml` to avoid merge conflicts with sibling lane PRs.