### PR TITLE
ci(quality): hybrid scoping — diff on PRs, full on develop/master

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -36,11 +36,20 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Lint and format check across all TS/JS/JSON/CSS files
         run: |
           echo "::group::Biome check"
-          pnpm run quality:lint
+          FILES=$(scripts/ci/changed-files.sh ts tsx js jsx json jsonc css)
+          if [ "$FILES" = "__FULL__" ]; then
+            pnpm run quality:lint
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            pnpm exec biome check $FILES
+          fi
           echo "::endgroup::"
           echo "Biome: OK (0 errors; warnings shown above are non-blocking)"
 
@@ -93,11 +102,20 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Per-file line count (default 400, relaxed 700, hard cap 1200)
         run: |
           echo "::group::File size scan"
-          pnpm run quality:size
+          FILES=$(scripts/ci/changed-files.sh ts tsx js jsx mjs cjs)
+          if [ "$FILES" = "__FULL__" ]; then
+            pnpm run quality:size
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            CHANGED_FILES="$FILES" node scripts/ci/check-file-sizes.mjs
+          fi
           echo "::endgroup::"
           echo "File size: OK (no hard-cap violations)"
 
@@ -108,11 +126,20 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Type / interface / enum location enforcer
         run: |
           echo "::group::types-location check"
-          node scripts/ci/check-types-location.mjs --enforce
+          FILES=$(scripts/ci/changed-files.sh ts tsx)
+          if [ "$FILES" = "__FULL__" ]; then
+            node scripts/ci/check-types-location.mjs --enforce
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            CHANGED_FILES="$FILES" node scripts/ci/check-types-location.mjs --enforce
+          fi
           echo "::endgroup::"
           echo "Type colocation: OK (no file exports > 3 types unless in *.types.ts)"
 
@@ -123,11 +150,20 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Components-per-file enforcer
         run: |
           echo "::group::components-per-file check"
-          pnpm run quality:components
+          FILES=$(scripts/ci/changed-files.sh tsx)
+          if [ "$FILES" = "__FULL__" ]; then
+            pnpm run quality:components
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            CHANGED_FILES="$FILES" node scripts/ci/check-components-per-file.mjs
+          fi
           echo "::endgroup::"
           echo "Components: OK (no file declares > 2 React components)"
 
@@ -195,13 +231,20 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: tsc --noEmit across web, desktop, mobile, cli, bots
         run: |
-          echo "::group::nx run-many -t type-check"
-          pnpm exec nx run-many -t type-check --projects=web,desktop,mobile,cli,bot-discord,bot-slack,bot-telegram,bot-whatsapp
+          echo "::group::nx type-check"
+          if [ -n "${GITHUB_BASE_REF:-}" ]; then
+            git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" 2>/dev/null || true
+            pnpm exec nx affected -t type-check --base=origin/$GITHUB_BASE_REF
+          else
+            pnpm exec nx run-many -t type-check --projects=web,desktop,mobile,cli,bot-discord,bot-slack,bot-telegram,bot-whatsapp
+          fi
           echo "::endgroup::"
-          echo "TypeScript: OK (all 8 workspaces pass strict tsc)"
+          echo "TypeScript: OK (all affected workspaces pass strict tsc)"
 
   # --- Python ruff --------------------------------------------------------
   python-ruff:
@@ -210,22 +253,27 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
           enable-cache: true
-      - name: ruff check (PL, RUF, FAST, S, B, A, COM, C4, DTZ, ISC, RET, SIM, ARG, PTH, TRY, PERF, UP, FURB, LOG, G + more)
+      - name: ruff check + format (PL, RUF, FAST, S, B, A, COM, C4, DTZ, ISC, RET, SIM, ARG, PTH, TRY, PERF, UP, FURB, LOG, G + more)
         run: |
-          echo "::group::ruff check"
-          uvx ruff check apps/api apps/voice-agent libs/shared/py
+          echo "::group::ruff check + format --check"
+          FILES=$(scripts/ci/changed-files.sh py)
+          if [ "$FILES" = "__FULL__" ]; then
+            uvx ruff check apps/api apps/voice-agent libs/shared/py
+            uvx ruff format --check apps/api apps/voice-agent libs/shared/py
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            uvx ruff check $FILES
+            uvx ruff format --check $FILES
+          fi
           echo "::endgroup::"
-          echo "ruff: OK (strict rule set passes)"
-      - name: ruff format check
-        run: |
-          echo "::group::ruff format --check"
-          uvx ruff format --check apps/api apps/voice-agent libs/shared/py
-          echo "::endgroup::"
-          echo "ruff format: OK (every file is already formatted)"
+          echo "ruff: OK (strict rule set passes; every file is already formatted)"
 
   # --- Python mypy --------------------------------------------------------
   python-mypy:
@@ -234,6 +282,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
@@ -247,7 +297,30 @@ jobs:
       - name: mypy across api + voice-agent + shared (staged-strict + shared.* strict override)
         run: |
           echo "::group::mypy"
-          uv run --project apps/api --group backend --group dev mypy apps/api/app apps/voice-agent/src libs/shared/py --ignore-missing-imports
+          # mypy needs the whole module graph per project, so it can't be scoped
+          # to individual changed files. On PRs we instead detect which Python
+          # projects changed (from the .py diff) and check only those project
+          # roots. libs/shared/py is a dependency of both apps, so any change
+          # there pulls both apps in. On push we check everything.
+          FILES=$(scripts/ci/changed-files.sh py)
+          if [ "$FILES" = "__FULL__" ]; then
+            uv run --project apps/api --group backend --group dev mypy apps/api/app apps/voice-agent/src libs/shared/py --ignore-missing-imports
+          elif [ -z "$FILES" ]; then
+            echo "No changed Python files — skipping."
+          else
+            TARGETS=""
+            if echo "$FILES" | grep -q '^libs/shared/py/'; then
+              TARGETS="apps/api/app apps/voice-agent/src libs/shared/py"
+            else
+              echo "$FILES" | grep -q '^apps/api/'         && TARGETS="$TARGETS apps/api/app"
+              echo "$FILES" | grep -q '^apps/voice-agent/' && TARGETS="$TARGETS apps/voice-agent/src"
+            fi
+            if [ -z "$TARGETS" ]; then
+              echo "No tracked Python project changed — skipping."
+            else
+              uv run --project apps/api --group backend --group dev mypy $TARGETS --ignore-missing-imports
+            fi
+          fi
           echo "::endgroup::"
           echo "mypy: OK (no type errors)"
 
@@ -258,6 +331,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
@@ -265,7 +340,14 @@ jobs:
       - name: Docstring coverage on public API surface
         run: |
           echo "::group::interrogate"
-          uvx interrogate -c pyproject.toml apps/api apps/voice-agent libs/shared/py
+          FILES=$(scripts/ci/changed-files.sh py)
+          if [ "$FILES" = "__FULL__" ]; then
+            uvx interrogate -c pyproject.toml apps/api apps/voice-agent libs/shared/py
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            uvx interrogate -c pyproject.toml $FILES
+          fi
           echo "::endgroup::"
           echo "Docstrings: OK (coverage ≥ 80%)"
 
@@ -276,6 +358,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
@@ -283,24 +367,37 @@ jobs:
       - name: Complexity scan (max-absolute F, max-modules E, max-average B)
         run: |
           echo "::group::xenon"
-          uvx xenon \
-            --max-absolute F \
-            --max-modules E \
-            --max-average B \
-            apps/api apps/voice-agent libs/shared/py \
-            -e 'apps/api/tests/**' \
-            -e 'apps/api/scripts/**' \
-            -e 'libs/shared/py/tests/**'
+          FILES=$(scripts/ci/changed-files.sh py)
+          if [ "$FILES" = "__FULL__" ]; then
+            uvx xenon \
+              --max-absolute F \
+              --max-modules E \
+              --max-average B \
+              apps/api apps/voice-agent libs/shared/py \
+              -e 'apps/api/tests/**' \
+              -e 'apps/api/scripts/**' \
+              -e 'libs/shared/py/tests/**'
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            uvx xenon \
+              --max-absolute F \
+              --max-modules E \
+              --max-average B \
+              $FILES
+          fi
           echo "::endgroup::"
           echo "Complexity: OK (no module exceeds rank D, codebase average ≤ B)"
 
-  # --- Python security (bandit + pip-audit) -------------------------------
+  # --- Python security (bandit gates; pip-audit advisory) -----------------
   python-security:
-    name: Python security (bandit zero-warning + pip-audit)
+    name: Python security (bandit; pip-audit advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
@@ -308,7 +405,14 @@ jobs:
       - name: Bandit security scan (zero-warning policy)
         run: |
           echo "::group::bandit (low severity, low confidence — no exclusions)"
-          uvx bandit -c pyproject.toml -r apps/api/app apps/voice-agent/src libs/shared/py --severity-level low --confidence-level low
+          FILES=$(scripts/ci/changed-files.sh py)
+          if [ "$FILES" = "__FULL__" ]; then
+            uvx bandit -c pyproject.toml -r apps/api/app apps/voice-agent/src libs/shared/py --severity-level low --confidence-level low
+          elif [ -z "$FILES" ]; then
+            echo "No matching changed files — skipping."
+          else
+            uvx bandit -c pyproject.toml $FILES --severity-level low --confidence-level low
+          fi
           echo "::endgroup::"
           echo "Security: OK (0 issues across all severity levels)"
       - name: pip-audit (dependency CVEs)

--- a/scripts/ci/changed-files.sh
+++ b/scripts/ci/changed-files.sh
@@ -35,12 +35,12 @@ set -euo pipefail
 FULL_SENTINEL="__FULL__"
 
 # Push / non-PR event: no base ref to diff against → signal full scan.
-if [ -z "${GITHUB_BASE_REF:-}" ]; then
+if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
   printf '%s\n' "$FULL_SENTINEL"
   exit 0
 fi
 
-if [ "$#" -eq 0 ]; then
+if [[ "$#" -eq 0 ]]; then
   echo "changed-files.sh: at least one extension argument is required" >&2
   exit 2
 fi
@@ -48,7 +48,7 @@ fi
 # Build an alternation of the requested extensions: ts|tsx|js → \.(ts|tsx|js)$
 ext_alt=""
 for ext in "$@"; do
-  if [ -z "$ext_alt" ]; then
+  if [[ -z "$ext_alt" ]]; then
     ext_alt="$ext"
   else
     ext_alt="$ext_alt|$ext"
@@ -70,5 +70,5 @@ git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" 2>/dev/null || true
 git diff --name-only --diff-filter=ACMR "origin/${GITHUB_BASE_REF}...HEAD" \
   | { grep -E "$ext_regex" || true; } \
   | while IFS= read -r f; do
-      [ -f "$f" ] && printf '%s\n' "$f"
+      [[ -f "$f" ]] && printf '%s\n' "$f"
     done

--- a/scripts/ci/changed-files.sh
+++ b/scripts/ci/changed-files.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# changed-files.sh — emit the list of changed files for a CI lane to scope to.
+#
+# Usage:
+#   scripts/ci/changed-files.sh <ext> [<ext> ...]
+#   e.g. scripts/ci/changed-files.sh ts tsx js jsx json css
+#        scripts/ci/changed-files.sh py
+#
+# Modes (signalled to callers via a sentinel on the first line of stdout):
+#
+#   PUSH / FULL-SCAN MODE  ($GITHUB_BASE_REF is empty — i.e. not a PR)
+#     Prints the single line "__FULL__" and exits 0. Callers MUST treat this
+#     as "scan the whole repo with the lane's existing full command".
+#
+#   PR MODE  ($GITHUB_BASE_REF is set — pull_request event)
+#     Prints one path per line: files changed vs the PR base (merge-base diff),
+#     filtered to the requested extensions and to files that still exist on
+#     HEAD (added / copied / modified / renamed; deletions excluded). When the
+#     PR changes zero matching files this prints NOTHING and exits 0 — callers
+#     MUST treat empty (but not "__FULL__") output as "no work, skip & pass".
+#
+# Caller contract (the three states):
+#   FILES=$(scripts/ci/changed-files.sh <exts>)
+#   if [ "$FILES" = "__FULL__" ]; then  <full command>          # push
+#   elif [ -z "$FILES" ]; then          echo "skip"; exit 0     # PR, nothing relevant
+#   else                                <tool> $FILES           # PR, diff-scoped
+#   fi
+#
+# Diff accuracy note: the merge-base ("...") diff requires the base ref to be
+# present locally, so PR lanes that consume this script must checkout with
+# `fetch-depth: 0`. The script fetches the base ref defensively as well.
+set -euo pipefail
+
+FULL_SENTINEL="__FULL__"
+
+# Push / non-PR event: no base ref to diff against → signal full scan.
+if [ -z "${GITHUB_BASE_REF:-}" ]; then
+  printf '%s\n' "$FULL_SENTINEL"
+  exit 0
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "changed-files.sh: at least one extension argument is required" >&2
+  exit 2
+fi
+
+# Build an alternation of the requested extensions: ts|tsx|js → \.(ts|tsx|js)$
+ext_alt=""
+for ext in "$@"; do
+  if [ -z "$ext_alt" ]; then
+    ext_alt="$ext"
+  else
+    ext_alt="$ext_alt|$ext"
+  fi
+done
+ext_regex="\.(${ext_alt})$"
+
+# Ensure the PR base ref is available for the merge-base diff. Best-effort:
+# on a fetch-depth:0 checkout this is a cheap no-op; on a shallow one it
+# unshallows just enough to resolve the base.
+git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" 2>/dev/null || true
+
+# `...HEAD` diffs against the merge-base of the base ref and HEAD — the same set
+# of files GitHub shows as "Files changed" in the PR. --diff-filter=ACMR drops
+# deletions so we never hand a tool a path that no longer exists.
+git diff --name-only --diff-filter=ACMR "origin/${GITHUB_BASE_REF}...HEAD" \
+  | grep -E "$ext_regex" \
+  | while IFS= read -r f; do
+      [ -f "$f" ] && printf '%s\n' "$f"
+    done

--- a/scripts/ci/changed-files.sh
+++ b/scripts/ci/changed-files.sh
@@ -64,8 +64,11 @@ git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF" 2>/dev/null || true
 # `...HEAD` diffs against the merge-base of the base ref and HEAD — the same set
 # of files GitHub shows as "Files changed" in the PR. --diff-filter=ACMR drops
 # deletions so we never hand a tool a path that no longer exists.
+# `|| true` on grep: a PR that changes zero matching files is a valid "skip"
+# case, not an error. Without it, grep's no-match exit 1 + `set -o pipefail`
+# would make this script exit 1 and fail the lane's `FILES=$(...)` step.
 git diff --name-only --diff-filter=ACMR "origin/${GITHUB_BASE_REF}...HEAD" \
-  | grep -E "$ext_regex" \
+  | { grep -E "$ext_regex" || true; } \
   | while IFS= read -r f; do
       [ -f "$f" ] && printf '%s\n' "$f"
     done

--- a/scripts/ci/check-components-per-file.mjs
+++ b/scripts/ci/check-components-per-file.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { explicitFileList } from "./lib/explicit-file-list.mjs";
 
 const ALLOWLIST_PREFIXES = [
   "apps/web/src/components/ui/",
@@ -49,18 +50,6 @@ const SCANNED_ROOTS = [
 
 function inScope(path) {
   return path.endsWith(".tsx") && SCANNED_ROOTS.some((r) => path.startsWith(r));
-}
-
-// Explicit file list (CI diff-scoping): newline-separated CHANGED_FILES env
-// var OR non-flag argv entries. When provided, only those in-scope files are
-// checked. Otherwise fall back to a full `git ls-files` repo scan.
-function explicitFileList() {
-  const fromEnv = (process.env.CHANGED_FILES ?? "")
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
-  return [...fromEnv, ...fromArgv];
 }
 
 function getFiles() {

--- a/scripts/ci/check-components-per-file.mjs
+++ b/scripts/ci/check-components-per-file.mjs
@@ -36,7 +36,38 @@ function isAllowed(path) {
   return false;
 }
 
+// This gate only governs .tsx component sources under these roots. The
+// explicit-list path mirrors that scope so a diff touching files outside it is
+// correctly ignored.
+const SCANNED_ROOTS = [
+  "apps/web/src/",
+  "apps/desktop/src/",
+  "apps/mobile/src/",
+  "libs/shared/ts/src/",
+  "packages/cli/src/",
+];
+
+function inScope(path) {
+  return path.endsWith(".tsx") && SCANNED_ROOTS.some((r) => path.startsWith(r));
+}
+
+// Explicit file list (CI diff-scoping): newline-separated CHANGED_FILES env
+// var OR non-flag argv entries. When provided, only those in-scope files are
+// checked. Otherwise fall back to a full `git ls-files` repo scan.
+function explicitFileList() {
+  const fromEnv = (process.env.CHANGED_FILES ?? "")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  return [...fromEnv, ...fromArgv];
+}
+
 function getFiles() {
+  const explicit = explicitFileList();
+  if (explicit.length > 0) {
+    return explicit.filter(inScope);
+  }
   // `git` is intentionally resolved via PATH; CI runners always have it.
   const out = execFileSync( // NOSONAR javascript:S4036
     "git", // NOSONAR javascript:S4036

--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -13,6 +13,7 @@
  */
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { explicitFileList } from "./lib/explicit-file-list.mjs";
 
 const DEFAULT_LIMIT = 400;
 const RELAXED_LIMIT = 700;
@@ -74,19 +75,6 @@ const exemptFromHardCap = (p) =>
   NO_HARD_CAP_PATTERNS.some((rx) => rx.test(p));
 
 const SCANNED_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
-
-// Explicit file list (CI diff-scoping): newline-separated CHANGED_FILES env
-// var OR non-flag argv entries. When provided, only those files are checked —
-// still subject to this script's own extension + ignore rules. Otherwise fall
-// back to a full `git ls-files` repo scan.
-function explicitFileList() {
-  const fromEnv = (process.env.CHANGED_FILES ?? "")
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
-  return [...fromEnv, ...fromArgv];
-}
 
 function getFiles() {
   const explicit = explicitFileList();

--- a/scripts/ci/check-file-sizes.mjs
+++ b/scripts/ci/check-file-sizes.mjs
@@ -73,7 +73,28 @@ const limitFor = (p) =>
 const exemptFromHardCap = (p) =>
   NO_HARD_CAP_PATTERNS.some((rx) => rx.test(p));
 
+const SCANNED_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+
+// Explicit file list (CI diff-scoping): newline-separated CHANGED_FILES env
+// var OR non-flag argv entries. When provided, only those files are checked —
+// still subject to this script's own extension + ignore rules. Otherwise fall
+// back to a full `git ls-files` repo scan.
+function explicitFileList() {
+  const fromEnv = (process.env.CHANGED_FILES ?? "")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  return [...fromEnv, ...fromArgv];
+}
+
 function getFiles() {
+  const explicit = explicitFileList();
+  if (explicit.length > 0) {
+    return explicit
+      .filter((p) => SCANNED_EXTENSIONS.some((ext) => p.endsWith(ext)))
+      .filter((p) => !shouldIgnore(p));
+  }
   // `git` is intentionally resolved via PATH; CI runners always have it.
   const out = execFileSync( // NOSONAR javascript:S4036
     "git", // NOSONAR javascript:S4036

--- a/scripts/ci/check-types-location.mjs
+++ b/scripts/ci/check-types-location.mjs
@@ -41,7 +41,34 @@ function isAllowed(path) {
   return false;
 }
 
+// This gate only governs source under apps/, libs/, packages/ with a .ts/.tsx
+// extension. The explicit-list path mirrors that scope so a diff that touches
+// unrelated files (e.g. root config) is correctly ignored.
+function inScope(path) {
+  const underTrackedRoot =
+    path.startsWith("apps/") ||
+    path.startsWith("libs/") ||
+    path.startsWith("packages/");
+  return underTrackedRoot && (path.endsWith(".ts") || path.endsWith(".tsx"));
+}
+
+// Explicit file list (CI diff-scoping): newline-separated CHANGED_FILES env
+// var OR non-flag argv entries. When provided, only those in-scope files are
+// checked. Otherwise fall back to a full `git ls-files` repo scan.
+function explicitFileList() {
+  const fromEnv = (process.env.CHANGED_FILES ?? "")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  return [...fromEnv, ...fromArgv];
+}
+
 function getFiles() {
+  const explicit = explicitFileList();
+  if (explicit.length > 0) {
+    return explicit.filter(inScope);
+  }
   // `git` is intentionally resolved via PATH on CI runners and local dev
   // shells where the binary is part of the runtime.
   const out = execFileSync( // NOSONAR javascript:S4036

--- a/scripts/ci/check-types-location.mjs
+++ b/scripts/ci/check-types-location.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { explicitFileList } from "./lib/explicit-file-list.mjs";
 
 function isTypeFile(path) {
   if (path.endsWith(".d.ts")) return true;
@@ -50,18 +51,6 @@ function inScope(path) {
     path.startsWith("libs/") ||
     path.startsWith("packages/");
   return underTrackedRoot && (path.endsWith(".ts") || path.endsWith(".tsx"));
-}
-
-// Explicit file list (CI diff-scoping): newline-separated CHANGED_FILES env
-// var OR non-flag argv entries. When provided, only those in-scope files are
-// checked. Otherwise fall back to a full `git ls-files` repo scan.
-function explicitFileList() {
-  const fromEnv = (process.env.CHANGED_FILES ?? "")
-    .split("\n")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
-  return [...fromEnv, ...fromArgv];
 }
 
 function getFiles() {

--- a/scripts/ci/lib/explicit-file-list.mjs
+++ b/scripts/ci/lib/explicit-file-list.mjs
@@ -1,0 +1,14 @@
+// Shared helper for the CI gate scripts (check-*.mjs).
+//
+// Returns the explicit list of files a lane is scoped to: the newline-separated
+// CHANGED_FILES env var plus any non-flag argv entries. Empty when neither is
+// provided, in which case the caller falls back to a full repo scan. Each
+// caller applies its own extension / scope / ignore filtering to the result.
+export function explicitFileList() {
+  const fromEnv = (process.env.CHANGED_FILES ?? "")
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromArgv = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  return [...fromEnv, ...fromArgv];
+}


### PR DESCRIPTION
## What

Hybrid CI scoping for the Code Quality workflow:

- **Push to `develop`/`master`** → every lane runs its existing **full** command, byte-for-byte unchanged. Nothing about the develop/master path changed.
- **`pull_request`** → per-file lanes scope to the **changed files** (merge-base diff vs the PR base); project-graph lanes (`type-check`, `python-mypy`) scope to **nx-affected / changed projects**.
- **Cross-file lanes stay full on every event** — they are inherently whole-repo and cannot be diff-scoped.

## How

### `scripts/ci/changed-files.sh` (new helper)
Takes extensions as args. Signals mode to callers via a sentinel on stdout:
- **Push / non-PR** (`$GITHUB_BASE_REF` empty): prints `__FULL__` and exits 0 → callers run the full command.
- **PR** (`$GITHUB_BASE_REF` set): `git diff --diff-filter=ACMR origin/$BASE...HEAD`, filtered to the given extensions and to files that still exist → one path per line. Zero matching files → empty output → callers skip the tool and pass.

Caller contract (3 states):
```
FILES=$(scripts/ci/changed-files.sh <exts>)
if [ "$FILES" = "__FULL__" ]; then <full command>          # push
elif [ -z "$FILES" ]; then        echo "skip"; exit 0      # PR, nothing relevant
else                              <tool> $FILES             # PR, diff-scoped
fi
```
PR per-file lanes checkout with `fetch-depth: 0` so the `...` merge-base diff resolves (shallow clones break it).

### `--files` mode for the node gate scripts
`check-file-sizes.mjs`, `check-types-location.mjs`, `check-components-per-file.mjs` now read an explicit list from `CHANGED_FILES` (newline-separated) or non-flag argv; when present they lint only those files (still applying each script's own include/exclude rules), otherwise full `git ls-files` scan as before. `--enforce` on `check-types-location` still works.

### Lanes changed (10)
**Per-file** (PR → changed files, push → full): `biome`, `python-ruff`, `python-interrogate`, `python-xenon`, `python-security` (bandit), `file-size`, `types-location`, `components-per-file`.
**Affected-project** (PR → affected/changed projects, push → full): `type-check` (`nx affected -t type-check --base=origin/$BASE`), `python-mypy` (mypy needs the whole module graph per project, so on PRs we detect which Python projects changed from the `.py` diff — a `libs/shared/py` change pulls in both apps since it's a shared dependency — and run mypy on those project roots only).

### Lanes untouched (6 cross-file, stay full always)
`duplicates` (jscpd), `circular` (madge), `dead-code` (knip + vulture), `deps` (syncpack/manypkg/pkg-json), `type-coverage`, `package-hygiene` (publint + attw). These are whole-repo by nature and cannot be diff-scoped without losing correctness.

### Honesty rename
`python-security` lane name was `Python security (bandit zero-warning + pip-audit)` but pip-audit runs `|| true` (advisory, non-blocking). Renamed to `Python security (bandit; pip-audit advisory)`. The `quality-gate` aggregator keys off the job id `python-security` (not the display name), so the verdict printout needs no change. pip-audit step is unchanged.

## Verification

```
YAML: python3 -c "import yaml; yaml.safe_load(...)" → YAML OK

changed-files.sh push mode (unset GITHUB_BASE_REF):
  $ changed-files.sh py    → __FULL__   (rc=0)
  $ changed-files.sh ts tsx → __FULL__  (rc=0)

changed-files.sh PR mode (GITHUB_BASE_REF=develop, real committed diff):
  $ changed-files.sh py                       → (empty — no .py changed)
  $ changed-files.sh ts tsx js jsx mjs cjs    → the 3 changed .mjs files only
  $ changed-files.sh sh                        → scripts/ci/changed-files.sh only

mjs --files mode (each script):
  scope to a violator       → flags it, rc=1
  scope to a clean file only → rc=0  (proves it does NOT scan the whole repo)
  no env (full scan)         → rc=0  (full behaviour intact)

per-job audit (yaml-parsed):
  10 scoped lanes  → scoping=True,  fetch-depth=0
  6 cross-file lanes → scoping=False, fetch-depth=None  (untouched)

shellcheck scripts/ci/changed-files.sh (v0.11.0) → clean
bash -n scripts/ci/changed-files.sh             → syntax OK

end-to-end sanity (file-size lane):
  PR path (BASE set)  → scoped to 3 mjs, rc=0
  push path (no BASE) → full scan, rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
