### PR TITLE
feat(infra): mount JuiceFS via juicedata/juicefs volume plugin (Swarm-native)

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -35,11 +35,15 @@ services:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
     command: python -m uvicorn app.main:app --host 0.0.0.0 --port 80 --no-access-log --workers 1 --timeout-keep-alive 65 --timeout-graceful-shutdown 30 --h11-max-incomplete-event-size 16777216
-    cap_add:
-      - SYS_ADMIN
     volumes:
-      - /dev/fuse:/dev/fuse
-      - juicefs_cache:/var/cache/juicefs
+      # JuiceFS via the official juicedata/juicefs volume plugin (Swarm-native).
+      # The plugin holds the FUSE privilege; this container stays unprivileged
+      # (no /dev/fuse, no SYS_ADMIN). Volume `gaia_jfs` is pre-created per node.
+      - type: volume
+        source: gaia_jfs
+        target: /mnt/jfs
+        volume:
+          nocopy: true
     environment:
       PYTHONUNBUFFERED: "1"
       FORCE_COLOR: "0"
@@ -109,11 +113,15 @@ services:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
     command: python -m arq app.worker.WorkerSettings
-    cap_add:
-      - SYS_ADMIN
     volumes:
-      - /dev/fuse:/dev/fuse
-      - juicefs_cache:/var/cache/juicefs
+      # JuiceFS via the official juicedata/juicefs volume plugin (Swarm-native).
+      # The plugin holds the FUSE privilege; this container stays unprivileged
+      # (no /dev/fuse, no SYS_ADMIN). Volume `gaia_jfs` is pre-created per node.
+      - type: volume
+        source: gaia_jfs
+        target: /mnt/jfs
+        volume:
+          nocopy: true
     environment:
       WORKER_TYPE: arq_worker
       PYTHONPATH: /app/apps/api
@@ -807,7 +815,12 @@ volumes:
   grafana_data:
   prometheus_data:
   promtail_positions:
-  juicefs_cache:
+  # JuiceFS volume backed by the juicedata/juicefs plugin. Pre-create per node:
+  #   docker volume create -d juicedata/juicefs -o name=gaia-0 -o metaurl=... \
+  #     -o access-key=... -o secret-key=... gaia_jfs
+  # (no -o mountFlags --cache-dir: that path doesn't exist in the plugin → mount EOF)
+  gaia_jfs:
+    external: true
 
 networks:
   gaia-prod-shared:


### PR DESCRIPTION
## Why

The in-container FUSE mount added in #735 **cannot work under Docker Swarm**: Swarm can't attach a device to a container (`devices:`, `--device`, `device_cgroup_rules`, `privileged:` are all dropped/rejected — verified on prod). The `/dev/fuse` bind-mount creates the node but not the cgroup-v2 device permission, so `fusermount3` fails with `Operation not permitted` and juicefs crash-loops (which also hammered the CockroachDB meta with millions of RU).

## What this does

Switches `gaia-backend` + `arq_worker` to the **official `juicedata/juicefs` Docker volume plugin**:
- The plugin performs the FUSE mount in its own privileged context; the app containers become **unprivileged** — drops `cap_add: SYS_ADMIN`, the `/dev/fuse` bind, and `juicefs_cache`.
- Mounts the external `gaia_jfs` volume at `/mnt/jfs`. No `docker.sock`.
- No app/image change — `bootstrap._is_mounted()` detects the mount and logs `mount already healthy`.

## Per-node prerequisite (not in this compose)

Each node needs, once: `docker plugin install juicedata/juicefs` + `docker volume create -d juicedata/juicefs -o name=gaia-0 -o metaurl=… gaia_jfs`. Full runbook: internal-docs PR #3 (`deployment/juicefs-fuse`).

## Status

**Validated live on prod** — both services mount the encrypted `gaia-0` volume via the plugin, no crash-loop, RU drain stopped. Deployed manually via `docker service update`; this PR brings the committed compose in line.