### PR TITLE
fix(web): make server-side SSG builds compile cleanly

### DIFF
--- a/apps/web/src/app/[locale]/(landing)/marketplace/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/marketplace/[slug]/page.tsx
@@ -4,6 +4,12 @@ import { cache } from "react";
 
 import JsonLd from "@/components/seo/JsonLd";
 import { getComparison } from "@/features/comparisons/data/comparisonsData";
+import type { IntegrationConfigResponse } from "@/features/integrations/api/integrationsApi";
+import type {
+  CommunityIntegration,
+  CommunityIntegrationsResponse,
+  PublicIntegrationResponse,
+} from "@/features/integrations/types";
 import {
   generateBreadcrumbSchema,
   generateFAQSchema,
@@ -19,31 +25,36 @@ export const revalidate = 60;
 
 // Fetch integration data for metadata and page
 // Backend accepts both slug and UUID for backward compatibility
-const getIntegration = cache(async (slug: string) => {
-  const baseUrl = getServerApiBaseUrl();
-  if (!baseUrl) return null;
+const getIntegration = cache(
+  async (slug: string): Promise<PublicIntegrationResponse | null> => {
+    const baseUrl = getServerApiBaseUrl();
+    if (!baseUrl) return null;
 
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-    const response = await fetch(`${baseUrl}/integrations/public/${slug}`, {
-      next: { revalidate: 60 },
-      signal: controller.signal,
-    });
+      const response = await fetch(`${baseUrl}/integrations/public/${slug}`, {
+        next: { revalidate: 60 },
+        signal: controller.signal,
+      });
 
-    clearTimeout(timeoutId);
+      clearTimeout(timeoutId);
 
-    if (!response.ok) return null;
-    return response.json();
-  } catch (error) {
-    console.error(`[marketplace/${slug}] Failed to fetch integration:`, error);
-    return null;
-  }
-});
+      if (!response.ok) return null;
+      return (await response.json()) as PublicIntegrationResponse;
+    } catch (error) {
+      console.error(
+        `[marketplace/${slug}] Failed to fetch integration:`,
+        error,
+      );
+      return null;
+    }
+  },
+);
 
 // Fetch all integrations for static generation
-async function getAllIntegrations() {
+async function getAllIntegrations(): Promise<CommunityIntegration[]> {
   const baseUrl = getServerApiBaseUrl();
   if (!baseUrl) return [];
 
@@ -56,25 +67,28 @@ async function getAllIntegrations() {
         { next: { revalidate: 60 } },
       );
       if (!response.ok) return [];
-      const data = await response.json();
-      return data.integrations || [];
+      const data = (await response.json()) as CommunityIntegrationsResponse;
+      return data.integrations ?? [];
     }
 
     const { fetchAllPaginated } = await import("@/lib/fetchAll");
-    const allIntegrations = await fetchAllPaginated(async (limit, offset) => {
-      const response = await fetch(
-        `${baseUrl}/integrations/community?limit=${limit}&offset=${offset}`,
-        { next: { revalidate: 60 } },
-      );
-      if (!response.ok) return { items: [], total: 0, hasMore: false };
+    const allIntegrations = await fetchAllPaginated<CommunityIntegration>(
+      async (limit, offset) => {
+        const response = await fetch(
+          `${baseUrl}/integrations/community?limit=${limit}&offset=${offset}`,
+          { next: { revalidate: 60 } },
+        );
+        if (!response.ok) return { items: [], total: 0, hasMore: false };
 
-      const data = await response.json();
-      return {
-        items: data.integrations || [],
-        total: data.total || 0,
-        hasMore: data.hasMore !== false,
-      };
-    }, 100);
+        const data = (await response.json()) as CommunityIntegrationsResponse;
+        return {
+          items: data.integrations ?? [],
+          total: data.total ?? 0,
+          hasMore: data.hasMore !== false,
+        };
+      },
+      100,
+    );
 
     return allIntegrations;
   } catch (error) {
@@ -92,8 +106,8 @@ async function getNativeIntegrationSlugs(): Promise<string[]> {
       next: { revalidate: 60 },
     });
     if (!response.ok) return [];
-    const data = await response.json();
-    return (data.integrations as Array<{ id: string; available?: boolean }>)
+    const data = (await response.json()) as IntegrationConfigResponse;
+    return data.integrations
       .filter((i) => i.id && i.available !== false)
       .map((i) => i.id);
   } catch (error) {
@@ -291,7 +305,7 @@ export default async function IntegrationPage({ params }: Props) {
       price: "0",
       priceCurrency: "USD",
     },
-    ...(integration.creator && {
+    ...(integration.creator?.name && {
       author: {
         "@type": "Person" as const,
         name: integration.creator.name,

--- a/apps/web/src/app/[locale]/(landing)/thanks/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/thanks/page.tsx
@@ -77,11 +77,13 @@ async function fetchToolsMetadata(): Promise<Record<string, ToolMetadata>> {
       return {};
     }
 
-    const data = await response.json();
-    const resultCount = Object.keys(data.results || {}).length;
+    const data = (await response.json()) as {
+      results?: Record<string, ToolMetadata>;
+    };
+    const resultCount = Object.keys(data.results ?? {}).length;
     console.log(`${logPrefix} ✓ Successfully fetched metadata for ${resultCount}/${tools.length} tools,
     `);
-    return data.results || {};
+    return data.results ?? {};
   } catch (error) {
     console.error(`
 ╔════════════════════════════════════════════════════════════════╗

--- a/apps/web/src/app/api/og/use-case/route.tsx
+++ b/apps/web/src/app/api/og/use-case/route.tsx
@@ -54,13 +54,17 @@ export async function GET(request: NextRequest) {
       ]);
 
       if (exploreResponse.ok) {
-        const data = await exploreResponse.json();
-        workflow = data.workflows?.find((w: { id: string }) => w.id === slug);
+        const data = (await exploreResponse.json()) as {
+          workflows?: OgWorkflow[];
+        };
+        workflow = data.workflows?.find((w) => w.id === slug) ?? null;
       }
 
       if (!workflow && communityResponse.ok) {
-        const data = await communityResponse.json();
-        workflow = data.workflows?.find((w: { id: string }) => w.id === slug);
+        const data = (await communityResponse.json()) as {
+          workflows?: OgWorkflow[];
+        };
+        workflow = data.workflows?.find((w) => w.id === slug) ?? null;
       }
 
       if (!workflow) {
@@ -69,8 +73,10 @@ export async function GET(request: NextRequest) {
           { cache: "no-store" },
         );
         if (publicResponse.ok) {
-          const data = await publicResponse.json();
-          workflow = data.workflow;
+          const data = (await publicResponse.json()) as {
+            workflow?: OgWorkflow;
+          };
+          workflow = data.workflow ?? null;
         }
       }
     } catch (e) {

--- a/apps/web/src/app/feed.xml/route.ts
+++ b/apps/web/src/app/feed.xml/route.ts
@@ -292,10 +292,14 @@ async function getIntegrationItems(baseUrl: string): Promise<FeedItem[]> {
           { next: { revalidate: 3600 } },
         );
         if (!response.ok) return { items: [], total: 0, hasMore: false };
-        const data = await response.json();
+        const data = (await response.json()) as {
+          integrations?: IntegrationEntry[];
+          total?: number;
+          hasMore?: boolean;
+        };
         return {
-          items: data.integrations || [],
-          total: data.total || 0,
+          items: data.integrations ?? [],
+          total: data.total ?? 0,
           hasMore: data.hasMore !== false,
         };
       },

--- a/apps/web/src/hooks/useGitHubContributors.ts
+++ b/apps/web/src/hooks/useGitHubContributors.ts
@@ -29,7 +29,7 @@ async function fetchContributorsCount(repo: string): Promise<number> {
     const match = linkHeader.match(/&page=(\d+)>; rel="last"/);
     return match ? parseInt(match[1], 10) : 1;
   } else {
-    const data = await response.json();
+    const data = (await response.json()) as GitHubContributor[];
     return data.length;
   }
 }

--- a/apps/web/src/lib/api/service.ts
+++ b/apps/web/src/lib/api/service.ts
@@ -52,13 +52,15 @@ async function request<T = unknown>(
     const handledByInterceptor =
       (error as { handled?: boolean }).handled === true;
 
-    // Track API errors in PostHog
-    trackEvent(ANALYTICS_EVENTS.API_ERROR, {
-      method,
-      url,
-      status: err.response?.status,
-      error_message: err.message,
-    });
+    // Track API errors in PostHog (client-only; analytics.ts is "use client")
+    if (typeof window !== "undefined") {
+      trackEvent(ANALYTICS_EVENTS.API_ERROR, {
+        method,
+        url,
+        status: err.response?.status,
+        error_message: err.message,
+      });
+    }
 
     if (!options.silent && !handledByInterceptor) {
       let errorMessage = options.errorMessage;

--- a/apps/web/src/lib/sitemapData.ts
+++ b/apps/web/src/lib/sitemapData.ts
@@ -145,15 +145,18 @@ async function getExploreWorkflowPages(
     }
     if (!response.ok) return [];
 
-    const data = await response.json();
-    return (data.workflows || []).map(
-      (wc: { slug: string; created_at: string; categories?: string[] }) => ({
-        url: `${baseUrl}/use-cases/${wc.slug}`,
-        lastModified: new Date(wc.created_at),
-        changeFrequency: "weekly" as const,
-        priority: wc.categories?.includes("featured") ? 0.8 : 0.7,
-      }),
-    );
+    type ExploreWorkflow = {
+      slug: string;
+      created_at: string;
+      categories?: string[];
+    };
+    const data = (await response.json()) as { workflows?: ExploreWorkflow[] };
+    return (data.workflows ?? []).map((wc) => ({
+      url: `${baseUrl}/use-cases/${wc.slug}`,
+      lastModified: new Date(wc.created_at),
+      changeFrequency: "weekly" as const,
+      priority: wc.categories?.includes("featured") ? 0.8 : 0.7,
+    }));
   } catch (error) {
     console.error("Error fetching explore workflows for sitemap:", error);
     return [];
@@ -183,15 +186,16 @@ async function getCommunityWorkflowPages(
         clearTimeout(timeout);
       }
       if (!response.ok) return [];
-      const data = await response.json();
-      return (data.workflows || []).map(
-        (workflow: { slug: string; created_at: string }) => ({
-          url: `${baseUrl}/use-cases/${workflow.slug}`,
-          lastModified: new Date(workflow.created_at),
-          changeFrequency: "weekly" as const,
-          priority: 0.6,
-        }),
-      );
+      type CommunityWorkflowEntry = { slug: string; created_at: string };
+      const data = (await response.json()) as {
+        workflows?: CommunityWorkflowEntry[];
+      };
+      return (data.workflows ?? []).map((workflow) => ({
+        url: `${baseUrl}/use-cases/${workflow.slug}`,
+        lastModified: new Date(workflow.created_at),
+        changeFrequency: "weekly" as const,
+        priority: 0.6,
+      }));
     }
 
     const allWorkflows: Array<{ slug: string; created_at: string }> =
@@ -208,11 +212,15 @@ async function getCommunityWorkflowPages(
           clearTimeout(timeout);
         }
         if (!response.ok) return { items: [], total: 0, hasMore: false };
-        const data = await response.json();
+        type CommunityWorkflowEntry = { slug: string; created_at: string };
+        const data = (await response.json()) as {
+          workflows?: CommunityWorkflowEntry[];
+          total?: number;
+        };
         return {
-          items: data.workflows || [],
-          total: data.total || 0,
-          hasMore: data.workflows?.length === limit,
+          items: data.workflows ?? [],
+          total: data.total ?? 0,
+          hasMore: (data.workflows?.length ?? 0) === limit,
         };
       }, 100);
 
@@ -255,50 +263,59 @@ async function getIntegrationPages(
         clearTimeout(timeout);
       }
       if (response.ok) {
-        const data = await response.json();
-        return (data.integrations || []).map(
-          (integration: {
-            slug: string;
-            publishedAt?: string;
-            createdAt?: string;
-          }) => ({
-            url: `${baseUrl}/marketplace/${integration.slug}`,
-            lastModified: new Date(
-              integration.publishedAt || integration.createdAt || Date.now(),
-            ),
-            changeFrequency: "weekly" as const,
-            priority: 0.7,
-          }),
-        );
+        type IntegrationEntry = {
+          slug: string;
+          publishedAt?: string;
+          createdAt?: string;
+        };
+        const data = (await response.json()) as {
+          integrations?: IntegrationEntry[];
+        };
+        return (data.integrations ?? []).map((integration) => ({
+          url: `${baseUrl}/marketplace/${integration.slug}`,
+          lastModified: new Date(
+            integration.publishedAt || integration.createdAt || Date.now(),
+          ),
+          changeFrequency: "weekly" as const,
+          priority: 0.7,
+        }));
       }
       return [];
     }
 
-    const allIntegrations: Array<{
+    type IntegrationEntry = {
       slug: string;
       publishedAt?: string;
       createdAt?: string;
-    }> = await fetchAllPaginated(async (limit, offset) => {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 10_000);
-      let response: Response;
-      try {
-        response = await fetch(
-          `${apiBaseUrl}/integrations/community?limit=${limit}&offset=${offset}`,
-          { next: { revalidate: 3600 }, signal: controller.signal },
-        );
-      } finally {
-        clearTimeout(timeout);
-      }
-      if (!response.ok) return { items: [], total: 0, hasMore: false };
+    };
+    const allIntegrations: IntegrationEntry[] = await fetchAllPaginated(
+      async (limit, offset) => {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10_000);
+        let response: Response;
+        try {
+          response = await fetch(
+            `${apiBaseUrl}/integrations/community?limit=${limit}&offset=${offset}`,
+            { next: { revalidate: 3600 }, signal: controller.signal },
+          );
+        } finally {
+          clearTimeout(timeout);
+        }
+        if (!response.ok) return { items: [], total: 0, hasMore: false };
 
-      const data = await response.json();
-      return {
-        items: data.integrations || [],
-        total: data.total || 0,
-        hasMore: data.hasMore !== false,
-      };
-    }, 100);
+        const data = (await response.json()) as {
+          integrations?: IntegrationEntry[];
+          total?: number;
+          hasMore?: boolean;
+        };
+        return {
+          items: data.integrations ?? [],
+          total: data.total ?? 0,
+          hasMore: data.hasMore !== false,
+        };
+      },
+      100,
+    );
 
     console.log(
       `[Sitemap] Generated ${allIntegrations.length} integration pages`,


### PR DESCRIPTION
## Summary

Two classes of issue were silently breaking `next build` on master — type-check passed via a permissive code path while `next build` hit them on first SSG call:

### 1. Client-only `trackEvent` imported into `apiService`

`apps/web/src/lib/analytics.ts` is `"use client"` and exports `trackEvent`. `apiService` (`src/lib/api/service.ts`) was calling `trackEvent` on every API error. When SSG paths (`generateStaticParams`, OG image route handlers, etc.) hit `apiService` server-side and the API errored, the build crashed with:

> Attempted to call trackEvent() from the server but trackEvent is on the client.

**Fix:** guard the call with `typeof window !== "undefined"`.

### 2. `response.json()` returns `unknown` in modern TS

Several SSG-time helpers were dereferencing `.integrations`, `.workflows`, `.results`, `.length`, `.workflow` on un-narrowed `unknown` data. The build's TS step fails on these. Replaced with proper typed casts using existing response types:

| File | Type used |
|---|---|
| `app/[locale]/(landing)/marketplace/[slug]/page.tsx` | `CommunityIntegrationsResponse`, `PublicIntegrationResponse`, `IntegrationConfigResponse`, `CommunityIntegration` |
| `lib/sitemapData.ts` | Inline named types for explore workflow + community workflow + integration entries |
| `app/feed.xml/route.ts` | Inline `IntegrationEntry` |
| `hooks/useGitHubContributors.ts` | `GitHubContributor[]` (already defined in the same file) |
| `app/[locale]/(landing)/thanks/page.tsx` | `ToolMetadata` (already defined in the same file) |
| `app/api/og/use-case/route.tsx` | `OgWorkflow` (already defined in the same file) |

Also tightened the marketplace `creator?.name` check so a `null` name doesn't leak into the `JsonLd` Thing schema (which rejects null).

## Test plan

- [x] `nx run web:type-check` passes
- [x] `nx lint web` passes (Biome auto-formatted via pre-commit hook)
- [ ] Vercel/CF Workers preview deploy succeeds end-to-end with all SSG pages
- [ ] Sanity-check a few SSG pages render with data (e.g. `/marketplace/[slug]`, `/use-cases/[slug]`, `/thanks`, `/api/og/use-case?slug=...`)