### PR TITLE
chore(entire): route agent checkpoints to dedicated gaia-checkpoints repo

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,4 +1,10 @@
 {
   "enabled": true,
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "theexperiencecompany/gaia-checkpoints"
+    }
+  },
   "telemetry": true
 }


### PR DESCRIPTION
## What

Points Entire's `checkpoint_remote` at `theexperiencecompany/gaia-checkpoints` (private) so agent session transcripts/checkpoints are stored in a dedicated repo instead of the main code repo.

## Why

The Entire pre-push hook decides where to ship checkpoints based on the **committed** `.entire/settings.json`. With no remote committed, it pushes the `entire/checkpoints/v1` branch to `origin` alongside every code push. Committing the setting routes checkpoints to the dedicated repo and stops the hook from pushing them to this repo.

## Change

- `.entire/settings.json`: add `strategy_options.checkpoint_remote` → `github:theexperiencecompany/gaia-checkpoints`

Existing checkpoint history has already been migrated to the new repo; the `entire/checkpoints/v1` branch is being removed from this repo.