### PR TITLE
fix(nx): exclude baked Grafana Dockerfile from the project graph (#713)

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -28,3 +28,8 @@ packages/cli/gaia
 .claude/worktrees
 .conductor
 
+# Baked Grafana image — has a Dockerfile but is not an Nx project. Without this,
+# the @nx/docker plugin infers an unnamed project and the whole graph fails to
+# build ("no name provided"), breaking every nx command.
+infra/docker/observability/grafana/Dockerfile
+


### PR DESCRIPTION
The @nx/docker plugin infers an Nx project from every Dockerfile. The Grafana provisioning image added in #711 lives at
infra/docker/observability/grafana/Dockerfile — outside any named project — so Nx inferred a project with no name and failed to build the project graph ("The projects in the following directories have no name provided").

That breaks EVERY nx command (type-check, lint, affected, docker-release) on develop and master, blocking all CI and the production deploy.

Add the Dockerfile to .nxignore so @nx/docker skips it — the same mechanism this file already uses to exclude worktree project definitions.