### PR TITLE
feat(api): deliver background executor messages to bots + source metadata

### DIFF
--- a/apps/api/app/agents/core/agent.py
+++ b/apps/api/app/agents/core/agent.py
@@ -133,6 +133,7 @@ async def _core_agent_logic(
         tool_category=request.toolCategory,
         active_todo_id=active_todo_id,
         execution_mode=execution_mode,
+        source=source,
         langfuse_trace_id=langfuse_trace_id,
         langfuse_tags=langfuse_tags,
     )

--- a/apps/api/app/agents/core/background/executor_runner.py
+++ b/apps/api/app/agents/core/background/executor_runner.py
@@ -43,9 +43,10 @@ from app.core.websocket_manager import websocket_manager
 from app.db.mongodb.collections import conversations_collection
 from app.db.redis import redis_cache
 from app.helpers.agent_helpers import build_agent_config, execute_graph_silent
-from app.models.chat_models import MessageModel, UpdateMessagesRequest
+from app.models.chat_models import ConversationSource, MessageModel, UpdateMessagesRequest
 from app.models.message_models import ReplyToMessageData
 from app.services.conversation_service import update_messages
+from app.services.platform_message_service import deliver_message_to_platform, is_bot_platform
 from app.utils.stream_utils import (
     absorb_collector_event,
     apply_outputs_to_tool_data,
@@ -119,6 +120,27 @@ async def _lookup_user_message_content(
     return ""
 
 
+async def _get_conversation_source(
+    conversation_id: str, user_id: str
+) -> ConversationSource | None:
+    """Return the conversation's persisted originating source (web/whatsapp/...).
+
+    This is the authoritative delivery-routing key: it says which channel the
+    conversation belongs to, independent of the run that produced the message
+    (so a scheduled/workflow run posting into a bot conversation still routes to
+    that platform). Returns None on miss/error — treated as a non-bot conversation.
+    """
+    try:
+        doc = await conversations_collection.find_one(
+            {"conversation_id": conversation_id, "user_id": user_id},
+            {"source": 1},
+        )
+    except Exception as e:
+        log.warning("_get_conversation_source: lookup failed", error=str(e))
+        return None
+    return ConversationSource.coerce(doc.get("source")) if doc else None
+
+
 def _collect_queued_tool_events(
     stream_id: str,
 ) -> list[dict[str, Any]] | None:
@@ -167,11 +189,19 @@ async def _deliver_bg_notification(
     tool_data: list[dict[str, Any]] | None = None,
     is_queued: bool = False,
 ) -> None:
-    """Run comms once with the executor result, then save + WS-push the message.
+    """Run comms once with the executor result, then save + deliver the message.
 
     Comms is invoked silently — no SSE stream. Its generated text becomes the
     user-visible bot message. The executor's terminal text is NOT shown to the
     user directly; it's internal context for comms.
+
+    The message is always saved to the conversation, then delivered over EXACTLY
+    ONE transport chosen by the conversation's own ``source``:
+      - bot conversations (whatsapp/telegram/discord/slack) → that platform's
+        API (bots have no WebSocket — it's their only inbound path)
+      - everything else (web/mobile/system) → the WebSocket push web/mobile listen on
+    Routing keys on the conversation, not the run that produced the message, so a
+    background/scheduled run posting into a bot conversation still reaches it.
 
     Args:
         result_text: Executor's terminal text (or error message).
@@ -227,35 +257,54 @@ async def _deliver_bg_notification(
         log.error("_deliver_bg_notification: failed to save message", error=str(e))
         return
 
-    ws_payload: dict[str, Any] = {
-        "type": "bot",
-        "response": notification_text,
-        "message_id": bot_message.message_id,
-        "date": bot_message.date,
-    }
-    if tool_data:
-        ws_payload["tool_data"] = tool_data
-    if task_id:
-        ws_payload["task_id"] = task_id
-    if show_reply_quote:
-        ws_payload["replyToMessage"] = {
-            "id": user_message_id,
-            "content": user_msg_content,
-            "role": "user",
+    # Deliver over exactly one transport, decided by the conversation's source.
+    # Bot conversations go to their platform's API; web/mobile/system go to the
+    # WebSocket push. (The web conversation list excludes bot sources, so a
+    # WebSocket push for a bot conversation would be dropped anyway.)
+    conversation_source = await _get_conversation_source(conversation_id, user_id)
+    if is_bot_platform(conversation_source):
+        delivered = await deliver_message_to_platform(
+            conversation_source,
+            user_id,
+            notification_text,
+        )
+        transport = "platform"
+    else:
+        ws_payload: dict[str, Any] = {
+            "type": "bot",
+            "response": notification_text,
+            "message_id": bot_message.message_id,
+            "date": bot_message.date,
         }
-    await _broadcast_message(
-        user_id,
-        {
-            "type": "conversation.new_message",
-            "conversation_id": conversation_id,
-            "message": ws_payload,
-        },
-    )
+        if tool_data:
+            ws_payload["tool_data"] = tool_data
+        if task_id:
+            ws_payload["task_id"] = task_id
+        if show_reply_quote:
+            ws_payload["replyToMessage"] = {
+                "id": user_message_id,
+                "content": user_msg_content,
+                "role": "user",
+            }
+        await _broadcast_message(
+            user_id,
+            {
+                "type": "conversation.new_message",
+                "conversation_id": conversation_id,
+                "message": ws_payload,
+            },
+        )
+        delivered = True
+        transport = "websocket"
+
     log.info(
         "_deliver_bg_notification: delivered message",
         message_id=bot_message.message_id,
         task_id=task_id,
         conversation_id=conversation_id,
+        conversation_source=conversation_source.value if conversation_source else None,
+        transport=transport,
+        delivered=delivered,
     )
 
 

--- a/apps/api/app/agents/core/background/executor_runner.py
+++ b/apps/api/app/agents/core/background/executor_runner.py
@@ -120,9 +120,7 @@ async def _lookup_user_message_content(
     return ""
 
 
-async def _get_conversation_source(
-    conversation_id: str, user_id: str
-) -> ConversationSource | None:
+async def _get_conversation_source(conversation_id: str, user_id: str) -> ConversationSource | None:
     """Return the conversation's persisted originating source (web/whatsapp/...).
 
     This is the authoritative delivery-routing key: it says which channel the

--- a/apps/api/app/agents/core/subagents/handoff_tools.py
+++ b/apps/api/app/agents/core/subagents/handoff_tools.py
@@ -52,6 +52,7 @@ from app.utils.agent_utils import (
     format_subagent_start_event,
     parse_subagent_id,
 )
+from app.utils.integration_checker import build_integration_connection_message
 from shared.py.wide_events import log
 
 SUBAGENTS_NAMESPACE = ("subagents",)
@@ -118,7 +119,7 @@ async def check_integration_connection(
 
         writer({"integration_connection_required": integration_data})
 
-        return f"Integration {subagent.name} is not connected. Please connect it first."
+        return build_integration_connection_message(subagent.name)
 
     except Exception as e:
         log.error(f"Error checking integration status for {integration_id}: {e}")
@@ -332,10 +333,7 @@ async def _resolve_subagent(
             return (
                 None,
                 None,
-                (
-                    f"Error: {agent_name} requires OAuth connection. "
-                    f"Please connect {subagent.name} first via settings."
-                ),
+                build_integration_connection_message(subagent.name),
                 False,
             )
 

--- a/apps/api/app/agents/tools/executor_tool.py
+++ b/apps/api/app/agents/tools/executor_tool.py
@@ -54,6 +54,8 @@ _CONFIGURABLE_SCALAR_KEYS = frozenset(
         "user_message_id",
         "active_todo_id",
         "execution_mode",
+        "conversation_source",
+        "source_category",
     }
 )
 

--- a/apps/api/app/agents/tools/integration_tool.py
+++ b/apps/api/app/agents/tools/integration_tool.py
@@ -37,6 +37,7 @@ from app.templates.docstrings.integration_tool_docs import (
     CONNECT_INTEGRATION,
     LIST_INTEGRATIONS,
 )
+from app.utils.integration_checker import build_integration_connection_message
 from shared.py.wide_events import log
 
 # Stopwords to filter out from search queries
@@ -355,10 +356,7 @@ async def connect_integration(
 
             writer({"integration_connection_required": integration_data})
 
-            results.append(
-                f"🔗 Connection initiated for {integration.name}. "
-                f"Please follow the authentication flow."
-            )
+            results.append(build_integration_connection_message(integration.name))
 
         return "\n".join(results) if results else "No integrations to connect."
 

--- a/apps/api/app/constants/notifications.py
+++ b/apps/api/app/constants/notifications.py
@@ -16,6 +16,7 @@ CHANNEL_TYPE_EMAIL = "email"
 CHANNEL_TYPE_TELEGRAM = "telegram"
 CHANNEL_TYPE_DISCORD = "discord"
 CHANNEL_TYPE_WHATSAPP = "whatsapp"
+CHANNEL_TYPE_SLACK = "slack"
 
 # External channel types that are auto-injected based on platform links
 EXTERNAL_NOTIFICATION_CHANNELS = (
@@ -44,3 +45,4 @@ DEFAULT_CHANNEL_PREFERENCES: dict[str, bool] = {
 DISCORD_API_BASE = "https://discord.com/api/v10"
 TELEGRAM_BOT_API_BASE = "https://api.telegram.org/bot"
 KAPSO_API_BASE_URL = "https://api.kapso.ai"
+SLACK_API_BASE = "https://slack.com/api"

--- a/apps/api/app/helpers/agent_helpers.py
+++ b/apps/api/app/helpers/agent_helpers.py
@@ -33,6 +33,7 @@ from app.core.lazy_loader import providers
 from app.core.stream_manager import stream_manager
 from app.db.mongodb.collections import integrations_collection
 from app.db.redis import get_cache, set_cache
+from app.models.chat_models import ConversationSource, SourceCategory
 from app.models.models_models import ModelConfig
 from app.services.mcp.mcp_resource_fetcher import fetch_mcp_ui_resource
 from app.utils.agent_utils import (
@@ -335,6 +336,12 @@ def build_agent_config(
     )
     effective_tags = langfuse_tags if langfuse_tags is not None else inherited.get("langfuse_tags")
 
+    # Specific channel (web/mobile/whatsapp/...) and its generalized category
+    # (UI/Bot/BG). The channel falls back to "background" when unset because the
+    # only callers that omit a source are the silent background paths.
+    source_channel = resolved["source"] or ConversationSource.BACKGROUND.value
+    source_category = SourceCategory.from_source(resolved["source"]).value
+
     configurable = {
         "thread_id": thread_id or conversation_id,
         "user_id": user.get("user_id"),
@@ -354,6 +361,7 @@ def build_agent_config(
         "active_todo_id": resolved["active_todo_id"],
         "execution_mode": resolved["execution_mode"] or "interactive",
         "conversation_source": resolved["source"],
+        "source_category": source_category,
         "__pinned_memories__": resolved["pinned_memories"],
         "__pinned_skills__": resolved["pinned_skills"],
     }
@@ -365,7 +373,11 @@ def build_agent_config(
     if effective_tags:
         configurable["langfuse_tags"] = effective_tags
 
-    metadata: dict = {"user_id": user.get("user_id")}
+    metadata: dict = {
+        "user_id": user.get("user_id"),
+        "source_category": source_category,
+        "source_channel": source_channel,
+    }
     if effective_trace_id:
         metadata["langfuse_trace_id"] = effective_trace_id
         metadata["langfuse_session_id"] = conversation_id

--- a/apps/api/app/models/chat_models.py
+++ b/apps/api/app/models/chat_models.py
@@ -105,6 +105,65 @@ class ConversationSource(str, Enum):
     SLACK = "slack"
     WHATSAPP = "whatsapp"
     WORKFLOW_SYSTEM = "workflow_system"
+    BACKGROUND = "background"
+
+    @classmethod
+    def coerce(cls, value: "ConversationSource | str | None") -> "ConversationSource | None":
+        """Parse a raw source value (e.g. a stored string) into the enum.
+
+        Returns None for blank or unrecognised values so callers can compare on
+        enum members instead of raw strings.
+        """
+        if value is None or isinstance(value, cls):
+            return value
+        try:
+            return cls(value)
+        except ValueError:
+            return None
+
+
+class SourceCategory(str, Enum):
+    """Generalized origin of a graph invocation.
+
+    Coarser than ``ConversationSource``: every specific channel rolls up to one
+    of these so traces and tools can branch on "where did this run come from"
+    without enumerating every platform.
+    """
+
+    BG = "bg"  # autonomous background work (workflows, scheduled todos, sweeps)
+    UI = "ui"  # first-party clients (web, mobile, desktop)
+    BOT = "bot"  # messaging-platform bots (whatsapp, telegram, discord, slack)
+
+    @classmethod
+    def from_source(cls, source: "ConversationSource | str | None") -> "SourceCategory":
+        """Map a specific ``ConversationSource`` to its category.
+
+        Unknown / unset sources fall back to ``BG`` — the only callers that
+        leave the source blank are the silent background paths.
+        """
+        channel = ConversationSource.coerce(source)
+        if channel in _UI_SOURCES:
+            return cls.UI
+        if channel in BOT_CONVERSATION_SOURCES:
+            return cls.BOT
+        return cls.BG
+
+
+# Specific channels that belong to each generalized category. Single source of
+# truth for "which conversation sources are messaging-platform bots" — reused by
+# delivery routing and the web conversation-list filter. Members are enums so all
+# comparisons happen on ConversationSource, never raw strings.
+_UI_SOURCES: frozenset[ConversationSource] = frozenset(
+    {ConversationSource.WEB, ConversationSource.MOBILE}
+)
+BOT_CONVERSATION_SOURCES: frozenset[ConversationSource] = frozenset(
+    {
+        ConversationSource.WHATSAPP,
+        ConversationSource.TELEGRAM,
+        ConversationSource.DISCORD,
+        ConversationSource.SLACK,
+    }
+)
 
 
 class ConversationModel(BaseModel):

--- a/apps/api/app/services/conversation_service.py
+++ b/apps/api/app/services/conversation_service.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, status
 
 from app.db.mongodb.collections import conversations_collection
 from app.models.chat_models import (
+    BOT_CONVERSATION_SOURCES,
     BatchSyncRequest,
     ConversationModel,
     SystemPurpose,
@@ -86,8 +87,7 @@ async def get_conversations(user: dict, page: int = 1, limit: int = 10) -> dict:
     }
 
     # Exclude conversations originating from bots (they are accessible via direct URL)
-    _BOT_SOURCES = ["telegram", "discord", "slack", "whatsapp"]
-    _source_filter = {"source": {"$nin": _BOT_SOURCES}}
+    _source_filter = {"source": {"$nin": [s.value for s in BOT_CONVERSATION_SOURCES]}}
 
     starred_filter = {"user_id": user_id, "starred": True, **_source_filter}
     non_starred_filter = {

--- a/apps/api/app/services/platform_message_service.py
+++ b/apps/api/app/services/platform_message_service.py
@@ -1,0 +1,69 @@
+"""Deliver agent-generated chat messages to a user's linked bot platform.
+
+The web UI receives background/proactive bot messages over a WebSocket
+(``conversation.new_message``). Bot users have no such socket — their only
+inbound path is a request/response SSE turn that has already closed by the
+time a background executor finishes. This service is the bot-side equivalent
+of that push: it routes the message to the originating platform (WhatsApp,
+Telegram, Discord, Slack) using the same channel adapters the notification
+system uses, which DM the user via their stored ``platform_links`` identity.
+"""
+
+from app.models.chat_models import ConversationSource
+from app.models.notification.notification_models import NotificationStatus
+from app.utils.notification.channels import (
+    ChannelAdapter,
+    DiscordChannelAdapter,
+    SlackChannelAdapter,
+    TelegramChannelAdapter,
+    WhatsAppChannelAdapter,
+)
+from shared.py.wide_events import log
+
+# Conversation sources that map to a messaging-platform bot, and the adapter
+# that delivers to each. Keyed by the ConversationSource enum so routing never
+# compares raw strings.
+_PLATFORM_ADAPTERS: dict[ConversationSource, type[ChannelAdapter]] = {
+    ConversationSource.WHATSAPP: WhatsAppChannelAdapter,
+    ConversationSource.TELEGRAM: TelegramChannelAdapter,
+    ConversationSource.DISCORD: DiscordChannelAdapter,
+    ConversationSource.SLACK: SlackChannelAdapter,
+}
+
+
+def is_bot_platform(source: ConversationSource | str | None) -> bool:
+    """Whether ``source`` is a messaging-platform bot we can deliver to."""
+    return ConversationSource.coerce(source) in _PLATFORM_ADAPTERS
+
+
+async def deliver_message_to_platform(
+    source: ConversationSource | str | None, user_id: str, text: str
+) -> bool:
+    """Deliver ``text`` to ``user_id``'s linked account on ``source``.
+
+    Returns True only if the platform accepted the message. Non-bot sources,
+    unlinked accounts, and send failures all return False — this is a
+    best-effort side channel, never raising into the caller's flow.
+    """
+    platform = ConversationSource.coerce(source)
+    adapter_cls = _PLATFORM_ADAPTERS.get(platform) if platform else None
+    if adapter_cls is None:
+        return False
+    if not text.strip():
+        return False
+
+    try:
+        result = await adapter_cls().deliver_text(text, user_id)
+    except Exception as e:
+        log.error("deliver_message_to_platform: delivery raised", source=str(source), error=str(e))
+        return False
+
+    delivered = result.status == NotificationStatus.DELIVERED and not result.skipped
+    if not delivered:
+        log.warning(
+            "deliver_message_to_platform: not delivered",
+            source=platform.value,
+            skipped=result.skipped,
+            error=result.error_message,
+        )
+    return delivered

--- a/apps/api/app/utils/integration_checker.py
+++ b/apps/api/app/utils/integration_checker.py
@@ -6,13 +6,18 @@ permissions and stream connection prompts to the frontend when needed.
 """
 
 import httpx
-from langgraph.config import get_stream_writer
+from langgraph.config import get_config, get_stream_writer
 
 from app.config.oauth_config import get_integration_by_id, get_integration_scopes
+from app.config.settings import settings
 from app.config.token_repository import token_repository
+from app.models.chat_models import SourceCategory
 from shared.py.wide_events import log
 
 http_async_client = httpx.AsyncClient(timeout=10.0)
+
+# Frontend path where a user connects any integration.
+INTEGRATIONS_CONNECT_PATH = "/integrations"
 
 # Mapping of tool categories to required integrations
 TOOL_INTEGRATION_MAPPING = {
@@ -22,6 +27,40 @@ TOOL_INTEGRATION_MAPPING = {
     "google_drive": "google_drive",
     # Add more mappings as needed
 }
+
+
+def _current_source_category() -> str | None:
+    """Read the generalized source category (ui/bot/bg) from the active graph run.
+
+    Uses LangGraph's ambient config (same mechanism as ``get_stream_writer``), so
+    no config threading is needed. Returns None outside a runnable context.
+    """
+    try:
+        config = get_config()
+    except RuntimeError:
+        return None
+    return config.get("configurable", {}).get("source_category")
+
+
+def build_integration_connection_message(integration_name: str) -> str:
+    """Agent-facing instruction for getting an integration connected.
+
+    On UI clients a connect card/button is rendered alongside the reply, so the
+    agent just points the user at it. On non-UI clients (bots / background) that
+    card is not visible, so the agent is told to put the connect URL directly in
+    its reply — otherwise the user has no way to act on it.
+    """
+    if _current_source_category() == SourceCategory.UI.value:
+        return (
+            f"{integration_name} needs to be connected. A connect card has been shown to the "
+            f"user — ask them to connect it, then try again."
+        )
+    connect_url = f"{settings.FRONTEND_URL.rstrip('/')}{INTEGRATIONS_CONNECT_PATH}"
+    return (
+        f"{integration_name} needs to be connected. The user is on a platform that can't show "
+        f"connect buttons — include this link directly in your reply and ask them to open it in a "
+        f"browser to connect {integration_name}, then try again: {connect_url}"
+    )
 
 
 async def check_user_has_integration(access_token: str, integration_id: str) -> bool:

--- a/apps/api/app/utils/notification/channels/__init__.py
+++ b/apps/api/app/utils/notification/channels/__init__.py
@@ -2,6 +2,7 @@ from app.utils.notification.channels.base import ChannelAdapter, SendFn
 from app.utils.notification.channels.discord import DiscordChannelAdapter
 from app.utils.notification.channels.external import ExternalPlatformAdapter
 from app.utils.notification.channels.inapp import InAppChannelAdapter
+from app.utils.notification.channels.slack import SlackChannelAdapter
 from app.utils.notification.channels.telegram import TelegramChannelAdapter
 from app.utils.notification.channels.whatsapp import WhatsAppChannelAdapter
 
@@ -11,6 +12,7 @@ __all__ = [
     "ExternalPlatformAdapter",
     "InAppChannelAdapter",
     "SendFn",
+    "SlackChannelAdapter",
     "TelegramChannelAdapter",
     "WhatsAppChannelAdapter",
 ]

--- a/apps/api/app/utils/notification/channels/base.py
+++ b/apps/api/app/utils/notification/channels/base.py
@@ -35,6 +35,16 @@ class ChannelAdapter(ABC):
         """Deliver notification via this channel."""
         pass
 
+    async def deliver_text(self, text: str, user_id: str) -> ChannelDeliveryStatus:
+        """Deliver a single plain chat message (raw Markdown) to ``user_id``.
+
+        Bypasses the notification ``transform`` step — used to push agent-generated
+        chat messages (not notifications) to a user's linked platform. The default
+        passes the text straight through; adapters whose Markdown conversion lives
+        in ``transform`` (rather than at send time) override this to convert first.
+        """
+        return await self.deliver({"text": text}, user_id)
+
     # -- Status helpers -----------------------------------------------------
 
     def _success(self) -> ChannelDeliveryStatus:

--- a/apps/api/app/utils/notification/channels/slack.py
+++ b/apps/api/app/utils/notification/channels/slack.py
@@ -1,0 +1,88 @@
+"""Slack notification channel adapter.
+
+Delivers messages to a user's linked Slack account via DM, using the
+workspace bot token (``SLACK_BOT_TOKEN``) and Slack's Web API. The bot opens
+a DM channel with the user (``conversations.open``) and posts to it
+(``chat.postMessage``).
+
+The platform_user_id stored in platform_links.slack is the Slack user id
+(e.g. "U0123456789"). Markdown is converted to Slack's mrkdwn at send time.
+
+Slack's Web API returns HTTP 200 even on logical failures, signalling the
+real outcome via the ``ok`` field — so every response is parsed and checked.
+"""
+
+from typing import Any
+
+import aiohttp
+
+from app.config.settings import settings
+from app.constants.notifications import CHANNEL_TYPE_SLACK, SLACK_API_BASE
+from app.models.notification.notification_models import ChannelDeliveryStatus
+from app.utils.notification.channels.base import SendFn
+from app.utils.notification.channels.external import ExternalPlatformAdapter
+from app.utils.platform_markdown import convert_to_slack_mrkdwn
+
+
+class SlackChannelAdapter(ExternalPlatformAdapter):
+    """Delivers notifications to a user's linked Slack account via DM."""
+
+    MAX_MESSAGE_LENGTH = 3000  # Slack renders cleanly well below its 40k hard limit
+
+    @property
+    def channel_type(self) -> str:
+        return CHANNEL_TYPE_SLACK
+
+    @property
+    def platform_name(self) -> str:
+        return CHANNEL_TYPE_SLACK
+
+    @property
+    def bold_marker(self) -> str:
+        # Slack uses *bold* (single asterisk); send-time mrkdwn conversion
+        # normalises any **bold** in the body to the same form.
+        return "*"
+
+    def _get_bot_token(self) -> str | None:
+        return settings.SLACK_BOT_TOKEN
+
+    def _session_kwargs(self, ctx: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "headers": {
+                "Authorization": f"Bearer {ctx['token']}",
+                "Content-Type": "application/json; charset=utf-8",
+            }
+        }
+
+    async def _setup_sender(
+        self, session: aiohttp.ClientSession, ctx: dict[str, Any]
+    ) -> tuple[SendFn | None, ChannelDeliveryStatus | None]:
+        # Open (or fetch) the DM channel with the user.
+        async with session.post(
+            f"{SLACK_API_BASE}/conversations.open",
+            json={"users": ctx["platform_user_id"]},
+        ) as resp:
+            if resp.status != 200:
+                return None, self._error(f"Slack conversations.open HTTP {resp.status}")
+            data = await resp.json()
+
+        if not data.get("ok"):
+            return None, self._error(f"Slack conversations.open error: {data.get('error')}")
+
+        dm_channel_id = (data.get("channel") or {}).get("id")
+        if not dm_channel_id:
+            return None, self._error("Slack DM channel id missing from response")
+
+        post_url = f"{SLACK_API_BASE}/chat.postMessage"
+
+        async def send(text: str) -> str | None:
+            payload = {"channel": dm_channel_id, "text": convert_to_slack_mrkdwn(text)}
+            async with session.post(post_url, json=payload) as r:
+                if r.status != 200:
+                    return await r.text()
+                body = await r.json()
+            if not body.get("ok"):
+                return str(body.get("error"))
+            return None
+
+        return send, None

--- a/apps/api/app/utils/notification/channels/whatsapp.py
+++ b/apps/api/app/utils/notification/channels/whatsapp.py
@@ -69,6 +69,15 @@ class WhatsAppChannelAdapter(ExternalPlatformAdapter):
             payload["text"] = convert_to_whatsapp_markdown(text)
         return payload
 
+    async def deliver_text(self, text: str, user_id: str) -> ChannelDeliveryStatus:
+        """Convert Markdown to WhatsApp formatting before delivery.
+
+        WhatsApp's Markdown conversion lives in ``transform`` (not at send time),
+        so the plain-text path must convert here or ``**bold**`` would render
+        literally.
+        """
+        return await self.deliver({"text": convert_to_whatsapp_markdown(text)}, user_id)
+
     def _get_bot_token(self) -> str | None:
         # For WhatsApp via Kapso, authentication is the API key, not a bot token.
         # We return the API key so _get_platform_context's token-check passes.

--- a/apps/api/app/utils/notification/orchestrator.py
+++ b/apps/api/app/utils/notification/orchestrator.py
@@ -31,6 +31,7 @@ from app.utils.notification.channels import (
     ChannelAdapter,
     DiscordChannelAdapter,
     InAppChannelAdapter,
+    SlackChannelAdapter,
     TelegramChannelAdapter,
     WhatsAppChannelAdapter,
 )
@@ -68,6 +69,7 @@ class NotificationOrchestrator:
         self.register_channel_adapter(TelegramChannelAdapter())
         self.register_channel_adapter(DiscordChannelAdapter())
         self.register_channel_adapter(WhatsAppChannelAdapter())
+        self.register_channel_adapter(SlackChannelAdapter())
 
         # Action handlers
         self.register_action_handler(ApiCallActionHandler())

--- a/apps/api/tests/unit/agents/test_executor_runner_delivery.py
+++ b/apps/api/tests/unit/agents/test_executor_runner_delivery.py
@@ -59,9 +59,7 @@ class TestDeliverBgNotificationRouting:
         ws.assert_not_awaited()  # exclusive: no WebSocket fan-out for bots
         save.assert_awaited_once()  # always persisted to history
 
-    @pytest.mark.parametrize(
-        "src", [ConversationSource.WEB, ConversationSource.MOBILE, None]
-    )
+    @pytest.mark.parametrize("src", [ConversationSource.WEB, ConversationSource.MOBILE, None])
     async def test_non_bot_conversation_broadcasts_over_websocket_only(self, src) -> None:
         save, platform, ws = await _deliver(src)
 

--- a/apps/api/tests/unit/agents/test_executor_runner_delivery.py
+++ b/apps/api/tests/unit/agents/test_executor_runner_delivery.py
@@ -1,0 +1,120 @@
+"""Unit tests for background-executor message delivery routing.
+
+The key invariant: a background result is delivered over EXACTLY ONE transport,
+chosen by the conversation's own source — bot conversations to their platform,
+everything else over WebSocket — and the message is always persisted.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agents.core.background import executor_runner as er
+from app.models.chat_models import ConversationSource
+
+
+async def _deliver(conv_source, *, comms_text="result text", result_text="raw"):
+    """Run _deliver_bg_notification with all I/O boundaries mocked.
+
+    Returns (save_mock, platform_mock, ws_mock) for assertions. The real
+    is_bot_platform routing logic runs unmocked against ``conv_source``.
+    """
+    with (
+        patch.object(er, "_invoke_comms_graph", new_callable=AsyncMock, return_value=comms_text),
+        patch.object(er, "update_messages", new_callable=AsyncMock) as save,
+        patch.object(
+            er, "_get_conversation_source", new_callable=AsyncMock, return_value=conv_source
+        ),
+        patch.object(
+            er, "deliver_message_to_platform", new_callable=AsyncMock, return_value=True
+        ) as platform,
+        patch.object(er, "_broadcast_message", new_callable=AsyncMock) as ws,
+    ):
+        await er._deliver_bg_notification(
+            result_text=result_text,
+            msg_type="final",
+            conversation_id="conv-1",
+            user={"user_id": "user-1"},
+        )
+    return save, platform, ws
+
+
+@pytest.mark.unit
+class TestDeliverBgNotificationRouting:
+    @pytest.mark.parametrize(
+        "src",
+        [
+            ConversationSource.WHATSAPP,
+            ConversationSource.SLACK,
+            ConversationSource.DISCORD,
+            ConversationSource.TELEGRAM,
+        ],
+    )
+    async def test_bot_conversation_delivers_to_platform_only(self, src) -> None:
+        save, platform, ws = await _deliver(src)
+
+        platform.assert_awaited_once()
+        assert platform.await_args.args[0] == src  # routed to the conversation's platform
+        assert platform.await_args.args[2] == "result text"  # the comms-generated text
+        ws.assert_not_awaited()  # exclusive: no WebSocket fan-out for bots
+        save.assert_awaited_once()  # always persisted to history
+
+    @pytest.mark.parametrize(
+        "src", [ConversationSource.WEB, ConversationSource.MOBILE, None]
+    )
+    async def test_non_bot_conversation_broadcasts_over_websocket_only(self, src) -> None:
+        save, platform, ws = await _deliver(src)
+
+        ws.assert_awaited_once()
+        platform.assert_not_awaited()  # exclusive: no platform send for web/mobile/system
+        save.assert_awaited_once()
+
+    async def test_websocket_payload_carries_conversation_and_message(self) -> None:
+        _save, _platform, ws = await _deliver(ConversationSource.WEB)
+        event = ws.await_args.args[1]
+        assert event["type"] == "conversation.new_message"
+        assert event["conversation_id"] == "conv-1"
+        assert event["message"]["response"] == "result text"
+
+    async def test_falls_back_to_raw_executor_text_when_comms_unavailable(self) -> None:
+        # comms returns "" → the raw executor text must still be delivered.
+        _save, platform, _ws = await _deliver(
+            ConversationSource.WHATSAPP, comms_text="", result_text="raw executor output"
+        )
+        assert platform.await_args.args[2] == "raw executor output"
+
+
+@pytest.mark.unit
+class TestGetConversationSource:
+    """The authoritative routing key: the conversation's persisted source."""
+
+    async def test_returns_coerced_enum_from_stored_string(self) -> None:
+        with patch.object(er, "conversations_collection") as col:
+            col.find_one = AsyncMock(return_value={"source": "whatsapp"})
+            src = await er._get_conversation_source("conv-1", "user-1")
+        assert src is ConversationSource.WHATSAPP  # coerced to the enum, not a raw str
+
+    async def test_query_is_scoped_to_conversation_and_owner(self) -> None:
+        with patch.object(er, "conversations_collection") as col:
+            col.find_one = AsyncMock(return_value={"source": "web"})
+            await er._get_conversation_source("conv-1", "user-1")
+        # must be scoped by BOTH conversation_id and user_id (no cross-user read)
+        assert col.find_one.await_args.args[0] == {
+            "conversation_id": "conv-1",
+            "user_id": "user-1",
+        }
+
+    async def test_missing_conversation_returns_none(self) -> None:
+        with patch.object(er, "conversations_collection") as col:
+            col.find_one = AsyncMock(return_value=None)
+            assert await er._get_conversation_source("conv-1", "user-1") is None
+
+    async def test_unknown_stored_value_coerces_to_none(self) -> None:
+        with patch.object(er, "conversations_collection") as col:
+            col.find_one = AsyncMock(return_value={"source": "legacy_garbage"})
+            assert await er._get_conversation_source("conv-1", "user-1") is None
+
+    async def test_db_error_returns_none(self) -> None:
+        with patch.object(er, "conversations_collection") as col:
+            col.find_one = AsyncMock(side_effect=RuntimeError("mongo down"))
+            assert await er._get_conversation_source("conv-1", "user-1") is None

--- a/apps/api/tests/unit/agents/test_handoff_tools.py
+++ b/apps/api/tests/unit/agents/test_handoff_tools.py
@@ -100,7 +100,7 @@ class TestCheckIntegrationConnection:
             result = await check_integration_connection("gmail", "user1")
 
         assert result is not None
-        assert "not connected" in result
+        assert "needs to be connected" in result
         assert mock_writer.call_count == 2  # progress + connection_required
 
     async def test_returns_none_on_exception(self):
@@ -413,7 +413,7 @@ class TestResolveSubagent:
             mock_ts_cls.return_value = mock_ts
             graph, name, error, is_custom = await _resolve_subagent("gmail", "user1")
         assert graph is None
-        assert "OAuth" in error
+        assert "needs to be connected" in error
 
     async def test_platform_mcp_requires_auth_no_user(self):
         mcp_cfg = MCPConfig(server_url="https://example.com", requires_auth=True)

--- a/apps/api/tests/unit/helpers/test_agent_helpers.py
+++ b/apps/api/tests/unit/helpers/test_agent_helpers.py
@@ -11,7 +11,6 @@ from app.helpers.agent_helpers import (
     build_initial_state,
     execute_graph_silent,
     execute_graph_streaming,
-    get_custom_integration_metadata,
     get_handoff_metadata,
 )
 from app.models.mcp_config import SubAgentConfig
@@ -113,118 +112,6 @@ class TestExtractTimezoneOffset:
         tz = timezone(timedelta(hours=12, minutes=45))
         dt = datetime(2025, 1, 1, tzinfo=tz)
         assert _extract_timezone_offset(dt) == "+12:45"
-
-
-# ---------------------------------------------------------------------------
-# get_custom_integration_metadata
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-class TestGetCustomIntegrationMetadata:
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_no_category_returns_empty(self, mock_get_registry):
-        mock_registry = MagicMock()
-        mock_registry.get_category_of_tool.return_value = None
-        mock_get_registry.return_value = mock_registry
-
-        result = await get_custom_integration_metadata("some_tool", USER_ID)
-        assert result == {}
-
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_non_mcp_category_returns_empty(self, mock_get_registry):
-        mock_registry = MagicMock()
-        mock_registry.get_category_of_tool.return_value = "gmail"
-        mock_get_registry.return_value = mock_registry
-
-        result = await get_custom_integration_metadata("gmail_send", USER_ID)
-        assert result == {}
-
-    @patch("app.helpers.agent_helpers.set_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.get_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.integrations_collection")
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_mcp_category_cache_hit(
-        self, mock_get_registry, mock_col, mock_get_cache, mock_set_cache
-    ):
-        mock_registry = MagicMock()
-        mock_registry.get_category_of_tool.return_value = "mcp_custom_reposearch_abc123"
-        mock_get_registry.return_value = mock_registry
-        mock_get_cache.return_value = {
-            "icon_url": "https://icon.png",
-            "integration_id": "custom_reposearch_abc123",
-        }
-
-        result = await get_custom_integration_metadata("repo_search", USER_ID)
-        assert result["icon_url"] == "https://icon.png"
-
-    @patch("app.helpers.agent_helpers.set_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.get_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.integrations_collection")
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_mcp_category_cache_miss_found_in_db(
-        self, mock_get_registry, mock_col, mock_get_cache, mock_set_cache
-    ):
-        mock_registry = MagicMock()
-        mock_registry.get_category_of_tool.return_value = "mcp_custom_tool"
-        mock_get_registry.return_value = mock_registry
-        mock_get_cache.return_value = None
-        mock_col.find_one = AsyncMock(
-            return_value={"name": "Custom Tool", "icon_url": "https://img.png"}
-        )
-
-        result = await get_custom_integration_metadata("my_tool", USER_ID)
-        assert result["integration_name"] == "Custom Tool"
-        assert result["icon_url"] == "https://img.png"
-        mock_set_cache.assert_called_once()
-
-    @patch("app.helpers.agent_helpers.set_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.get_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.integrations_collection")
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_mcp_category_not_found_in_db(
-        self, mock_get_registry, mock_col, mock_get_cache, mock_set_cache
-    ):
-        mock_registry = MagicMock()
-        mock_registry.get_category_of_tool.return_value = "mcp_unknown"
-        mock_get_registry.return_value = mock_registry
-        mock_get_cache.return_value = None
-        mock_col.find_one = AsyncMock(return_value=None)
-
-        result = await get_custom_integration_metadata("unknown_tool", USER_ID)
-        assert result == {}
-        # Negative result cached
-        mock_set_cache.assert_called_once()
-
-    @patch("app.helpers.agent_helpers.set_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.get_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.integrations_collection")
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_mcp_category_db_error_returns_empty(
-        self, mock_get_registry, mock_col, mock_get_cache, mock_set_cache
-    ):
-        mock_registry = MagicMock()
-        mock_registry.get_category_of_tool.return_value = "mcp_broken"
-        mock_get_registry.return_value = mock_registry
-        mock_get_cache.return_value = None
-        mock_col.find_one = AsyncMock(side_effect=Exception("DB down"))
-
-        result = await get_custom_integration_metadata("broken_tool", USER_ID)
-        assert result == {}
-
-    @patch("app.helpers.agent_helpers.get_cache", new_callable=AsyncMock)
-    @patch("app.helpers.agent_helpers.get_tool_registry", new_callable=AsyncMock)
-    async def test_mcp_category_with_uuid_suffix_stripped(self, mock_get_registry, mock_get_cache):
-        """UUID-like suffix (>= 32 chars with dashes) should be stripped from integration ID."""
-        mock_registry = MagicMock()
-        # category: mcp_{integration_id}_{uuid_user_id}
-        uuid_suffix = "550e8400-e29b-41d4-a716-446655440000"
-        mock_registry.get_category_of_tool.return_value = f"mcp_myintegration_{uuid_suffix}"
-        mock_get_registry.return_value = mock_registry
-        mock_get_cache.return_value = {"integration_id": "myintegration"}
-
-        result = await get_custom_integration_metadata("tool_x", USER_ID)
-        assert result["integration_id"] == "myintegration"
 
 
 # ---------------------------------------------------------------------------
@@ -495,6 +382,94 @@ class TestBuildAgentConfig:
         assert config["configurable"]["selected_tool"] == "search"
         assert config["configurable"]["tool_category"] == "web"
 
+    @patch("app.helpers.agent_helpers.providers")
+    @patch("app.helpers.agent_helpers.settings")
+    def test_bot_source_sets_bot_category_and_channel(
+        self, mock_settings, mock_providers
+    ) -> None:
+        mock_settings.ENV = "development"
+        mock_settings.OPIK_API_KEY = None
+        mock_settings.OPIK_WORKSPACE = None
+        mock_providers.get.return_value = None
+
+        config = build_agent_config(
+            conversation_id=CONV_ID,
+            user=FAKE_USER,
+            user_time=_make_user_time(),
+            agent_name="comms_agent",
+            source="whatsapp",
+        )
+        # raw channel preserved in configurable; generalized category derived
+        assert config["configurable"]["conversation_source"] == "whatsapp"
+        assert config["configurable"]["source_category"] == "bot"
+        # both surfaced on trace metadata for observability
+        assert config["metadata"]["source_category"] == "bot"
+        assert config["metadata"]["source_channel"] == "whatsapp"
+
+    @patch("app.helpers.agent_helpers.providers")
+    @patch("app.helpers.agent_helpers.settings")
+    def test_web_source_sets_ui_category(self, mock_settings, mock_providers) -> None:
+        mock_settings.ENV = "development"
+        mock_settings.OPIK_API_KEY = None
+        mock_settings.OPIK_WORKSPACE = None
+        mock_providers.get.return_value = None
+
+        config = build_agent_config(
+            conversation_id=CONV_ID,
+            user=FAKE_USER,
+            user_time=_make_user_time(),
+            agent_name="comms_agent",
+            source="web",
+        )
+        assert config["configurable"]["source_category"] == "ui"
+        assert config["metadata"]["source_category"] == "ui"
+        assert config["metadata"]["source_channel"] == "web"
+
+    @patch("app.helpers.agent_helpers.providers")
+    @patch("app.helpers.agent_helpers.settings")
+    def test_missing_source_defaults_to_background(
+        self, mock_settings, mock_providers
+    ) -> None:
+        mock_settings.ENV = "development"
+        mock_settings.OPIK_API_KEY = None
+        mock_settings.OPIK_WORKSPACE = None
+        mock_providers.get.return_value = None
+
+        config = build_agent_config(
+            conversation_id=CONV_ID,
+            user=FAKE_USER,
+            user_time=_make_user_time(),
+            agent_name="comms_agent",
+        )
+        # no source -> BG category, channel labelled "background" in metadata
+        assert config["configurable"]["conversation_source"] is None
+        assert config["configurable"]["source_category"] == "bg"
+        assert config["metadata"]["source_category"] == "bg"
+        assert config["metadata"]["source_channel"] == "background"
+
+    @patch("app.helpers.agent_helpers.providers")
+    @patch("app.helpers.agent_helpers.settings")
+    def test_source_inherited_from_base_configurable(
+        self, mock_settings, mock_providers
+    ) -> None:
+        """A child agent (e.g. executor) inherits the channel from its parent and
+        recomputes the category — so background runs are still tagged Bot/UI."""
+        mock_settings.ENV = "development"
+        mock_settings.OPIK_API_KEY = None
+        mock_settings.OPIK_WORKSPACE = None
+        mock_providers.get.return_value = None
+
+        config = build_agent_config(
+            conversation_id=CONV_ID,
+            user=FAKE_USER,
+            user_time=_make_user_time(),
+            agent_name="executor",
+            base_configurable={"conversation_source": "telegram"},
+        )
+        assert config["configurable"]["conversation_source"] == "telegram"
+        assert config["configurable"]["source_category"] == "bot"
+        assert config["metadata"]["source_channel"] == "telegram"
+
 
 # ---------------------------------------------------------------------------
 # build_initial_state
@@ -579,7 +554,7 @@ class TestExecuteGraphSilent:
         msg, tool_data = await execute_graph_silent(
             graph,
             {"query": "test"},
-            {"configurable": {"user_id": USER_ID}},
+            {"agent_name": "comms_agent", "configurable": {"user_id": USER_ID}},
         )
 
         assert msg == "Hello world"
@@ -598,10 +573,11 @@ class TestExecuteGraphSilent:
         graph = AsyncMock()
         graph.astream = MagicMock(return_value=_async_iter(events))
 
+        # agent_name is comms_agent, so only the `silent` flag should suppress it.
         msg, _ = await execute_graph_silent(
             graph,
             {},
-            {"configurable": {"user_id": USER_ID}},
+            {"agent_name": "comms_agent", "configurable": {"user_id": USER_ID}},
         )
         assert msg == ""
 
@@ -619,10 +595,11 @@ class TestExecuteGraphSilent:
         graph = AsyncMock()
         graph.astream = MagicMock(return_value=_async_iter(events))
 
+        # Non-comms agent: content must NOT be accumulated even though it exists.
         msg, _ = await execute_graph_silent(
             graph,
             {},
-            {"configurable": {"user_id": USER_ID}},
+            {"agent_name": "executor_agent", "configurable": {"user_id": USER_ID}},
         )
         assert msg == ""
 
@@ -676,6 +653,7 @@ class TestExecuteGraphSilent:
     @patch("app.helpers.agent_helpers.format_tool_call_entry", new_callable=AsyncMock)
     @patch("app.helpers.agent_helpers.get_handoff_metadata", new_callable=AsyncMock)
     async def test_updates_handoff_tool_calls(self, mock_handoff, mock_format):
+        """handoff tool calls on the agent node resolve + forward handoff metadata."""
         mock_handoff.return_value = {
             "icon_url": "https://icon.png",
             "integration_id": "github",
@@ -686,7 +664,7 @@ class TestExecuteGraphSilent:
         msg.tool_calls = [{"id": "tc1", "name": "handoff", "args": {"subagent_id": "github"}}]
 
         events = [
-            ((), "updates", {"node1": {"messages": [msg]}}),
+            ((), "updates", {"agent": {"messages": [msg]}}),
         ]
 
         graph = AsyncMock()
@@ -699,22 +677,21 @@ class TestExecuteGraphSilent:
         )
 
         mock_handoff.assert_called_once_with("github")
-        assert len(tool_data["tool_data"]) == 1
+        # The resolved handoff metadata must be forwarded into the formatted entry.
+        assert mock_format.await_args.kwargs["integration_id"] == "github"
+        assert tool_data["tool_data"] == [{"tool_name": "handoff", "data": {}}]
 
     @patch("app.helpers.agent_helpers.format_tool_call_entry", new_callable=AsyncMock)
-    @patch(
-        "app.helpers.agent_helpers.get_custom_integration_metadata",
-        new_callable=AsyncMock,
-    )
-    async def test_updates_custom_tool_calls(self, mock_custom_meta, mock_format):
-        mock_custom_meta.return_value = {"icon_url": None, "integration_id": "mcp_x"}
+    async def test_updates_regular_tool_calls_thread_user_id(self, mock_format):
+        """Non-handoff tool calls are formatted with the originating user_id (so
+        format_tool_call_entry can resolve MCP metadata) and appended."""
         mock_format.return_value = {"tool_name": "custom_tool", "data": {}}
 
         msg = MagicMock()
         msg.tool_calls = [{"id": "tc2", "name": "custom_tool", "args": {}}]
 
         events = [
-            ((), "updates", {"node1": {"messages": [msg]}}),
+            ((), "updates", {"agent": {"messages": [msg]}}),
         ]
 
         graph = AsyncMock()
@@ -726,10 +703,39 @@ class TestExecuteGraphSilent:
             {"configurable": {"user_id": USER_ID}},
         )
 
-        mock_custom_meta.assert_called_once()
+        mock_format.assert_awaited_once()
+        assert mock_format.await_args.kwargs["user_id"] == USER_ID
+        assert tool_data["tool_data"] == [{"tool_name": "custom_tool", "data": {}}]
+
+    async def test_updates_ignores_non_agent_nodes(self):
+        """Tool calls from non-'agent' nodes (e.g. pre-model hooks replaying old
+        history) must not be collected."""
+        msg = MagicMock()
+        msg.tool_calls = [{"id": "tc_hook", "name": "some_tool", "args": {}}]
+
+        events = [
+            ((), "updates", {"pre_model_hook": {"messages": [msg]}}),
+        ]
+
+        graph = AsyncMock()
+        graph.astream = MagicMock(return_value=_async_iter(events))
+
+        with patch(
+            "app.helpers.agent_helpers.format_tool_call_entry",
+            new_callable=AsyncMock,
+            return_value={"tool_name": "some_tool"},
+        ) as mock_format:
+            _, tool_data = await execute_graph_silent(
+                graph,
+                {},
+                {"configurable": {"user_id": USER_ID}},
+            )
+
+        mock_format.assert_not_awaited()
+        assert tool_data["tool_data"] == []
 
     async def test_updates_skips_plan_tasks(self):
-        """plan_tasks and update_tasks tool calls should be skipped."""
+        """plan_tasks and update_tasks tool calls are filtered before formatting."""
         msg = MagicMock()
         msg.tool_calls = [
             {"id": "tc_plan", "name": "plan_tasks", "args": {}},
@@ -737,51 +743,51 @@ class TestExecuteGraphSilent:
         ]
 
         events = [
-            ((), "updates", {"node1": {"messages": [msg]}}),
+            ((), "updates", {"agent": {"messages": [msg]}}),
         ]
 
         graph = AsyncMock()
         graph.astream = MagicMock(return_value=_async_iter(events))
 
-        _, tool_data = await execute_graph_silent(
-            graph,
-            {},
-            {"configurable": {"user_id": USER_ID}},
-        )
-
-        assert len(tool_data["tool_data"]) == 0
-
-    async def test_updates_deduplicates_tool_calls(self):
-        """Same tool call ID should not be emitted twice."""
-        msg = MagicMock()
-        msg.tool_calls = [{"id": "tc_dup", "name": "some_tool", "args": {}}]
-
-        events = [
-            ((), "updates", {"node1": {"messages": [msg]}}),
-            ((), "updates", {"node2": {"messages": [msg]}}),
-        ]
-
-        graph = AsyncMock()
-        graph.astream = MagicMock(return_value=_async_iter(events))
-
-        with (
-            patch(
-                "app.helpers.agent_helpers.get_custom_integration_metadata",
-                new_callable=AsyncMock,
-                return_value={},
-            ),
-            patch(
-                "app.helpers.agent_helpers.format_tool_call_entry",
-                new_callable=AsyncMock,
-                return_value={"tool_name": "t"},
-            ),
-        ):
+        with patch(
+            "app.helpers.agent_helpers.format_tool_call_entry",
+            new_callable=AsyncMock,
+            return_value={"tool_name": "should_not_appear"},
+        ) as mock_format:
             _, tool_data = await execute_graph_silent(
                 graph,
                 {},
                 {"configurable": {"user_id": USER_ID}},
             )
 
+        mock_format.assert_not_awaited()
+        assert len(tool_data["tool_data"]) == 0
+
+    async def test_updates_deduplicates_tool_calls(self):
+        """Same tool call ID across multiple agent updates is emitted once."""
+        msg = MagicMock()
+        msg.tool_calls = [{"id": "tc_dup", "name": "some_tool", "args": {}}]
+
+        events = [
+            ((), "updates", {"agent": {"messages": [msg]}}),
+            ((), "updates", {"agent": {"messages": [msg]}}),
+        ]
+
+        graph = AsyncMock()
+        graph.astream = MagicMock(return_value=_async_iter(events))
+
+        with patch(
+            "app.helpers.agent_helpers.format_tool_call_entry",
+            new_callable=AsyncMock,
+            return_value={"tool_name": "t"},
+        ) as mock_format:
+            _, tool_data = await execute_graph_silent(
+                graph,
+                {},
+                {"configurable": {"user_id": USER_ID}},
+            )
+
+        assert mock_format.await_count == 1  # the duplicate is not formatted again
         assert len(tool_data["tool_data"]) == 1
 
 
@@ -852,7 +858,9 @@ class TestExecuteGraphStreaming:
         graph.astream = MagicMock(return_value=_async_iter(events))
 
         results = []
-        async for s in execute_graph_streaming(graph, {}, {"configurable": {}}):
+        async for s in execute_graph_streaming(
+            graph, {}, {"agent_name": "comms_agent", "configurable": {}}
+        ):
             results.append(s)
 
         assert any("Hello" in r for r in results)

--- a/apps/api/tests/unit/helpers/test_agent_helpers.py
+++ b/apps/api/tests/unit/helpers/test_agent_helpers.py
@@ -384,9 +384,7 @@ class TestBuildAgentConfig:
 
     @patch("app.helpers.agent_helpers.providers")
     @patch("app.helpers.agent_helpers.settings")
-    def test_bot_source_sets_bot_category_and_channel(
-        self, mock_settings, mock_providers
-    ) -> None:
+    def test_bot_source_sets_bot_category_and_channel(self, mock_settings, mock_providers) -> None:
         mock_settings.ENV = "development"
         mock_settings.OPIK_API_KEY = None
         mock_settings.OPIK_WORKSPACE = None
@@ -427,9 +425,7 @@ class TestBuildAgentConfig:
 
     @patch("app.helpers.agent_helpers.providers")
     @patch("app.helpers.agent_helpers.settings")
-    def test_missing_source_defaults_to_background(
-        self, mock_settings, mock_providers
-    ) -> None:
+    def test_missing_source_defaults_to_background(self, mock_settings, mock_providers) -> None:
         mock_settings.ENV = "development"
         mock_settings.OPIK_API_KEY = None
         mock_settings.OPIK_WORKSPACE = None
@@ -449,9 +445,7 @@ class TestBuildAgentConfig:
 
     @patch("app.helpers.agent_helpers.providers")
     @patch("app.helpers.agent_helpers.settings")
-    def test_source_inherited_from_base_configurable(
-        self, mock_settings, mock_providers
-    ) -> None:
+    def test_source_inherited_from_base_configurable(self, mock_settings, mock_providers) -> None:
         """A child agent (e.g. executor) inherits the channel from its parent and
         recomputes the category — so background runs are still tagged Bot/UI."""
         mock_settings.ENV = "development"

--- a/apps/api/tests/unit/models/test_schema_validation.py
+++ b/apps/api/tests/unit/models/test_schema_validation.py
@@ -10,6 +10,7 @@ from app.models.chat_models import (
     ConversationSyncItem,
     ImageData,
     MessageModel,
+    SourceCategory,
     SystemPurpose,
     UpdateMessagesRequest,
 )
@@ -409,3 +410,48 @@ class TestMemoryModels:
     def test_create_memory_request_missing_content(self):
         with pytest.raises(ValidationError):
             CreateMemoryRequest()
+
+
+@pytest.mark.unit
+class TestConversationSourceCoerce:
+    """ConversationSource.coerce parses raw values into the enum (or None)."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("whatsapp", ConversationSource.WHATSAPP),
+            ("web", ConversationSource.WEB),
+            ("background", ConversationSource.BACKGROUND),
+            (ConversationSource.SLACK, ConversationSource.SLACK),
+        ],
+    )
+    def test_valid_values_coerce_to_enum(self, raw, expected):
+        assert ConversationSource.coerce(raw) is expected
+
+    @pytest.mark.parametrize("raw", [None, "", "nonsense", "gmail"])
+    def test_invalid_values_return_none(self, raw):
+        assert ConversationSource.coerce(raw) is None
+
+
+@pytest.mark.unit
+class TestSourceCategoryFromSource:
+    """SourceCategory.from_source maps a specific channel to its category."""
+
+    @pytest.mark.parametrize(
+        "source,category",
+        [
+            ("web", SourceCategory.UI),
+            ("mobile", SourceCategory.UI),
+            ("whatsapp", SourceCategory.BOT),
+            ("telegram", SourceCategory.BOT),
+            ("discord", SourceCategory.BOT),
+            ("slack", SourceCategory.BOT),
+            (ConversationSource.WHATSAPP, SourceCategory.BOT),
+            ("workflow_system", SourceCategory.BG),
+            ("background", SourceCategory.BG),
+            (None, SourceCategory.BG),
+            ("nonsense", SourceCategory.BG),
+        ],
+    )
+    def test_category_mapping(self, source, category):
+        assert SourceCategory.from_source(source) is category

--- a/apps/api/tests/unit/services/test_platform_message_service.py
+++ b/apps/api/tests/unit/services/test_platform_message_service.py
@@ -126,9 +126,7 @@ class TestAdapterRegistryConsistency:
         # versa), this fails — a bot user would otherwise silently get nothing.
         assert set(pms._PLATFORM_ADAPTERS) == BOT_CONVERSATION_SOURCES
 
-    @pytest.mark.parametrize(
-        "source", sorted(BOT_CONVERSATION_SOURCES, key=lambda s: s.value)
-    )
+    @pytest.mark.parametrize("source", sorted(BOT_CONVERSATION_SOURCES, key=lambda s: s.value))
     def test_every_bot_source_is_routable_and_categorised(self, source) -> None:
         assert pms.is_bot_platform(source) is True
         assert SourceCategory.from_source(source) is SourceCategory.BOT
@@ -149,9 +147,7 @@ class TestDeliverMessageEndToEnd:
     @pytest.mark.parametrize("source", list(_EXPECTED_ADAPTER))
     async def test_unlinked_user_returns_false(self, source) -> None:
         # dispatcher -> real adapter -> _get_platform_context -> PlatformLinkService
-        with patch(
-            "app.utils.notification.channels.external.PlatformLinkService"
-        ) as svc:
+        with patch("app.utils.notification.channels.external.PlatformLinkService") as svc:
             svc.get_linked_platforms = AsyncMock(return_value={})
             ok = await pms.deliver_message_to_platform(source, "user-1", "hello")
         assert ok is False

--- a/apps/api/tests/unit/services/test_platform_message_service.py
+++ b/apps/api/tests/unit/services/test_platform_message_service.py
@@ -1,0 +1,190 @@
+"""Unit tests for the bot-platform message dispatcher.
+
+These verify the routing guarantee: a conversation source is dispatched to the
+correct platform adapter (and only that one), and non-bot sources are never
+delivered to any platform.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.chat_models import (
+    BOT_CONVERSATION_SOURCES,
+    ConversationSource,
+    SourceCategory,
+)
+from app.models.notification.notification_models import (
+    ChannelDeliveryStatus,
+    NotificationStatus,
+)
+from app.services import platform_message_service as pms
+from app.utils.notification.channels.discord import DiscordChannelAdapter
+from app.utils.notification.channels.slack import SlackChannelAdapter
+from app.utils.notification.channels.telegram import TelegramChannelAdapter
+from app.utils.notification.channels.whatsapp import WhatsAppChannelAdapter
+
+# Maps each bot source to the adapter class that must handle it.
+_EXPECTED_ADAPTER = {
+    ConversationSource.WHATSAPP: WhatsAppChannelAdapter,
+    ConversationSource.TELEGRAM: TelegramChannelAdapter,
+    ConversationSource.DISCORD: DiscordChannelAdapter,
+    ConversationSource.SLACK: SlackChannelAdapter,
+}
+
+
+def _delivered() -> ChannelDeliveryStatus:
+    return ChannelDeliveryStatus(channel_type="x", status=NotificationStatus.DELIVERED)
+
+
+@pytest.mark.unit
+class TestIsBotPlatform:
+    @pytest.mark.parametrize(
+        "source",
+        ["whatsapp", "telegram", "discord", "slack", ConversationSource.WHATSAPP],
+    )
+    def test_bot_sources_are_true(self, source) -> None:
+        assert pms.is_bot_platform(source) is True
+
+    @pytest.mark.parametrize(
+        "source",
+        ["web", "mobile", "workflow_system", "background", "nonsense", None],
+    )
+    def test_non_bot_sources_are_false(self, source) -> None:
+        assert pms.is_bot_platform(source) is False
+
+
+@pytest.mark.unit
+class TestDeliverMessageToPlatform:
+    @pytest.mark.parametrize("source", list(_EXPECTED_ADAPTER))
+    async def test_routes_to_correct_adapter_only(self, source) -> None:
+        """Each bot source reaches its own adapter's deliver_text — and no other."""
+        with (
+            patch.object(WhatsAppChannelAdapter, "deliver_text", new_callable=AsyncMock) as wa,
+            patch.object(TelegramChannelAdapter, "deliver_text", new_callable=AsyncMock) as tg,
+            patch.object(DiscordChannelAdapter, "deliver_text", new_callable=AsyncMock) as dc,
+            patch.object(SlackChannelAdapter, "deliver_text", new_callable=AsyncMock) as sl,
+        ):
+            mocks = {
+                ConversationSource.WHATSAPP: wa,
+                ConversationSource.TELEGRAM: tg,
+                ConversationSource.DISCORD: dc,
+                ConversationSource.SLACK: sl,
+            }
+            for m in mocks.values():
+                m.return_value = _delivered()
+
+            ok = await pms.deliver_message_to_platform(source, "user-1", "hello")
+
+            assert ok is True
+            mocks[source].assert_awaited_once_with("hello", "user-1")
+            for other, m in mocks.items():
+                if other != source:
+                    m.assert_not_awaited()
+
+    @pytest.mark.parametrize("source", ["web", "mobile", "workflow_system", None])
+    async def test_non_bot_source_delivers_nothing(self, source) -> None:
+        with patch.object(WhatsAppChannelAdapter, "deliver_text", new_callable=AsyncMock) as wa:
+            ok = await pms.deliver_message_to_platform(source, "user-1", "hello")
+        assert ok is False
+        wa.assert_not_awaited()
+
+    async def test_blank_text_is_not_delivered(self) -> None:
+        with patch.object(WhatsAppChannelAdapter, "deliver_text", new_callable=AsyncMock) as wa:
+            ok = await pms.deliver_message_to_platform("whatsapp", "user-1", "   ")
+        assert ok is False
+        wa.assert_not_awaited()
+
+    async def test_skipped_status_returns_false(self) -> None:
+        skipped = ChannelDeliveryStatus(
+            channel_type="whatsapp", status=NotificationStatus.FAILED, skipped=True
+        )
+        with patch.object(
+            WhatsAppChannelAdapter, "deliver_text", new_callable=AsyncMock, return_value=skipped
+        ):
+            ok = await pms.deliver_message_to_platform("whatsapp", "user-1", "hello")
+        assert ok is False
+
+    async def test_adapter_exception_is_swallowed_and_returns_false(self) -> None:
+        with patch.object(
+            WhatsAppChannelAdapter,
+            "deliver_text",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            ok = await pms.deliver_message_to_platform("whatsapp", "user-1", "hello")
+        assert ok is False
+
+
+@pytest.mark.unit
+class TestAdapterRegistryConsistency:
+    """Guard against wiring drift: the dispatcher, the domain bot-source set,
+    is_bot_platform, and SourceCategory must all agree on the same platforms."""
+
+    def test_registry_matches_domain_bot_sources(self) -> None:
+        # If someone adds a bot ConversationSource without an adapter (or vice
+        # versa), this fails — a bot user would otherwise silently get nothing.
+        assert set(pms._PLATFORM_ADAPTERS) == BOT_CONVERSATION_SOURCES
+
+    @pytest.mark.parametrize(
+        "source", sorted(BOT_CONVERSATION_SOURCES, key=lambda s: s.value)
+    )
+    def test_every_bot_source_is_routable_and_categorised(self, source) -> None:
+        assert pms.is_bot_platform(source) is True
+        assert SourceCategory.from_source(source) is SourceCategory.BOT
+
+
+def _aiohttp_session_cm(session: MagicMock) -> MagicMock:
+    """Build an `async with aiohttp.ClientSession(...)` mock yielding `session`."""
+    cls = MagicMock()
+    cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return cls
+
+
+@pytest.mark.unit
+class TestDeliverMessageEndToEnd:
+    """Full chain through the REAL adapters (only platform-link + HTTP mocked)."""
+
+    @pytest.mark.parametrize("source", list(_EXPECTED_ADAPTER))
+    async def test_unlinked_user_returns_false(self, source) -> None:
+        # dispatcher -> real adapter -> _get_platform_context -> PlatformLinkService
+        with patch(
+            "app.utils.notification.channels.external.PlatformLinkService"
+        ) as svc:
+            svc.get_linked_platforms = AsyncMock(return_value={})
+            ok = await pms.deliver_message_to_platform(source, "user-1", "hello")
+        assert ok is False
+
+    async def test_whatsapp_linked_delivers_via_kapso(self) -> None:
+        resp = AsyncMock()
+        resp.status = 200
+        resp.text = AsyncMock(return_value="")
+        post_cm = AsyncMock()
+        post_cm.__aenter__ = AsyncMock(return_value=resp)
+        post_cm.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.post.return_value = post_cm
+
+        with (
+            patch("app.utils.notification.channels.external.PlatformLinkService") as svc,
+            patch("app.utils.notification.channels.whatsapp.settings") as wa_settings,
+            patch(
+                "app.utils.notification.channels.external.aiohttp.ClientSession",
+                _aiohttp_session_cm(session),
+            ),
+        ):
+            svc.get_linked_platforms = AsyncMock(
+                return_value={"whatsapp": {"platformUserId": "15551234567"}}
+            )
+            wa_settings.KAPSO_API_KEY = "kapso-key"
+            wa_settings.KAPSO_PHONE_NUMBER_ID = "PNID"
+
+            ok = await pms.deliver_message_to_platform("whatsapp", "user-1", "**hi**")
+
+        assert ok is True
+        url = session.post.call_args.args[0]
+        payload = session.post.call_args.kwargs["json"]
+        assert "/messages" in url
+        assert payload["to"] == "+15551234567"  # delivered to the linked number
+        assert payload["text"]["body"] == "*hi*"  # markdown converted for WhatsApp

--- a/apps/api/tests/unit/tools/test_integration_tool_standalone.py
+++ b/apps/api/tests/unit/tools/test_integration_tool_standalone.py
@@ -236,12 +236,73 @@ class TestConnectIntegration:
         result = await connect_integration.coroutine(  # type: ignore[attr-defined]
             config=_cfg(), integration_names=["gmail"]
         )
-        assert "Connection initiated" in result
+        assert "needs to be connected" in result
         # Writer should be called with integration_connection_required
         integration_calls = [
             c for c in w.call_args_list if "integration_connection_required" in c[0][0]
         ]
         assert len(integration_calls) == 1
+
+    @patch(f"{MODULE}.get_stream_writer")
+    @patch(
+        f"{MODULE}.check_single_integration_status",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
+    @patch(
+        f"{MODULE}.OAUTH_INTEGRATIONS",
+        [_make_integration("gmail", "Gmail", short_name="gmail")],
+    )
+    async def test_bot_context_includes_connect_url(
+        self, mock_check: AsyncMock, mock_gsw: MagicMock
+    ) -> None:
+        """On a bot platform the agent reply must carry the connect URL inline."""
+        mock_gsw.return_value = _writer()
+
+        from app.agents.tools.integration_tool import connect_integration
+
+        with (
+            patch(
+                "app.utils.integration_checker.get_config",
+                return_value={"configurable": {"source_category": "bot"}},
+            ),
+            patch("app.utils.integration_checker.settings") as s,
+        ):
+            s.FRONTEND_URL = "https://app.example.com"
+            result = await connect_integration.coroutine(  # type: ignore[attr-defined]
+                config=_cfg(), integration_names=["gmail"]
+            )
+
+        assert "https://app.example.com/integrations" in result
+
+    @patch(f"{MODULE}.get_stream_writer")
+    @patch(
+        f"{MODULE}.check_single_integration_status",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
+    @patch(
+        f"{MODULE}.OAUTH_INTEGRATIONS",
+        [_make_integration("gmail", "Gmail", short_name="gmail")],
+    )
+    async def test_ui_context_points_to_card_without_url(
+        self, mock_check: AsyncMock, mock_gsw: MagicMock
+    ) -> None:
+        """On UI the reply points at the rendered card, never a raw URL."""
+        mock_gsw.return_value = _writer()
+
+        from app.agents.tools.integration_tool import connect_integration
+
+        with patch(
+            "app.utils.integration_checker.get_config",
+            return_value={"configurable": {"source_category": "ui"}},
+        ):
+            result = await connect_integration.coroutine(  # type: ignore[attr-defined]
+                config=_cfg(), integration_names=["gmail"]
+            )
+
+        assert "http" not in result
+        assert "card" in result.lower()
 
     @patch(f"{MODULE}.get_stream_writer")
     @patch(

--- a/apps/api/tests/unit/utils/test_integration_checker.py
+++ b/apps/api/tests/unit/utils/test_integration_checker.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.utils.integration_checker import (
     TOOL_INTEGRATION_MAPPING,
+    build_integration_connection_message,
     check_and_prompt_integration,
     check_user_has_integration,
     get_required_integration_for_tool_category,
@@ -451,3 +452,54 @@ class TestCheckAndPromptIntegration:
         assert result is True
         mock_check.assert_not_awaited()
         mock_stream.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# build_integration_connection_message
+# ---------------------------------------------------------------------------
+
+_FAKE_FRONTEND = "https://app.example.com"
+
+
+@pytest.mark.unit
+class TestBuildIntegrationConnectionMessage:
+    """The connect message is platform-aware: UI points at the card, non-UI
+    embeds the connect URL inline so bot users can act on it."""
+
+    def test_ui_source_points_to_card_without_url(self) -> None:
+        with patch(
+            "app.utils.integration_checker.get_config",
+            return_value={"configurable": {"source_category": "ui"}},
+        ):
+            msg = build_integration_connection_message("Gmail")
+        assert "Gmail" in msg
+        assert "card" in msg.lower()
+        assert "http" not in msg
+        assert "/integrations" not in msg
+
+    @pytest.mark.parametrize("category", ["bot", "bg"])
+    def test_non_ui_source_includes_connect_url(self, category: str) -> None:
+        with (
+            patch(
+                "app.utils.integration_checker.get_config",
+                return_value={"configurable": {"source_category": category}},
+            ),
+            patch("app.utils.integration_checker.settings") as mock_settings,
+        ):
+            mock_settings.FRONTEND_URL = _FAKE_FRONTEND
+            msg = build_integration_connection_message("Gmail")
+        assert f"{_FAKE_FRONTEND}/integrations" in msg
+        assert "Gmail" in msg
+
+    def test_outside_runnable_context_defaults_to_url(self) -> None:
+        # get_config raises RuntimeError outside a graph run -> treat as non-UI.
+        with (
+            patch(
+                "app.utils.integration_checker.get_config",
+                side_effect=RuntimeError("no runnable context"),
+            ),
+            patch("app.utils.integration_checker.settings") as mock_settings,
+        ):
+            mock_settings.FRONTEND_URL = _FAKE_FRONTEND
+            msg = build_integration_connection_message("Slack")
+        assert f"{_FAKE_FRONTEND}/integrations" in msg

--- a/apps/api/tests/unit/utils/test_notification_channels.py
+++ b/apps/api/tests/unit/utils/test_notification_channels.py
@@ -8,6 +8,7 @@ import pytest
 from app.constants.notifications import (
     CHANNEL_TYPE_DISCORD,
     CHANNEL_TYPE_INAPP,
+    CHANNEL_TYPE_SLACK,
     CHANNEL_TYPE_TELEGRAM,
 )
 from app.models.notification.notification_models import (
@@ -26,7 +27,10 @@ from app.models.notification.notification_models import (
 )
 from app.utils.notification.channels.discord import DiscordChannelAdapter
 from app.utils.notification.channels.inapp import InAppChannelAdapter
+from app.utils.notification.channels.slack import SlackChannelAdapter
 from app.utils.notification.channels.telegram import TelegramChannelAdapter
+from app.utils.notification.channels.whatsapp import WhatsAppChannelAdapter
+from app.utils.platform_markdown import convert_to_whatsapp_markdown
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1273,3 +1277,172 @@ class TestTelegramSendMarkdown:
                 result = await adapter._send_markdown(mock_session, ctx, "long text")
 
         assert result == "chunk 2 failed"
+
+
+# ========================================================================
+# SlackChannelAdapter specifics
+# ========================================================================
+
+
+def _aiohttp_cm(resp: Any) -> AsyncMock:
+    """Wrap a mock response as an async context manager (aiohttp session.post)."""
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.mark.unit
+class TestSlackAdapterProperties:
+    def test_channel_type(self) -> None:
+        assert SlackChannelAdapter().channel_type == CHANNEL_TYPE_SLACK
+
+    def test_platform_name(self) -> None:
+        assert SlackChannelAdapter().platform_name == CHANNEL_TYPE_SLACK
+
+    def test_get_bot_token(self) -> None:
+        with patch("app.utils.notification.channels.slack.settings") as s:
+            s.SLACK_BOT_TOKEN = "xoxb-test"
+            assert SlackChannelAdapter()._get_bot_token() == "xoxb-test"
+
+    def test_session_kwargs_uses_bearer_auth(self) -> None:
+        kwargs = SlackChannelAdapter()._session_kwargs({"token": "xoxb-1"})
+        assert kwargs["headers"]["Authorization"] == "Bearer xoxb-1"
+
+
+@pytest.mark.unit
+class TestSlackSetupSender:
+    """SlackChannelAdapter._setup_sender opens a DM then yields a send fn."""
+
+    async def test_opens_dm_with_user_id_and_returns_sender(self) -> None:
+        adapter = SlackChannelAdapter()
+        ctx = {"token": "xoxb", "platform_user_id": "U123"}
+
+        open_resp = AsyncMock()
+        open_resp.status = 200
+        open_resp.json = AsyncMock(return_value={"ok": True, "channel": {"id": "D1"}})
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = _aiohttp_cm(open_resp)
+
+        send_fn, err = await adapter._setup_sender(mock_session, ctx)
+
+        assert err is None
+        assert send_fn is not None
+        url, kwargs = mock_session.post.call_args.args[0], mock_session.post.call_args.kwargs
+        assert "conversations.open" in url
+        assert kwargs["json"] == {"users": "U123"}
+
+    async def test_ok_false_on_open_returns_error(self) -> None:
+        adapter = SlackChannelAdapter()
+        ctx = {"token": "xoxb", "platform_user_id": "U123"}
+
+        open_resp = AsyncMock()
+        open_resp.status = 200
+        open_resp.json = AsyncMock(return_value={"ok": False, "error": "user_not_found"})
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = _aiohttp_cm(open_resp)
+
+        send_fn, err = await adapter._setup_sender(mock_session, ctx)
+
+        assert send_fn is None
+        assert err is not None
+        assert err.status == NotificationStatus.FAILED
+        assert "user_not_found" in (err.error_message or "")
+
+    async def test_missing_dm_channel_id_returns_error(self) -> None:
+        adapter = SlackChannelAdapter()
+        ctx = {"token": "xoxb", "platform_user_id": "U123"}
+
+        open_resp = AsyncMock()
+        open_resp.status = 200
+        open_resp.json = AsyncMock(return_value={"ok": True, "channel": {}})
+
+        mock_session = MagicMock()
+        mock_session.post.return_value = _aiohttp_cm(open_resp)
+
+        send_fn, err = await adapter._setup_sender(mock_session, ctx)
+
+        assert send_fn is None
+        assert err is not None
+
+
+@pytest.mark.unit
+class TestSlackSendFunction:
+    """The send fn posts to chat.postMessage, converts mrkdwn, and honours `ok`."""
+
+    async def test_send_posts_to_dm_and_converts_markdown(self) -> None:
+        adapter = SlackChannelAdapter()
+        ctx = {"token": "xoxb", "platform_user_id": "U123"}
+
+        open_resp = AsyncMock()
+        open_resp.status = 200
+        open_resp.json = AsyncMock(return_value={"ok": True, "channel": {"id": "D1"}})
+        post_resp = AsyncMock()
+        post_resp.status = 200
+        post_resp.json = AsyncMock(return_value={"ok": True})
+
+        mock_session = MagicMock()
+        mock_session.post.side_effect = [_aiohttp_cm(open_resp), _aiohttp_cm(post_resp)]
+
+        send_fn, err = await adapter._setup_sender(mock_session, ctx)
+        assert err is None
+        result = await send_fn("**bold**")
+
+        assert result is None  # success
+        post_call = mock_session.post.call_args_list[1]
+        assert "chat.postMessage" in post_call.args[0]
+        payload = post_call.kwargs["json"]
+        assert payload["channel"] == "D1"
+        # **bold** must be converted to Slack mrkdwn (*bold*), not sent raw
+        assert payload["text"] == "*bold*"
+        assert payload["text"] != "**bold**"
+
+    async def test_send_returns_error_when_ok_false(self) -> None:
+        adapter = SlackChannelAdapter()
+        ctx = {"token": "xoxb", "platform_user_id": "U123"}
+
+        open_resp = AsyncMock()
+        open_resp.status = 200
+        open_resp.json = AsyncMock(return_value={"ok": True, "channel": {"id": "D1"}})
+        post_resp = AsyncMock()
+        post_resp.status = 200
+        post_resp.json = AsyncMock(return_value={"ok": False, "error": "channel_not_found"})
+
+        mock_session = MagicMock()
+        mock_session.post.side_effect = [_aiohttp_cm(open_resp), _aiohttp_cm(post_resp)]
+
+        send_fn, _err = await adapter._setup_sender(mock_session, ctx)
+        result = await send_fn("hi")
+
+        assert result == "channel_not_found"
+
+
+# ========================================================================
+# ChannelAdapter.deliver_text (raw chat-message delivery primitive)
+# ========================================================================
+
+
+@pytest.mark.unit
+class TestDeliverText:
+    async def test_base_passes_raw_text_through(self) -> None:
+        """The base default delivers raw Markdown verbatim (Discord renders natively)."""
+        adapter = DiscordChannelAdapter()
+        adapter.deliver = AsyncMock(return_value="status-sentinel")  # boundary
+
+        out = await adapter.deliver_text("**keep raw**", "user-1")
+
+        adapter.deliver.assert_awaited_once_with({"text": "**keep raw**"}, "user-1")
+        assert out == "status-sentinel"
+
+    async def test_whatsapp_converts_markdown_before_deliver(self) -> None:
+        """WhatsApp converts to its markdown (conversion lives in transform, not send)."""
+        adapter = WhatsAppChannelAdapter()
+        adapter.deliver = AsyncMock(return_value="status-sentinel")
+
+        await adapter.deliver_text("**bold**", "user-1")
+
+        sent = adapter.deliver.await_args.args[0]
+        assert sent["text"] == convert_to_whatsapp_markdown("**bold**")
+        assert sent["text"] != "**bold**"  # proves conversion actually ran


### PR DESCRIPTION
## What

Background executor results were previously pushed only over WebSocket, so bot users (WhatsApp/Telegram/Discord/Slack) never received them — only web/mobile did. Now each background message is saved once and delivered over **exactly one** transport chosen by the conversation's own persisted `source`: bot conversations go to their platform's API (reusing the existing notification channel adapters, plus a **new Slack adapter**), while web/mobile/system conversations use the WebSocket push — no cross-channel fan-out.

Graph invocations now also carry a generalized source category (`BG`/`UI`/`Bot`) and the specific channel in both the run config and trace metadata, with all platform/source comparisons funnelled through the `ConversationSource` enum. Separately, when a tool needs an unconnected integration, bot users now get the connect URL inline in the reply (UI still renders the connect card).

## Tests

Adds mutation-verified unit tests across the whole path (routing dispatcher, exclusive `_deliver_bg_notification` routing, `_get_conversation_source`, Slack adapter, `deliver_text`, source classification, `build_agent_config` metadata, and the platform-aware integration response) and repairs the previously-uncollectable `test_agent_helpers.py` — re-enabling ~44 silently-dead tests. `ruff` and `mypy` pass across the backend.