### PR TITLE
fix(web): patch placeholder API URL in prerendered HTML, RSC, and required-server-files.json

### DIFF
--- a/apps/web/docker-entrypoint.sh
+++ b/apps/web/docker-entrypoint.sh
@@ -4,6 +4,11 @@
 # Replaces the build-time placeholder API URL with the real URL derived from
 # NEXT_PUBLIC_APP_URL. This lets one image work across multiple PR previews
 # on different ports without per-PR rebuilds.
+#
+# NEXT_PUBLIC_API_BASE_URL is read on the server at render time, so the
+# placeholder gets baked into every server-rendered output: client JS, server
+# JS, prerendered HTML, RSC flight payloads (including .segment.rsc), and the
+# required-server-files.json runtime config. All of these need patching.
 set -e
 
 PLACEHOLDER="http://preview.placeholder.buildtime/api/v1/"
@@ -12,9 +17,9 @@ if [ -n "${NEXT_PUBLIC_APP_URL:-}" ]; then
   REAL_URL="${NEXT_PUBLIC_APP_URL%/}/api/v1/"
 
   if [ "${REAL_URL}" != "${PLACEHOLDER}" ]; then
-    # Replace in both server-side chunks (.next/server) and client-side
-    # static chunks (.next/static) produced by the standalone build.
-    find /app/apps/web/.next -type f -name "*.js" 2>/dev/null \
+    find /app/apps/web/.next -type f \
+      \( -name "*.js" -o -name "*.html" -o -name "*.rsc" -o -name "*.json" \) \
+      2>/dev/null \
       | xargs grep -l "${PLACEHOLDER}" 2>/dev/null \
       | xargs -r sed -i "s|${PLACEHOLDER}|${REAL_URL}|g"
   fi


### PR DESCRIPTION
## Summary

The runtime entrypoint that swaps the build-time `NEXT_PUBLIC_API_BASE_URL` placeholder for the per-preview real URL only scanned `*.js`, but Next.js bakes `NEXT_PUBLIC_*` values into far more than client JS. On a fresh staging preview container, the placeholder `http://preview.placeholder.buildtime/api/v1/` was still present in 29 files inside `/app/apps/web/.next`:

- 7 prerendered `.html` files
- 21 RSC flight payloads (`.rsc` + `.segment.rsc`)
- 1 runtime config: `required-server-files.json`

Because `/signup` and `/login` are statically prerendered, clicking "Continue with WorkOS" hit `http://preview.placeholder.buildtime/api/v1/oauth/login/workos` and broke login on every preview.

This widens the `find -name` expression in `apps/web/docker-entrypoint.sh` to also cover `.html`, `.rsc`, and `.json`, so every baked reference is rewritten at container startup.

## Test plan

- [x] Manually patched both running containers on the home staging server (develop @ 8101, PR #706 @ 8102) with the same find expression — placeholder count went 29 → 0 in each, login redirect now points at the correct per-preview URL.
- [ ] Confirm next staging rebuild (after merge) ships an image whose entrypoint runs the wider patch at startup with no manual intervention.