### PR TITLE
fix(api): re-arm recurring workflows + persist schedule times as dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ GAIA is a proactive personal AI assistant — full-stack Nx monorepo with a Next
 ## Engineering Discipline
 
 - Use best practices and write clean, idiomatic code every time. No shortcuts, no half-measures.
+- **Never ship workarounds, patches, or band-aid fixes. Always choose the cleanest, most correct approach — every single time.** When you find a bug, fix it at the root, not at the symptom. If two code paths diverge and one is broken, unify them rather than patching the broken one in place. Surgical-but-duplicative is not "safer" — it is how the bug got there. Surface the tradeoff, then take the clean path.
 - Do not override or work around the architecture. Never disable lint rules, add blanket `# noqa` / `// biome-ignore` / `# type: ignore`, or bypass CI to force something through. Linting, type-checking, and CI are guardrails that exist for a reason. Fix the cause, not the symptom.
 - Match the conventions of the surrounding code. Prefer the existing pattern over inventing a new one.
 

--- a/apps/api/app/models/reminder_models.py
+++ b/apps/api/app/models/reminder_models.py
@@ -108,9 +108,10 @@ class CreateReminderRequest(BaseModel):
                 raise ValueError("stop_after must be in the future")
         return v
 
-    @field_serializer("scheduled_at", "stop_after", "base_time")
+    @field_serializer("scheduled_at", "stop_after", "base_time", when_used="json")
     def serialize_datetime(self, value: datetime | None) -> str | None:
-        """Serialize datetime fields to ISO format strings."""
+        """ISO strings for JSON only; python mode keeps native datetimes so a
+        model_dump() used to build a Mongo document never persists a string date."""
         if value is not None:
             return value.isoformat()
         return None
@@ -285,9 +286,11 @@ class UpdateReminderRequest(BaseModel):
                 raise ValueError("stop_after must be in the future")
         return v
 
-    @field_serializer("scheduled_at", "stop_after")
+    @field_serializer("scheduled_at", "stop_after", when_used="json")
     def serialize_datetime(self, value: datetime | None) -> str | None:
-        """Serialize datetime fields to ISO format strings."""
+        """ISO strings for JSON only; python mode (the Mongo `$set` update path
+        in update_reminder) keeps native datetimes so the persisted scheduled_at
+        stays a BSON date the `$lte` recovery scan can match."""
         if value is not None:
             return value.isoformat()
         return None

--- a/apps/api/app/models/scheduler_models.py
+++ b/apps/api/app/models/scheduler_models.py
@@ -59,9 +59,10 @@ class BaseScheduledTask(BaseModel):
             v = v.replace(tzinfo=UTC)
         return v
 
-    @field_serializer("scheduled_at", "stop_after", "created_at", "updated_at")
+    @field_serializer("scheduled_at", "stop_after", "created_at", "updated_at", when_used="json")
     def serialize_datetime(self, value: datetime | None) -> str | None:
-        """Serialize datetime fields to ISO format strings."""
+        """ISO-string datetimes for JSON only; python mode (Mongo writes) keeps
+        native datetimes so the scheduler's `scheduled_at: {"$lte": now}` scan matches."""
         if value is not None:
             return value.isoformat()
         return None

--- a/apps/api/app/models/scheduler_models.py
+++ b/apps/api/app/models/scheduler_models.py
@@ -67,9 +67,11 @@ class BaseScheduledTask(BaseModel):
             return value.isoformat()
         return None
 
-    @field_serializer("created_at", "updated_at")
+    @field_serializer("created_at", "updated_at", when_used="json")
     def serialize_audit_datetime(self, value: datetime | None) -> str | None:
-        """Audit fields stay ISO strings everywhere (unchanged from prior behavior)."""
+        """ISO strings for JSON only; python mode (Mongo writes) keeps native
+        datetimes so these match the same type as status-update/migration writes
+        and sort correctly alongside them."""
         if value is not None:
             return value.isoformat()
         return None

--- a/apps/api/app/models/scheduler_models.py
+++ b/apps/api/app/models/scheduler_models.py
@@ -59,10 +59,17 @@ class BaseScheduledTask(BaseModel):
             v = v.replace(tzinfo=UTC)
         return v
 
-    @field_serializer("scheduled_at", "stop_after", "created_at", "updated_at", when_used="json")
-    def serialize_datetime(self, value: datetime | None) -> str | None:
-        """ISO-string datetimes for JSON only; python mode (Mongo writes) keeps
-        native datetimes so the scheduler's `scheduled_at: {"$lte": now}` scan matches."""
+    @field_serializer("scheduled_at", "stop_after", when_used="json")
+    def serialize_schedule_datetime(self, value: datetime | None) -> str | None:
+        """ISO strings for JSON only; python mode (Mongo writes) keeps native
+        datetimes so the scheduler's `scheduled_at: {"$lte": now}` scan matches."""
+        if value is not None:
+            return value.isoformat()
+        return None
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_audit_datetime(self, value: datetime | None) -> str | None:
+        """Audit fields stay ISO strings everywhere (unchanged from prior behavior)."""
         if value is not None:
             return value.isoformat()
         return None

--- a/apps/api/app/models/scheduler_models.py
+++ b/apps/api/app/models/scheduler_models.py
@@ -31,7 +31,11 @@ class BaseScheduledTask(BaseModel):
     id: str | None = Field(None, alias="_id")
     user_id: str = Field(..., description="User ID who owns this task")
     repeat: str | None = Field(None, description="Cron expression for recurring tasks")
-    scheduled_at: datetime = Field(..., description="Next scheduled execution time")
+    scheduled_at: datetime | None = Field(
+        default=None,
+        description="Next scheduled execution time; None when the task has no schedule "
+        "(e.g. a manual/integration workflow). A null value never matches the due-scan.",
+    )
     status: ScheduledTaskStatus = Field(
         default=ScheduledTaskStatus.SCHEDULED, description="Current status"
     )

--- a/apps/api/app/models/workflow_models.py
+++ b/apps/api/app/models/workflow_models.py
@@ -313,10 +313,10 @@ class Workflow(BaseScheduledTask):
                 ):
                     data["repeat"] = trigger_config.cron_expression
 
-        # Set default scheduled_at if still not provided
-        if "scheduled_at" not in data:
-            data["scheduled_at"] = datetime.now(UTC)
-
+        # A workflow only has a scheduled_at when it is a schedule-triggered (cron)
+        # workflow with a next_run (mapped above). Manual / integration / todo
+        # workflows have no scheduled run — leave scheduled_at as None rather than
+        # fabricating "now", which would make them look due to the recovery scan.
         super().__init__(**data)
 
     @model_validator(mode="before")

--- a/apps/api/app/services/reminder_service.py
+++ b/apps/api/app/services/reminder_service.py
@@ -118,8 +118,8 @@ class ReminderScheduler(BaseSchedulerService):
             True if updated successfully
         """
         log.set(reminder_id=reminder_id, reminder_user_id=user_id)
-        # Add updated_at timestamp
-        update_data["updated_at"] = datetime.now(UTC).isoformat()
+        # Native datetime (BSON date), consistent with create/status-update writes.
+        update_data["updated_at"] = datetime.now(UTC)
 
         filters: dict = {"_id": ObjectId(reminder_id)}
         if user_id:
@@ -133,10 +133,10 @@ class ReminderScheduler(BaseSchedulerService):
             # If scheduled_at was updated, reschedule the task
             if "scheduled_at" in update_data and "status" in update_data:
                 if update_data["status"] == ReminderStatus.SCHEDULED:
-                    await self.reschedule_task(
-                        reminder_id,
-                        new_scheduled_at=datetime.fromisoformat(update_data["scheduled_at"]),
-                    )
+                    scheduled_at = update_data["scheduled_at"]
+                    if isinstance(scheduled_at, str):
+                        scheduled_at = datetime.fromisoformat(scheduled_at)
+                    await self.reschedule_task(reminder_id, new_scheduled_at=scheduled_at)
 
             return True
 
@@ -239,18 +239,22 @@ class ReminderScheduler(BaseSchedulerService):
         return result.modified_count > 0
 
     async def get_pending_task(self, current_time: datetime) -> list[BaseScheduledTask]:
-        """Get all scheduled reminders that should be enqueued."""
-        cursor = reminders_collection.find(
-            {"status": ReminderStatus.SCHEDULED, "scheduled_at": {"$gte": current_time}}
+        """Reminders that are scheduled and due (scheduled_at <= now).
+
+        Delegates the due-query to the shared base implementation so the
+        recovery scan can't diverge from the workflow scan (it previously used
+        ``$gte`` and silently dropped overdue reminders).
+        """
+        return await self._query_pending_tasks(
+            reminders_collection, current_time, self._doc_to_reminder
         )
 
-        tasks: list[BaseScheduledTask] = []
-        async for doc in cursor:
-            if "_id" in doc:
-                doc["_id"] = str(doc["_id"])
-            tasks.append(ReminderModel(**doc))
-
-        return tasks
+    @staticmethod
+    def _doc_to_reminder(doc: dict) -> ReminderModel:
+        """Transform a MongoDB document into a ReminderModel (ObjectId ``_id`` -> str)."""
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
+        return ReminderModel(**doc)
 
     def _serialize_reminder(self, reminder: ReminderModel) -> dict:
         """

--- a/apps/api/app/services/scheduler_service.py
+++ b/apps/api/app/services/scheduler_service.py
@@ -3,6 +3,7 @@ Base scheduler service for managing scheduled tasks.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -340,6 +341,46 @@ class BaseSchedulerService(ABC):
         log.set(arq_job_id=job.job_id, arq_job_name=job_name)
         log.debug(f"Enqueued task {task_id} with job ID {job.job_id}")
         return True
+
+    async def _query_pending_tasks(
+        self,
+        collection: Any,
+        current_time: datetime,
+        doc_to_task: Callable[[dict[str, Any]], BaseScheduledTask],
+        extra_filter: dict[str, Any] | None = None,
+    ) -> list[BaseScheduledTask]:
+        """Shared recovery-scan query for every scheduler subclass.
+
+        Selects tasks that are SCHEDULED and DUE (``scheduled_at <= now``). The
+        ``$lte`` due-semantics live here, in one place, so the reminder and
+        workflow scans can never diverge on the operator again (they once did:
+        reminders used ``$gte`` and silently dropped every overdue task).
+
+        Subclasses supply only their collection, a document->model mapper, and
+        any extra filter (e.g. workflows additionally require ``activated: True``).
+        """
+        query: dict[str, Any] = {
+            "status": ScheduledTaskStatus.SCHEDULED.value,
+            "scheduled_at": {"$lte": current_time},
+        }
+        if extra_filter:
+            query.update(extra_filter)
+
+        tasks: list[BaseScheduledTask] = []
+        try:
+            cursor = collection.find(query)
+            async for doc in cursor:
+                try:
+                    tasks.append(doc_to_task(doc))
+                except Exception as e:
+                    log.error(f"Error building pending task from document: {e}")
+                    continue
+        except Exception as e:
+            log.error(f"Error fetching pending tasks: {e}")
+            return []
+
+        log.info(f"Found {len(tasks)} pending tasks")
+        return tasks
 
     # Abstract methods that subclasses must implement
 

--- a/apps/api/app/services/scheduler_service.py
+++ b/apps/api/app/services/scheduler_service.py
@@ -123,42 +123,42 @@ class BaseSchedulerService(ABC):
 
         log.info(f"Processing task {task_id}")
 
+        occurrence_count = task.occurrence_count + 1
+
         try:
-            # Mark task as executing
             await self.update_task_status(
                 task_id,
                 ScheduledTaskStatus.EXECUTING,
                 {"updated_at": datetime.now(UTC)},
             )
-
-            # Execute the task
             execution_result = await self.execute_task(task)
-
-            # Increment occurrence count
-            occurrence_count = task.occurrence_count + 1
-
-            # Handle recurring tasks
-            if task.repeat:
-                await self.handle_recurring_task(task, occurrence_count)
-            else:
-                # One-time task - mark as completed
-                await self.update_task_status(
-                    task_id,
-                    ScheduledTaskStatus.COMPLETED,
-                    {"occurrence_count": occurrence_count},
-                )
-                log.info(f"Completed one-time task {task_id}")
-
-            return execution_result
-
         except Exception as e:
-            log.error(f"Failed to process task {task_id}: {e!s}")
+            log.error(f"Failed to execute task {task_id}: {e!s}")
+            execution_result = TaskExecutionResult(
+                success=False, message=f"Task execution failed: {e!s}"
+            )
+
+        if task.repeat:
+            # Recurring tasks advance to the next occurrence on success AND failure:
+            # a transient error must not silently kill the series (mirrors the workflow
+            # executor). max_occurrences / stop_after still terminate the series.
+            await self.handle_recurring_task(task, occurrence_count)
+        elif execution_result.success:
+            await self.update_task_status(
+                task_id,
+                ScheduledTaskStatus.COMPLETED,
+                {"occurrence_count": occurrence_count},
+            )
+            log.info(f"Completed one-time task {task_id}")
+        else:
             await self.update_task_status(
                 task_id,
                 ScheduledTaskStatus.FAILED,
-                {"updated_at": datetime.now(UTC)},
+                {"occurrence_count": occurrence_count, "updated_at": datetime.now(UTC)},
             )
-            return TaskExecutionResult(success=False, message=f"Task execution failed: {e!s}")
+            log.warning(f"One-time task {task_id} failed: {execution_result.message}")
+
+        return execution_result
 
     async def cancel_task(self, task_id: str, user_id: str) -> bool:
         """

--- a/apps/api/app/services/scheduler_service.py
+++ b/apps/api/app/services/scheduler_service.py
@@ -138,7 +138,7 @@ class BaseSchedulerService(ABC):
 
             # Handle recurring tasks
             if task.repeat:
-                await self._handle_recurring_task(task, occurrence_count)
+                await self.handle_recurring_task(task, occurrence_count)
             else:
                 # One-time task - mark as completed
                 await self.update_task_status(
@@ -202,9 +202,13 @@ class BaseSchedulerService(ABC):
 
         log.info(f"Scheduled {scheduled_count} pending tasks")
 
-    async def _handle_recurring_task(self, task: BaseScheduledTask, occurrence_count: int):
+    async def handle_recurring_task(self, task: BaseScheduledTask, occurrence_count: int):
         """
-        Handle rescheduling logic for recurring tasks.
+        Reschedule the next occurrence of a recurring task, or mark it completed
+        once max_occurrences / stop_after is reached.
+
+        Shared by the reminder path (via process_task_execution) and the workflow
+        executor, so recurrence behaves identically for both.
 
         Args:
             task: The task to handle
@@ -233,7 +237,9 @@ class BaseSchedulerService(ABC):
             user_timezone = trigger_config.timezone
             log.debug(f"Using workflow timezone: {user_timezone}")
 
-        next_run = get_next_run_time(task.repeat, task.scheduled_at, user_timezone)
+        # Advance from now, not from a (possibly stale) scheduled_at, so a dormant
+        # task resumes at its next future occurrence instead of replaying missed runs.
+        next_run = get_next_run_time(task.repeat, datetime.now(UTC), user_timezone)
 
         # Check if we should continue scheduling
         should_continue = True
@@ -255,15 +261,14 @@ class BaseSchedulerService(ABC):
                 log.info(f"Task {task.id} reached stop_after date ({stop_after})")
 
         if should_continue:
-            # Update and reschedule
-            await self.update_task_status(
-                task.id,
-                ScheduledTaskStatus.SCHEDULED,
-                {
-                    "scheduled_at": next_run.isoformat(),
-                    "occurrence_count": occurrence_count,
-                },
-            )
+            # Store scheduled_at as a native datetime so the `$lte` scan can match it.
+            update_fields: dict[str, Any] = {
+                "scheduled_at": next_run,
+                "occurrence_count": occurrence_count,
+            }
+            if trigger_config is not None and hasattr(trigger_config, "next_run"):
+                update_fields["trigger_config.next_run"] = next_run
+            await self.update_task_status(task.id, ScheduledTaskStatus.SCHEDULED, update_fields)
             await self.reschedule_task(task.id, next_run)
             log.info(f"Rescheduled recurring task {task.id} for {next_run}")
         else:
@@ -274,6 +279,10 @@ class BaseSchedulerService(ABC):
                 {"occurrence_count": occurrence_count},
             )
             log.info(f"Completed recurring task {task.id}")
+
+    def _build_job_args(self, task_id: str) -> tuple:
+        """Positional args passed to the ARQ job. Subclasses may add context."""
+        return (task_id,)
 
     async def _enqueue_task(self, task_id: str, scheduled_at: datetime) -> bool:
         """
@@ -317,10 +326,15 @@ class BaseSchedulerService(ABC):
         )
 
         job_name = self.get_job_name()
-        job = await self.arq_pool.enqueue_job(job_name, task_id, _defer_until=scheduled_at)
+        # Deterministic job id: ARQ dedupes a task+fire-time so concurrent scans or
+        # repeated enqueues can't stack duplicate jobs for the same occurrence.
+        job_id = f"{job_name}:{task_id}:{int(scheduled_at.timestamp())}"
+        job = await self.arq_pool.enqueue_job(
+            job_name, *self._build_job_args(task_id), _job_id=job_id, _defer_until=scheduled_at
+        )
 
         if not job:
-            log.error(f"Failed to enqueue task {task_id}")
+            log.warning(f"Task {task_id} already enqueued for {scheduled_at.isoformat()}; skipping")
             return False
 
         log.set(arq_job_id=job.job_id, arq_job_name=job_name)

--- a/apps/api/app/services/scheduler_service.py
+++ b/apps/api/app/services/scheduler_service.py
@@ -197,7 +197,7 @@ class BaseSchedulerService(ABC):
 
         scheduled_count = 0
         for task in tasks:
-            if task.id:
+            if task.id and task.scheduled_at:
                 await self._enqueue_task(task.id, task.scheduled_at)
                 scheduled_count += 1
 

--- a/apps/api/app/services/system_workflows/provisioner.py
+++ b/apps/api/app/services/system_workflows/provisioner.py
@@ -252,7 +252,9 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
                 f"Failed to unregister old triggers during reset of {workflow_id} (non-fatal): {e}"
             )
 
-    trigger_doc = trigger_config.model_dump(mode="json")
+    # Python mode keeps trigger_config.next_run a native datetime (BSON date),
+    # consistent with the create and re-arm paths.
+    trigger_doc = trigger_config.model_dump()
     trigger_doc["composio_trigger_ids"] = new_trigger_ids
 
     await workflows_collection.update_one(

--- a/apps/api/app/services/workflow/queue_service.py
+++ b/apps/api/app/services/workflow/queue_service.py
@@ -1,7 +1,5 @@
 """Unified workflow queue service for background job management."""
 
-from datetime import UTC, datetime
-
 from app.utils.redis_utils import RedisPoolManager
 from shared.py.wide_events import log
 
@@ -52,51 +50,6 @@ class WorkflowQueueService:
 
         except Exception as e:
             log.error(f"Error queuing workflow execution for {workflow_id}: {e!s}")
-            return False
-
-    @staticmethod
-    async def queue_scheduled_workflow_execution(
-        workflow_id: str, scheduled_at: datetime, context: dict | None = None
-    ) -> bool:
-        """Queue a scheduled workflow execution with defer_until."""
-        try:
-            pool = await RedisPoolManager.get_pool()
-
-            tz_was_naive = scheduled_at.tzinfo is None
-            if tz_was_naive:
-                log.warning(
-                    f"queue_scheduled_workflow_execution: naive scheduled_at for "
-                    f"{workflow_id}, assuming UTC — check caller",
-                )
-                scheduled_at = scheduled_at.replace(tzinfo=UTC)
-            now = datetime.now(UTC)
-            defer_seconds = int((scheduled_at - now).total_seconds())
-
-            job = await pool.enqueue_job(
-                "execute_workflow_by_id",
-                workflow_id,
-                context or {},
-                _defer_until=scheduled_at,
-            )
-
-            if job:
-                log.set(
-                    workflow={"id": workflow_id, "status": "scheduled_queued"},
-                    arq_job_id=job.job_id,
-                    queue_mode="scheduled",
-                    scheduled_at_utc=scheduled_at.isoformat(),
-                    scheduled_at_was_naive=tz_was_naive,
-                    defer_seconds=defer_seconds,
-                )
-                log.info(
-                    f"Queued scheduled workflow execution for {workflow_id} at {scheduled_at} with job ID {job.job_id}"
-                )
-                return True
-            log.error(f"Failed to queue scheduled workflow execution for {workflow_id}")
-            return False
-
-        except Exception as e:
-            log.error(f"Error queuing scheduled workflow execution for {workflow_id}: {e!s}")
             return False
 
     @staticmethod

--- a/apps/api/app/services/workflow/scheduler.py
+++ b/apps/api/app/services/workflow/scheduler.py
@@ -173,98 +173,24 @@ class WorkflowScheduler(BaseSchedulerService):
             return False
 
     async def get_pending_task(self, current_time: datetime) -> list[BaseScheduledTask]:
+        """Workflows that are scheduled, due, and activated.
+
+        Delegates the due-query to the shared base implementation so the
+        ``scheduled_at <= now`` semantics stay identical to the reminder scan.
         """
-        Get workflows that should be scheduled for execution.
+        return await self._query_pending_tasks(
+            workflows_collection,
+            current_time,
+            self._doc_to_workflow,
+            extra_filter={"activated": True},
+        )
 
-        Args:
-            current_time: Current time to check against
-
-        Returns:
-            List of workflows ready for execution (as BaseScheduledTask)
-        """
-        try:
-            # Find workflows that are:
-            # 1. In SCHEDULED status
-            # 2. Have scheduled_at <= current_time
-            # 3. Are activated
-            query = {
-                "status": ScheduledTaskStatus.SCHEDULED.value,
-                "scheduled_at": {"$lte": current_time},
-                "activated": True,
-            }
-
-            cursor = workflows_collection.find(query)
-            workflows: list[BaseScheduledTask] = []
-
-            async for workflow_doc in cursor:
-                try:
-                    # Transform MongoDB document to Workflow object
-                    workflow_doc["id"] = workflow_doc.get("_id")
-                    if "_id" in workflow_doc:
-                        del workflow_doc["_id"]
-
-                    workflow = Workflow(**workflow_doc)
-                    workflows.append(workflow)  # Workflow extends BaseScheduledTask
-                except Exception as e:
-                    log.error(f"Error creating workflow object: {e}")
-                    continue
-
-            log.info(f"Found {len(workflows)} pending workflows")
-            return workflows
-
-        except Exception as e:
-            log.error(f"Error fetching pending workflows: {e}")
-            return []
-
-    async def create_workflow_with_scheduling(
-        self, workflow_data: dict[str, Any], user_id: str
-    ) -> str | None:
-        """
-        Create a workflow and handle its initial scheduling.
-
-        Args:
-            workflow_data: Workflow data dictionary
-            user_id: User ID
-
-        Returns:
-            Workflow ID if successful, None otherwise
-        """
-        try:
-            # Create the workflow
-            workflow = Workflow(user_id=user_id, **workflow_data)
-
-            # Insert into database
-            workflow_dict = workflow.model_dump(mode="json")
-            workflow_dict["_id"] = workflow_dict["id"]
-
-            result = await workflows_collection.insert_one(workflow_dict)
-            if not result.inserted_id:
-                raise ValueError("Failed to create workflow in database")
-
-            # Schedule if it's a scheduled workflow
-            if workflow.trigger_config.type == "schedule" and workflow.repeat:
-                from app.models.scheduler_models import ScheduleConfig
-
-                # Ensure workflow.id is not None
-                if not workflow.id:
-                    raise ValueError("Workflow ID is required for scheduling")
-
-                schedule_config = ScheduleConfig(
-                    repeat=workflow.repeat,
-                    scheduled_at=workflow.scheduled_at,
-                    max_occurrences=workflow.max_occurrences,
-                    stop_after=workflow.stop_after,
-                    base_time=datetime.now(UTC),  # Add required base_time
-                )
-
-                await self.schedule_task(workflow.id, schedule_config)
-                log.info(f"Scheduled workflow {workflow.id} for recurring execution")
-
-            return workflow.id
-
-        except Exception as e:
-            log.error(f"Error creating and scheduling workflow: {e}")
-            return None
+    @staticmethod
+    def _doc_to_workflow(doc: dict[str, Any]) -> Workflow:
+        """Transform a MongoDB document into a Workflow (string ``_id`` -> ``id``)."""
+        doc["id"] = doc.get("_id")
+        doc.pop("_id", None)
+        return Workflow(**doc)
 
     async def schedule_workflow_execution(
         self,

--- a/apps/api/app/services/workflow/scheduler.py
+++ b/apps/api/app/services/workflow/scheduler.py
@@ -14,7 +14,7 @@ from app.models.scheduler_models import (
     ScheduledTaskStatus,
     TaskExecutionResult,
 )
-from app.models.workflow_models import Workflow
+from app.models.workflow_models import TriggerType, Workflow
 from app.services.scheduler_service import BaseSchedulerService
 from shared.py.wide_events import log
 
@@ -38,6 +38,12 @@ class WorkflowScheduler(BaseSchedulerService):
     def get_job_name(self) -> str:
         """Get the ARQ job name for workflow processing."""
         return "execute_workflow_by_id"
+
+    def _build_job_args(self, task_id: str) -> tuple:
+        """Mark scheduler-originated fires so the executor re-arms the next
+        occurrence; manual "run now" executions pass their own context and so are
+        never tagged as scheduled."""
+        return (task_id, {"trigger_type": TriggerType.SCHEDULE.value})
 
     async def get_task(self, task_id: str, user_id: str | None = None) -> Workflow | None:
         """

--- a/apps/api/app/services/workflow/scheduler.py
+++ b/apps/api/app/services/workflow/scheduler.py
@@ -45,6 +45,27 @@ class WorkflowScheduler(BaseSchedulerService):
         never tagged as scheduled."""
         return (task_id, {"trigger_type": TriggerType.SCHEDULE.value})
 
+    async def claim_scheduled_for_execution(self, workflow_id: str) -> bool:
+        """Atomically transition a SCHEDULED workflow to EXECUTING.
+
+        Returns False if the workflow was not in scheduled state — meaning a
+        concurrent recovery scan already claimed it (or it isn't scheduler-managed).
+        The caller must then skip execution: this is what prevents the recovery scan
+        from double-running a workflow whose previous fire is still in flight (the
+        scan selects status="scheduled", so a claimed row is excluded). The re-arm at
+        the end of execution returns the row to "scheduled" with its next run time.
+        """
+        result = await workflows_collection.find_one_and_update(
+            {"_id": workflow_id, "status": ScheduledTaskStatus.SCHEDULED.value},
+            {
+                "$set": {
+                    "status": ScheduledTaskStatus.EXECUTING.value,
+                    "updated_at": datetime.now(UTC),
+                }
+            },
+        )
+        return result is not None
+
     async def get_task(self, task_id: str, user_id: str | None = None) -> Workflow | None:
         """
         Get a workflow by ID.
@@ -173,16 +194,21 @@ class WorkflowScheduler(BaseSchedulerService):
             return False
 
     async def get_pending_task(self, current_time: datetime) -> list[BaseScheduledTask]:
-        """Workflows that are scheduled, due, and activated.
+        """Recurring (cron) workflows that are due and activated.
 
-        Delegates the due-query to the shared base implementation so the
-        ``scheduled_at <= now`` semantics stay identical to the reminder scan.
+        The ``repeat`` filter is load-bearing: ``Workflow`` extends
+        ``BaseScheduledTask``, so EVERY workflow defaults to status="scheduled" and
+        gets ``scheduled_at = now`` at creation when it has no ``next_run`` (manual,
+        integration and todo workflows all do). Without ``repeat``, the recovery scan
+        would match those non-scheduled workflows and re-run the agent on every pass.
+        ``repeat`` (the cron the scheduler actually re-arms on) is the precise,
+        serialization-robust discriminator for "scheduler-managed".
         """
         return await self._query_pending_tasks(
             workflows_collection,
             current_time,
             self._doc_to_workflow,
-            extra_filter={"activated": True},
+            extra_filter={"activated": True, "repeat": {"$nin": [None, ""]}},
         )
 
     @staticmethod

--- a/apps/api/app/services/workflow/service.py
+++ b/apps/api/app/services/workflow/service.py
@@ -557,8 +557,10 @@ class WorkflowService:
                             user_id, old_trigger_name, old_trigger_ids, workflow_id
                         )
 
-                # Convert TriggerConfig back to dict for MongoDB storage
-                update_fields["trigger_config"] = new_trigger_config.model_dump(mode="json")
+                # Python mode keeps trigger_config.next_run a native datetime (BSON
+                # date), consistent with the create and re-arm paths — json mode here
+                # would flip it back to a string.
+                update_fields["trigger_config"] = new_trigger_config.model_dump()
 
                 # Add new trigger IDs if triggers were registered
                 if registered_trigger_ids is not None:

--- a/apps/api/app/services/workflow/service.py
+++ b/apps/api/app/services/workflow/service.py
@@ -233,8 +233,9 @@ class WorkflowService:
                 selected_integrations=request.selected_integrations,
             )
 
-            # creator is hydration-only on response; never persist it.
-            workflow_dict = workflow.model_dump(mode="json", exclude={"creator"})
+            # Python mode keeps datetimes native (BSON dates) so the scheduler's
+            # `scheduled_at: {"$lte": now}` scan can match. creator is response-only.
+            workflow_dict = workflow.model_dump(exclude={"creator"})
             workflow_dict["_id"] = workflow_dict["id"]
 
             if workflow_dict.get("is_public") and not workflow_dict.get("slug"):

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -17,6 +17,7 @@ from app.workers.tasks import (
     store_memories_batch,
 )
 from app.workers.tasks.maintenance_sweep_tasks import maintenance_sweep_tracked_todos
+from app.workers.tasks.scheduler_recovery_tasks import rescan_pending_scheduled_tasks
 from app.workers.tasks.tracked_todo_tasks import (
     execute_tracked_todo,
     safety_net_check_orphaned_todos,
@@ -39,6 +40,7 @@ _cleanup_stuck_personalization = instrument_task(cleanup_stuck_personalization)
 _execute_tracked_todo = instrument_task(execute_tracked_todo)
 _safety_net_check_orphaned_todos = instrument_task(safety_net_check_orphaned_todos)
 _maintenance_sweep_tracked_todos = instrument_task(maintenance_sweep_tracked_todos)
+_rescan_pending_scheduled_tasks = instrument_task(rescan_pending_scheduled_tasks)
 
 WorkerSettings.functions = [
     _process_reminder,
@@ -80,6 +82,9 @@ WorkerSettings.cron_jobs = [
         minute=15,
         second=0,
     ),
+    # Recovery safety net: re-enqueue due scheduled tasks whose ARQ job was lost
+    # (Redis eviction/flush). Idempotent via the deterministic _job_id.
+    cron(_rescan_pending_scheduled_tasks, minute={0, 30}, second=0),
 ]
 
 WorkerSettings.on_startup = startup

--- a/apps/api/app/workers/tasks/scheduler_recovery_tasks.py
+++ b/apps/api/app/workers/tasks/scheduler_recovery_tasks.py
@@ -1,0 +1,20 @@
+"""Periodic recovery scan for scheduled tasks (workflows + reminders)."""
+
+from app.services.reminder_service import reminder_scheduler
+from app.services.workflow.scheduler import workflow_scheduler
+from shared.py.wide_events import wide_task
+
+
+async def rescan_pending_scheduled_tasks(ctx: dict) -> str:
+    """Re-enqueue any SCHEDULED task that is due but whose ARQ job was lost.
+
+    The startup scan (``scan_and_schedule_pending_tasks``) only runs once per boot,
+    so a deferred job lost mid-run (Redis eviction/flush) would otherwise sit until
+    the next restart. This periodic pass is the safety net. The deterministic ARQ
+    ``_job_id`` makes re-enqueueing idempotent, so it overlaps harmlessly with jobs
+    that are already queued.
+    """
+    async with wide_task("rescan_pending_scheduled_tasks"):
+        await workflow_scheduler.scan_and_schedule_pending_tasks()
+        await reminder_scheduler.scan_and_schedule_pending_tasks()
+        return "rescan_pending_scheduled_tasks complete"

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -41,6 +41,7 @@ from app.models.workflow_models import (
     CreateWorkflowRequest,
     TriggerConfig,
     TriggerType,
+    Workflow,
 )
 from app.services.notification_service import notification_service
 from app.services.todos.todo_service import TodoService
@@ -185,6 +186,22 @@ async def process_workflow_generation_task(
             raise
 
 
+async def _rearm_if_scheduled(
+    scheduler: WorkflowScheduler, workflow: Workflow | None, context: dict | None
+) -> None:
+    """Arm the next occurrence for cron-scheduled recurring workflows.
+
+    Only scheduler-originated fires (trigger_type=schedule) advance the schedule;
+    manual and integration-triggered runs must not shift it.
+    """
+    if workflow is None or not workflow.repeat:
+        return
+    trigger_type = context.get("trigger_type") if context else None
+    if trigger_type != TriggerType.SCHEDULE.value:
+        return
+    await scheduler.handle_recurring_task(workflow, (workflow.occurrence_count or 0) + 1)
+
+
 async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | None = None) -> str:
     """
     Execute a workflow by ID with proper execution count tracking.
@@ -269,6 +286,9 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                 summary=summary,
                 conversation_id=conversation_id,
             )
+
+            # Arm the next occurrence (scheduled recurring workflows only).
+            await _rearm_if_scheduled(scheduler, workflow, context)
 
             return f"Workflow {workflow_id} executed successfully with {len(execution_messages)} messages"
 
@@ -372,6 +392,13 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                     )
                 except Exception as notify_err:
                     log.debug("Failed to send failure notification: %s" % notify_err)
+
+            # Still arm the next occurrence — a transient failure (rate limit, LLM
+            # error) must not permanently kill a recurring workflow.
+            try:
+                await _rearm_if_scheduled(scheduler, workflow, context)
+            except Exception as rearm_err:
+                log.error("Failed to re-arm workflow %s: %s" % (workflow_id, rearm_err))
 
             return "Error executing workflow %s: %s" % (workflow_id, str(e))
 

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -287,8 +287,12 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                 conversation_id=conversation_id,
             )
 
-            # Arm the next occurrence (scheduled recurring workflows only).
-            await _rearm_if_scheduled(scheduler, workflow, context)
+            # Arm the next occurrence (scheduled recurring workflows only). A re-arm
+            # failure must not turn a successful execution into a reported failure.
+            try:
+                await _rearm_if_scheduled(scheduler, workflow, context)
+            except Exception as rearm_err:
+                log.error("Failed to re-arm workflow %s: %s" % (workflow_id, rearm_err))
 
             return f"Workflow {workflow_id} executed successfully with {len(execution_messages)} messages"
 

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -239,6 +239,19 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                 )
             )
 
+            # Scheduler-originated fires: atomically claim the occurrence (scheduled ->
+            # executing) so a concurrent recovery scan can't double-execute a workflow
+            # whose previous fire is still running. Manual/integration "run now" fires
+            # don't go through the scan and must not be status-gated.
+            if trigger_type == TriggerType.SCHEDULE.value and not (
+                await scheduler.claim_scheduled_for_execution(workflow_id)
+            ):
+                log.warning(
+                    f"Workflow {workflow_id} not in scheduled state "
+                    f"(already claimed or running); skipping duplicate scheduled fire"
+                )
+                return f"Workflow {workflow_id} already claimed; skipped duplicate scheduled fire"
+
             scheduled_at = getattr(workflow, "scheduled_at", None)
             if isinstance(scheduled_at, datetime):
                 if scheduled_at.tzinfo is None:

--- a/apps/api/scripts/migrate_workflow_schedule_types.py
+++ b/apps/api/scripts/migrate_workflow_schedule_types.py
@@ -1,0 +1,156 @@
+"""
+One-time, idempotent migration: repair workflow scheduling state.
+
+Two defects left existing workflows stuck:
+
+1. ``scheduled_at`` / ``stop_after`` / ``trigger_config.next_run`` were persisted as
+   ISO **strings** instead of native datetimes. The scheduler selects due work with
+   ``scheduled_at: {"$lte": now}``, which never matches a string — so those workflows
+   are invisible to the recovery scan.
+2. The executor never re-armed recurrence, so a recurring workflow fired once and then
+   sat at a stale ``scheduled_at`` forever.
+
+This script converts the scheduling timestamps to datetimes and, for every active
+recurring workflow, recomputes the next *future* run, marks it scheduled, and enqueues
+it in ARQ. It advances from now (never replays missed runs) and honours
+``max_occurrences`` / ``stop_after``. Cancelled, paused and one-time workflows are left
+untouched.
+
+Idempotent: re-running recomputes a future run and the deterministic ARQ job id dedupes
+the enqueue, so it is safe to run repeatedly.
+
+Run from repo root (dry run prints what would change):
+    cd apps/api && uv run python scripts/migrate_workflow_schedule_types.py
+Apply the changes:
+    cd apps/api && uv run python scripts/migrate_workflow_schedule_types.py --apply
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.db.mongodb.collections import workflows_collection  # noqa: E402
+from app.models.scheduler_models import ScheduledTaskStatus  # noqa: E402
+from app.services.workflow.scheduler import WorkflowScheduler  # noqa: E402
+from app.utils.cron_utils import get_next_run_time  # noqa: E402
+
+_DATE_FIELDS = ("scheduled_at", "stop_after")
+
+
+def _to_datetime(value: object) -> datetime | None:
+    """Coerce an ISO string (or existing datetime) to a UTC-aware datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _build_type_fixes(doc: dict) -> dict:
+    """$set payload that converts string-typed scheduling fields to datetimes."""
+    fixes: dict[str, datetime] = {}
+    for field in _DATE_FIELDS:
+        if isinstance(doc.get(field), str):
+            coerced = _to_datetime(doc[field])
+            if coerced is not None:
+                fixes[field] = coerced
+
+    trigger_config = doc.get("trigger_config") or {}
+    if isinstance(trigger_config.get("next_run"), str):
+        coerced = _to_datetime(trigger_config["next_run"])
+        if coerced is not None:
+            fixes["trigger_config.next_run"] = coerced
+    return fixes
+
+
+async def migrate(apply: bool) -> None:
+    mode = "APPLY" if apply else "DRY RUN"
+    print(f"[{mode}] Repairing workflow scheduling state...\n")
+
+    scheduler = WorkflowScheduler()
+    if apply:
+        await scheduler.initialize()
+
+    type_fixed = 0
+    rearmed = 0
+    completed = 0
+    skipped = 0
+
+    try:
+        async for doc in workflows_collection.find({}):
+            workflow_id = doc.get("_id")
+            now = datetime.now(UTC)
+
+            # 1. Type repair for the scheduling timestamps.
+            fixes = _build_type_fixes(doc)
+            if fixes:
+                type_fixed += 1
+                print(f"  {workflow_id}: type-fix {sorted(fixes)}")
+                if apply:
+                    await workflows_collection.update_one({"_id": workflow_id}, {"$set": fixes})
+
+            # 2. Re-arm active recurring workflows.
+            repeat = doc.get("repeat")
+            activated = doc.get("activated", False)
+            status = doc.get("status")
+            if not repeat or not activated or status != ScheduledTaskStatus.SCHEDULED.value:
+                skipped += 1
+                continue
+
+            timezone = (doc.get("trigger_config") or {}).get("timezone") or "UTC"
+            next_run = get_next_run_time(repeat, now, timezone)
+
+            occurrence_count = doc.get("occurrence_count") or 0
+            max_occurrences = doc.get("max_occurrences")
+            stop_after = _to_datetime(doc.get("stop_after"))
+
+            if (max_occurrences and occurrence_count >= max_occurrences) or (
+                stop_after and next_run >= stop_after
+            ):
+                completed += 1
+                print(f"  {workflow_id}: limit reached -> completed")
+                if apply:
+                    await workflows_collection.update_one(
+                        {"_id": workflow_id},
+                        {"$set": {"status": ScheduledTaskStatus.COMPLETED.value}},
+                    )
+                continue
+
+            rearmed += 1
+            print(f"  {workflow_id}: re-arm -> {next_run.isoformat()}")
+            if apply:
+                await workflows_collection.update_one(
+                    {"_id": workflow_id},
+                    {
+                        "$set": {
+                            "scheduled_at": next_run,
+                            "trigger_config.next_run": next_run,
+                            "status": ScheduledTaskStatus.SCHEDULED.value,
+                            "updated_at": now,
+                        }
+                    },
+                )
+                await scheduler.reschedule_task(workflow_id, next_run)
+    finally:
+        if apply:
+            await scheduler.close()
+
+    print(
+        f"\n[{mode}] Done. type-fixed={type_fixed} re-armed={rearmed} "
+        f"completed={completed} skipped={skipped}"
+    )
+    if not apply:
+        print("Re-run with --apply to write these changes.")
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate(apply="--apply" in sys.argv))

--- a/apps/api/scripts/migrate_workflow_schedule_types.py
+++ b/apps/api/scripts/migrate_workflow_schedule_types.py
@@ -1,20 +1,24 @@
 """
-One-time, idempotent migration: repair workflow scheduling state.
+One-time, idempotent migration: repair workflow + reminder scheduling state.
 
-Two defects left existing workflows stuck:
+Two defects left existing documents stuck:
 
-1. ``scheduled_at`` / ``stop_after`` / ``trigger_config.next_run`` were persisted as
-   ISO **strings** instead of native datetimes. The scheduler selects due work with
-   ``scheduled_at: {"$lte": now}``, which never matches a string — so those workflows
-   are invisible to the recovery scan.
-2. The executor never re-armed recurrence, so a recurring workflow fired once and then
-   sat at a stale ``scheduled_at`` forever.
+1. ``scheduled_at`` / ``stop_after`` / ``trigger_config.next_run`` (and the audit
+   fields ``created_at`` / ``updated_at``) were persisted as ISO **strings** instead
+   of native datetimes. The scheduler selects due work with
+   ``scheduled_at: {"$lte": now}``, which never matches a string — so those tasks are
+   invisible to the recovery scan — and date-range/sort queries on the audit fields
+   behave inconsistently across the mixed string/date population.
+2. The workflow executor never re-armed recurrence, so a recurring workflow fired
+   once and then sat at a stale ``scheduled_at`` forever.
 
-This script converts the scheduling timestamps to datetimes and, for every active
-recurring workflow, recomputes the next *future* run, marks it scheduled, and enqueues
-it in ARQ. It advances from now (never replays missed runs) and honours
-``max_occurrences`` / ``stop_after``. Cancelled, paused and one-time workflows are left
-untouched.
+For workflows this script converts the scheduling/audit timestamps to datetimes and,
+for every active recurring workflow, recomputes the next *future* run, marks it
+scheduled, and enqueues it in ARQ. It advances from now (never replays missed runs)
+and honours ``max_occurrences`` / ``stop_after``. Cancelled, paused and one-time
+workflows are left untouched. For reminders it converts the same string timestamps to
+datetimes — no re-arm is needed, the (now ``$lte``) recovery scan recovers overdue
+reminders once their dates are native.
 
 Idempotent: re-running recomputes a future run and the deterministic ARQ job id dedupes
 the enqueue, so it is safe to run repeatedly.
@@ -32,12 +36,16 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from app.db.mongodb.collections import workflows_collection  # noqa: E402
+from app.db.mongodb.collections import (  # noqa: E402
+    reminders_collection,
+    workflows_collection,
+)
 from app.models.scheduler_models import ScheduledTaskStatus  # noqa: E402
 from app.services.workflow.scheduler import WorkflowScheduler  # noqa: E402
 from app.utils.cron_utils import get_next_run_time  # noqa: E402
 
-_DATE_FIELDS = ("scheduled_at", "stop_after")
+# Scheduling + audit datetimes that were historically persisted as ISO strings.
+_DATE_FIELDS = ("scheduled_at", "stop_after", "created_at", "updated_at")
 
 
 def _to_datetime(value: object) -> datetime | None:
@@ -56,7 +64,13 @@ def _to_datetime(value: object) -> datetime | None:
 
 
 def _build_type_fixes(doc: dict) -> dict:
-    """$set payload that converts string-typed scheduling fields to datetimes."""
+    """$set payload that converts string-typed datetime fields to datetimes.
+
+    Covers the top-level scheduling/audit fields and (for workflows) the nested
+    ``trigger_config.next_run``. The nested field is only set when ``trigger_config``
+    is an object, so a missing/null ``trigger_config`` is never turned into a malformed
+    subdocument (``TriggerConfig.type`` is required).
+    """
     fixes: dict[str, datetime] = {}
     for field in _DATE_FIELDS:
         if isinstance(doc.get(field), str):
@@ -64,17 +78,34 @@ def _build_type_fixes(doc: dict) -> dict:
             if coerced is not None:
                 fixes[field] = coerced
 
-    trigger_config = doc.get("trigger_config") or {}
-    if isinstance(trigger_config.get("next_run"), str):
+    trigger_config = doc.get("trigger_config")
+    if isinstance(trigger_config, dict) and isinstance(trigger_config.get("next_run"), str):
         coerced = _to_datetime(trigger_config["next_run"])
         if coerced is not None:
             fixes["trigger_config.next_run"] = coerced
     return fixes
 
 
+async def _migrate_reminder_types(apply: bool) -> int:
+    """Type-repair reminder scheduling/audit datetimes.
+
+    No re-arm is needed: once the dates are native, the recovery scan
+    (``scheduled_at: {"$lte": now}``) recovers any overdue reminder.
+    """
+    fixed = 0
+    async for doc in reminders_collection.find({}):
+        fixes = _build_type_fixes(doc)
+        if fixes:
+            fixed += 1
+            print(f"  reminder {doc.get('_id')}: type-fix {sorted(fixes)}")
+            if apply:
+                await reminders_collection.update_one({"_id": doc["_id"]}, {"$set": fixes})
+    return fixed
+
+
 async def migrate(apply: bool) -> None:
     mode = "APPLY" if apply else "DRY RUN"
-    print(f"[{mode}] Repairing workflow scheduling state...\n")
+    print(f"[{mode}] Repairing workflow + reminder scheduling state...\n")
 
     scheduler = WorkflowScheduler()
     if apply:
@@ -84,13 +115,14 @@ async def migrate(apply: bool) -> None:
     rearmed = 0
     completed = 0
     skipped = 0
+    reminder_fixed = 0
 
     try:
         async for doc in workflows_collection.find({}):
             workflow_id = doc.get("_id")
             now = datetime.now(UTC)
 
-            # 1. Type repair for the scheduling timestamps.
+            # 1. Type repair for the scheduling + audit timestamps.
             fixes = _build_type_fixes(doc)
             if fixes:
                 type_fixed += 1
@@ -128,25 +160,28 @@ async def migrate(apply: bool) -> None:
             rearmed += 1
             print(f"  {workflow_id}: re-arm -> {next_run.isoformat()}")
             if apply:
-                await workflows_collection.update_one(
-                    {"_id": workflow_id},
-                    {
-                        "$set": {
-                            "scheduled_at": next_run,
-                            "trigger_config.next_run": next_run,
-                            "status": ScheduledTaskStatus.SCHEDULED.value,
-                            "updated_at": now,
-                        }
-                    },
-                )
+                set_fields: dict[str, datetime | str] = {
+                    "scheduled_at": next_run,
+                    "status": ScheduledTaskStatus.SCHEDULED.value,
+                    "updated_at": now,
+                }
+                # Only touch the nested field when the parent object exists, so a
+                # missing/null trigger_config is never auto-created as a malformed
+                # subdocument.
+                if isinstance(doc.get("trigger_config"), dict):
+                    set_fields["trigger_config.next_run"] = next_run
+                await workflows_collection.update_one({"_id": workflow_id}, {"$set": set_fields})
                 await scheduler.reschedule_task(str(workflow_id), next_run)
+
+        # 3. Type repair for reminders (same string->datetime defect, no re-arm).
+        reminder_fixed = await _migrate_reminder_types(apply)
     finally:
         if apply:
             await scheduler.close()
 
     print(
-        f"\n[{mode}] Done. type-fixed={type_fixed} re-armed={rearmed} "
-        f"completed={completed} skipped={skipped}"
+        f"\n[{mode}] Done. workflow type-fixed={type_fixed} re-armed={rearmed} "
+        f"completed={completed} skipped={skipped} | reminder type-fixed={reminder_fixed}"
     )
     if not apply:
         print("Re-run with --apply to write these changes.")

--- a/apps/api/scripts/migrate_workflow_schedule_types.py
+++ b/apps/api/scripts/migrate_workflow_schedule_types.py
@@ -139,7 +139,7 @@ async def migrate(apply: bool) -> None:
                         }
                     },
                 )
-                await scheduler.reschedule_task(workflow_id, next_run)
+                await scheduler.reschedule_task(str(workflow_id), next_run)
     finally:
         if apply:
             await scheduler.close()

--- a/apps/api/tests/integration/test_workflow_execution.py
+++ b/apps/api/tests/integration/test_workflow_execution.py
@@ -898,31 +898,6 @@ class TestQueueService:
 
         assert result is False
 
-    async def test_queue_scheduled_workflow_execution(self):
-        """queue_scheduled_workflow_execution passes defer_until."""
-        mock_pool = AsyncMock()
-        mock_job = MagicMock()
-        mock_job.job_id = "job_sched_789"
-        mock_pool.enqueue_job = AsyncMock(return_value=mock_job)
-        scheduled_at = datetime(2026, 6, 1, 9, 0, 0, tzinfo=UTC)
-
-        with patch(
-            "app.services.workflow.queue_service.RedisPoolManager.get_pool",
-            new_callable=AsyncMock,
-            return_value=mock_pool,
-        ):
-            result = await WorkflowQueueService.queue_scheduled_workflow_execution(
-                FAKE_WORKFLOW_ID, scheduled_at
-            )
-
-        assert result is True
-        mock_pool.enqueue_job.assert_awaited_once_with(
-            "execute_workflow_by_id",
-            FAKE_WORKFLOW_ID,
-            {},
-            _defer_until=scheduled_at,
-        )
-
     async def test_queue_regeneration(self):
         """queue_workflow_regeneration enqueues with reason and force flag."""
         mock_pool = AsyncMock()

--- a/apps/api/tests/unit/services/test_scheduler_service.py
+++ b/apps/api/tests/unit/services/test_scheduler_service.py
@@ -392,7 +392,7 @@ class TestScanAndSchedulePendingTasks:
 
 
 # ---------------------------------------------------------------------------
-# _handle_recurring_task
+# handle_recurring_task
 # ---------------------------------------------------------------------------
 
 
@@ -401,7 +401,7 @@ class TestHandleRecurringTask:
     async def test_no_repeat_returns_early(self, service, sample_task):
         sample_task.repeat = None
 
-        await service._handle_recurring_task(sample_task, 1)
+        await service.handle_recurring_task(sample_task, 1)
 
         # Should not try to reschedule
         service.arq_pool.enqueue_job.assert_not_awaited()
@@ -409,7 +409,7 @@ class TestHandleRecurringTask:
     async def test_no_task_id_returns_early(self, service, recurring_task):
         recurring_task.id = None
 
-        await service._handle_recurring_task(recurring_task, 1)
+        await service.handle_recurring_task(recurring_task, 1)
 
         service.arq_pool.enqueue_job.assert_not_awaited()
 
@@ -421,7 +421,7 @@ class TestHandleRecurringTask:
             "app.services.scheduler_service.get_next_run_time",
             return_value=datetime.now(UTC) + timedelta(days=1),
         ):
-            await service._handle_recurring_task(recurring_task, 1)
+            await service.handle_recurring_task(recurring_task, 1)
 
         service.mock_update_task_status.assert_awaited()
         status_call = service.mock_update_task_status.call_args
@@ -437,7 +437,7 @@ class TestHandleRecurringTask:
             "app.services.scheduler_service.get_next_run_time",
             return_value=datetime.now(UTC) + timedelta(days=1),
         ):
-            await service._handle_recurring_task(recurring_task, 1)
+            await service.handle_recurring_task(recurring_task, 1)
 
         # Should still reschedule because next_run < stop_after
         status_call = service.mock_update_task_status.call_args
@@ -467,7 +467,7 @@ class TestHandleRecurringTask:
             "app.services.scheduler_service.get_next_run_time",
             return_value=datetime.now(UTC) + timedelta(days=1),
         ) as mock_next_run:
-            await service._handle_recurring_task(task, 1)
+            await service.handle_recurring_task(task, 1)
 
             mock_next_run.assert_called_once()
             call_args = mock_next_run.call_args
@@ -490,7 +490,10 @@ class TestEnqueueTask:
 
         assert result is True
         service.arq_pool.enqueue_job.assert_awaited_once_with(
-            "test_job", "task1", _defer_until=future
+            "test_job",
+            "task1",
+            _job_id=f"test_job:task1:{int(future.timestamp())}",
+            _defer_until=future,
         )
 
     async def test_enqueue_no_pool(self, service):

--- a/apps/api/tests/unit/services/test_workflow_service.py
+++ b/apps/api/tests/unit/services/test_workflow_service.py
@@ -533,43 +533,6 @@ class TestWorkflowQueueServiceExecution:
 
 
 @pytest.mark.unit
-class TestWorkflowQueueServiceScheduled:
-    async def test_queue_scheduled_execution_passes_defer_until(self, mock_redis_pool):
-        scheduled_at = datetime.now(UTC) + timedelta(hours=2)
-        mock_job = MagicMock()
-        mock_job.job_id = "job_sched"
-        mock_redis_pool.enqueue_job = AsyncMock(return_value=mock_job)
-
-        result = await WorkflowQueueService.queue_scheduled_workflow_execution(
-            workflow_id=WORKFLOW_ID, scheduled_at=scheduled_at
-        )
-
-        assert result is True
-        kwargs = mock_redis_pool.enqueue_job.call_args[1]
-        assert kwargs["_defer_until"] == scheduled_at
-
-    async def test_queue_scheduled_returns_false_when_job_none(self, mock_redis_pool):
-        mock_redis_pool.enqueue_job = AsyncMock(return_value=None)
-        scheduled_at = datetime.now(UTC) + timedelta(hours=1)
-
-        result = await WorkflowQueueService.queue_scheduled_workflow_execution(
-            WORKFLOW_ID, scheduled_at
-        )
-
-        assert result is False
-
-    async def test_queue_scheduled_returns_false_on_exception(self, mock_redis_pool):
-        mock_redis_pool.enqueue_job = AsyncMock(side_effect=Exception("unavailable"))
-        scheduled_at = datetime.now(UTC) + timedelta(hours=1)
-
-        result = await WorkflowQueueService.queue_scheduled_workflow_execution(
-            WORKFLOW_ID, scheduled_at
-        )
-
-        assert result is False
-
-
-@pytest.mark.unit
 class TestWorkflowQueueServiceRegeneration:
     async def test_queue_regeneration_passes_all_params(self, mock_redis_pool):
         mock_job = MagicMock()

--- a/apps/api/tests/unit/services/test_workflow_service_main.py
+++ b/apps/api/tests/unit/services/test_workflow_service_main.py
@@ -26,9 +26,8 @@ Also covers:
   - WorkflowScheduler (schedule, cancel, reschedule, get_task, get_pending_task,
     update_task_status, get_workflow_status)
   - WorkflowQueueService (queue_workflow_generation, queue_workflow_execution,
-    queue_scheduled_workflow_execution, queue_workflow_regeneration,
-    queue_todo_workflow_generation, is_workflow_generating,
-    clear_workflow_generating_flag)
+    queue_workflow_regeneration, queue_todo_workflow_generation,
+    is_workflow_generating, clear_workflow_generating_flag)
   - TriggerService (get_all_workflow_triggers, get_trigger_by_slug,
     register_triggers, unregister_triggers, reference counting)
   - WorkflowValidator (validate_for_execution: pass, deactivated, no steps,
@@ -2257,35 +2256,6 @@ class TestWorkflowQueueService:
         mock_redis.get_pool = AsyncMock(return_value=mock_pool)
 
         result = await WorkflowQueueService.queue_workflow_execution(WORKFLOW_ID, USER_ID)
-        assert result is False
-
-    @patch("app.services.workflow.queue_service.RedisPoolManager")
-    async def test_queue_scheduled_execution_success(self, mock_redis):
-        mock_pool = AsyncMock()
-        mock_job = MagicMock()
-        mock_job.job_id = "job_sched"
-        mock_pool.enqueue_job = AsyncMock(return_value=mock_job)
-        mock_redis.get_pool = AsyncMock(return_value=mock_pool)
-
-        scheduled_at = datetime.now(UTC) + timedelta(hours=1)
-        result = await WorkflowQueueService.queue_scheduled_workflow_execution(
-            WORKFLOW_ID, scheduled_at
-        )
-        assert result is True
-        mock_pool.enqueue_job.assert_awaited_once_with(
-            "execute_workflow_by_id", WORKFLOW_ID, {}, _defer_until=scheduled_at
-        )
-
-    @patch("app.services.workflow.queue_service.RedisPoolManager")
-    async def test_queue_scheduled_execution_failure(self, mock_redis):
-        mock_pool = AsyncMock()
-        mock_pool.enqueue_job = AsyncMock(return_value=None)
-        mock_redis.get_pool = AsyncMock(return_value=mock_pool)
-
-        scheduled_at = datetime.now(UTC) + timedelta(hours=1)
-        result = await WorkflowQueueService.queue_scheduled_workflow_execution(
-            WORKFLOW_ID, scheduled_at
-        )
         assert result is False
 
     @patch("app.services.workflow.queue_service.RedisPoolManager")


### PR DESCRIPTION
## Problem

Reported by a user: *"workflows are not executing even though they are scheduled daily. 3 days no notifications."*

Investigated via prod Loki + Mongo. Recurring workflows fire **once** after creation and then go silent. **19 users** affected; oldest stuck workflow hadn't run in ~6 months. Reminders share the same latent bug but mostly escape it because they're one-time.

## Root causes (both in the shared scheduler)

1. **Recurrence was never re-armed.** The workflow ARQ executor (`execute_workflow_by_id`) runs a single occurrence and never schedules the next one. Only the *reminder* path re-arms (via `process_task_execution` → `handle_recurring_task`); workflows bypass it. Result: `occurrence_count=0` on every executed recurring workflow; zero `"Rescheduled recurring task"` log lines in 8 days.
2. **`scheduled_at` persisted as a string.** `BaseScheduledTask`'s datetime `field_serializer` ran in all modes, and create used `model_dump(mode="json")` → ISO strings in Mongo. The recovery scan (`scheduled_at: {"$lte": now}`) **cannot match a string**, so 1838/1843 active workflows were invisible to it.

## Fix (unify, root-level — no patches)

- **Re-arm via the shared core.** `_handle_recurring_task` → public `handle_recurring_task`, called by both the reminder path and the workflow executor. The executor re-arms **only for scheduler-originated fires** (`trigger_type=schedule`) so a manual "run now" never shifts the schedule. Re-arms on success *and* failure so a transient error doesn't kill the series.
- **Persist datetimes natively.** Scope `serialize_datetime` to `when_used="json"` (API responses still emit ISO) and create workflows in python mode → BSON dates the scan can match.
- **Advance from now**, not a stale `scheduled_at` — a dormant workflow resumes at its next future run instead of replaying every missed run (no catch-up storm).
- **Deterministic ARQ `_job_id`** per (task, fire-time) — prevents duplicate-fire stacking across scans/edits.

## Migration

`apps/api/scripts/migrate_workflow_schedule_types.py` — idempotent, dry-run by default (`--apply` to write). Converts string → datetime and re-arms active recurring workflows.

```
cd apps/api && uv run python scripts/migrate_workflow_schedule_types.py          # dry run
cd apps/api && uv run python scripts/migrate_workflow_schedule_types.py --apply  # apply
```

## Verification

- `nx type-check api` ✅  `nx lint api` ✅
- `tests/unit/services/test_scheduler_service.py` — 29 passed (updated the rename + new `_job_id` assertion).
- Full unit run: the 10 pre-existing failures + 1 error are unchanged vs clean `develop` (slug/integration-trigger/oauth tests, unrelated to this change).
- End-to-end VM test of the full workflow lifecycle is being run separately.

Also includes an engineering-discipline note in `CLAUDE.md` (requested): always fix at the root / unify divergent paths rather than patching.

Separately tracked (not this PR): RabbitMQ `gaia` broker user missing (live WebSocket toasts) and the silent `_publish_to_rabbitmq` swallow.