### PR TITLE
fix(infra): zero-downtime prod deploys — swarm configs, baked grafana, ingress

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,12 +280,14 @@ jobs:
 
       - name: Determine image tag
         id: tag
+        env:
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
+          if [ "$GIT_REF" = "refs/heads/master" ]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
-            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-            echo "tag=dev-${SHORT_SHA}" >> $GITHUB_OUTPUT
+            echo "tag=dev-$(printf '%s' "$GIT_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Grafana image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,7 +259,7 @@ jobs:
   # tiny COPY layer over the upstream image, and the prod stack always references
   # gaia-grafana:latest.
   docker-grafana:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -275,8 +275,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Determine image tag
         id: tag
@@ -289,7 +289,7 @@ jobs:
           fi
 
       - name: Build and push Grafana image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: infra/docker/observability/grafana
           file: infra/docker/observability/grafana/Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,9 +254,53 @@ jobs:
         if: steps.web-affected.outputs.web != 'true'
         run: echo "Web not affected, skipping Docker build"
 
+  # Grafana provisioning (dashboards/datasources/alerting) is baked into a custom
+  # image so production needs no host bind mount. Built unconditionally — it's a
+  # tiny COPY layer over the upstream image, and the prod stack always references
+  # gaia-grafana:latest.
+  docker-grafana:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            echo "tag=dev-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push Grafana image
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: infra/docker/observability/grafana
+          file: infra/docker/observability/grafana/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/gaia-grafana:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/gaia-grafana:${{ github.sha }}
+
   deployment-plan:
-    # Keep deploy planning behind both build lanes so trigger jobs never race ahead.
-    needs: [docker-release, docker-web]
+    # Keep deploy planning behind all build lanes so trigger jobs never race ahead.
+    needs: [docker-release, docker-web, docker-grafana]
     runs-on: ubuntu-latest
     outputs:
       backend_deploy: ${{ steps.plan.outputs.backend_deploy }}

--- a/.github/workflows/deploy-swarm-prod.yml
+++ b/.github/workflows/deploy-swarm-prod.yml
@@ -48,6 +48,8 @@ jobs:
     environment: production
     permissions:
       contents: read
+      # Pull the private gaia-grafana image on the swarm nodes via --with-registry-auth.
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -69,6 +71,20 @@ jobs:
 
       - name: Deploy stack
         run: |
+          set -euo pipefail
+          # Observability configs ship as Swarm configs (stored in the cluster),
+          # not host bind mounts, so this deploys cleanly via the remote context
+          # with no files on the VM. Swarm configs are immutable, so their names
+          # carry a content hash: a changed config file produces a new config
+          # object that services roll onto. Compute it over all config files.
+          OBS_CFG_HASH=$(cat \
+            infra/docker/observability/prometheus.yml \
+            infra/docker/observability/loki-config.yaml \
+            infra/docker/observability/promtail-config.yaml \
+            infra/docker/observability/blackbox.yml \
+            infra/docker/observability/rabbitmq-enabled-plugins \
+            | sha256sum | cut -c1-12)
+          export OBS_CFG_HASH
           docker --context prod stack deploy \
             --with-registry-auth \
             -c infra/docker/docker-compose.prod.yml \

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -51,15 +51,19 @@ services:
       - gaia_infisical_project_id
       - gaia_metrics_token
     ports:
-      # Published on the host so the host's Nginx can proxy api.heygaia.io here.
-      # NOTE: Swarm `mode: host` does NOT enforce `host_ip` (see moby/moby#32299),
-      # so this binds to 0.0.0.0:8000. The Hetzner Cloud Firewall only allows
-      # 22/80/443 from the public internet, so 8000 is only reachable from
-      # localhost (Nginx) in practice. Do not remove the firewall rule.
+      # Published via the swarm routing mesh (ingress) so the host's Nginx can
+      # proxy api.heygaia.io here. ingress (not host) makes rolling updates
+      # zero-downtime: the routing mesh keeps serving the old task until the new
+      # one is healthy, then drains it. host mode cannot do this — only one
+      # container may bind the host port, so start-first updates fail with
+      # "address already in use" and Swarm rolls back.
+      # Exposure is unchanged: ingress also binds 0.0.0.0:8000. The Hetzner Cloud
+      # Firewall only allows 22/80/443 from the public internet, so 8000 is only
+      # reachable from localhost (Nginx) in practice. Do not remove the firewall rule.
       - target: 80
         published: 8000
         protocol: tcp
-        mode: host
+        mode: ingress
     networks:
       gaia-prod-shared:
         aliases:
@@ -160,10 +164,12 @@ services:
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/discord/* from the public internet.
+      # ingress (not host) so rolling updates are zero-downtime; the Hetzner
+      # firewall keeps the port localhost-only. Do not remove the firewall rule.
       - target: 3200
         published: 3200
         protocol: tcp
-        mode: host
+        mode: ingress
     networks:
       gaia-prod-shared:
         aliases:
@@ -204,10 +210,12 @@ services:
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/slack/* from the public internet.
+      # ingress (not host) so rolling updates are zero-downtime; the Hetzner
+      # firewall keeps the port localhost-only. Do not remove the firewall rule.
       - target: 3201
         published: 3201
         protocol: tcp
-        mode: host
+        mode: ingress
     networks:
       gaia-prod-shared:
         aliases:
@@ -248,10 +256,12 @@ services:
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/telegram/* from the public internet.
+      # ingress (not host) so rolling updates are zero-downtime; the Hetzner
+      # firewall keeps the port localhost-only. Do not remove the firewall rule.
       - target: 3202
         published: 3202
         protocol: tcp
-        mode: host
+        mode: ingress
     networks:
       gaia-prod-shared:
         aliases:
@@ -292,10 +302,12 @@ services:
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /api/v1/webhook/whatsapp + /bots/whatsapp/*.
+      # ingress (not host) so rolling updates are zero-downtime; the Hetzner
+      # firewall keeps the port localhost-only. Do not remove the firewall rule.
       - target: 3203
         published: 3203
         protocol: tcp
-        mode: host
+        mode: ingress
     networks:
       gaia-prod-shared:
         aliases:
@@ -427,7 +439,9 @@ services:
     # disaster recovery / fresh volume bootstrapping — see docs/deployment/secrets.mdx.
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
-      - ./observability/rabbitmq-enabled-plugins:/etc/rabbitmq/enabled_plugins:ro
+    configs:
+      - source: rabbitmq_enabled_plugins
+        target: /etc/rabbitmq/enabled_plugins
     networks:
       gaia-prod-shared:
         aliases:
@@ -553,8 +567,9 @@ services:
 
   blackbox_exporter:
     image: prom/blackbox-exporter:v0.25.0
-    volumes:
-      - ./observability/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    configs:
+      - source: blackbox_yml
+        target: /etc/blackbox_exporter/config.yml
     networks:
       - gaia-prod-shared
     deploy:
@@ -570,9 +585,11 @@ services:
     image: prom/prometheus:v3.1.0
     user: root  # needed to read /var/run/docker.sock for Swarm SD
     volumes:
-      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    configs:
+      - source: prometheus_yml
+        target: /etc/prometheus/prometheus.yml
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.retention.time=30d"
@@ -607,8 +624,10 @@ services:
     # Grafana and Promtail reach it at `loki:3100` via the overlay network.
     image: grafana/loki:3.3.2
     volumes:
-      - ./observability/loki-config.yaml:/etc/loki/local-config.yaml
       - loki_data:/loki
+    configs:
+      - source: loki_config
+        target: /etc/loki/local-config.yaml
     command: -config.file=/etc/loki/local-config.yaml
     networks:
       gaia-prod-shared:
@@ -637,9 +656,11 @@ services:
     # mode: global — runs one instance per swarm node to collect all container logs
     user: root
     volumes:
-      - ./observability/promtail-config.yaml:/etc/promtail/config.yaml
       - /var/run/docker.sock:/var/run/docker.sock
       - promtail_positions:/tmp
+    configs:
+      - source: promtail_config
+        target: /etc/promtail/config.yaml
     command: -config.file=/etc/promtail/config.yaml -config.expand-env=true
     environment:
       LOKI_PUSH_URL: ${LOKI_PUSH_URL:-http://loki:3100/loki/api/v1/push}
@@ -661,7 +682,10 @@ services:
           cpus: "0.25"
 
   grafana:
-    image: grafana/grafana:11.4.0
+    # Provisioning (datasources, dashboards, alerting) is baked into this image
+    # — see infra/docker/observability/grafana/Dockerfile — so prod needs no host
+    # bind mount and the stack deploys cleanly from CI via a remote context.
+    image: ghcr.io/theexperiencecompany/gaia-grafana:latest
     ports:
       # Loopback only — Nginx on the host proxies logs.heygaia.io to this.
       - target: 3000
@@ -670,7 +694,6 @@ services:
         mode: host
     volumes:
       - grafana_data:/var/lib/grafana
-      - ./observability/grafana/provisioning:/etc/grafana/provisioning
     environment:
       GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/gaia_grafana_admin_password
       GF_USERS_ALLOW_SIGN_UP: "false"
@@ -730,6 +753,28 @@ services:
       placement:
         constraints:
           - node.role == manager
+
+configs:
+  # Single-file observability configs live in the Swarm raft instead of host
+  # bind mounts, so the stack deploys from CI (remote context) with no config
+  # files on the VM. Swarm configs are immutable, so each name carries a content
+  # hash (OBS_CFG_HASH, computed by the deploy workflow) — a changed file
+  # produces a new config object that services roll onto.
+  prometheus_yml:
+    name: prometheus_yml_${OBS_CFG_HASH:-dev}
+    file: ./observability/prometheus.yml
+  loki_config:
+    name: loki_config_${OBS_CFG_HASH:-dev}
+    file: ./observability/loki-config.yaml
+  promtail_config:
+    name: promtail_config_${OBS_CFG_HASH:-dev}
+    file: ./observability/promtail-config.yaml
+  blackbox_yml:
+    name: blackbox_yml_${OBS_CFG_HASH:-dev}
+    file: ./observability/blackbox.yml
+  rabbitmq_enabled_plugins:
+    name: rabbitmq_enabled_plugins_${OBS_CFG_HASH:-dev}
+    file: ./observability/rabbitmq-enabled-plugins
 
 volumes:
   chroma_data:

--- a/infra/docker/observability/grafana/Dockerfile
+++ b/infra/docker/observability/grafana/Dockerfile
@@ -1,0 +1,10 @@
+# Bakes Grafana provisioning (datasources, dashboards, alerting) into the image
+# so production needs no host bind mount — the swarm stack then deploys cleanly
+# from CI via a remote Docker context. Built and pushed by
+# .github/workflows/build.yml as ghcr.io/theexperiencecompany/gaia-grafana.
+#
+# Build context is this directory:
+#   docker build -t gaia-grafana infra/docker/observability/grafana
+FROM grafana/grafana:11.4.0
+
+COPY provisioning /etc/grafana/provisioning


### PR DESCRIPTION
## What & why

Production deploys were broken in two independent ways. Diagnosed live on the prod swarm:

**1. Observability stack + RabbitMQ down → `logs.heygaia.io` 502.**
`grafana`, `loki`, `prometheus`, `promtail`, `blackbox` and `rabbitmq` use relative host bind mounts (`./observability/*`). The deploy workflow runs `docker stack deploy` from the CI runner via a *remote* Docker context, so those paths resolve to the **runner's** filesystem — which the VM doesn't have — and every bind-mounted service is rejected:
```
invalid mount config: bind source path does not exist:
/home/runner/_work/gaia/gaia/infra/docker/observability/grafana/provisioning
```
RabbitMQ is core infra, so this is more than dashboards.

**2. Every backend/bot deploy silently rolled back.**
They published ports with `mode: host` but updated `order: start-first`. Host mode lets only one container bind the host port, so start-first (old + new briefly coexist) fails with `address already in use` → Swarm reverts to the previous image. This is why a freshly-built image never went live.

## Changes

- **Swarm `configs:`** for the 5 single-file mounts (prometheus / loki / promtail / blackbox / rabbitmq). They live in the cluster raft — no files on the VM — so the remote-context `stack deploy` works. Names carry a content hash (`OBS_CFG_HASH`, computed in the deploy step) because Swarm configs are immutable; a changed file rotates to a new object.
- **Baked Grafana image** (`infra/docker/observability/grafana/Dockerfile` → `ghcr.io/.../gaia-grafana`) instead of bind-mounting the 14-file provisioning directory. Built in `build.yml`.
- **`mode: host` → `ingress`** for backend + 4 bots (keeping `start-first`). The routing mesh serves the old task until the new one is healthy → real zero-downtime. Same `0.0.0.0` exposure as before, gated by the Hetzner Cloud Firewall.
- Deploy job gets `packages: read` to pull the (private) grafana image via `--with-registry-auth`.

## Security note

`ingress` does **not** change exposure: host mode already binds `0.0.0.0` (Swarm ignores `host_ip`, moby#32299) and relies on the Hetzner firewall (22/80/443 only). The internal services (postgres/redis/etc.) remain overlay-only — untouched. The firewall rule must stay.

## Rollout — one-time switchover

`gaia-grafana` is built automatically before the deploy; nothing to do there.

Swarm can't hot-swap a published port between `host` and `ingress` on the same port number, so the **first** deploy must recreate the 5 published services once, on the VM:
```bash
docker service rm gaia-prod_gaia-backend gaia-prod_discord-bot \
  gaia-prod_slack-bot gaia-prod_telegram-bot gaia-prod_whatsapp-bot
```
then run the deploy (`Deploy Swarm Production` or the normal master deploy). They come back in ingress mode — one brief API blip, zero-downtime on every deploy after. `arq_worker` and the observability services switch cleanly (no held host ports).

> Observability + RabbitMQ are currently down in prod (the bug above); they recover on the first deploy with these changes.

## Validation

- `docker compose -f infra/docker/docker-compose.prod.yml config` parses clean.
- No `./observability` bind mounts remain; 5 config refs wired; 5 `mode: ingress`.
- Both workflow YAMLs parse; pre-commit (yaml/secrets) passed.
