### PR TITLE
feat(api): connect tool ID-only + bot-aware integration connect URL

### DIFF
--- a/apps/api/app/agents/templates/agent_template.py
+++ b/apps/api/app/agents/templates/agent_template.py
@@ -52,6 +52,7 @@ OUTPUT RESTRICTIONS for this platform:
 - The user CANNOT see tool_data UI, MCP apps, or any frontend components
 - When showing structured data (search results, calendar events, emails, etc.), format as clean text lists
 - Artifacts and HTML content blocks are invisible to the user — describe results in plain text instead
+- When an integration needs to be connected: paste the connect URL directly in your reply — there is no connect button on this platform, the URL is the only way for the user to connect
 
 WHAT TO DO INSTEAD:
 - Present all information as formatted text using the platform's native formatting

--- a/apps/api/app/agents/tools/integration_tool.py
+++ b/apps/api/app/agents/tools/integration_tool.py
@@ -303,7 +303,9 @@ async def connect_integration(
 
         if isinstance(integration_ids, str):
             integration_ids = [integration_ids]
-        integration_ids = list(dict.fromkeys(iid.lower().strip() for iid in integration_ids if iid.strip()))
+        integration_ids = list(
+            dict.fromkeys(iid.lower().strip() for iid in integration_ids if iid.strip())
+        )
 
         writer = get_stream_writer()
 

--- a/apps/api/app/agents/tools/integration_tool.py
+++ b/apps/api/app/agents/tools/integration_tool.py
@@ -288,9 +288,9 @@ async def suggest_integrations(
 @tool
 @with_doc(CONNECT_INTEGRATION)
 async def connect_integration(
-    integration_names: Annotated[
+    integration_ids: Annotated[
         list[str],
-        "List of integration names or IDs to connect (e.g., ['gmail', 'notion', 'twitter']). Can also be a single integration.",
+        "List of exact integration IDs to connect (e.g., ['gmail', 'notion', 'twitter']).",
     ],
     config: RunnableConfig,
 ) -> str:
@@ -301,35 +301,26 @@ async def connect_integration(
         if not user_id:
             return "Error: User ID not found in configuration."
 
-        # Ensure integration_names is a list
-        if isinstance(integration_names, str):
-            integration_names = [integration_names]
+        if isinstance(integration_ids, str):
+            integration_ids = [integration_ids]
+        integration_ids = [iid.lower().strip() for iid in integration_ids]
 
         writer = get_stream_writer()
 
         results = []
         connections_to_initiate = []
 
-        for integration_name in integration_names:
-            # Find the integration by name or ID
-            integration = None
-            search_name = integration_name.lower().strip()
-
-            for integ in OAUTH_INTEGRATIONS:
-                if (
-                    integ.id.lower() == search_name
-                    or integ.name.lower() == search_name
-                    or (integ.short_name and integ.short_name.lower() == search_name)
-                ):
-                    integration = integ
-                    break
+        for integration_id in integration_ids:
+            integration = next(
+                (integ for integ in OAUTH_INTEGRATIONS if integ.id.lower() == integration_id),
+                None,
+            )
 
             if not integration:
-                # Return list of available integrations as suggestion
-                available = [i.name for i in OAUTH_INTEGRATIONS if i.available]
+                available = [i.id for i in OAUTH_INTEGRATIONS if i.available]
                 results.append(
-                    f"❌ '{integration_name}' not found. "
-                    f"Available: {', '.join(available[:5])}{'...' if len(available) > 5 else ''}"
+                    f"❌ '{integration_id}' not found. "
+                    f"Available IDs: {', '.join(available[:5])}{'...' if len(available) > 5 else ''}"
                 )
                 continue
 
@@ -337,16 +328,13 @@ async def connect_integration(
                 results.append(f"⏳ {integration.name} is not available yet. Coming soon!")
                 continue
 
-            # Check if already connected using unified service
             is_connected = await check_single_integration_status(integration.id, user_id)
             if is_connected:
                 results.append(f"✅ {integration.name} is already connected!")
                 continue
 
-            # Queue for connection
             connections_to_initiate.append(integration)
 
-        # Initiate connections for all queued integrations
         for integration in connections_to_initiate:
             writer({"progress": f"Initiating {integration.name} connection..."})
 
@@ -363,7 +351,7 @@ async def connect_integration(
         return "\n".join(results) if results else "No integrations to connect."
 
     except Exception as e:
-        log.error(f"Error connecting integrations {integration_names}: {e}")
+        log.error(f"Error connecting integrations {integration_ids}: {e}")
         return f"Error connecting integrations: {e!s}"
 
 

--- a/apps/api/app/agents/tools/integration_tool.py
+++ b/apps/api/app/agents/tools/integration_tool.py
@@ -303,7 +303,7 @@ async def connect_integration(
 
         if isinstance(integration_ids, str):
             integration_ids = [integration_ids]
-        integration_ids = [iid.lower().strip() for iid in integration_ids]
+        integration_ids = list(dict.fromkeys(iid.lower().strip() for iid in integration_ids if iid.strip()))
 
         writer = get_stream_writer()
 

--- a/apps/api/app/templates/docstrings/integration_tool_docs.py
+++ b/apps/api/app/templates/docstrings/integration_tool_docs.py
@@ -49,18 +49,15 @@ Use this tool when the user asks to:
 - "Set up multiple integrations"
 
 PARAMETERS:
-- `integration_names` (List[str]): List of integration names or IDs to connect
-  - Can be integration IDs (e.g., "gmail", "notion")
-  - Can be integration names (e.g., "Gmail", "Notion")
-  - Can be short names if available
-  - Can be a single integration or multiple integrations
+- `integration_ids` (List[str]): List of exact integration IDs to connect.
+  - Use integration IDs (e.g., "gmail", "notion", "twitter") — call list_integrations first if unsure
+  - Can be a single ID or multiple IDs
 
 BEHAVIOR:
-- Validates each integration name/ID
+- Validates each integration ID (exact match only)
 - Checks if integration is available
 - Checks if integration is already connected
 - Initiates OAuth/connection flow for disconnected integrations
-- Triggers frontend UI to handle authentication
 
 IMPORTANT:
 - This tool does NOT directly connect integrations
@@ -70,15 +67,15 @@ IMPORTANT:
 
 RETURN VALUE:
 Returns a status message for each integration:
-- ✅ Already connected
-- 🔗 Connection initiated (user needs to complete OAuth)
-- ❌ Not found (suggests available integrations)
-- ⏳ Not available yet (coming soon)
+- Already connected
+- Connection initiated (user needs to complete OAuth)
+- Not found (suggests available IDs)
+- Not available yet (coming soon)
 
 Examples:
-- User: "Connect Gmail" → integration_names: ["gmail"]
-- User: "Set up Gmail and Notion" → integration_names: ["gmail", "notion"]
-- User: "Link my calendar" → integration_names: ["calendar"]
+- User: "Connect Gmail" → integration_ids: ["gmail"]
+- User: "Set up Gmail and Notion" → integration_ids: ["gmail", "notion"]
+- User: "Link my calendar" → integration_ids: ["googlecalendar"]
 """
 
 CHECK_INTEGRATIONS_STATUS = """

--- a/apps/api/app/utils/integration_checker.py
+++ b/apps/api/app/utils/integration_checker.py
@@ -9,15 +9,11 @@ import httpx
 from langgraph.config import get_config, get_stream_writer
 
 from app.config.oauth_config import get_integration_by_id, get_integration_scopes
-from app.config.settings import settings
 from app.config.token_repository import token_repository
 from app.models.chat_models import SourceCategory
 from shared.py.wide_events import log
 
 http_async_client = httpx.AsyncClient(timeout=10.0)
-
-# Frontend path where a user connects any integration.
-INTEGRATIONS_CONNECT_PATH = "/integrations"
 
 # Mapping of tool categories to required integrations
 TOOL_INTEGRATION_MAPPING = {
@@ -42,30 +38,26 @@ def _current_source_category() -> str | None:
     return config.get("configurable", {}).get("source_category")
 
 
-def build_integration_connection_message(
-    integration_name: str, connect_url: str | None = None
-) -> str:
+def build_integration_connection_message(integration_name: str, connect_url: str) -> str:
     """Agent-facing instruction for getting an integration connected.
 
-    On UI clients a connect card/button is rendered alongside the reply, so the
-    agent just points the user at it. On non-UI clients (bots / background) that
-    card is not visible, so the agent is told to put the connect URL directly in
-    its reply — otherwise the user has no way to act on it.
-
-    ``connect_url`` is the login-free, single-use connect link minted by the
-    caller (see ``connect_link_service``). When absent we fall back to the
-    generic integrations page (which requires a GAIA login).
+    On UI clients a connect card/button is rendered alongside the reply. The
+    agent receives the URL for context but must NOT include it in its reply —
+    the card already gives the user a one-click button. On bot/background
+    clients there is no UI, so the agent must put the link directly in its
+    text reply so the user can navigate to it.
     """
     if _current_source_category() == SourceCategory.UI.value:
         return (
-            f"{integration_name} needs to be connected. A connect card has been shown to the "
-            f"user — ask them to connect it, then try again."
+            f"{integration_name} needs to be connected. A connect button has been shown to the "
+            f"user — do NOT include any URL in your reply, the UI card handles it. "
+            f"Ask the user to click the connect button, then try again. "
+            f"(connect URL for context only, do not render: {connect_url})"
         )
-    url = connect_url or f"{settings.FRONTEND_URL.rstrip('/')}{INTEGRATIONS_CONNECT_PATH}"
     return (
-        f"{integration_name} needs to be connected. The user is on a platform that can't show "
-        f"connect buttons — include this link directly in your reply and ask them to open it in a "
-        f"browser to connect {integration_name}, then try again: {url}"
+        f"{integration_name} needs to be connected. The user is on a text-only platform (no UI). "
+        f"Include this URL verbatim in your result so the comms agent can relay it to the user: "
+        f"{connect_url}"
     )
 
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "setup": "mise run setup:deps"
+    "setup": "mise trust -a & mise run setup:deps"
   }
 }


### PR DESCRIPTION
Tightens the `connect_integration` tool to accept exact integration IDs only (drops name/short_name fuzzy matching), with normalization moved before the loop. Removes the dead fallback URL construction in `build_integration_connection_message` (the `connect_url` is always provided by callers) along with the now-unused `INTEGRATIONS_CONNECT_PATH` constant and `settings` import. Adds surface-aware messaging: UI clients receive the connect URL silently with a no-render instruction; bot/text-only clients get an explicit instruction to pass the URL verbatim through to comms. The text-only platform addendum in `agent_template` now tells comms to paste connect URLs directly when no UI connect button exists.