### PR TITLE
fix(web): scope Cloudflare image loader to CF builds so staging/Electron images work

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -30,6 +30,13 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+// The Cloudflare Image Resizing loader (/cdn-cgi/image/) is only valid when the
+// app is served through the Cloudflare edge. Only the Cloudflare build sets this
+// flag (see the cf:build/deploy/preview scripts in package.json). Every other
+// build — Docker staging, Electron standalone — leaves it unset and falls back
+// to Next's built-in image optimizer, otherwise every image 404s off-edge.
+const useCloudflareImageLoader = process.env.IMAGE_LOADER === "cloudflare";
+
 const nextConfig = {
   productionBrowserSourceMaps: true,
   compiler: {
@@ -164,9 +171,11 @@ const nextConfig = {
   images: {
     // Offload optimization to Cloudflare Image Resizing (/cdn-cgi/image/) via a
     // custom loader — edge-cached, off the worker. Requires Transformations
-    // enabled on the zone. See image-loader.ts.
-    loader: "custom",
-    loaderFile: "./image-loader.ts",
+    // enabled on the zone. Gated on the Cloudflare build (see image-loader.ts);
+    // off-edge builds fall through to Next's built-in optimizer.
+    ...(useCloudflareImageLoader
+      ? { loader: "custom", loaderFile: "./image-loader.ts" }
+      : {}),
     dangerouslyAllowSVG: true,
     minimumCacheTTL: 2_592_000, // 30 days — overrides short upstream Cache-Control (e.g. GitHub's 5 min)
     remotePatterns: [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,9 +33,9 @@
     "lint:fix": "npm run fix",
     "format": "biome format --write .",
     "promote-static": "node scripts/promote-static-landing.mjs",
-    "cf:build": "opennextjs-cloudflare build && npm run promote-static",
-    "deploy": "opennextjs-cloudflare build && npm run promote-static && opennextjs-cloudflare deploy",
-    "preview": "opennextjs-cloudflare build && npm run promote-static && opennextjs-cloudflare preview",
+    "cf:build": "IMAGE_LOADER=cloudflare opennextjs-cloudflare build && npm run promote-static",
+    "deploy": "npm run cf:build && opennextjs-cloudflare deploy",
+    "preview": "npm run cf:build && opennextjs-cloudflare preview",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

PR #740 set a **global** custom image loader in `next.config.mjs`:

```js
images: { loader: "custom", loaderFile: "./image-loader.ts" }
```

That loader rewrites every `next/image` URL to `/cdn-cgi/image/...` in any production build — a **Cloudflare-edge-only** endpoint. The Docker staging deploy (home server, `next build` + `output: standalone`, behind Traefik/Tailscale) and the Electron desktop standalone build are **not** behind Cloudflare, so every optimized image 404s. This broke images on all staging previews built off develop.

## Fix

Gate the custom loader to the Cloudflare build only:

- `next.config.mjs` — apply `loader: "custom"` / `loaderFile` only when `IMAGE_LOADER=cloudflare`. Every other build falls through to Next's built-in optimizer (pre-#740 behavior).
- `package.json` — `cf:build` sets `IMAGE_LOADER=cloudflare`; `deploy`/`preview` now chain through `cf:build` so the build command + flag live in one place.

**Prod unaffected**: prod deploys via `pnpm run deploy` → `cf:build`, which sets the flag, so it keeps the Cloudflare edge loader exactly as before. Staging/Electron simply stop using it.

Verified: `tsc` clean, `nx lint web` clean.