### PR TITLE
chore(docker): upgrade dev postgres to 18

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -142,17 +142,14 @@ services:
 
   # Postgres Service
   postgres:
-    # Pinned to 17: postgres:18 changed the expected mount layout to
-    # /var/lib/postgresql (not /var/lib/postgresql/data). Upgrading is a
-    # separate migration concern outside this work.
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     container_name: postgres
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
       POSTGRES_DB: langgraph
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
       # postgres-init/*.sql runs once on first init — creates gaia_juicefs_0
       - ./postgres-init:/docker-entrypoint-initdb.d:ro
     ports:


### PR DESCRIPTION
## What

Bring the local dev compose (`infra/docker/docker-compose.yml`) back onto PostgreSQL 18, matching `docker-compose.prod.yml` and `docker-compose.selfhost.yml` — both already on `postgres:18-alpine`. Dev was the only file still pinned to 17.

## Changes

- `image: postgres:17-alpine` → `postgres:18-alpine`
- pgdata mount `/var/lib/postgresql/data` → `/var/lib/postgresql` (postgres:18 moved the data dir; this was the actual reason for the original 17 pin)

## ⚠️ Local action required

Existing local `pgdata` volumes hold a **PG17** cluster, which PG18 cannot read directly. Devs must recreate the volume on first pull:

\`\`\`bash
cd infra/docker
docker compose down
docker volume rm docker_pgdata   # name may vary — check \`docker volume ls | grep pgdata\`
docker compose up -d
\`\`\`

The `postgres-init/*.sql` seed re-runs on the fresh volume.