### PR TITLE
ci(quality): scope PR python scans to source files

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -340,7 +340,7 @@ jobs:
       - name: Docstring coverage on public API surface
         run: |
           echo "::group::interrogate"
-          FILES=$(scripts/ci/changed-files.sh py)
+          FILES=$(scripts/ci/changed-py-source.sh)
           if [ "$FILES" = "__FULL__" ]; then
             uvx interrogate -c pyproject.toml apps/api apps/voice-agent libs/shared/py
           elif [ -z "$FILES" ]; then
@@ -367,7 +367,7 @@ jobs:
       - name: Complexity scan (max-absolute F, max-modules E, max-average B)
         run: |
           echo "::group::xenon"
-          FILES=$(scripts/ci/changed-files.sh py)
+          FILES=$(scripts/ci/changed-py-source.sh)
           if [ "$FILES" = "__FULL__" ]; then
             uvx xenon \
               --max-absolute F \
@@ -405,7 +405,7 @@ jobs:
       - name: Bandit security scan (zero-warning policy)
         run: |
           echo "::group::bandit (low severity, low confidence — no exclusions)"
-          FILES=$(scripts/ci/changed-files.sh py)
+          FILES=$(scripts/ci/changed-py-source.sh)
           if [ "$FILES" = "__FULL__" ]; then
             uvx bandit -c pyproject.toml -r apps/api/app apps/voice-agent/src libs/shared/py --severity-level low --confidence-level low
           elif [ -z "$FILES" ]; then

--- a/scripts/ci/changed-py-source.sh
+++ b/scripts/ci/changed-py-source.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# changed-py-source.sh — like `changed-files.sh py`, but drops the paths the
+# Python tools exclude in a full scan (tests, scripts, migrations, …).
+#
+# Passing explicit files to interrogate/xenon/bandit bypasses their config
+# excludes, so a changed test file gets scanned on a PR when a full scan would
+# skip it. The exclude list is read from pyproject's [tool.interrogate].exclude
+# so there is a single source of truth.
+#
+# Same output contract as changed-files.sh: "__FULL__", empty, or a file list.
+set -euo pipefail
+
+FILES=$(scripts/ci/changed-files.sh py)
+
+if [[ "$FILES" == "__FULL__" || -z "$FILES" ]]; then
+  printf '%s\n' "$FILES"
+  exit 0
+fi
+
+# Program via -c so the file list can be piped on stdin. Each exclude glob
+# reduces to a path segment (**/tests) or a basename (**/conftest.py).
+printf '%s\n' "$FILES" | python3 -c '
+import pathlib
+import sys
+import tomllib
+
+patterns = tomllib.loads(pathlib.Path("pyproject.toml").read_text())[
+    "tool"
+]["interrogate"]["exclude"]
+
+segments, basenames = set(), set()
+for pat in patterns:
+    core = pat.strip("/")
+    if core.startswith("**/"):
+        core = core[3:]
+    if core.endswith("/**"):
+        core = core[:-3]
+    core = core.strip("/")
+    if "/" in core or "*" in core:
+        continue
+    (basenames if core.endswith(".py") else segments).add(core)
+
+for line in filter(None, sys.stdin.read().splitlines()):
+    parts = line.split("/")
+    if segments & set(parts) or parts[-1] in basenames:
+        continue
+    print(line)
+'


### PR DESCRIPTION
On PRs, `interrogate`/`xenon`/`bandit` receive the explicit changed files. Explicit paths bypass each tool's config excludes, so a changed **test** or **script** file gets analyzed even though a full scan skips it — e.g. a test file counts toward docstring coverage and fails the interrogate lane.

Add `scripts/ci/changed-py-source.sh`: it wraps `changed-files.sh py` and drops the paths listed in `pyproject`'s `[tool.interrogate].exclude` (tests, scripts, migrations, alembic, `conftest.py`, `setup.py`). The exclude list is read from `pyproject` so there's a single source of truth. `ruff` (lints tests by design) and `mypy` (project-root scoped) are not consumers.

Verified: filter keeps `app/foo.py`, `scripts_helper.py`, `latest_tests/y.py`; drops `tests/…`, `scripts/…`, `conftest.py`, `alembic/…`, `setup.py`. `__FULL__`/empty/list contract preserved.