### PR TITLE
fix(api,web): return 403 for disconnected integrations so logged-in users aren't shown the login modal

### DIFF
--- a/apps/api/app/api/v1/dependencies/google_scope_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/google_scope_dependencies.py
@@ -76,6 +76,7 @@ def require_integration(integration_short_name: str):
                 detail = {
                     "type": "integration",
                     "error_code": INTEGRATION_NOT_CONNECTED,
+                    "toolkit": integration_short_name,
                     "message": f"Missing connection: {integration_config.name}. Please connect integrations in settings.",
                 }
                 raise HTTPException(

--- a/apps/api/app/api/v1/dependencies/google_scope_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/google_scope_dependencies.py
@@ -22,6 +22,7 @@ import httpx
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.config.oauth_config import get_integration_by_id, get_short_name_mapping
+from app.constants.error_codes import INTEGRATION_NOT_CONNECTED
 from app.services.oauth.oauth_service import check_integration_status
 from shared.py.wide_events import log
 
@@ -74,6 +75,7 @@ def require_integration(integration_short_name: str):
             if not is_connected:
                 detail = {
                     "type": "integration",
+                    "error_code": INTEGRATION_NOT_CONNECTED,
                     "message": f"Missing connection: {integration_config.name}. Please connect integrations in settings.",
                 }
                 raise HTTPException(

--- a/apps/api/app/api/v1/dependencies/oauth_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/oauth_dependencies.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from bson import ObjectId
 from fastapi import Depends, Header, HTTPException, Request, WebSocket, status
 
+from app.constants.error_codes import NOT_AUTHENTICATED
 from app.db.mongodb.collections import users_collection
 from shared.py.wide_events import log
 
@@ -57,10 +58,22 @@ async def get_current_user(request: Request):
     """
     if not hasattr(request.state, "authenticated") or not request.state.authenticated:
         log.info("No authenticated user found in request state")
-        raise HTTPException(status_code=401, detail="Unauthorized: Authentication required")
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error_code": NOT_AUTHENTICATED,
+                "message": "Authentication required",
+            },
+        )
     if not request.state.user:
         log.error("User marked as authenticated but no user data found")
-        raise HTTPException(status_code=401, detail="Unauthorized: User data missing")
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error_code": NOT_AUTHENTICATED,
+                "message": "User data missing",
+            },
+        )
 
     user = request.state.user
     log.set(

--- a/apps/api/app/constants/error_codes.py
+++ b/apps/api/app/constants/error_codes.py
@@ -1,0 +1,7 @@
+"""Machine-readable API error codes (mirrored in web errorCodes.ts)."""
+
+# 401 — GAIA session missing/invalid/expired; client shows the login modal.
+NOT_AUTHENTICATED = "NOT_AUTHENTICATED"
+
+# 403 — authenticated but the integration has no active connection.
+INTEGRATION_NOT_CONNECTED = "INTEGRATION_NOT_CONNECTED"

--- a/apps/api/app/services/calendar_service.py
+++ b/apps/api/app/services/calendar_service.py
@@ -4,6 +4,7 @@ from typing import Any, Union
 from fastapi import HTTPException
 
 from app.constants.calendar import DEFAULT_CALENDAR_COLOR
+from app.constants.error_codes import INTEGRATION_NOT_CONNECTED
 from app.db.mongodb.collections import get_sync_collection
 from app.models.calendar_models import (
     EventCreateRequest,
@@ -44,6 +45,19 @@ def _proxy(
             query=query,
         )
     except AppError as exc:
+        # Integration not connected → emit the structured "integration" detail
+        # the web client already understands (same shape as require_integration),
+        # so it shows an actionable reconnect toast instead of the login modal.
+        if exc.meta.get("error_code") == INTEGRATION_NOT_CONNECTED:
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail={
+                    "type": "integration",
+                    "error_code": INTEGRATION_NOT_CONNECTED,
+                    "toolkit": exc.meta.get("toolkit"),
+                    "message": "Reconnect Google Calendar to load your events.",
+                },
+            ) from exc
         provider_response = exc.meta.get("provider_response")
         detail: Any = exc.message
         if isinstance(provider_response, dict):

--- a/apps/api/app/services/composio/proxy_client.py
+++ b/apps/api/app/services/composio/proxy_client.py
@@ -19,6 +19,7 @@ import time
 from typing import Any, Literal
 
 from app.config.oauth_config import get_composio_social_configs
+from app.constants.error_codes import INTEGRATION_NOT_CONNECTED
 from app.utils.errors import AppError
 from shared.py.wide_events import log
 
@@ -123,12 +124,21 @@ def _resolve_connected_account_id(user_id: str, toolkit: str) -> str:
             f"composio: no ACTIVE account for user={user_id} toolkit={toolkit} "
             f"(total_accounts={total_accounts}, sample={account_summary})"
         )
+        # 403, not 401: the user's GAIA session is valid — they simply have no
+        # active connection for this integration. Returning 401 makes the web
+        # client's axios interceptor treat it as session expiry and pop the
+        # "please log in" modal at a logged-in user (e.g. /dashboard firing
+        # /calendar/events). 403 routes to the "reconnect integration" path.
         raise AppError(
             message=f"No active {toolkit} connection",
             why=f"User {user_id} has no active connected account for {toolkit}",
             fix=f"Reconnect the {toolkit} integration",
-            status_code=401,
-            meta={"toolkit": toolkit, "user_id": user_id},
+            status_code=403,
+            meta={
+                "toolkit": toolkit,
+                "user_id": user_id,
+                "error_code": INTEGRATION_NOT_CONNECTED,
+            },
         )
 
     log.info(
@@ -221,20 +231,28 @@ def _proxy_call(
 
     status = int(response.status)
     if status >= 400:
-        # 401 = Composio's stored token is rejected and refresh already failed.
+        # A provider 401 means Composio's stored token was rejected and refresh
+        # already failed — the *integration* needs reconnecting, not the user's
+        # GAIA session. Surface it as 403 so the web client routes it to the
+        # reconnect-integration path instead of passing 401 through and falsely
+        # telling a logged-in user to sign in again.
         if status == 401:
             invalidate_connected_account_cache(user_id=user_id, toolkit=toolkit)
+        gaia_status = 403 if status == 401 else (status if 400 <= status < 600 else 502)
+        meta: dict[str, Any] = {
+            "toolkit": toolkit,
+            "endpoint": endpoint,
+            "method": method,
+            "provider_status": status,
+            "provider_response": response.data,
+        }
+        if status == 401:
+            meta["error_code"] = INTEGRATION_NOT_CONNECTED
         raise AppError(
             message=f"{toolkit} API error ({status})",
             why=f"Provider returned non-2xx for {method} {endpoint}",
-            status_code=status if 400 <= status < 600 else 502,
-            meta={
-                "toolkit": toolkit,
-                "endpoint": endpoint,
-                "method": method,
-                "provider_status": status,
-                "provider_response": response.data,
-            },
+            status_code=gaia_status,
+            meta=meta,
         )
 
     # Normalize header keys to lowercase. Upstream APIs return mixed casing

--- a/apps/api/tests/unit/services/test_proxy_client.py
+++ b/apps/api/tests/unit/services/test_proxy_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.constants.error_codes import INTEGRATION_NOT_CONNECTED
 from app.services.composio import proxy_client
 from app.services.composio.proxy_client import (
     _build_parameters,
@@ -114,7 +115,8 @@ class TestResolveConnectedAccountId:
         with _patch_auth_config(), _patch_composio(composio):
             with pytest.raises(AppError) as exc:
                 _resolve_connected_account_id("u1", "GMAIL")
-        assert exc.value.status_code == 401
+        assert exc.value.status_code == 403
+        assert exc.value.meta["error_code"] == INTEGRATION_NOT_CONNECTED
 
     def test_returns_active_account_id(self) -> None:
         composio = _make_composio(account_id="acc_xyz")

--- a/apps/web/src/lib/api/errorCodes.ts
+++ b/apps/web/src/lib/api/errorCodes.ts
@@ -1,0 +1,4 @@
+// API error codes shared with the backend (apps/api/app/constants/error_codes.py).
+export const API_ERROR_CODES = {
+  NOT_AUTHENTICATED: "NOT_AUTHENTICATED",
+} as const;

--- a/apps/web/src/lib/api/errorCodes.ts
+++ b/apps/web/src/lib/api/errorCodes.ts
@@ -1,4 +1,5 @@
 // API error codes shared with the backend (apps/api/app/constants/error_codes.py).
 export const API_ERROR_CODES = {
   NOT_AUTHENTICATED: "NOT_AUTHENTICATED",
+  INTEGRATION_NOT_CONNECTED: "INTEGRATION_NOT_CONNECTED",
 } as const;

--- a/apps/web/src/utils/interceptorUtils.ts
+++ b/apps/web/src/utils/interceptorUtils.ts
@@ -6,6 +6,7 @@ import {
   showRateLimitToast,
   showTokenLimitToast,
 } from "@/components/shared/RateLimitToast";
+import { API_ERROR_CODES } from "@/lib/api/errorCodes";
 import { toast } from "@/lib/toast";
 import { useLoginModalStore } from "@/stores/loginModalStore";
 
@@ -13,11 +14,19 @@ interface ErrorHandlerDependencies {
   router: AppRouterInstance;
 }
 
+const getErrorCode = (data: unknown): string | undefined => {
+  const detail =
+    data && typeof data === "object" && "detail" in data
+      ? (data as { detail: unknown }).detail
+      : undefined;
+  if (detail && typeof detail === "object" && "error_code" in detail)
+    return (detail as { error_code?: string }).error_code;
+  return undefined;
+};
+
 /**
- * Surfaces API error UI for app-shell requests: toasts on 5xx/429/403,
- * login modal on 401. Only mounted inside the (main) provider tree —
- * landing pages never surface background-fetch errors because anonymous
- * visitors should not be interrupted by UI they did not trigger.
+ * Surfaces API error UI for app-shell requests. Only mounted inside the (main)
+ * provider tree.
  */
 export const processAxiosError = (
   error: AxiosError & { handled?: boolean },
@@ -35,7 +44,11 @@ export const processAxiosError = (
 
   switch (status) {
     case 401:
-      useLoginModalStore.getState().openModal();
+      // Only a genuine auth failure prompts re-login. Integration/permission
+      // problems come back as 403, never 401.
+      if (getErrorCode(data) === API_ERROR_CODES.NOT_AUTHENTICATED) {
+        useLoginModalStore.getState().openModal();
+      }
       error.handled = true;
       break;
 
@@ -84,14 +97,18 @@ const handleForbiddenError = (
     "type" in detail &&
     detail.type === "integration"
   ) {
-    const integrationDetail = detail as { type: string; message?: string };
-    const toastKey = `integration-${integrationDetail.type || "default"}`;
+    const integrationDetail = detail as {
+      type: string;
+      message?: string;
+      toolkit?: string;
+    };
+    const toastKey = `integration-${integrationDetail.toolkit || "default"}`;
 
     toast.error(integrationDetail.message || "Integration required.", {
       id: toastKey,
       duration: Infinity,
       action: {
-        label: "Connect",
+        label: "Reconnect",
         onClick: () => {
           router.push("/integrations");
         },


### PR DESCRIPTION
## Problem

Visiting **/dashboard** while logged in showed a "please log in" modal, even though the session was valid (chat and other pages worked fine).

## Root cause

The dashboard fetches `/calendar/events` (chat never does). When the Google Calendar integration has no active connection, the Composio proxy raised **`401 Unauthorized`** (`"No active GOOGLECALENDAR connection"`). The web axios interceptor treats **every** `401` as session expiry → opens the login modal.

`401` means *"not authenticated."* A missing integration connection is *"authenticated, but a precondition isn't met"* → that's a **`403`**. The frontend already renders `403 + {type:"integration"}` as an actionable toast.

## Changes

**Backend**
- `proxy_client`: integration-not-connected and provider-token-rejected now return **403** tagged `INTEGRATION_NOT_CONNECTED` (was 401).
- `get_current_user`: genuine auth 401s tagged `NOT_AUTHENTICATED`.
- `calendar_service` / `require_integration`: emit the structured `{type:"integration", ...}` detail the web client already understands.

**Frontend**
- Interceptor opens the login modal **only** for `401 + NOT_AUTHENTICATED`; integration 403s show a single deduped "Reconnect" toast.

## Verification
- `nx lint api`, `nx type-check api`, `nx type-check web` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)