### PR TITLE
fix(nx): exclude baked Grafana Dockerfile from project graph (unblocks CI)

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -28,3 +28,8 @@ packages/cli/gaia
 .claude/worktrees
 .conductor
 
+# Baked Grafana image — has a Dockerfile but is not an Nx project. Without this,
+# the @nx/docker plugin infers an unnamed project and the whole graph fails to
+# build ("no name provided"), breaking every nx command.
+infra/docker/observability/grafana/Dockerfile
+


### PR DESCRIPTION
## What

`#711` added `infra/docker/observability/grafana/Dockerfile` (the baked Grafana image). The **`@nx/docker`** plugin infers an Nx project from every Dockerfile, but this one lives outside any named project, so Nx inferred a project with **no name** and the whole project graph fails to build:

```
NX  Failed to process project graph.
The projects in the following directories have no name provided:
  - infra/docker/observability/grafana
```

This breaks **every** nx command (type-check, lint, affected, `docker-release`) on **develop and master** — all CI is red and the prod deploy is blocked (`docker-release` failed → `deployment-plan`/`trigger-deploy` skipped).

## Fix

Add the Dockerfile to `.nxignore` so `@nx/docker` skips it — the same mechanism `.nxignore` already uses in this repo to exclude worktree project definitions. One line, no behavior change to any real project.

## Note

This must reach **master** too (master is currently broken). After merging to develop, fast-forward/merge develop → master. Once green, the prod deploy can proceed (next up: the one-time `host`→`ingress` service recreate from #711).
