### PR TITLE
fix(observability): real Slack alerting via secret + working Promtail healthcheck

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -17,6 +17,8 @@ secrets:
     external: true
   gaia_grafana_admin_password:
     external: true
+  gaia_grafana_slack_webhook:
+    external: true
   gaia_postgres_password:
     external: true
     name: gaia_postgres_password_v2
@@ -667,10 +669,17 @@ services:
     networks:
       - gaia-prod-shared
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO /dev/null http://localhost:9080/ready || exit 1"]
+      # The promtail image has no wget/curl/nc, so check that the HTTP server is
+      # listening on 9080 (hex 2378) via /proc/net/tcp{,6} with awk instead.
+      # Promtail image has no wget/curl/nc. Match the listener on port 9080
+      # (hex 2378) in /proc/net/tcp{,6} — pattern ":2378 0" anchors against the
+      # space+start of the remote-addr column. No $ chars so compose interpolation
+      # cannot mangle it.
+      test: ["CMD-SHELL", "grep -q ':2378 0' /proc/net/tcp /proc/net/tcp6"]
       interval: 30s
-      timeout: 10s
+      timeout: 5s
       retries: 3
+      start_period: 20s
     deploy:
       mode: global
       restart_policy:
@@ -699,10 +708,9 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_ANALYTICS_REPORTING_ENABLED: "false"
       GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:4000}
-      SLACK_ALERT_WEBHOOK_URL: ${SLACK_ALERT_WEBHOOK_URL}
-      SLACK_ALERT_CHANNEL: ${SLACK_ALERT_CHANNEL:-#alerts}
     secrets:
       - gaia_grafana_admin_password
+      - gaia_grafana_slack_webhook
     networks:
       - gaia-prod-shared
     healthcheck:

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -707,7 +707,10 @@ services:
       GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/gaia_grafana_admin_password
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_ANALYTICS_REPORTING_ENABLED: "false"
-      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:4000}
+      # Public URL Grafana uses to build every generated link (alert "View"
+      # links in Slack, share links, dashboard URLs). Without this the default
+      # resolves to localhost:4000 and Slack alerts link nowhere.
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-https://logs.heygaia.io}
     secrets:
       - gaia_grafana_admin_password
       - gaia_grafana_slack_webhook

--- a/infra/docker/observability/grafana/provisioning/alerting/contact-points.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/contact-points.yaml
@@ -1,7 +1,10 @@
 apiVersion: 1
 
-# Slack contact point. Set SLACK_ALERT_WEBHOOK_URL in the Grafana container's
-# environment (via docker-compose .env) before enabling alerts in production.
+# Slack contact point. The webhook URL is NOT committed — Grafana reads it at
+# provision time from the `gaia_grafana_slack_webhook` swarm secret via the
+# $__file{} reference. The secret is mounted into the grafana service
+# (see docker-compose.prod.yml); create it once with:
+#   printf '%s' "$WEBHOOK" | docker secret create gaia_grafana_slack_webhook -
 contactPoints:
   - orgId: 1
     name: slack-alerts
@@ -9,13 +12,7 @@ contactPoints:
       - uid: slack-alerts
         type: slack
         settings:
-          # Uses Incoming Webhook mode. Set SLACK_ALERT_WEBHOOK_URL and
-          # SLACK_ALERT_CHANNEL in the Grafana container's environment (via
-          # .env) for real alerts. When unset, the sentinel defaults keep
-          # Grafana in webhook mode so it boots without a token — alerts
-          # won't deliver until a real URL is configured.
-          url: ${SLACK_ALERT_WEBHOOK_URL:-https://hooks.slack.com/services/placeholder}
-          recipient: "${SLACK_ALERT_CHANNEL:-#alerts}"
+          url: $__file{/run/secrets/gaia_grafana_slack_webhook}
           title: "{{ template \"slack.default.title\" . }}"
           text: "{{ template \"slack.default.text\" . }}"
         disableResolveMessage: false


### PR DESCRIPTION
## What & why

Two latent bugs that the swarm-configs / baked-grafana fixes exposed (services finally tried to start and hit their own broken config):

1. **Grafana crashed on boot**, taking `logs.heygaia.io` to 502.
   The slack contact point used `${VAR:-default}` — Grafana doesn't honor `:-default` in provisioning, so `url` and `recipient` both resolved to empty:
   ```
   Error: failure to parse file contact-points.yaml: failure parsing contact points:
   slack-alerts: recipient must be specified when using the Slack chat API
   ```

2. **Promtail crash-looped.**
   The compose healthcheck calls `wget`, but the promtail image has **no `wget`**:
   ```
   /bin/sh: 1: wget: not found
   ```
   Every probe failed → Swarm killed the unhealthy task → loop.

## Fixes

- **`contact-points.yaml`**: type `slack`, URL from a Docker swarm secret via Grafana's `$__file{}` reference. Nothing secret is committed.
  ```yaml
  url: $__file{/run/secrets/gaia_grafana_slack_webhook}
  ```
- **`compose grafana`**: mount the `gaia_grafana_slack_webhook` secret (declared `external: true`); drop the now-unused `SLACK_ALERT_WEBHOOK_URL` / `SLACK_ALERT_CHANNEL` env vars.
- **`compose promtail healthcheck`**: `grep ':2378 0' /proc/net/tcp{,6}` — works in the minimal promtail image (just needs `grep` + `/proc`), no `$` chars so compose interpolation can't mangle it, plus `start_period: 20s`.

## Verified on the live prod swarm

- **Grafana** boot-tested with this provisioning + the secret mounted: `finished to provision alerting`, `HTTP Server Listen`, `status=running`. The live Grafana service is currently running an equivalent image — `logs.heygaia.io` → 302.
- **Promtail healthcheck** validated against the *actual* running promtail container on prod → `HEALTHY`. Live promtail is `1/1`, stable.
- **Slack delivery end-to-end**: a synthetic run sent all 9 production alert rules to the slack-alerts policy with **zero** "Notify for alerts failed" errors. Slack received them.

## Rollout

The `gaia_grafana_slack_webhook` swarm secret is **already created** on the production swarm — the next `stack deploy` will mount it via this compose. No manual step required.

For a fresh swarm (lab/rehearsal), create the secret once:
```bash
printf '%s' "$WEBHOOK" | docker secret create gaia_grafana_slack_webhook -
```

## Out of scope (separate)

- A stale `swarm-worker` node (Down/Drain, 5 weeks old) is still in `docker node ls` — cosmetic, doesn't affect anything (drain excludes it from scheduling). Can be cleaned up with `docker node rm swarm-worker` whenever convenient.
