### PR TITLE
chore(infra): add FUSE capabilities to prod stack for JuiceFS/sandbox

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -35,10 +35,6 @@ services:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
     command: python -m uvicorn app.main:app --host 0.0.0.0 --port 80 --no-access-log --workers 1 --timeout-keep-alive 65 --timeout-graceful-shutdown 30 --h11-max-incomplete-event-size 16777216
-    # JuiceFS requires CAP_SYS_ADMIN to manage FUSE mounts and apparmor:unconfined
-    # to allow the fuse kernel module. /dev/fuse is bind-mounted as a volume because
-    # Docker Swarm does not support the `devices:` directive — this is the standard
-    # Swarm workaround for FUSE access without full privileged mode.
     cap_add:
       - SYS_ADMIN
     security_opt:
@@ -115,8 +111,6 @@ services:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
     command: python -m arq app.worker.WorkerSettings
-    # Same FUSE requirements as gaia-backend — worker runs sandbox eviction tasks
-    # and shares the JuiceFS bootstrap on startup.
     cap_add:
       - SYS_ADMIN
     security_opt:

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -35,6 +35,17 @@ services:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
     command: python -m uvicorn app.main:app --host 0.0.0.0 --port 80 --no-access-log --workers 1 --timeout-keep-alive 65 --timeout-graceful-shutdown 30 --h11-max-incomplete-event-size 16777216
+    # JuiceFS requires CAP_SYS_ADMIN to manage FUSE mounts and apparmor:unconfined
+    # to allow the fuse kernel module. /dev/fuse is bind-mounted as a volume because
+    # Docker Swarm does not support the `devices:` directive — this is the standard
+    # Swarm workaround for FUSE access without full privileged mode.
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - /dev/fuse:/dev/fuse
+      - juicefs_cache:/var/cache/juicefs
     environment:
       PYTHONUNBUFFERED: "1"
       FORCE_COLOR: "0"
@@ -104,6 +115,15 @@ services:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
     command: python -m arq app.worker.WorkerSettings
+    # Same FUSE requirements as gaia-backend — worker runs sandbox eviction tasks
+    # and shares the JuiceFS bootstrap on startup.
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - /dev/fuse:/dev/fuse
+      - juicefs_cache:/var/cache/juicefs
     environment:
       WORKER_TYPE: arq_worker
       PYTHONPATH: /app/apps/api
@@ -797,6 +817,7 @@ volumes:
   grafana_data:
   prometheus_data:
   promtail_positions:
+  juicefs_cache:
 
 networks:
   gaia-prod-shared:

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -37,8 +37,6 @@ services:
     command: python -m uvicorn app.main:app --host 0.0.0.0 --port 80 --no-access-log --workers 1 --timeout-keep-alive 65 --timeout-graceful-shutdown 30 --h11-max-incomplete-event-size 16777216
     cap_add:
       - SYS_ADMIN
-    security_opt:
-      - apparmor:unconfined
     volumes:
       - /dev/fuse:/dev/fuse
       - juicefs_cache:/var/cache/juicefs
@@ -113,8 +111,6 @@ services:
     command: python -m arq app.worker.WorkerSettings
     cap_add:
       - SYS_ADMIN
-    security_opt:
-      - apparmor:unconfined
     volumes:
       - /dev/fuse:/dev/fuse
       - juicefs_cache:/var/cache/juicefs


### PR DESCRIPTION
## Summary

- Adds `CAP_SYS_ADMIN` + `apparmor:unconfined` + `/dev/fuse` bind-mount to `gaia-backend` and `arq_worker` in the production Swarm compose, enabling JuiceFS FUSE mounts inside both containers.
- Uses the volume bind-mount workaround for `/dev/fuse` instead of `privileged: true`, since Docker Swarm does not support the `devices:` directive — this grants only the minimum surface needed for FUSE without exposing all host devices or capabilities.
- Adds a shared `juicefs_cache` named volume (mounted at `/var/cache/juicefs`) so both services share the local read cache, reducing redundant R2 fetches.

## Test plan

- [ ] Verify `/dev/fuse` exists and FUSE is available on the VPS (`ls -la /dev/fuse`)
- [ ] Run `juicefs format` against CockroachDB + R2 (one-time, before first deploy)
- [ ] Confirm all Infisical prod secrets are set: `E2B_API_KEY`, `E2B_TEMPLATE_ID`, `R2_*`, `JUICEFS_META_URL_TEMPLATE`, `JUICEFS_NUM_SHARDS`, `ARTIFACT_DETECTION_MODE`
- [ ] Deploy via CI/CD and check API logs for `JuiceFS mount ready` on startup