### PR TITLE
chore(quality): fix TS strict errors + enforce type-check lane

### DIFF
--- a/.github/quality-gate/enforced/type-check
+++ b/.github/quality-gate/enforced/type-check
@@ -1,0 +1,1 @@
+enforced

--- a/apps/mobile/src/components/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary.tsx
@@ -22,7 +22,7 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+  override componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error("ErrorBoundary caught error:", error, info);
     this.props.onError?.(error, info);
   }
@@ -31,7 +31,7 @@ export class ErrorBoundary extends Component<Props, State> {
     this.setState({ hasError: false, error: null });
   };
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
         return this.props.fallback;

--- a/apps/mobile/src/components/OfflineBanner.tsx
+++ b/apps/mobile/src/components/OfflineBanner.tsx
@@ -34,6 +34,7 @@ export function OfflineBanner() {
       }, 2000);
       return () => clearTimeout(timer);
     }
+    return undefined;
   }, [isOnline, wasOffline, translateY]);
 
   const handleDismiss = useCallback(() => {

--- a/apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx
@@ -261,6 +261,7 @@ export function ChatScreenContent({
       );
       return () => clearInterval(interval);
     }
+    return undefined;
   }, [isTyping, progress, lastUserMessage]);
 
   const displayMessage = progress || thinkingMessage;

--- a/apps/mobile/src/features/chat/components/openui/OpenUIRenderer.tsx
+++ b/apps/mobile/src/features/chat/components/openui/OpenUIRenderer.tsx
@@ -168,19 +168,19 @@ class OpenUIErrorBoundary extends React.Component<
     return { hasError: true, errorMessage: error.message };
   }
 
-  componentDidUpdate(prevProps: { code: string }) {
+  override componentDidUpdate(prevProps: { code: string }) {
     if (this.state.hasError && prevProps.code !== this.props.code) {
       this.setState({ hasError: false, errorMessage: "" });
     }
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+  override componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error("[OpenUIRenderer] Render error:", error, info, {
       code: this.props.code,
     });
   }
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       return (
         <OpenUIErrorCard

--- a/apps/web/src/app/[locale]/(main)/notifications/page.tsx
+++ b/apps/web/src/app/[locale]/(main)/notifications/page.tsx
@@ -55,8 +55,10 @@ export default function NotificationsPage() {
   const handleBulkMarkAsRead = useCallback(
     async (notificationIds: string[]) => {
       try {
-        if (notificationIds.length === 0)
-          return toast.error("No events to mark as read");
+        if (notificationIds.length === 0) {
+          toast.error("No events to mark as read");
+          return;
+        }
         await NotificationsAPI.bulkMarkAsRead(notificationIds);
         // Refresh both lists in parallel
         await Promise.all([refetchUnread(), refetchAll()]);

--- a/apps/web/src/components/shared/ErrorBoundary.tsx
+++ b/apps/web/src/components/shared/ErrorBoundary.tsx
@@ -27,7 +27,7 @@ class ErrorBoundary extends React.Component<
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // Log error details for debugging or reporting
     console.error("Error caught in Error Boundary:", error, errorInfo);
 
@@ -40,7 +40,7 @@ class ErrorBoundary extends React.Component<
     });
   }
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       return (
         <div className="fixed top-0 left-0 flex h-screen max-h-screen w-screen flex-col items-center justify-center bg-linear-to-b from-[#00bbff] to-black">

--- a/apps/web/src/config/openui/components/analytics.tsx
+++ b/apps/web/src/config/openui/components/analytics.tsx
@@ -526,6 +526,7 @@ export function PieChartView(props: z.infer<typeof pieChartSchema>) {
                       </text>
                     );
                   }
+                  return null;
                 }}
               />
             </Pie>
@@ -776,6 +777,7 @@ export function GaugeChartView(props: z.infer<typeof gaugeChartSchema>) {
                       </text>
                     );
                   }
+                  return null;
                 }}
               />
             </PolarRadiusAxis>
@@ -847,6 +849,7 @@ export function GaugeChartView(props: z.infer<typeof gaugeChartSchema>) {
                       </text>
                     );
                   }
+                  return null;
                 }}
               />
             </PolarRadiusAxis>
@@ -920,6 +923,7 @@ export function GaugeChartView(props: z.infer<typeof gaugeChartSchema>) {
                     </text>
                   );
                 }
+                return null;
               }}
             />
           </PolarRadiusAxis>

--- a/apps/web/src/features/calendar/components/CalendarListCard.tsx
+++ b/apps/web/src/features/calendar/components/CalendarListCard.tsx
@@ -121,4 +121,6 @@ export default function CalendarListCard({
       </CollapsibleListWrapper>
     );
   }
+
+  return null;
 }

--- a/apps/web/src/features/calendar/components/CalendarListFetchCard.tsx
+++ b/apps/web/src/features/calendar/components/CalendarListFetchCard.tsx
@@ -56,4 +56,6 @@ export default function CalendarListFetchCard({
         </ScrollShadow>
       </div>
     );
+
+  return null;
 }

--- a/apps/web/src/features/chat/components/bubbles/bot/GoogleDocsSection.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/GoogleDocsSection.tsx
@@ -68,6 +68,8 @@ const GoogleDocsSection: React.FC<GoogleDocsSectionProps> = ({
       </div>
     );
   }
+
+  return null;
 };
 
 export default GoogleDocsSection;

--- a/apps/web/src/features/chat/components/code-block/FlowchartPreview.tsx
+++ b/apps/web/src/features/chat/components/code-block/FlowchartPreview.tsx
@@ -131,6 +131,7 @@ const FlowchartPreview: React.FC<FlowchartPreviewProps> = ({ children }) => {
         element.removeEventListener("wheel", handleWheel);
       };
     }
+    return undefined;
   }, [handleWheel]);
 
   return (

--- a/apps/web/src/features/chat/components/composer/ComposerInput.tsx
+++ b/apps/web/src/features/chat/components/composer/ComposerInput.tsx
@@ -436,6 +436,7 @@ const ComposerInput = React.forwardRef<ComposerInputRef, SearchbarInputProps>(
         document.addEventListener("click", handleClickOutside);
         return () => document.removeEventListener("click", handleClickOutside);
       }
+      return undefined;
     }, [slashCommandState.isActive, inputRef]);
 
     return (

--- a/apps/web/src/features/chat/components/interface/OpenUIRenderer.tsx
+++ b/apps/web/src/features/chat/components/interface/OpenUIRenderer.tsx
@@ -137,19 +137,19 @@ class OpenUIErrorBoundary extends React.Component<
     return { hasError: true, errorMessage: error.message };
   }
 
-  componentDidUpdate(prevProps: { code: string }) {
+  override componentDidUpdate(prevProps: { code: string }) {
     if (this.state.hasError && prevProps.code !== this.props.code) {
       this.setState({ hasError: false, errorMessage: "" });
     }
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
+  override componentDidCatch(error: Error, info: React.ErrorInfo) {
     console.error("[OpenUIRenderer] Render error:", error, info, {
       code: this.props.code,
     });
   }
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       return (
         <OpenUIErrorCard

--- a/apps/web/src/features/chat/components/voice-agent/session-view.tsx
+++ b/apps/web/src/features/chat/components/voice-agent/session-view.tsx
@@ -193,6 +193,7 @@ export const SessionView = ({
 
       return () => clearTimeout(timeout);
     }
+    return undefined;
   }, [agentState, sessionStarted, room]);
 
   return (

--- a/apps/web/src/features/chat/hooks/useChatStream.ts
+++ b/apps/web/src/features/chat/hooks/useChatStream.ts
@@ -700,6 +700,7 @@ export const useChatStream = () => {
       if (Object.keys(streamingData).length === 0) return;
       if (handleImageGeneration(streamingData)) return;
       await handleStreamingContent(streamingData);
+      return undefined;
     } catch (error) {
       console.error("[useChatStream] Error handling stream event:", {
         error,

--- a/apps/web/src/features/landing/components/demo/workflow-demo/DemoCommunityCards.tsx
+++ b/apps/web/src/features/landing/components/demo/workflow-demo/DemoCommunityCards.tsx
@@ -37,6 +37,7 @@ export default function DemoCommunityCards({
       const t = setTimeout(() => setRippleActive(false), 600);
       return () => clearTimeout(t);
     }
+    return undefined;
   }, [phase]);
 
   useEffect(() => {

--- a/apps/web/src/features/landing/components/demo/workflow-demo/DemoExecutionChat.tsx
+++ b/apps/web/src/features/landing/components/demo/workflow-demo/DemoExecutionChat.tsx
@@ -80,6 +80,7 @@ export default function DemoExecutionChat({
       });
       return () => staggerTimers.forEach(clearTimeout);
     }
+    return undefined;
   }, [phase]);
 
   // Typing effect for response
@@ -97,6 +98,7 @@ export default function DemoExecutionChat({
       }, 18);
       return () => clearInterval(tick);
     }
+    return undefined;
   }, [phase]);
 
   // Reset between cycles

--- a/apps/web/src/features/mail/components/EmailListCard.tsx
+++ b/apps/web/src/features/mail/components/EmailListCard.tsx
@@ -175,4 +175,6 @@ export default function EmailListCard({
       </CollapsibleListWrapper>
     );
   }
+
+  return null;
 }

--- a/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx
@@ -179,6 +179,8 @@ export function RunCountDisplay({
         <span className="text-nowrap">{formatRunCount(totalExecutions)}</span>
       </div>
     );
+
+  return null;
 }
 
 // Reusable Activation Status Chip

--- a/apps/web/src/lib/websocket/useWebSocketConnection.ts
+++ b/apps/web/src/lib/websocket/useWebSocketConnection.ts
@@ -49,6 +49,7 @@ export function useWebSocketConnection() {
     } else {
       console.log("[WebSocket] Not connecting - no user email available");
     }
+    return undefined;
   }, [user?.email]);
 
   // Handle page visibility changes — subscribe once, read latest email from ref

--- a/libs/shared/ts/src/api/timezone.ts
+++ b/libs/shared/ts/src/api/timezone.ts
@@ -1,5 +1,5 @@
 export function getUserTimezone(): string {
-  if (typeof window !== "undefined") {
+  if (typeof globalThis !== "undefined" && "window" in globalThis) {
     try {
       return Intl.DateTimeFormat().resolvedOptions().timeZone;
     } catch (error) {


### PR DESCRIPTION
## What

Fixes the ~31 `tsc` strict errors blocking the **TypeScript strict type-check (all workspaces)** CI lane, then enforces the lane via a marker file.

CI command:
```
pnpm exec nx run-many -t type-check --projects=web,desktop,mobile,cli,bot-discord,bot-slack,bot-telegram,bot-whatsapp
```

`cli`, `desktop`, and all four bots already passed. `mobile` (8 errors) and `web` (~23 errors) were failing.

## Errors fixed

### TS4114 — missing `override` on React.Component members
- `apps/mobile/src/components/ErrorBoundary.tsx` — `componentDidCatch`, `render` → added `override`
- `apps/mobile/src/features/chat/components/openui/OpenUIRenderer.tsx` — `componentDidUpdate`, `componentDidCatch`, `render` → added `override`
- `apps/web/src/components/shared/ErrorBoundary.tsx` — `componentDidCatch`, `render` → added `override`
- `apps/web/src/features/chat/components/interface/OpenUIRenderer.tsx` — `componentDidUpdate`, `componentDidCatch`, `render` → added `override`

### TS7030 — "Not all code paths return a value"
useEffect hooks that returned a cleanup only inside an `if` branch → added explicit `return undefined;` for the fall-through path:
- `apps/mobile/src/components/OfflineBanner.tsx`
- `apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx`
- `apps/web/src/features/chat/components/code-block/FlowchartPreview.tsx`
- `apps/web/src/features/chat/components/composer/ComposerInput.tsx`
- `apps/web/src/features/chat/components/voice-agent/session-view.tsx`
- `apps/web/src/features/landing/components/demo/workflow-demo/DemoCommunityCards.tsx`
- `apps/web/src/features/landing/components/demo/workflow-demo/DemoExecutionChat.tsx` (two effects)
- `apps/web/src/lib/websocket/useWebSocketConnection.ts`

React components / FCs that returned JSX only inside a conditional → added explicit `return null;`:
- `apps/web/src/features/calendar/components/CalendarListCard.tsx`
- `apps/web/src/features/calendar/components/CalendarListFetchCard.tsx`
- `apps/web/src/features/chat/components/bubbles/bot/GoogleDocsSection.tsx`
- `apps/web/src/features/mail/components/EmailListCard.tsx`
- `apps/web/src/features/workflows/components/shared/WorkflowCardComponents.tsx`

recharts `<Label content={...}>` render callbacks that returned JSX only when `viewBox` was valid → added `return null;` for the guarded-out path (4 sites):
- `apps/web/src/config/openui/components/analytics.tsx` (lines 498, 747, 826, 891)

`apps/web/src/app/[locale]/(main)/notifications/page.tsx` — early guard did `return toast.error(...)` (returns a value) while the success path returned nothing. Split into a `toast.error(...)` call followed by a bare `return;` so the callback consistently returns nothing.

`apps/web/src/features/chat/hooks/useChatStream.ts` — `handleStreamEvent` (typed `Promise<undefined | string>`) fell through its success path without an explicit return while error paths returned strings → added explicit `return undefined;`.

### TS2304 — `Cannot find name 'window'` in shared lib
- `libs/shared/ts/src/api/timezone.ts` — `getUserTimezone` already SSR-guarded with `typeof window !== "undefined"`, but the file is consumed by mobile (which maps `@gaia/shared` to source and whose tsconfig `lib` is `["ESNext"]`, no DOM). Replaced the bare `window` reference with `typeof globalThis !== "undefined" && "window" in globalThis`, which is type-safe under ESNext-only `lib` and preserves identical browser-vs-server runtime behavior. No DOM lib change, no `any`.

No `any`, no `@ts-ignore` / `@ts-expect-error` used. Runtime behavior preserved.

## Enforcement

Adds `.github/quality-gate/enforced/type-check` (contents: `enforced`). The CI workflow (`.github/workflows/code-quality.yml`) is intentionally **not** edited to avoid merge conflicts with sibling lane PRs.

## Verification

```
> nx run bot-slack:type-check
> nx run bot-discord:type-check
> nx run bot-telegram:type-check
> nx run bot-whatsapp:type-check
> nx run cli:type-check
> nx run desktop:type-check
> nx run mobile:type-check
> nx run web:type-check

 NX   Successfully ran target type-check for 8 projects
```

## Dependency

Depends on PR #694.
