### PR TITLE
chore(quality): colocate types in *.types.ts + enforce types-location lane

### DIFF
--- a/.github/quality-gate/enforced/types-location
+++ b/.github/quality-gate/enforced/types-location
@@ -1,0 +1,1 @@
+enforced

--- a/apps/web/src/features/landing/components/demo/todos-demo/todosDemoConstants.ts
+++ b/apps/web/src/features/landing/components/demo/todos-demo/todosDemoConstants.ts
@@ -1,36 +1,11 @@
-export interface DemoProject {
-  id: string;
-  name: string;
-  color: string;
-}
+import type { DemoProject, DemoTodo } from "./todosDemoConstants.types";
 
-export interface DemoSubTask {
-  id: string;
-  title: string;
-  completed: boolean;
-}
-
-export interface DemoWorkflowStep {
-  id: string;
-  title: string;
-  description: string;
-  category: string;
-}
-
-export interface DemoTodo {
-  id: string;
-  title: string;
-  description?: string;
-  priority: "high" | "medium" | "low" | "none";
-  labels: string[];
-  project_id: string;
-  due_date?: string;
-  completed: boolean;
-  subtasks: DemoSubTask[];
-  workflow_categories: string[];
-  workflow_steps: DemoWorkflowStep[];
-  created_at: string;
-}
+export type {
+  DemoProject,
+  DemoSubTask,
+  DemoTodo,
+  DemoWorkflowStep,
+} from "./todosDemoConstants.types";
 
 export const DEMO_PROJECTS: DemoProject[] = [
   { id: "inbox", name: "Inbox", color: "#71717a" },

--- a/apps/web/src/features/landing/components/demo/todos-demo/todosDemoConstants.types.ts
+++ b/apps/web/src/features/landing/components/demo/todos-demo/todosDemoConstants.types.ts
@@ -1,0 +1,33 @@
+export interface DemoProject {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface DemoSubTask {
+  id: string;
+  title: string;
+  completed: boolean;
+}
+
+export interface DemoWorkflowStep {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+}
+
+export interface DemoTodo {
+  id: string;
+  title: string;
+  description?: string;
+  priority: "high" | "medium" | "low" | "none";
+  labels: string[];
+  project_id: string;
+  due_date?: string;
+  completed: boolean;
+  subtasks: DemoSubTask[];
+  workflow_categories: string[];
+  workflow_steps: DemoWorkflowStep[];
+  created_at: string;
+}

--- a/apps/web/src/features/landing/data/featuresData.ts
+++ b/apps/web/src/features/landing/data/featuresData.ts
@@ -3,51 +3,16 @@ import { AUTOMATION_FEATURES } from "./features/automation";
 import { INTEGRATIONS_FEATURES } from "./features/integrations";
 import { MULTI_PLATFORM_FEATURES } from "./features/multiPlatform";
 import { PRODUCTIVITY_FEATURES } from "./features/productivity";
+import type { FeatureCategory, FeatureData } from "./featuresData.types";
 
-export type FeatureCategory =
-  | "AI Intelligence"
-  | "Productivity"
-  | "Automation"
-  | "Integrations"
-  | "Multi-Platform";
-
-export interface FeatureBenefit {
-  icon: string;
-  title: string;
-  description: string;
-}
-
-export interface HowItWorksStep {
-  number: string;
-  title: string;
-  description: string;
-}
-
-export interface FeatureFAQ {
-  question: string;
-  answer: string;
-}
-
-export interface FeatureUseCase {
-  title: string;
-  description: string;
-}
-
-export interface FeatureData {
-  slug: string;
-  category: FeatureCategory;
-  icon: string;
-  title: string;
-  tagline: string;
-  headline: string;
-  subheadline: string;
-  benefits: [FeatureBenefit, FeatureBenefit, FeatureBenefit];
-  howItWorks?: [HowItWorksStep, HowItWorksStep, HowItWorksStep];
-  faqs?: [FeatureFAQ, FeatureFAQ, FeatureFAQ, FeatureFAQ];
-  useCases?: [FeatureUseCase, FeatureUseCase, FeatureUseCase];
-  relatedSlugs?: [string, string, string];
-  demoComponent: string;
-}
+export type {
+  FeatureBenefit,
+  FeatureCategory,
+  FeatureData,
+  FeatureFAQ,
+  FeatureUseCase,
+  HowItWorksStep,
+} from "./featuresData.types";
 
 export const FEATURE_CATEGORIES: FeatureCategory[] = [
   "AI Intelligence",

--- a/apps/web/src/features/landing/data/featuresData.types.ts
+++ b/apps/web/src/features/landing/data/featuresData.types.ts
@@ -1,0 +1,44 @@
+export type FeatureCategory =
+  | "AI Intelligence"
+  | "Productivity"
+  | "Automation"
+  | "Integrations"
+  | "Multi-Platform";
+
+export interface FeatureBenefit {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface HowItWorksStep {
+  number: string;
+  title: string;
+  description: string;
+}
+
+export interface FeatureFAQ {
+  question: string;
+  answer: string;
+}
+
+export interface FeatureUseCase {
+  title: string;
+  description: string;
+}
+
+export interface FeatureData {
+  slug: string;
+  category: FeatureCategory;
+  icon: string;
+  title: string;
+  tagline: string;
+  headline: string;
+  subheadline: string;
+  benefits: [FeatureBenefit, FeatureBenefit, FeatureBenefit];
+  howItWorks?: [HowItWorksStep, HowItWorksStep, HowItWorksStep];
+  faqs?: [FeatureFAQ, FeatureFAQ, FeatureFAQ, FeatureFAQ];
+  useCases?: [FeatureUseCase, FeatureUseCase, FeatureUseCase];
+  relatedSlugs?: [string, string, string];
+  demoComponent: string;
+}

--- a/apps/web/src/features/mail/hooks/useEmailComposition.ts
+++ b/apps/web/src/features/mail/hooks/useEmailComposition.ts
@@ -13,53 +13,18 @@ import { mailApi } from "@/features/mail/api/mailApi";
 import type { EmailSuggestion } from "@/features/mail/components/EmailChip";
 import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
+import type {
+  EmailCompositionFormState,
+  EmailCompositionUIState,
+  UseEmailCompositionReturn,
+} from "./useEmailComposition.types";
 
-export interface EmailCompositionFormState {
-  toEmails: Tag[];
-  subject: string;
-  body: string;
-  prompt: string;
-  writingStyle: string;
-  contentLength: string;
-  clarityOption: string;
-}
-
-export interface EmailCompositionUIState {
-  loading: boolean;
-  error: string | null;
-  isAiModalOpen: boolean;
-  activeTagIndex: number | null;
-}
-
-export interface EmailCompositionActions {
-  setToEmails: (emails: Tag[] | ((prev: Tag[]) => Tag[])) => void;
-  setSubject: (subject: string) => void;
-  setBody: (body: string) => void;
-  setPrompt: (prompt: string) => void;
-  setWritingStyle: (style: string) => void;
-  setContentLength: (length: string) => void;
-  setClarityOption: (clarity: string) => void;
-  setIsAiModalOpen: (open: boolean) => void;
-  setActiveTagIndex: React.Dispatch<React.SetStateAction<number | null>>;
-  setError: (error: string | null) => void;
-  handleAiSelect: (suggestions: EmailSuggestion[]) => void;
-  handleAskGaia: (overrideStyle?: string) => Promise<void>;
-  handleAskGaiaKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  resetForm: () => void;
-}
-
-export interface UseEmailCompositionReturn {
-  formState: EmailCompositionFormState;
-  uiState: EmailCompositionUIState;
-  actions: EmailCompositionActions;
-  editor: ReturnType<typeof useEditor>;
-  editorConfig: Partial<EditorOptions>;
-  options: {
-    writingStyles: Array<{ id: string; label: string }>;
-    contentLengthOptions: Array<{ id: string; label: string }>;
-    clarityOptions: Array<{ id: string; label: string }>;
-  };
-}
+export type {
+  EmailCompositionActions,
+  EmailCompositionFormState,
+  EmailCompositionUIState,
+  UseEmailCompositionReturn,
+} from "./useEmailComposition.types";
 
 const defaultFormState: EmailCompositionFormState = {
   toEmails: [],

--- a/apps/web/src/features/mail/hooks/useEmailComposition.types.ts
+++ b/apps/web/src/features/mail/hooks/useEmailComposition.types.ts
@@ -1,0 +1,50 @@
+import type { EditorOptions, useEditor } from "@tiptap/react";
+import type { Tag } from "emblor";
+import type { EmailSuggestion } from "@/features/mail/components/EmailChip";
+
+export interface EmailCompositionFormState {
+  toEmails: Tag[];
+  subject: string;
+  body: string;
+  prompt: string;
+  writingStyle: string;
+  contentLength: string;
+  clarityOption: string;
+}
+
+export interface EmailCompositionUIState {
+  loading: boolean;
+  error: string | null;
+  isAiModalOpen: boolean;
+  activeTagIndex: number | null;
+}
+
+export interface EmailCompositionActions {
+  setToEmails: (emails: Tag[] | ((prev: Tag[]) => Tag[])) => void;
+  setSubject: (subject: string) => void;
+  setBody: (body: string) => void;
+  setPrompt: (prompt: string) => void;
+  setWritingStyle: (style: string) => void;
+  setContentLength: (length: string) => void;
+  setClarityOption: (clarity: string) => void;
+  setIsAiModalOpen: (open: boolean) => void;
+  setActiveTagIndex: React.Dispatch<React.SetStateAction<number | null>>;
+  setError: (error: string | null) => void;
+  handleAiSelect: (suggestions: EmailSuggestion[]) => void;
+  handleAskGaia: (overrideStyle?: string) => Promise<void>;
+  handleAskGaiaKeyPress: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  resetForm: () => void;
+}
+
+export interface UseEmailCompositionReturn {
+  formState: EmailCompositionFormState;
+  uiState: EmailCompositionUIState;
+  actions: EmailCompositionActions;
+  editor: ReturnType<typeof useEditor>;
+  editorConfig: Partial<EditorOptions>;
+  options: {
+    writingStyles: Array<{ id: string; label: string }>;
+    contentLengthOptions: Array<{ id: string; label: string }>;
+    clarityOptions: Array<{ id: string; label: string }>;
+  };
+}

--- a/apps/web/src/features/onboarding/constants/platformPreviewMessages.ts
+++ b/apps/web/src/features/onboarding/constants/platformPreviewMessages.ts
@@ -10,21 +10,18 @@
  */
 
 import type {
-  ChatMessageItem,
-  ChatPlatform,
-} from "@/features/landing/components/iphone/ChatDemo";
+  PlatformPreviewPlatform,
+  PlatformScript,
+  ProfessionArchetype,
+  UserIdentity,
+} from "./platformPreviewMessages.types";
 
-export type PlatformPreviewPlatform = Extract<
-  ChatPlatform,
-  "telegram" | "whatsapp" | "slack" | "discord"
->;
-
-export type ProfessionArchetype =
-  | "builder"
-  | "operator"
-  | "founder"
-  | "scholar"
-  | "default";
+export type {
+  PlatformPreviewPlatform,
+  PlatformScript,
+  ProfessionArchetype,
+  UserIdentity,
+} from "./platformPreviewMessages.types";
 
 const PROFESSION_TO_ARCHETYPE: Record<string, ProfessionArchetype> = {
   engineer: "builder",
@@ -58,12 +55,6 @@ export function getArchetype(
 ): ProfessionArchetype {
   if (!profession) return "default";
   return PROFESSION_TO_ARCHETYPE[profession.toLowerCase()] ?? "default";
-}
-
-export interface PlatformScript {
-  title: string;
-  subtitle?: string;
-  messages: ChatMessageItem[];
 }
 
 type ArchetypeScripts = Record<PlatformPreviewPlatform, PlatformScript>;
@@ -697,11 +688,6 @@ const ARCHETYPE_SCRIPTS: Record<ProfessionArchetype, ArchetypeScripts> = {
   scholar: SCHOLAR,
   default: DEFAULT_SCRIPTS,
 };
-
-export interface UserIdentity {
-  name: string | undefined;
-  avatar: string | undefined;
-}
 
 export function getPlatformScript(
   profession: string | undefined,

--- a/apps/web/src/features/onboarding/constants/platformPreviewMessages.types.ts
+++ b/apps/web/src/features/onboarding/constants/platformPreviewMessages.types.ts
@@ -1,0 +1,27 @@
+import type {
+  ChatMessageItem,
+  ChatPlatform,
+} from "@/features/landing/components/iphone/ChatDemo";
+
+export type PlatformPreviewPlatform = Extract<
+  ChatPlatform,
+  "telegram" | "whatsapp" | "slack" | "discord"
+>;
+
+export type ProfessionArchetype =
+  | "builder"
+  | "operator"
+  | "founder"
+  | "scholar"
+  | "default";
+
+export interface PlatformScript {
+  title: string;
+  subtitle?: string;
+  messages: ChatMessageItem[];
+}
+
+export interface UserIdentity {
+  name: string | undefined;
+  avatar: string | undefined;
+}

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -2,40 +2,16 @@ import fs from "fs";
 import matter from "gray-matter";
 import path from "path";
 import { cache } from "react";
+import type { BlogPost, BlogPostFrontmatter } from "./blog.types";
+
+export type {
+  Author,
+  BlogPost,
+  BlogPostFrontmatter,
+  BlogPostMeta,
+} from "./blog.types";
 
 const postsDirectory = path.join(process.cwd(), "content/blog");
-
-export interface Author {
-  name: string;
-  role: string;
-  avatar: string;
-  linkedin?: string;
-  twitter?: string;
-}
-
-export interface BlogPost {
-  slug: string;
-  title: string;
-  date: string;
-  authors: Author[];
-  category: string;
-  image: string;
-  content: string;
-  featured?: boolean;
-}
-
-/** BlogPost without content — safe to pass across RSC→client boundaries */
-export type BlogPostMeta = Omit<BlogPost, "content">;
-
-export interface BlogPostFrontmatter {
-  title: string;
-  date: string;
-  authors: Author[];
-  category: string;
-  image: string;
-  slug: string;
-  featured?: boolean;
-}
 
 /**
  * Get all blog post slugs

--- a/apps/web/src/lib/blog.types.ts
+++ b/apps/web/src/lib/blog.types.ts
@@ -1,0 +1,31 @@
+export interface Author {
+  name: string;
+  role: string;
+  avatar: string;
+  linkedin?: string;
+  twitter?: string;
+}
+
+export interface BlogPost {
+  slug: string;
+  title: string;
+  date: string;
+  authors: Author[];
+  category: string;
+  image: string;
+  content: string;
+  featured?: boolean;
+}
+
+/** BlogPost without content — safe to pass across RSC→client boundaries */
+export type BlogPostMeta = Omit<BlogPost, "content">;
+
+export interface BlogPostFrontmatter {
+  title: string;
+  date: string;
+  authors: Author[];
+  category: string;
+  image: string;
+  slug: string;
+  featured?: boolean;
+}

--- a/libs/shared/ts/src/utils/quickAdd.ts
+++ b/libs/shared/ts/src/utils/quickAdd.ts
@@ -1,4 +1,17 @@
 import { Priority } from "../types/todo";
+import type {
+  QuickAddOptions,
+  QuickAddProject,
+  QuickAddProjectMatch,
+  QuickAddResult,
+} from "./quickAdd.types";
+
+export type {
+  QuickAddOptions,
+  QuickAddProject,
+  QuickAddProjectMatch,
+  QuickAddResult,
+} from "./quickAdd.types";
 
 /**
  * A pure quick-add parser that mirrors the rules used by the web client's
@@ -18,33 +31,6 @@ import { Priority } from "../types/todo";
  */
 
 const DAY_MS = 86_400_000;
-
-export interface QuickAddProject {
-  id: string;
-  name: string;
-}
-
-export interface QuickAddProjectMatch {
-  id?: string;
-  name: string;
-}
-
-export interface QuickAddOptions {
-  projects?: QuickAddProject[];
-  /** Override "now" — useful for tests. Defaults to `new Date()`. */
-  now?: Date;
-  /** IANA timezone string. Defaults to the runtime's resolved timezone. */
-  timezone?: string;
-}
-
-export interface QuickAddResult {
-  cleanedText: string;
-  project?: QuickAddProjectMatch;
-  labels: string[];
-  priority?: Priority;
-  dueDate: Date | null;
-  timezone?: string;
-}
 
 const WEEKDAY_NAMES = [
   "sunday",

--- a/libs/shared/ts/src/utils/quickAdd.types.ts
+++ b/libs/shared/ts/src/utils/quickAdd.types.ts
@@ -1,0 +1,28 @@
+import type { Priority } from "../types/todo";
+
+export interface QuickAddProject {
+  id: string;
+  name: string;
+}
+
+export interface QuickAddProjectMatch {
+  id?: string;
+  name: string;
+}
+
+export interface QuickAddOptions {
+  projects?: QuickAddProject[];
+  /** Override "now" — useful for tests. Defaults to `new Date()`. */
+  now?: Date;
+  /** IANA timezone string. Defaults to the runtime's resolved timezone. */
+  timezone?: string;
+}
+
+export interface QuickAddResult {
+  cleanedText: string;
+  project?: QuickAddProjectMatch;
+  labels: string[];
+  priority?: Priority;
+  dueDate: Date | null;
+  timezone?: string;
+}

--- a/packages/cli/src/lib/env-parser.ts
+++ b/packages/cli/src/lib/env-parser.ts
@@ -1,35 +1,19 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execa } from "execa";
+import type {
+  EnvCategory,
+  EnvVar,
+  SetupMode,
+  WebEnvVar,
+} from "./env-parser.types";
 
-export type SetupMode = "selfhost" | "developer";
-
-export interface EnvVar {
-  name: string;
-  required: boolean;
-  category: string;
-  description: string;
-  affectedFeatures: string;
-  defaultValue?: string;
-  docsUrl?: string;
-}
-
-export interface EnvCategory {
-  name: string;
-  description: string;
-  affectedFeatures: string;
-  requiredInProd: boolean;
-  allRequired: boolean;
-  docsUrl?: string;
-  alternativeGroup?: string;
-  variables: EnvVar[];
-}
-
-export interface WebEnvVar {
-  name: string;
-  value: string;
-  category: string;
-}
+export type {
+  EnvCategory,
+  EnvVar,
+  SetupMode,
+  WebEnvVar,
+} from "./env-parser.types";
 
 // Infrastructure connection strings set by setup mode.
 //

--- a/packages/cli/src/lib/env-parser.types.ts
+++ b/packages/cli/src/lib/env-parser.types.ts
@@ -1,0 +1,28 @@
+export type SetupMode = "selfhost" | "developer";
+
+export interface EnvVar {
+  name: string;
+  required: boolean;
+  category: string;
+  description: string;
+  affectedFeatures: string;
+  defaultValue?: string;
+  docsUrl?: string;
+}
+
+export interface EnvCategory {
+  name: string;
+  description: string;
+  affectedFeatures: string;
+  requiredInProd: boolean;
+  allRequired: boolean;
+  docsUrl?: string;
+  alternativeGroup?: string;
+  variables: EnvVar[];
+}
+
+export interface WebEnvVar {
+  name: string;
+  value: string;
+  category: string;
+}


### PR DESCRIPTION
## What

Resolves the **types-location** code-quality lane: a non-`*.types.ts` file may export at most 3 type declarations (`export type|interface|enum`). 7 files exceeded the limit. Each one now uses a **facade re-export** pattern so public import paths stay unchanged.

CI command: `node scripts/ci/check-types-location.mjs --enforce`

## Facade pattern

For every violating file `<basename>.ts`:

1. A sibling `<basename>.types.ts` was created holding **all** the moved `type`/`interface`/`enum` declarations (plus any imports those types need).
2. The original file now:
   - `import type { ... } from "./<basename>.types"` — only the types it uses internally, and
   - `export type { ... } from "./<basename>.types"` — re-exports **all** of them.

Re-exports (`export type { X } from "./y"`) do not match the rule's declaration regex, so the original file declares 0 types and passes. Existing consumers that import from the original path still resolve via the re-export, so **no consumer changes were required**. Value imports the original still needs at runtime were kept (e.g. `quickAdd.ts` keeps `import { Priority }` because it uses `Priority.HIGH` as a value).

## Files (original → new sibling)

| Original (now re-exports) | New `*.types.ts` | Types moved |
|---|---|---|
| `apps/web/src/features/landing/data/featuresData.ts` | `featuresData.types.ts` | `FeatureCategory`, `FeatureBenefit`, `HowItWorksStep`, `FeatureFAQ`, `FeatureUseCase`, `FeatureData` (6) |
| `apps/web/src/features/landing/components/demo/todos-demo/todosDemoConstants.ts` | `todosDemoConstants.types.ts` | `DemoProject`, `DemoSubTask`, `DemoWorkflowStep`, `DemoTodo` (4) |
| `apps/web/src/features/mail/hooks/useEmailComposition.ts` | `useEmailComposition.types.ts` | `EmailCompositionFormState`, `EmailCompositionUIState`, `EmailCompositionActions`, `UseEmailCompositionReturn` (4) |
| `apps/web/src/features/onboarding/constants/platformPreviewMessages.ts` | `platformPreviewMessages.types.ts` | `PlatformPreviewPlatform`, `ProfessionArchetype`, `PlatformScript`, `UserIdentity` (4) |
| `apps/web/src/lib/blog.ts` | `blog.types.ts` | `Author`, `BlogPost`, `BlogPostMeta`, `BlogPostFrontmatter` (4) |
| `libs/shared/ts/src/utils/quickAdd.ts` | `quickAdd.types.ts` | `QuickAddProject`, `QuickAddProjectMatch`, `QuickAddOptions`, `QuickAddResult` (4) |
| `packages/cli/src/lib/env-parser.ts` | `env-parser.types.ts` | `SetupMode`, `EnvVar`, `EnvCategory`, `WebEnvVar` (4) |

Only type declarations were moved. No runtime values or logic changed.

## Enforcement

Adds the marker file `.github/quality-gate/enforced/types-location`. The workflow (`code-quality.yml`) is intentionally **not** edited to avoid merge conflicts with the other ratcheted lane PRs.

## Verification

- `node scripts/ci/check-types-location.mjs --enforce` → `✅ Types live in dedicated type files.` (exit 0)
- `biome check` on all 14 touched files → exit 0 (two pre-existing warnings in `useEmailComposition.ts` / `quickAdd.ts` are on untouched lines)
- `tsc --noEmit` on `packages/cli` → 0 errors
- `nx type-check web` → identical 23 pre-existing errors with and without this change, **none** in any touched file or new `.types.ts` (this change introduces 0 new type errors)

Depends on #694 (which adds the quality-gate enforcement scaffolding and the `enforced/` marker mechanism).