### PR TITLE
perf(workspace): event-driven workspace materialization + chat title fix

### DIFF
--- a/apps/api/app/agents/workspace/system_files.py
+++ b/apps/api/app/agents/workspace/system_files.py
@@ -43,8 +43,8 @@ class SystemFile(NamedTuple):
     body: str
 
 
-# Static docs that anchor the workspace. Paths match what write_user_root_docs /
-# the gaia-tasks + user-todos materializers write, so reads stay consistent.
+# Static docs that anchor the workspace. Paths match what the skill catalog /
+# gaia-tasks + user-todos materializers write, so reads stay consistent.
 _STATIC_DOCS: list[tuple[str, str]] = [
     ("INDEX.md", INDEX_MD),
     ("sessions/GUIDE.md", SESSIONS_GUIDE_MD),

--- a/apps/api/app/api/v1/endpoints/bot.py
+++ b/apps/api/app/api/v1/endpoints/bot.py
@@ -35,7 +35,7 @@ from app.services.bot_service import BotService
 from app.services.bot_token_service import create_bot_session_token
 from app.services.chat.stream import run_chat_stream_background
 from app.services.integrations.marketplace import get_integration_details
-from app.services.integrations.user_integrations import get_user_connected_integrations
+from app.services.integrations.user_integrations import get_user_integration_records
 from app.services.platform_link_service import Platform, PlatformLinkService
 from shared.py.wide_events import log
 
@@ -404,7 +404,7 @@ async def get_settings(
 
     connected_integrations_list = []
     try:
-        integrations = await get_user_connected_integrations(user_id)
+        integrations = await get_user_integration_records(user_id)
         for integration_doc in integrations:
             integration_id = integration_doc.get("integration_id")
             status = integration_doc.get("status", "created")

--- a/apps/api/app/core/provider_registration.py
+++ b/apps/api/app/core/provider_registration.py
@@ -70,9 +70,8 @@ from app.services.mcp.mcp_client_pool import init_mcp_client_pool
 from app.services.sandbox.pool import init_sandbox_pool
 from app.services.startup_validation import validate_startup_requirements
 from app.services.storage.bootstrap import init_juicefs_mount
-from app.services.storage.system_workspace import ensure_system_subtree
 from app.services.tools.tools_warmup import warmup_tools_cache
-from app.services.workspace_sync import sync_stale_user_workspaces
+from app.services.workspace_sync import init_system_subtree, resync_stale_user_workspaces
 from shared.py.wide_events import log
 
 
@@ -163,25 +162,6 @@ def _spawn_background_services(
     _spawn_background_task(name, _run_all)
 
 
-async def _init_system_subtree() -> None:
-    """Materialize the global shared ``_system`` subtree once the mount is live.
-
-    Replaces the old per-chat-turn ``ensure_system_subtree`` call — the subtree
-    is global and only changes when the skill library ships, so startup is the
-    right place. Idempotent + hash-gated; no-ops without a mount (dev).
-    """
-    await providers.aget("juicefs_mount")
-    await ensure_system_subtree()
-
-
-async def _resync_stale_user_workspaces() -> None:
-    """Re-provision active users whose skill catalog is stale vs. the current
-    library (e.g. after a deploy shipped new builtin skills). Runtime half of
-    the skill-library sync; the developer script covers backfill/ad-hoc."""
-    await providers.aget("juicefs_mount")
-    await sync_stale_user_workspaces(active_only=True)
-
-
 async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
     """
     Unified startup function for both FastAPI and ARQ worker contexts.
@@ -246,7 +226,7 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
         (lambda: providers.aget("juicefs_mount"), "juicefs_mount"),
         # Global shared system subtree (INDEX/GUIDE/builtin skills) — once, here,
         # not per chat turn. Awaits the mount internally.
-        (_init_system_subtree, "system_subtree"),
+        (init_system_subtree, "system_subtree"),
     ]
 
     # Outbound bot-message queues must exist before any executor reply or
@@ -258,7 +238,7 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
         eager_services.append((init_websocket_consumer, "websocket_consumer"))
         # Re-sync active users whose skill catalog is stale (deploy shipped new
         # skills). Detached so it never blocks boot; runs only in the web app.
-        _spawn_background_task("workspace_stale_resync", _resync_stale_user_workspaces)
+        _spawn_background_task("workspace_stale_resync", resync_stale_user_workspaces)
 
     startup_services: list[tuple[Callable[[], Awaitable[object]], str]] = list(eager_services)
     startup_services.append(

--- a/apps/api/app/core/provider_registration.py
+++ b/apps/api/app/core/provider_registration.py
@@ -224,8 +224,8 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
         # The provider is a no-op when R2/JFS settings are unconfigured, so
         # this is safe to include unconditionally.
         (lambda: providers.aget("juicefs_mount"), "juicefs_mount"),
-        # Global shared system subtree (INDEX/GUIDE/builtin skills) — once, here,
-        # not per chat turn. Awaits the mount internally.
+        # Global shared system subtree (INDEX/GUIDE/builtin skills) — once,
+        # Awaits the mount internally.
         (init_system_subtree, "system_subtree"),
     ]
 

--- a/apps/api/app/core/provider_registration.py
+++ b/apps/api/app/core/provider_registration.py
@@ -70,7 +70,9 @@ from app.services.mcp.mcp_client_pool import init_mcp_client_pool
 from app.services.sandbox.pool import init_sandbox_pool
 from app.services.startup_validation import validate_startup_requirements
 from app.services.storage.bootstrap import init_juicefs_mount
+from app.services.storage.system_workspace import ensure_system_subtree
 from app.services.tools.tools_warmup import warmup_tools_cache
+from app.services.workspace_sync import sync_stale_user_workspaces
 from shared.py.wide_events import log
 
 
@@ -161,6 +163,25 @@ def _spawn_background_services(
     _spawn_background_task(name, _run_all)
 
 
+async def _init_system_subtree() -> None:
+    """Materialize the global shared ``_system`` subtree once the mount is live.
+
+    Replaces the old per-chat-turn ``ensure_system_subtree`` call — the subtree
+    is global and only changes when the skill library ships, so startup is the
+    right place. Idempotent + hash-gated; no-ops without a mount (dev).
+    """
+    await providers.aget("juicefs_mount")
+    await ensure_system_subtree()
+
+
+async def _resync_stale_user_workspaces() -> None:
+    """Re-provision active users whose skill catalog is stale vs. the current
+    library (e.g. after a deploy shipped new builtin skills). Runtime half of
+    the skill-library sync; the developer script covers backfill/ad-hoc."""
+    await providers.aget("juicefs_mount")
+    await sync_stale_user_workspaces(active_only=True)
+
+
 async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
     """
     Unified startup function for both FastAPI and ARQ worker contexts.
@@ -223,6 +244,9 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
         # The provider is a no-op when R2/JFS settings are unconfigured, so
         # this is safe to include unconditionally.
         (lambda: providers.aget("juicefs_mount"), "juicefs_mount"),
+        # Global shared system subtree (INDEX/GUIDE/builtin skills) — once, here,
+        # not per chat turn. Awaits the mount internally.
+        (_init_system_subtree, "system_subtree"),
     ]
 
     # Outbound bot-message queues must exist before any executor reply or
@@ -232,6 +256,9 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
     # Context-specific services: WebSocket only needed for web interface
     if context == "main_app":
         eager_services.append((init_websocket_consumer, "websocket_consumer"))
+        # Re-sync active users whose skill catalog is stale (deploy shipped new
+        # skills). Detached so it never blocks boot; runs only in the web app.
+        _spawn_background_task("workspace_stale_resync", _resync_stale_user_workspaces)
 
     startup_services: list[tuple[Callable[[], Awaitable[object]], str]] = list(eager_services)
     startup_services.append(

--- a/apps/api/app/helpers/message_helpers.py
+++ b/apps/api/app/helpers/message_helpers.py
@@ -34,7 +34,7 @@ from app.models.message_models import (
 )
 from app.models.user_models import OnboardingPhase
 from app.services.gaia_knowledge_service import gaia_knowledge_service
-from app.services.integrations.user_integrations import get_user_connected_integrations
+from app.services.integrations.user_integrations import get_user_integration_records
 from app.services.memory_service import memory_service
 from app.services.tracked_todo_service import tracked_todo_service
 from app.services.workflow import WorkflowService
@@ -245,7 +245,7 @@ async def _get_connected_integrations_manifest(user_id: str) -> str:
     in-memory OAuth config (no extra DB calls); unknown ids fall back to the id.
     """
     try:
-        docs = await get_user_connected_integrations(user_id)
+        docs = await get_user_integration_records(user_id)
     except Exception as e:
         log.warning(f"Error building connected-integrations manifest: {e}")
         return ""

--- a/apps/api/app/scripts/sync_user_workspaces.py
+++ b/apps/api/app/scripts/sync_user_workspaces.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Provision / re-sync user workspaces in bulk.
+
+Re-materializes the per-user JuiceFS workspace (system-file symlinks + user-root
+docs + SKILL.md / instructions catalog) for many users at once. Run this when:
+
+- You ship new builtin skills and want existing users re-synced immediately. A
+  deploy already re-syncs *active* users at startup; this forces it and/or
+  covers inactive users.
+- Backfilling users who predate registration-time provisioning.
+
+Per-user work is delegated to the same idempotent, hash-gated path used at
+registration, so this is safe to re-run.
+
+Usage::
+
+    cd apps/api
+    uv run python -m app.scripts.sync_user_workspaces                 # active users, stale only
+    uv run python -m app.scripts.sync_user_workspaces --all           # every user, stale only
+    uv run python -m app.scripts.sync_user_workspaces --all --force   # every user, ignore marker
+    uv run python -m app.scripts.sync_user_workspaces --active-days 90
+
+Requires the JuiceFS mount (run inside the dockered API / prod). No-ops on a
+host without the mount.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from app.services.workspace_sync import sync_stale_user_workspaces
+
+
+async def _run(args: argparse.Namespace) -> int:
+    result = await sync_stale_user_workspaces(
+        active_only=not args.all,
+        active_days=args.active_days,
+        force=args.force,
+    )
+    print(
+        f"workspace sync complete: scanned={result['scanned']} "
+        f"synced={result['synced']} skipped={result['skipped']}"
+    )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Process every user, not just those with recent activity.",
+    )
+    parser.add_argument(
+        "--active-days",
+        type=int,
+        default=None,
+        help="Activity window in days (default: SESSION_RETENTION_DAYS).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-provision even when the on-disk skills marker is already current.",
+    )
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(_run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/app/services/chat/persistence.py
+++ b/apps/api/app/services/chat/persistence.py
@@ -25,6 +25,7 @@ from app.models.message_models import MessageRequestWithHistory
 from app.models.payment_models import PlanType
 from app.services.conversation_service import update_messages
 from app.services.payments.payment_service import payment_service
+from app.services.storage import JuiceFSUnavailable, ensure_session_dirs
 from app.utils.chat_utils import create_conversation
 from shared.py.wide_events import log
 
@@ -58,6 +59,18 @@ async def initialize_new_conversation(
         generate_description=False,
         conversation_id=conversation_id,
     )
+
+    # Conversation creation owns the per-conversation session dirs (scratch/,
+    # user-uploaded/, artifacts/) — this is the only event that creates a
+    # conversation, so dir creation no longer runs on every chat turn. Soft-fail
+    # when JuiceFS is unmounted (native dev); file/artifact tools surface the
+    # missing mount clearly if used.
+    user_id = user.get("user_id")
+    if user_id:
+        try:
+            await ensure_session_dirs(user_id, conversation_id)
+        except JuiceFSUnavailable:
+            pass
 
     init_data = {
         "conversation_id": conversation_id,

--- a/apps/api/app/services/chat/stream.py
+++ b/apps/api/app/services/chat/stream.py
@@ -42,7 +42,7 @@ from app.services.chat.state import (
 )
 from app.services.chat.workspace import (
     forward_artifact_events,
-    prepare_user_workspace,
+    schedule_last_active_touch,
 )
 from app.services.storage import flush_fs_metrics
 from app.utils.chat_utils import generate_and_update_description
@@ -141,14 +141,10 @@ async def _run_chat_stream(
     try:
         _set_stream_log_context(body, user_id, conversation_id, stream_id, is_new_conversation)
 
-        if user_id:
-            await prepare_user_workspace(user_id, conversation_id)
-            artifact_task = asyncio.create_task(
-                forward_artifact_events(
-                    user_id, conversation_id, stream_id, state.tool_data, source
-                )
-            )
-
+        # Create the conversation row first (cheap: one insert, plus session dirs
+        # for a new conversation). Nothing slow precedes it now — per-user
+        # workspace materialization is event-driven (registration / integration
+        # changes / startup), no longer a per-turn step.
         await _publish_init_chunk(
             body,
             user,
@@ -161,12 +157,21 @@ async def _run_chat_stream(
 
         # Start description generation only after the conversation row exists
         # (created in ``_publish_init_chunk``). Starting it earlier races the
-        # row insert: the title LLM can finish before workspace prep, and the
-        # ``$set`` description update would silently match zero documents,
-        # leaving the title stuck at "New Chat" after a refresh.
-        description_task = _start_description_task(
-            is_new_conversation, body, conversation_id, user
-        )
+        # row insert: the title LLM can finish first and the ``$set`` description
+        # update would silently match zero documents, leaving the title stuck at
+        # "New Chat" after a refresh.
+        description_task = _start_description_task(is_new_conversation, body, conversation_id, user)
+
+        if user_id:
+            # Keep the session alive for idle-prune (fire-and-forget) and bridge
+            # the executor's artifact events to this stream.
+            schedule_last_active_touch(user_id, conversation_id)
+            artifact_task = asyncio.create_task(
+                forward_artifact_events(
+                    user_id, conversation_id, stream_id, state.tool_data, source
+                )
+            )
+
         usage_callback = UsageMetadataCallbackHandler()
         description_task = await _consume_agent_stream(
             body,

--- a/apps/api/app/services/chat/stream.py
+++ b/apps/api/app/services/chat/stream.py
@@ -139,7 +139,6 @@ async def _run_chat_stream(
     register_executor_capture(stream_id)
 
     try:
-        description_task = _start_description_task(is_new_conversation, body, conversation_id, user)
         _set_stream_log_context(body, user_id, conversation_id, stream_id, is_new_conversation)
 
         if user_id:
@@ -158,6 +157,15 @@ async def _run_chat_stream(
             state,
             start_event,
             is_new_conversation,
+        )
+
+        # Start description generation only after the conversation row exists
+        # (created in ``_publish_init_chunk``). Starting it earlier races the
+        # row insert: the title LLM can finish before workspace prep, and the
+        # ``$set`` description update would silently match zero documents,
+        # leaving the title stuck at "New Chat" after a refresh.
+        description_task = _start_description_task(
+            is_new_conversation, body, conversation_id, user
         )
         usage_callback = UsageMetadataCallbackHandler()
         description_task = await _consume_agent_stream(

--- a/apps/api/app/services/chat/stream.py
+++ b/apps/api/app/services/chat/stream.py
@@ -141,10 +141,6 @@ async def _run_chat_stream(
     try:
         _set_stream_log_context(body, user_id, conversation_id, stream_id, is_new_conversation)
 
-        # Create the conversation row first (cheap: one insert, plus session dirs
-        # for a new conversation). Nothing slow precedes it now — per-user
-        # workspace materialization is event-driven (registration / integration
-        # changes / startup), no longer a per-turn step.
         await _publish_init_chunk(
             body,
             user,

--- a/apps/api/app/services/chat/workspace.py
+++ b/apps/api/app/services/chat/workspace.py
@@ -1,9 +1,12 @@
-"""Per-turn workspace setup and artifact-event forwarding.
+"""Per-turn workspace upkeep and artifact-event forwarding.
 
-:func:`prepare_user_workspace` is the fused host-side bootstrap — what used to
-be three sequential ``asyncio.to_thread`` hops (sessions dir + INDEX/GUIDE +
-integrations tree) is now one call into the storage layer. It soft-fails when
-the JuiceFS mount is missing so chat still serves in dev.
+:func:`schedule_last_active_touch` is the only workspace work a chat turn now
+does — a fire-and-forget bump of the session's ``last_active`` so the daily
+idle-prune doesn't reap an actively-used conversation. The heavy per-user
+materialization (system files, skill/instruction catalog, integration tree) is
+event-driven elsewhere: registration, integration connect/disconnect, and
+startup. Session dirs are created at conversation creation
+(:func:`app.services.chat.persistence.initialize_new_conversation`).
 
 :func:`forward_artifact_events` is the bridge between the coding tools
 (which write to ``artifacts:{user_id}`` on Redis pub/sub) and the live SSE
@@ -22,11 +25,8 @@ from app.core.stream_manager import stream_manager
 from app.db.redis import redis_cache
 from app.models.chat_models import ConversationSource
 from app.services.artifact_events import artifact_channel
-from app.services.integrations.user_integrations import (
-    get_user_connected_integrations,
-)
 from app.services.outbound_delivery import publish_outbound_file
-from app.services.storage import JuiceFSUnavailable, bootstrap_user_session
+from app.services.storage import JuiceFSUnavailable, touch_session_last_active
 from shared.py.wide_events import log
 
 
@@ -42,29 +42,34 @@ def _bot_source(source: str | None) -> ConversationSource | None:
     return cs if cs in OUTBOUND_QUEUES else None
 
 
-async def prepare_user_workspace(user_id: str, conversation_id: str) -> None:
-    """Materialize the user's session dirs + INDEX/GUIDE + integrations tree.
+_last_active_tasks: set[asyncio.Task[None]] = set()
 
-    Soft-fails when JuiceFS isn't mounted (dev mode) so the chat stream still
-    serves; coding-tool errors will surface clearly if the user tries to use
-    the sandbox.
+
+def schedule_last_active_touch(user_id: str, conversation_id: str) -> None:
+    """Fire-and-forget bump of the session's ``last_active`` for idle-prune.
+
+    The heavy per-user workspace materialization is no longer done on the chat
+    turn — it's event-driven (registration, integration connect/disconnect,
+    startup). All a turn owes the workspace is keeping the conversation's
+    ``last_active`` current so the daily idle-prune doesn't reap an actively-used
+    session. Non-blocking; soft-fails when JuiceFS is unmounted (dev).
     """
     try:
-        docs = await get_user_connected_integrations(user_id)
-    except Exception as e:  # noqa: BLE001 — Mongo flake must not block chat
-        log.warning(f"[chat] could not load connected integrations: {e}")
-        docs = []
-    connected_ids = {
-        str(d.get("integration_id"))
-        for d in docs
-        if d.get("status") == "connected" and d.get("integration_id")
-    }
-    try:
-        await bootstrap_user_session(user_id, conversation_id, connected_ids)
-    except JuiceFSUnavailable:
-        return  # dev mode — proceed; tool errors will surface clearly
-    except Exception as e:  # noqa: BLE001 — never block chat on FS infra
-        log.warning(f"[chat] session dir setup failed: {e}")
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    async def _touch() -> None:
+        try:
+            await touch_session_last_active(user_id, conversation_id)
+        except JuiceFSUnavailable:
+            return  # dev mode — no mount, nothing to touch
+        except Exception as e:  # noqa: BLE001 — last_active bump must not affect chat
+            log.warning(f"[chat] last_active touch failed: {e}")
+
+    task = loop.create_task(_touch())
+    _last_active_tasks.add(task)
+    task.add_done_callback(_last_active_tasks.discard)
 
 
 async def forward_artifact_events(

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -424,8 +424,7 @@ async def disconnect_integration(user_id: str, integration_id: str) -> Integrati
 
     await _invalidate_caches(user_id, integration_id, resolved.managed_by)
 
-    # Reflect the reduced connected set in the user's workspace VFS now
-    # (fire-and-forget), instead of on the next chat turn.
+    # Reflect the reduced connected set in the user's workspace VFS.
     schedule_user_integrations_sync(user_id)
 
     log.set(

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -29,6 +29,7 @@ from app.services.integrations.user_integration_status import (
     update_user_integration_status,
 )
 from app.services.integrations.user_integrations import remove_user_integration
+from app.services.integrations_fs import schedule_user_integrations_sync
 from app.services.mcp.mcp_client import get_mcp_client
 from app.services.mcp.mcp_token_store import MCPTokenStore
 from app.services.oauth.oauth_state_service import create_oauth_state
@@ -422,6 +423,10 @@ async def disconnect_integration(user_id: str, integration_id: str) -> Integrati
         raise ValueError(f"Integration {integration_id} disconnect not supported")
 
     await _invalidate_caches(user_id, integration_id, resolved.managed_by)
+
+    # Reflect the reduced connected set in the user's workspace VFS now
+    # (fire-and-forget), instead of on the next chat turn.
+    schedule_user_integrations_sync(user_id)
 
     log.set(
         integration={

--- a/apps/api/app/services/integrations/user_integration_status.py
+++ b/apps/api/app/services/integrations/user_integration_status.py
@@ -57,8 +57,7 @@ async def update_user_integration_status(
     if result.modified_count > 0 or result.upserted_id or result.matched_count > 0:
         log.info(f"Updated user {user_id} integration {integration_id} status to {status}")
         if status == "connected":
-            # Reflect the newly-connected integration in the user's workspace VFS
-            # now (fire-and-forget), instead of on the next chat turn.
+            # Reflect the new connected set in the user's workspace VFS.
             schedule_user_integrations_sync(user_id)
         return True
 

--- a/apps/api/app/services/integrations/user_integration_status.py
+++ b/apps/api/app/services/integrations/user_integration_status.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 
 from app.db.mongodb.collections import user_integrations_collection
 from app.decorators.caching import CacheInvalidator
+from app.services.integrations_fs import schedule_user_integrations_sync
 from shared.py.wide_events import log
 
 
@@ -55,6 +56,10 @@ async def update_user_integration_status(
     # (matched_count > 0 means document exists with same values - still success)
     if result.modified_count > 0 or result.upserted_id or result.matched_count > 0:
         log.info(f"Updated user {user_id} integration {integration_id} status to {status}")
+        if status == "connected":
+            # Reflect the newly-connected integration in the user's workspace VFS
+            # now (fire-and-forget), instead of on the next chat turn.
+            schedule_user_integrations_sync(user_id)
         return True
 
     return False

--- a/apps/api/app/services/integrations/user_integrations.py
+++ b/apps/api/app/services/integrations/user_integrations.py
@@ -177,17 +177,16 @@ async def get_user_integration_capabilities(user_id: str) -> dict[str, Any]:
         for tool in category.tools:
             tool_names_set.add(tool.name)
 
-    # Get user's connected integrations
-    connected_integrations = await get_user_integration_records(user_id)
+    # Only the user's *connected* (authenticated) integrations. These tool names
+    # feed user-clickable follow-up suggestions, so a merely-added but
+    # not-yet-connected integration must not surface — its suggested action would
+    # fail at execution time.
+    connected_ids = await get_connected_integration_ids(user_id)
 
     integration_names = []
     capabilities = {}
 
-    for user_int_doc in connected_integrations:
-        integration_id = user_int_doc.get("integration_id")
-        if not integration_id:
-            continue
-
+    for integration_id in connected_ids:
         # Get integration details with tools
         integration = await get_integration_details(integration_id)
         if not integration:

--- a/apps/api/app/services/integrations/user_integrations.py
+++ b/apps/api/app/services/integrations/user_integrations.py
@@ -63,6 +63,21 @@ async def get_user_connected_integrations(user_id: str) -> list[dict[str, Any]]:
     return results
 
 
+async def get_connected_integration_ids(user_id: str) -> set[str]:
+    """Return the integration ids the user has actually *connected*.
+
+    Single source of the ``status == "connected"`` filter shared by the
+    workspace materializers (chat path, registration, integration sync, bulk
+    sync) so they can never disagree on what "connected" means.
+    """
+    docs = await get_user_connected_integrations(user_id)
+    return {
+        str(d["integration_id"])
+        for d in docs
+        if d.get("status") == "connected" and d.get("integration_id")
+    }
+
+
 @CacheInvalidator(key_patterns=["tools:user:{user_id}:*", "tool_namespaces:{user_id}"])
 async def add_user_integration(
     user_id: str,

--- a/apps/api/app/services/integrations/user_integrations.py
+++ b/apps/api/app/services/integrations/user_integrations.py
@@ -48,11 +48,12 @@ async def get_user_integrations(user_id: str) -> UserIntegrationsListResponse:
 
 
 @Cacheable(key_pattern="tools:user:{user_id}:integrations", ttl=ONE_DAY_TTL)
-async def get_user_connected_integrations(user_id: str) -> list[dict[str, Any]]:
-    """Get all user integrations (both 'created' and 'connected' status).
+async def get_user_integration_records(user_id: str) -> list[dict[str, Any]]:
+    """Return the raw records for all of a user's integrations.
 
-    Note: Despite the name, this now returns ALL integrations to allow
-    status display in bots and other interfaces.
+    Includes both ``created`` (added, not yet authenticated) and ``connected``
+    states — callers that only want usable integrations filter on
+    ``status == "connected"`` (see ``get_connected_integration_ids``).
     """
     results = []
     cursor = user_integrations_collection.find({"user_id": user_id})
@@ -70,7 +71,7 @@ async def get_connected_integration_ids(user_id: str) -> set[str]:
     workspace materializers (chat path, registration, integration sync, bulk
     sync) so they can never disagree on what "connected" means.
     """
-    docs = await get_user_connected_integrations(user_id)
+    docs = await get_user_integration_records(user_id)
     return {
         str(d["integration_id"])
         for d in docs
@@ -177,7 +178,7 @@ async def get_user_integration_capabilities(user_id: str) -> dict[str, Any]:
             tool_names_set.add(tool.name)
 
     # Get user's connected integrations
-    connected_integrations = await get_user_connected_integrations(user_id)
+    connected_integrations = await get_user_integration_records(user_id)
 
     integration_names = []
     capabilities = {}

--- a/apps/api/app/services/integrations_fs.py
+++ b/apps/api/app/services/integrations_fs.py
@@ -1,0 +1,29 @@
+"""Integration → workspace VFS sync glue.
+
+Re-materializes a user's SKILL.md / instructions catalog when their connected
+integration set changes (connect or disconnect). Mirrors the gaia-tasks and
+user-todos glue modules: a fire-and-forget, hash-gated scheduler keyed on
+``user_id`` (see :func:`app.services._vfs_scheduler.make_scheduler`).
+
+Wired into the integration status chokepoints (``update_user_integration_status``
+on connect, ``disconnect_integration`` on disconnect) so the workspace reflects
+integrations the moment they change — not on the next chat turn.
+"""
+
+from __future__ import annotations
+
+from app.services._vfs_scheduler import make_scheduler
+from app.services.integrations.user_integrations import get_connected_integration_ids
+from app.services.storage import materialize_user_integrations
+
+
+async def sync_user_integrations(user_id: str) -> int:
+    """Re-materialize the user's integration catalog from the current connected set."""
+    await materialize_user_integrations(user_id, await get_connected_integration_ids(user_id))
+    return 0
+
+
+# Fire-and-forget wrapper for the connect/disconnect write paths.
+schedule_user_integrations_sync = make_scheduler(
+    sync_user_integrations, log_name="integrations_vfs"
+)

--- a/apps/api/app/services/mcp/mcp_client.py
+++ b/apps/api/app/services/mcp/mcp_client.py
@@ -49,7 +49,7 @@ from app.services.integrations.user_integration_status import (
     update_user_integration_status,
 )
 from app.services.integrations.user_integrations import (
-    get_user_connected_integrations,
+    get_user_integration_records,
 )
 from app.services.mcp.mcp_client_pool import get_mcp_client_pool
 from app.services.mcp.mcp_token_store import MCPTokenStore
@@ -1535,7 +1535,7 @@ class MCPClient:
 
         # Slow path: check user's persisted connected integrations.
         try:
-            user_integrations = await get_user_connected_integrations(self.user_id)
+            user_integrations = await get_user_integration_records(self.user_id)
         except Exception as e:
             log.warning(
                 f"Failed to load user integrations while matching server_url {server_url}: {e}",

--- a/apps/api/app/services/oauth/oauth_service.py
+++ b/apps/api/app/services/oauth/oauth_service.py
@@ -33,6 +33,7 @@ from app.services.provider_metadata_service import (
     fetch_and_store_provider_metadata,
 )
 from app.services.system_workflows.provisioner import provision_system_workflows
+from app.services.workspace_sync import schedule_user_provision
 from app.utils.email_utils import add_contact_to_resend, send_welcome_email
 from app.utils.redis_utils import RedisPoolManager
 from shared.py.wide_events import log
@@ -129,6 +130,10 @@ async def store_user_info(
     except Exception as e:
         log.error(f"Failed to add contact to Resend audience for {email}: {e!s}")
         # Don't raise exception - user creation should still succeed
+
+    # Provision the user's workspace (system files + skills catalog) now, instead
+    # of lazily on the first chat turn. Fire-and-forget so signup isn't blocked.
+    schedule_user_provision(str(result.inserted_id))
 
     return result.inserted_id, True
 

--- a/apps/api/app/services/storage/__init__.py
+++ b/apps/api/app/services/storage/__init__.py
@@ -26,7 +26,6 @@ from app.services.storage.metrics import (
 )
 from app.services.storage.sessions import (
     ArtifactInfo,
-    bootstrap_user_session,
     chmod_path,
     delete_session_dir,
     ensure_session_dirs,
@@ -36,6 +35,7 @@ from app.services.storage.sessions import (
     list_user_uploaded,
     materialize_user_integrations,
     pin_session_artifact,
+    provision_user_workspace,
     resolve_session_path,
     stat_artifact,
     touch_session_last_active,
@@ -47,7 +47,6 @@ __all__ = [
     "JuiceFSUnavailable",
     "SAFE_PATH_ID_PATTERN",
     "add_fs_bytes",
-    "bootstrap_user_session",
     "chmod_path",
     "delete_session_dir",
     "delete_user_skill",
@@ -65,6 +64,7 @@ __all__ = [
     "list_user_uploaded",
     "materialize_user_integrations",
     "pin_session_artifact",
+    "provision_user_workspace",
     "read_user_file",
     "record_fs_op",
     "resolve_session_path",

--- a/apps/api/app/services/storage/juicefs.py
+++ b/apps/api/app/services/storage/juicefs.py
@@ -31,8 +31,20 @@ def _mount_root() -> Path:
 
 
 def _is_mounted() -> bool:
-    root = _mount_root()
-    return root.exists() and root.is_dir()
+    """Whether the JuiceFS sidecar is actually mounted at the configured root.
+
+    Checks for a real mountpoint, not merely an existing directory. The
+    Dockerfile pre-creates an empty ``/mnt/jfs``; if the mount never converges
+    (e.g. the metadata engine is unreachable), an ``is_dir()`` check would
+    wrongly pass and every storage helper would silently write to the
+    container's local disk — invisible to the sandbox, which mounts the real
+    JuiceFS namespace. ``is_mount()`` is stat-based (no subprocess), so it stays
+    cheap enough for the hot path, and returns ``False`` for a missing path.
+    """
+    try:
+        return _mount_root().is_mount()
+    except OSError:
+        return False
 
 
 def _require_mount() -> Path:

--- a/apps/api/app/services/storage/metrics.py
+++ b/apps/api/app/services/storage/metrics.py
@@ -2,10 +2,10 @@
 
 Why this exists
 ---------------
-Every chat turn fans out into a handful of FS-shaped operations: the host
-JuiceFS mount sees `bootstrap_user_session`, every coding tool call resolves
-into a sandbox `commands.run` round-trip, the artifact watcher does a
-`list_artifacts`, and so on. Each one is cheap on its own; together they
+Every chat turn fans out into a handful of FS-shaped operations: a new
+conversation creates session dirs (`ensure_session_dirs`), every coding tool
+call resolves into a sandbox `commands.run` round-trip, the artifact watcher
+does a `list_artifacts`, and so on. Each one is cheap on its own; together they
 quietly dominate end-to-end latency once the cache misses or the meta DB
 takes a coffee break.
 
@@ -280,8 +280,7 @@ class FsOps:
     JUICEFS_FORMAT: Final[str] = "juicefs_format"
     JUICEFS_STATUS: Final[str] = "juicefs_status"
 
-    # Per-session host writes (the chat-stream entry path).
-    BOOTSTRAP_USER_SESSION: Final[str] = "bootstrap_user_session"
+    # Per-session host writes.
     ENSURE_SESSION_DIRS: Final[str] = "ensure_session_dirs"
     MATERIALIZE_INTEGRATIONS: Final[str] = "materialize_integrations"
     SYNC_GAIA_TASKS_VFS: Final[str] = "sync_gaia_tasks_vfs"

--- a/apps/api/app/services/storage/sessions/__init__.py
+++ b/apps/api/app/services/storage/sessions/__init__.py
@@ -20,19 +20,18 @@ from app.services.storage.sessions.artifacts import (
     stat_artifact,
 )
 from app.services.storage.sessions.lifecycle import (
-    bootstrap_user_session,
     chmod_path,
     delete_session_dir,
     ensure_session_dirs,
     list_session_ids,
     list_stale_sessions,
     materialize_user_integrations,
+    provision_user_workspace,
     touch_session_last_active,
 )
 
 __all__ = [
     "ArtifactInfo",
-    "bootstrap_user_session",
     "chmod_path",
     "delete_session_dir",
     "ensure_session_dirs",
@@ -42,6 +41,7 @@ __all__ = [
     "list_user_uploaded",
     "materialize_user_integrations",
     "pin_session_artifact",
+    "provision_user_workspace",
     "resolve_session_path",
     "stat_artifact",
     "touch_session_last_active",

--- a/apps/api/app/services/storage/sessions/lifecycle.py
+++ b/apps/api/app/services/storage/sessions/lifecycle.py
@@ -1,9 +1,10 @@
-"""Session lifecycle — bootstrap, dir creation, deletion, idle scan.
+"""Session lifecycle — dir creation, user provisioning, deletion, idle scan.
 
-Orchestrates the per-turn FS work for a chat conversation. ``bootstrap_user_session``
-is the hot path called on every chat-stream entry; the rest is admin (idle
-prune, user-level integration materialization, hard delete) reached from
-workers and the ``/sessions`` admin endpoints.
+``ensure_session_dirs`` creates a conversation's session dirs (at conversation
+creation). ``provision_user_workspace`` / ``materialize_user_integrations`` do
+the user-level materialization, driven by registration, integration changes,
+and startup — not by the chat turn. The rest is admin (idle prune, hard delete,
+stale scan) reached from workers and the ``/sessions`` admin endpoints.
 """
 
 from __future__ import annotations
@@ -40,82 +41,10 @@ from app.services.storage.sessions.skills import (
 )
 
 
-async def bootstrap_user_session(
-    user_id: str,
-    conv_id: str,
-    connected_ids: set[str] | None = None,
-) -> Path:
-    """Idempotent + hash-gated session bootstrap for a chat turn.
-
-    Combines session-dir creation, ``.meta.json`` touch, SKILL.md catalog
-    materialization, the gaia-tasks VFS sync, and the user-todos VFS
-    sync. Steady-state turns do zero writes when the library hash, the
-    connected set, the gaia-tasks catalog, and the user-todos catalog
-    haven't changed since the last bootstrap.
-
-    Order matters: gaia-tasks runs first because it owns the legacy
-    ``/workspace/todos/`` cleanup (the prior release used that path for
-    gaia-tasks). user-todos then populates the now-empty ``/todos/``.
-    """
-    # Late-bound to break a structural cycle: ``app.services.storage`` re-
-    # exports ``sessions`` (which re-exports this module), and the
-    # gaia-tasks / user-todos modules import ``storage.juicefs`` — which
-    # forces ``storage/__init__.py`` to run mid-import. Importing here,
-    # after the package graph is fully resolved, is the only break that
-    # does not require restructuring multiple ``__init__.py`` files.
-    from app.services.gaia_tasks_fs import sync_user_gaia_tasks
-    from app.services.integration_instructions_service import (
-        get_all_instructions,
-        instructions_signature,
-    )
-    from app.services.storage.system_workspace import (
-        ensure_system_subtree,
-        link_system_files_into_workspace,
-    )
-    from app.services.user_todos_fs import sync_user_todos
-
-    connected = connected_ids or set()
-    expected_hash = library_hash()
-    instructions = await get_all_instructions(user_id)
-    instructions_sig = instructions_signature(instructions)
-
-    def _go() -> Path:
-        base = session_base(user_id, conv_id)
-        u_root = base.parent.parent
-        _ensure_session_subdirs(base)
-        _stamp_meta_on_bootstrap(base / SESSION_META_FILENAME)
-        write_user_root_docs(u_root)
-        _materialize_if_stale(u_root, expected_hash, connected, instructions, instructions_sig)
-        return base
-
-    async with fs_timer(FsOps.BOOTSTRAP_USER_SESSION):
-        # System files (INDEX/GUIDE/builtin skills) are de-duplicated: one shared
-        # `_system` copy + per-user symlinks. Run this BEFORE the copy-writers so
-        # they see the symlinks (matches_text treats a symlink as "matches") and
-        # skip rewriting them. If the shared subtree is unavailable, the linker
-        # no-ops and the copy-writers transparently fall back to per-user copies.
-        await ensure_system_subtree()
-        await link_system_files_into_workspace(user_id)
-        base = await asyncio.to_thread(_go)
-        await sync_user_gaia_tasks(user_id)
-        await sync_user_todos(user_id)
-        return base
-
-
 def _ensure_session_subdirs(base: Path) -> None:
     """Create the scratch/, user-uploaded/, artifacts/ trio under a session root."""
     for sub in (SCRATCH_DIRNAME, USER_UPLOADED_DIRNAME, ARTIFACTS_DIRNAME):
         (base / sub).mkdir(parents=True, exist_ok=True)
-
-
-def _stamp_meta_on_bootstrap(meta: Path) -> None:
-    """Set ``created_at`` (once), ``msg_count`` (once), and bump ``last_active``."""
-    data = read_session_meta(meta)
-    now = now_iso()
-    data.setdefault("created_at", now)
-    data.setdefault("msg_count", 0)
-    data["last_active"] = now
-    write_session_meta(meta, data)
 
 
 def _materialize_if_stale(
@@ -195,6 +124,32 @@ async def materialize_user_integrations(user_id: str, connected_ids: set[str]) -
 
     async with fs_timer(FsOps.MATERIALIZE_INTEGRATIONS):
         await asyncio.to_thread(_go)
+
+
+async def provision_user_workspace(user_id: str, connected_ids: set[str] | None = None) -> None:
+    """User-level workspace provisioning: system-file symlinks + user-root docs
+    (INDEX/GUIDE) + the SKILL.md / instructions catalog.
+
+    This is the user-level half of the former per-turn ``bootstrap_user_session``,
+    now run on the events that actually change it — registration, integration
+    connect/disconnect, and startup — instead of every chat turn. Idempotent and
+    hash-gated, so repeat calls are near-zero I/O. Soft-fails when JuiceFS is
+    unmounted (native dev).
+    """
+    # Late-bound to break the storage package import cycle (see the note in
+    # ``bootstrap_user_session``).
+    from app.services.storage.system_workspace import link_system_files_into_workspace
+
+    await link_system_files_into_workspace(user_id)
+
+    def _docs() -> None:
+        if not _is_mounted():
+            return
+        write_user_root_docs(user_root(user_id))
+
+    async with fs_timer(FsOps.MATERIALIZE_INTEGRATIONS):
+        await asyncio.to_thread(_docs)
+    await materialize_user_integrations(user_id, connected_ids or set())
 
 
 async def delete_session_dir(user_id: str, conv_id: str) -> None:

--- a/apps/api/app/services/storage/sessions/lifecycle.py
+++ b/apps/api/app/services/storage/sessions/lifecycle.py
@@ -37,7 +37,6 @@ from app.services.storage.sessions.skills import (
     read_skills_marker,
     read_text_or_none,
     write_skills_marker,
-    write_user_root_docs,
 )
 
 
@@ -91,7 +90,6 @@ async def ensure_session_dirs(user_id: str, conv_id: str) -> Path:
         if not meta.exists():
             now = now_iso()
             write_session_meta(meta, {"created_at": now, "last_active": now, "msg_count": 0})
-        write_user_root_docs(base.parent.parent)
         return base
 
     async with fs_timer(FsOps.ENSURE_SESSION_DIRS):
@@ -103,9 +101,8 @@ async def materialize_user_integrations(user_id: str, connected_ids: set[str]) -
 
     Soft-fails if the JuiceFS mount is missing (dev mode).
     """
-    # Late-bound to break the same structural import cycle as in
-    # ``bootstrap_user_session`` (storage -> sessions -> lifecycle -> service,
-    # where the service transitively re-enters storage via the decorators pkg).
+    # Late-bound to break the storage -> sessions -> lifecycle -> service ->
+    # storage import cycle (the service transitively re-enters the storage pkg).
     from app.services.integration_instructions_service import (
         get_all_instructions,
         instructions_signature,
@@ -127,28 +124,20 @@ async def materialize_user_integrations(user_id: str, connected_ids: set[str]) -
 
 
 async def provision_user_workspace(user_id: str, connected_ids: set[str] | None = None) -> None:
-    """User-level workspace provisioning: system-file symlinks + user-root docs
-    (INDEX/GUIDE) + the SKILL.md / instructions catalog.
+    """User-level workspace provisioning: system-file symlinks (INDEX/GUIDE +
+    builtin skills) + the SKILL.md / instructions catalog.
 
-    This is the user-level half of the former per-turn ``bootstrap_user_session``,
-    now run on the events that actually change it — registration, integration
+    Run on the events that actually change it — registration, integration
     connect/disconnect, and startup — instead of every chat turn. Idempotent and
     hash-gated, so repeat calls are near-zero I/O. Soft-fails when JuiceFS is
     unmounted (native dev).
     """
-    # Late-bound to break the storage package import cycle (see the note in
-    # ``bootstrap_user_session``).
+    # Late-bound: ``app.services.storage`` re-exports this module, so importing
+    # ``system_workspace`` (which imports ``storage.juicefs``) at top level would
+    # re-enter the half-initialized storage package.
     from app.services.storage.system_workspace import link_system_files_into_workspace
 
     await link_system_files_into_workspace(user_id)
-
-    def _docs() -> None:
-        if not _is_mounted():
-            return
-        write_user_root_docs(user_root(user_id))
-
-    async with fs_timer(FsOps.MATERIALIZE_INTEGRATIONS):
-        await asyncio.to_thread(_docs)
     await materialize_user_integrations(user_id, connected_ids or set())
 
 

--- a/apps/api/app/services/storage/sessions/skills.py
+++ b/apps/api/app/services/storage/sessions/skills.py
@@ -1,11 +1,11 @@
-"""SKILL.md catalog materialization + user-root docs.
+"""SKILL.md catalog materialization.
 
 Walks the in-memory skill registry (``app.agents.workspace.skill_loader``)
 and writes the per-user ``integrations/<iid>/agent/skills/`` + ``skills/``
-trees on JuiceFS, alongside the INDEX/GUIDE markdown files that anchor the
-workspace. All writes are hash-compared first — steady-state turns do
-zero I/O when the library hash and connected-integration signature haven't
-changed.
+trees on JuiceFS (plus the ``integrations/GUIDE.md`` anchor). All writes are
+hash-compared first — steady-state turns do zero I/O when the library hash and
+connected-integration signature haven't changed. The root INDEX/GUIDE docs are
+system files, materialized as symlinks by ``link_system_files_into_workspace``.
 
 A separate ``.connected`` marker is dropped (or removed) under each
 integration's ``agent/`` directory so the agent's prompt can tell, in a
@@ -22,9 +22,7 @@ from app.agents.workspace.skill_loader import (
     skills_by_subagent,
 )
 from app.agents.workspace.system_docs import (
-    INDEX_MD,
     INTEGRATIONS_GUIDE_MD,
-    SESSIONS_GUIDE_MD,
 )
 from app.services.storage._vfs_common import matches_text
 from app.services.storage.juicefs import ensure_safe_path_id
@@ -42,18 +40,6 @@ def read_text_or_none(path: Path) -> str | None:
         return path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None
-
-
-def write_user_root_docs(user_root: Path) -> None:
-    """Idempotently write ``INDEX.md`` and ``sessions/GUIDE.md``."""
-    index = user_root / "INDEX.md"
-    if not matches_text(index, INDEX_MD):
-        index.parent.mkdir(parents=True, exist_ok=True)
-        index.write_text(INDEX_MD, encoding="utf-8")
-    sessions_guide = user_root / "sessions" / GUIDE_FILENAME
-    if not matches_text(sessions_guide, SESSIONS_GUIDE_MD):
-        sessions_guide.parent.mkdir(parents=True, exist_ok=True)
-        sessions_guide.write_text(SESSIONS_GUIDE_MD, encoding="utf-8")
 
 
 def read_skills_marker(user_root: Path) -> str | None:

--- a/apps/api/app/services/todos/todo_service.py
+++ b/apps/api/app/services/todos/todo_service.py
@@ -751,6 +751,9 @@ class TodoService:
 
         await cls._invalidate_cache(user_id, operation="bulk_update")
 
+        if result.modified_count:
+            schedule_user_todos_sync(user_id)
+
         return BulkOperationResponse(
             success=request.todo_ids[: result.modified_count],  # Approximation
             failed=[],
@@ -794,6 +797,9 @@ class TodoService:
 
         await cls._invalidate_cache(user_id, operation="bulk_delete")
 
+        if result.deleted_count:
+            schedule_user_todos_sync(user_id)
+
         return BulkOperationResponse(
             success=todo_ids[: result.deleted_count],  # Approximation
             failed=[],
@@ -826,6 +832,9 @@ class TodoService:
         )
 
         await cls._invalidate_cache(user_id, project_id=request.project_id, operation="bulk_move")
+
+        if result.modified_count:
+            schedule_user_todos_sync(user_id)
 
         return BulkOperationResponse(
             success=request.todo_ids if result.modified_count > 0 else [],

--- a/apps/api/app/services/workspace_sync.py
+++ b/apps/api/app/services/workspace_sync.py
@@ -1,0 +1,101 @@
+"""Bulk user-workspace provisioning/sync.
+
+Re-materializes the per-user JuiceFS workspace (system symlinks + user-root docs
++ SKILL.md / instructions catalog) for many users at once. Two callers share
+this core:
+
+* **App startup** (`unified_startup`): bounded run over *active* users whose
+  on-disk skills marker is stale vs. the current ``library_hash()`` — so a
+  deploy that ships new builtin skills re-syncs everyone who's been using GAIA,
+  without touching the chat-turn hot path.
+* **Developer CLI** (`app/scripts/sync_user_workspaces.py`): one-off backfill of
+  users who predate registration-time provisioning, or a forced re-sync.
+
+Per-user work is delegated to :func:`provision_user_workspace`, which is
+idempotent and hash-gated; this module only decides *which* users to touch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+from app.agents.workspace.skill_loader import library_hash
+from app.config.settings import settings
+from app.db.mongodb.collections import conversations_collection, users_collection
+from app.services._vfs_scheduler import make_scheduler
+from app.services.integrations.user_integrations import get_connected_integration_ids
+from app.services.storage import provision_user_workspace
+from app.services.storage.juicefs import _is_mounted
+from app.services.storage.sessions._paths import user_root
+from app.services.storage.sessions.skills import read_skills_marker
+from shared.py.wide_events import log
+
+
+async def _provision(user_id: str) -> int:
+    """Provision a single user's workspace (adapter for the fire-and-forget scheduler)."""
+    await provision_user_workspace(user_id)
+    return 0
+
+
+# Fire-and-forget wrapper for registration: provision a brand-new user's
+# workspace without blocking signup. No-ops when JuiceFS is unmounted (dev).
+schedule_user_provision = make_scheduler(_provision, log_name="user_provision")
+
+
+async def _active_user_ids(active_days: int) -> list[str]:
+    """User ids with a conversation updated within ``active_days``."""
+    cutoff = datetime.now(UTC) - timedelta(days=active_days)
+    ids = await conversations_collection.distinct("user_id", {"updatedAt": {"$gte": cutoff}})
+    return [str(uid) for uid in ids if uid]
+
+
+async def _all_user_ids() -> list[str]:
+    """Every user id."""
+    cursor = users_collection.find({}, {"_id": 1})
+    return [str(doc["_id"]) async for doc in cursor]
+
+
+async def sync_stale_user_workspaces(
+    *,
+    active_only: bool = True,
+    active_days: int | None = None,
+    force: bool = False,
+) -> dict[str, int]:
+    """Re-provision users whose skills marker != current ``library_hash()``.
+
+    ``active_only`` restricts to users with recent conversation activity (the
+    startup default). ``force`` re-provisions regardless of the marker. Returns
+    ``{"scanned", "synced", "skipped"}``. No-ops when JuiceFS is unmounted.
+    """
+    if not _is_mounted():
+        log.info("workspace_sync.skipped_no_mount")
+        return {"scanned": 0, "synced": 0, "skipped": 0}
+
+    expected = library_hash()
+    days = active_days if active_days is not None else settings.SESSION_RETENTION_DAYS
+    user_ids = await (_active_user_ids(days) if active_only else _all_user_ids())
+
+    scanned = synced = skipped = 0
+    for user_id in user_ids:
+        scanned += 1
+        if not force:
+            marker = await asyncio.to_thread(read_skills_marker, user_root(user_id))
+            if marker == expected:
+                skipped += 1
+                continue
+        try:
+            await provision_user_workspace(user_id, await get_connected_integration_ids(user_id))
+            synced += 1
+        except Exception as e:  # noqa: BLE001 — one bad user must not abort the batch
+            log.warning("workspace_sync.user_failed", user_id=user_id, error=str(e))
+
+    log.info(
+        "workspace_sync.done",
+        scanned=scanned,
+        synced=synced,
+        skipped=skipped,
+        force=force,
+        active_only=active_only,
+    )
+    return {"scanned": scanned, "synced": synced, "skipped": skipped}

--- a/apps/api/app/services/workspace_sync.py
+++ b/apps/api/app/services/workspace_sync.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime, timedelta
 
 from app.agents.workspace.skill_loader import library_hash
 from app.config.settings import settings
+from app.core.lazy_loader import providers
 from app.db.mongodb.collections import conversations_collection, users_collection
 from app.services._vfs_scheduler import make_scheduler
 from app.services.integrations.user_integrations import get_connected_integration_ids
@@ -29,6 +30,7 @@ from app.services.storage import provision_user_workspace
 from app.services.storage.juicefs import _is_mounted
 from app.services.storage.sessions._paths import user_root
 from app.services.storage.sessions.skills import read_skills_marker
+from app.services.storage.system_workspace import ensure_system_subtree
 from shared.py.wide_events import log
 
 
@@ -99,3 +101,19 @@ async def sync_stale_user_workspaces(
         active_only=active_only,
     )
     return {"scanned": scanned, "synced": synced, "skipped": skipped}
+
+
+async def init_system_subtree() -> None:
+    """Startup: materialize the global shared ``_system`` subtree once the mount
+    is live. The subtree is global and only changes when the skill library ships,
+    so startup is the right place. Idempotent + hash-gated; no-ops without a mount."""
+    await providers.aget("juicefs_mount")
+    await ensure_system_subtree()
+
+
+async def resync_stale_user_workspaces() -> None:
+    """Startup: re-provision active users whose skill catalog is stale vs. the
+    current library (e.g. a deploy shipped new builtin skills). The developer
+    script covers backfill / ad-hoc runs."""
+    await providers.aget("juicefs_mount")
+    await sync_stale_user_workspaces(active_only=True)

--- a/apps/api/mise.toml
+++ b/apps/api/mise.toml
@@ -16,6 +16,11 @@ PROJECT_NAME = "{{ config_root | basename }}"
 description = "Run development server with hot reload"
 run = "uv run --group backend uvicorn app.main:app --port 8000 --reload --reload-dir app --log-level info"
 
+[tasks."dev:vm"]
+description = "Run the API dockered (port 8000) with the JuiceFS FUSE mount — for workspace v2, sandbox file ops, and artifact streaming, which a native host process can't provide. Brings up the `backend` compose profile only (does not touch web). NOTE: a real JuiceFS mount needs R2 creds in .env (R2_ACCOUNT_ID / R2_BUCKET / R2_ACCESS_KEY / R2_SECRET_KEY + JUICEFS_META_URL_TEMPLATE); without them the entrypoint skips the mount and the storage helpers no-op, same as native `mise dev`. Stop the native `mise dev` API first (port 8000 conflict)."
+env = { COMPOSE_PROFILES = "backend" }
+run = "nx run docker:docker:up && nx run docker:docker:logs"
+
 [tasks.start]
 description = "Run production server"
 run = "uv run --group backend fastapi run"

--- a/apps/api/scripts/materialize_user_workspace.py
+++ b/apps/api/scripts/materialize_user_workspace.py
@@ -42,34 +42,26 @@ from app.agents.workspace.skill_loader import (
 )
 from app.services.storage import (
     JuiceFSUnavailable,
-    bootstrap_user_session,
+    provision_user_workspace,
 )
 
 
 async def _connected_for(user_id: str) -> set[str]:
     """Connected integration ids from Mongo (status == "connected")."""
-    from app.services.integrations.user_integrations import (
-        get_user_connected_integrations,
-    )
+    from app.services.integrations.user_integrations import get_connected_integration_ids
 
-    docs = await get_user_connected_integrations(user_id)
-    return {
-        str(d.get("integration_id"))
-        for d in docs
-        if d.get("status") == "connected" and d.get("integration_id")
-    }
+    return await get_connected_integration_ids(user_id)
 
 
 async def _materialize_one(user_id: str, connected_override: set[str] | None) -> None:
     connected = (
         connected_override if connected_override is not None else await _connected_for(user_id)
     )
-    # The unified bootstrap lays down INDEX/GUIDE + the full SKILL.md catalog
-    # in one pass. A sentinel conv id keeps the call shape consistent for users
-    # with no live conversation in flight; the resulting session dir is
-    # disposable and the prune worker reaps it on the normal cadence.
+    # User-level provisioning lays down the system-file symlinks (INDEX/GUIDE)
+    # + the full SKILL.md catalog in one hash-gated pass. Soft-fails when the
+    # JuiceFS mount is missing.
     try:
-        await bootstrap_user_session(user_id, "_bootstrap", connected)
+        await provision_user_workspace(user_id, connected)
     except JuiceFSUnavailable:
         print(f"[skip] {user_id}: JuiceFS mount unavailable", file=sys.stderr)
         return

--- a/apps/api/tests/integration/test_bot_auth_chain.py
+++ b/apps/api/tests/integration/test_bot_auth_chain.py
@@ -564,7 +564,7 @@ class TestBotEndpointSettings:
                 return_value=user_doc,
             ),
             patch(
-                "app.api.v1.endpoints.bot.get_user_connected_integrations",
+                "app.api.v1.endpoints.bot.get_user_integration_records",
                 new_callable=AsyncMock,
                 return_value=[],
             ),

--- a/apps/api/tests/unit/api/test_bot_endpoint.py
+++ b/apps/api/tests/unit/api/test_bot_endpoint.py
@@ -254,7 +254,7 @@ class TestGetSettings:
     """GET /api/v1/bot/settings/{platform}/{platform_user_id}"""
 
     @patch(
-        "app.api.v1.endpoints.bot.get_user_connected_integrations",
+        "app.api.v1.endpoints.bot.get_user_integration_records",
         new_callable=AsyncMock,
     )
     @patch(

--- a/apps/api/tests/unit/services/test_event_driven_workspace.py
+++ b/apps/api/tests/unit/services/test_event_driven_workspace.py
@@ -24,6 +24,29 @@ IFS = "app.services.integrations_fs"
 UINT = "app.services.integrations.user_integrations"
 USTATUS = "app.services.integrations.user_integration_status"
 OAUTH = "app.services.oauth.oauth_service"
+JFS = "app.services.storage.juicefs"
+
+
+# ---------------------------------------------------------------------------
+# _is_mounted — must require a REAL mountpoint, not just an existing dir.
+# Guards the gap where a never-converged mount over a pre-created /mnt/jfs dir
+# would silently route writes to the container's local disk.
+# ---------------------------------------------------------------------------
+
+
+def test_is_mounted_rejects_plain_existing_dir(tmp_path):
+    from app.services.storage import juicefs
+
+    # tmp_path exists and is a directory, but is NOT a mountpoint.
+    with patch.object(juicefs, "_mount_root", return_value=tmp_path):
+        assert juicefs._is_mounted() is False
+
+
+def test_is_mounted_false_for_missing_path():
+    from app.services.storage import juicefs
+
+    with patch.object(juicefs, "_mount_root", return_value=Path("/no/such/mount/xyz123")):
+        assert juicefs._is_mounted() is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/services/test_event_driven_workspace.py
+++ b/apps/api/tests/unit/services/test_event_driven_workspace.py
@@ -1,0 +1,339 @@
+"""Brutal unit tests for event-driven workspace materialization.
+
+Covers the pieces that moved per-user workspace work off the chat turn:
+- ``workspace_sync.sync_stale_user_workspaces`` (the startup/CLI bulk sync)
+- ``workspace_sync.init_system_subtree`` / ``resync_stale_user_workspaces``
+- ``integrations_fs.sync_user_integrations`` (connect/disconnect VFS sync)
+- ``user_integrations.get_connected_integration_ids`` (the shared filter)
+- the connect-path wiring in ``update_user_integration_status``
+- the registration-path wiring in ``oauth_service.store_user_info``
+
+The JuiceFS + Mongo boundaries are mocked; these test decision logic to its
+limits (no mount, empty sets, stale vs current markers, force, partial
+failure, new-vs-existing user), not the filesystem.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+WS = "app.services.workspace_sync"
+IFS = "app.services.integrations_fs"
+UINT = "app.services.integrations.user_integrations"
+USTATUS = "app.services.integrations.user_integration_status"
+OAUTH = "app.services.oauth.oauth_service"
+
+
+# ---------------------------------------------------------------------------
+# workspace_sync.sync_stale_user_workspaces
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wsync():
+    """Patch every external dependency of sync_stale_user_workspaces."""
+    with (
+        patch(f"{WS}._is_mounted", return_value=True) as is_mounted,
+        patch(f"{WS}.library_hash", return_value="HASH_CURRENT"),
+        patch(f"{WS}.user_root", side_effect=lambda uid: Path(f"/fake/{uid}")),
+        patch(f"{WS}.read_skills_marker") as read_marker,
+        patch(f"{WS}.provision_user_workspace", new_callable=AsyncMock) as provision,
+        patch(
+            f"{WS}.get_connected_integration_ids",
+            new_callable=AsyncMock,
+            return_value={"gmail"},
+        ) as connected,
+        patch(f"{WS}._active_user_ids", new_callable=AsyncMock) as active_ids,
+        patch(f"{WS}._all_user_ids", new_callable=AsyncMock) as all_ids,
+    ):
+        yield SimpleNamespace(
+            is_mounted=is_mounted,
+            read_marker=read_marker,
+            provision=provision,
+            connected=connected,
+            active_ids=active_ids,
+            all_ids=all_ids,
+        )
+
+
+async def _run_sync(**kwargs):
+    from app.services.workspace_sync import sync_stale_user_workspaces
+
+    return await sync_stale_user_workspaces(**kwargs)
+
+
+async def test_no_mount_short_circuits(wsync):
+    wsync.is_mounted.return_value = False
+    result = await _run_sync()
+    assert result == {"scanned": 0, "synced": 0, "skipped": 0}
+    wsync.active_ids.assert_not_called()
+    wsync.provision.assert_not_called()
+
+
+async def test_all_stale_provisioned(wsync):
+    wsync.active_ids.return_value = ["u1", "u2"]
+    wsync.read_marker.side_effect = ["OLD", "OLD"]
+    result = await _run_sync()
+    assert result == {"scanned": 2, "synced": 2, "skipped": 0}
+    assert wsync.provision.await_count == 2
+
+
+async def test_current_marker_skipped(wsync):
+    wsync.active_ids.return_value = ["u1", "u2"]
+    wsync.read_marker.side_effect = ["HASH_CURRENT", "HASH_CURRENT"]
+    result = await _run_sync()
+    assert result == {"scanned": 2, "synced": 0, "skipped": 2}
+    wsync.provision.assert_not_called()
+
+
+async def test_mixed_stale_and_current(wsync):
+    wsync.active_ids.return_value = ["fresh", "stale"]
+    wsync.read_marker.side_effect = ["HASH_CURRENT", "OLD"]
+    result = await _run_sync()
+    assert result == {"scanned": 2, "synced": 1, "skipped": 1}
+    wsync.provision.assert_awaited_once_with("stale", {"gmail"})
+
+
+async def test_force_ignores_marker(wsync):
+    wsync.active_ids.return_value = ["u1", "u2"]
+    # read_marker must never be consulted when force=True
+    wsync.read_marker.side_effect = AssertionError("marker read despite force")
+    result = await _run_sync(force=True)
+    assert result == {"scanned": 2, "synced": 2, "skipped": 0}
+
+
+async def test_one_user_failure_does_not_abort_batch(wsync):
+    wsync.active_ids.return_value = ["bad", "good"]
+    wsync.read_marker.side_effect = ["OLD", "OLD"]
+    wsync.provision.side_effect = [RuntimeError("boom"), None]
+    result = await _run_sync()
+    # 'bad' raised, 'good' still provisioned; neither aborts the run.
+    assert result == {"scanned": 2, "synced": 1, "skipped": 0}
+    assert wsync.provision.await_count == 2
+
+
+async def test_active_only_false_uses_all_users(wsync):
+    wsync.all_ids.return_value = ["a", "b", "c"]
+    wsync.read_marker.side_effect = ["OLD", "OLD", "OLD"]
+    result = await _run_sync(active_only=False)
+    assert result["scanned"] == 3
+    wsync.all_ids.assert_awaited_once()
+    wsync.active_ids.assert_not_called()
+
+
+async def test_empty_user_set(wsync):
+    wsync.active_ids.return_value = []
+    result = await _run_sync()
+    assert result == {"scanned": 0, "synced": 0, "skipped": 0}
+    wsync.provision.assert_not_called()
+
+
+async def test_provision_receives_connected_ids(wsync):
+    wsync.active_ids.return_value = ["u1"]
+    wsync.read_marker.side_effect = ["OLD"]
+    wsync.connected.return_value = {"slack", "notion"}
+    await _run_sync()
+    wsync.provision.assert_awaited_once_with("u1", {"slack", "notion"})
+
+
+# ---------------------------------------------------------------------------
+# workspace_sync startup wrappers
+# ---------------------------------------------------------------------------
+
+
+async def test_init_system_subtree_waits_for_mount_then_materializes():
+    calls = []
+    aget = AsyncMock(side_effect=lambda name: calls.append(("mount", name)))
+    subtree = AsyncMock(side_effect=lambda: calls.append(("subtree",)))
+    with (
+        patch(f"{WS}.providers", SimpleNamespace(aget=aget)),
+        patch(f"{WS}.ensure_system_subtree", subtree),
+    ):
+        from app.services.workspace_sync import init_system_subtree
+
+        await init_system_subtree()
+    assert calls == [("mount", "juicefs_mount"), ("subtree",)]
+
+
+async def test_resync_runs_active_only():
+    with (
+        patch(f"{WS}.providers", SimpleNamespace(aget=AsyncMock())),
+        patch(f"{WS}.sync_stale_user_workspaces", new_callable=AsyncMock) as sync,
+    ):
+        from app.services.workspace_sync import resync_stale_user_workspaces
+
+        await resync_stale_user_workspaces()
+    sync.assert_awaited_once_with(active_only=True)
+
+
+# ---------------------------------------------------------------------------
+# integrations_fs.sync_user_integrations
+# ---------------------------------------------------------------------------
+
+
+async def test_sync_user_integrations_materializes_connected_set():
+    with (
+        patch(
+            f"{IFS}.get_connected_integration_ids",
+            new_callable=AsyncMock,
+            return_value={"gmail", "slack"},
+        ),
+        patch(f"{IFS}.materialize_user_integrations", new_callable=AsyncMock) as mat,
+    ):
+        from app.services.integrations_fs import sync_user_integrations
+
+        rc = await sync_user_integrations("user-1")
+    assert rc == 0
+    mat.assert_awaited_once_with("user-1", {"gmail", "slack"})
+
+
+async def test_sync_user_integrations_empty_set_still_materializes():
+    """A full disconnect leaves an empty set — must still rewrite the catalog."""
+    with (
+        patch(
+            f"{IFS}.get_connected_integration_ids",
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(f"{IFS}.materialize_user_integrations", new_callable=AsyncMock) as mat,
+    ):
+        from app.services.integrations_fs import sync_user_integrations
+
+        await sync_user_integrations("user-1")
+    mat.assert_awaited_once_with("user-1", set())
+
+
+# ---------------------------------------------------------------------------
+# get_connected_integration_ids — the shared filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "docs, expected",
+    [
+        ([], set()),
+        ([{"integration_id": "gmail", "status": "connected"}], {"gmail"}),
+        ([{"integration_id": "gmail", "status": "created"}], set()),
+        ([{"status": "connected"}], set()),  # missing integration_id
+        (
+            [
+                {"integration_id": "x", "status": "connected"},
+                {"integration_id": "x", "status": "connected"},
+            ],
+            {"x"},
+        ),
+        (
+            [
+                {"integration_id": "a", "status": "connected"},
+                {"integration_id": "b", "status": "created"},
+                {"integration_id": "c", "status": "connected"},
+            ],
+            {"a", "c"},
+        ),
+    ],
+)
+async def test_get_connected_integration_ids_filter(docs, expected):
+    with patch(
+        f"{UINT}.get_user_integration_records",
+        new_callable=AsyncMock,
+        return_value=docs,
+    ):
+        from app.services.integrations.user_integrations import get_connected_integration_ids
+
+        assert await get_connected_integration_ids("u") == expected
+
+
+# ---------------------------------------------------------------------------
+# connect-path wiring: update_user_integration_status
+# ---------------------------------------------------------------------------
+
+
+def _update_result(*, modified=1, upserted=None, matched=1):
+    return SimpleNamespace(modified_count=modified, upserted_id=upserted, matched_count=matched)
+
+
+async def test_connect_schedules_sync():
+    coll = MagicMock()
+    coll.update_one = AsyncMock(return_value=_update_result())
+    with (
+        patch(f"{USTATUS}.user_integrations_collection", coll),
+        patch(f"{USTATUS}.schedule_user_integrations_sync") as sched,
+    ):
+        from app.services.integrations.user_integration_status import update_user_integration_status
+
+        ok = await update_user_integration_status("u", "gmail", "connected")
+    assert ok is True
+    sched.assert_called_once_with("u")
+
+
+async def test_created_status_does_not_schedule_sync():
+    coll = MagicMock()
+    coll.update_one = AsyncMock(return_value=_update_result())
+    with (
+        patch(f"{USTATUS}.user_integrations_collection", coll),
+        patch(f"{USTATUS}.schedule_user_integrations_sync") as sched,
+    ):
+        from app.services.integrations.user_integration_status import update_user_integration_status
+
+        await update_user_integration_status("u", "gmail", "created")
+    sched.assert_not_called()
+
+
+async def test_failed_update_does_not_schedule_sync():
+    coll = MagicMock()
+    coll.update_one = AsyncMock(return_value=_update_result(modified=0, upserted=None, matched=0))
+    with (
+        patch(f"{USTATUS}.user_integrations_collection", coll),
+        patch(f"{USTATUS}.schedule_user_integrations_sync") as sched,
+    ):
+        from app.services.integrations.user_integration_status import update_user_integration_status
+
+        ok = await update_user_integration_status("u", "gmail", "connected")
+    assert ok is False
+    sched.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# registration-path wiring: oauth_service.store_user_info
+# ---------------------------------------------------------------------------
+
+
+def _oauth_patches(coll, sched):
+    return (
+        patch(f"{OAUTH}.users_collection", coll),
+        patch(f"{OAUTH}.schedule_user_provision", sched),
+        patch(f"{OAUTH}.track_login", MagicMock()),
+        patch(f"{OAUTH}.track_signup", MagicMock()),
+        patch(f"{OAUTH}.send_welcome_email", new_callable=AsyncMock),
+        patch(f"{OAUTH}.add_contact_to_resend", new_callable=AsyncMock),
+    )
+
+
+async def test_new_user_provisions_workspace():
+    coll = MagicMock()
+    coll.find_one = AsyncMock(return_value=None)  # no existing user
+    coll.insert_one = AsyncMock(return_value=SimpleNamespace(inserted_id="NEW123"))
+    sched = MagicMock()
+    p = _oauth_patches(coll, sched)
+    with p[0], p[1], p[2], p[3], p[4], p[5]:
+        from app.services.oauth.oauth_service import store_user_info
+
+        user_id, is_new = await store_user_info("Ada", "ada@x.com", None)
+    assert is_new is True
+    sched.assert_called_once_with("NEW123")
+
+
+async def test_existing_user_does_not_provision():
+    coll = MagicMock()
+    coll.find_one = AsyncMock(return_value={"_id": "EXISTING", "picture": "p.png"})
+    coll.update_one = AsyncMock()
+    sched = MagicMock()
+    p = _oauth_patches(coll, sched)
+    with p[0], p[1], p[2], p[3], p[4], p[5]:
+        from app.services.oauth.oauth_service import store_user_info
+
+        user_id, is_new = await store_user_info("Ada", "ada@x.com", None)
+    assert is_new is False
+    sched.assert_not_called()

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -1068,7 +1068,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_integration_records",
+        "app.services.integrations.user_integrations.get_connected_integration_ids",
         new_callable=AsyncMock,
     )
     @patch(
@@ -1087,9 +1087,7 @@ class TestGetUserIntegrationCapabilities:
         registry.get_core_categories.return_value = [core_category]
         mock_registry.return_value = registry
 
-        mock_connected.return_value = [
-            {"integration_id": "github", "status": "connected"},
-        ]
+        mock_connected.return_value = {"github"}
 
         int_tool = IntegrationTool(name="create_issue", description="Create an issue")
         mock_details.return_value = IntegrationResponse(
@@ -1116,7 +1114,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_integration_records",
+        "app.services.integrations.user_integrations.get_connected_integration_ids",
         new_callable=AsyncMock,
     )
     @patch(
@@ -1130,9 +1128,7 @@ class TestGetUserIntegrationCapabilities:
         registry.get_core_categories.return_value = []
         mock_registry.return_value = registry
 
-        mock_connected.return_value = [
-            {"integration_id": "deleted"},
-        ]
+        mock_connected.return_value = {"deleted"}
         mock_details.return_value = None
 
         result = await get_user_integration_capabilities.__wrapped__(USER_ID)
@@ -1145,33 +1141,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_integration_records",
-        new_callable=AsyncMock,
-    )
-    @patch(
-        "app.services.integrations.user_integrations.get_tool_registry",
-        new_callable=AsyncMock,
-    )
-    async def test_skips_entries_without_integration_id(
-        self, mock_registry, mock_connected, mock_details
-    ):
-        registry = MagicMock()
-        registry.get_core_categories.return_value = []
-        mock_registry.return_value = registry
-
-        mock_connected.return_value = [
-            {"status": "connected"},  # Missing integration_id
-        ]
-
-        result = await get_user_integration_capabilities.__wrapped__(USER_ID)
-        assert result["integration_names"] == []
-
-    @patch(
-        "app.services.integrations.user_integrations.get_integration_details",
-        new_callable=AsyncMock,
-    )
-    @patch(
-        "app.services.integrations.user_integrations.get_user_integration_records",
+        "app.services.integrations.user_integrations.get_connected_integration_ids",
         new_callable=AsyncMock,
     )
     @patch(
@@ -1182,7 +1152,7 @@ class TestGetUserIntegrationCapabilities:
         registry = MagicMock()
         registry.get_core_categories.return_value = []
         mock_registry.return_value = registry
-        mock_connected.return_value = []
+        mock_connected.return_value = set()
 
         result = await get_user_integration_capabilities.__wrapped__(USER_ID)
 

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -7,7 +7,7 @@ Covers:
 - integration_connection_service.py (build_integrations_config, connect_mcp_integration,
   connect_composio_integration, connect_self_integration, disconnect_integration,
   _invalidate_caches)
-- user_integrations.py (get_user_integrations, get_user_connected_integrations,
+- user_integrations.py (get_user_integrations, get_user_integration_records,
   add_user_integration, remove_user_integration, check_user_has_integration,
   get_user_integration_capabilities)
 - user_integration_status.py (update_user_integration_status)
@@ -63,8 +63,8 @@ from app.services.integrations.user_integration_status import (
 from app.services.integrations.user_integrations import (
     add_user_integration,
     check_user_has_integration,
-    get_user_connected_integrations,
     get_user_integration_capabilities,
+    get_user_integration_records,
     get_user_integrations,
     remove_user_integration,
 )
@@ -889,7 +889,7 @@ class TestGetUserConnectedIntegrations:
         mock_cursor.__aiter__ = aiter_docs
         mock_collection.find = MagicMock(return_value=mock_cursor)
 
-        result = await get_user_connected_integrations.__wrapped__(USER_ID)
+        result = await get_user_integration_records.__wrapped__(USER_ID)
 
         assert len(result) == 1
         assert result[0]["integration_id"] == "github"
@@ -905,7 +905,7 @@ class TestGetUserConnectedIntegrations:
         mock_cursor.__aiter__ = aiter_empty
         mock_collection.find = MagicMock(return_value=mock_cursor)
 
-        result = await get_user_connected_integrations.__wrapped__(USER_ID)
+        result = await get_user_integration_records.__wrapped__(USER_ID)
         assert result == []
 
 
@@ -1068,7 +1068,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_connected_integrations",
+        "app.services.integrations.user_integrations.get_user_integration_records",
         new_callable=AsyncMock,
     )
     @patch(
@@ -1116,7 +1116,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_connected_integrations",
+        "app.services.integrations.user_integrations.get_user_integration_records",
         new_callable=AsyncMock,
     )
     @patch(
@@ -1145,7 +1145,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_connected_integrations",
+        "app.services.integrations.user_integrations.get_user_integration_records",
         new_callable=AsyncMock,
     )
     @patch(
@@ -1171,7 +1171,7 @@ class TestGetUserIntegrationCapabilities:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.user_integrations.get_user_connected_integrations",
+        "app.services.integrations.user_integrations.get_user_integration_records",
         new_callable=AsyncMock,
     )
     @patch(

--- a/apps/api/tests/unit/services/test_mcp_client.py
+++ b/apps/api/tests/unit/services/test_mcp_client.py
@@ -2357,7 +2357,7 @@ class TestMCPClientFindIntegrationIdByServerUrl:
         with (
             patch("app.services.mcp.mcp_client.IntegrationResolver") as mock_resolver,
             patch(
-                "app.services.mcp.mcp_client.get_user_connected_integrations",
+                "app.services.mcp.mcp_client.get_user_integration_records",
                 new_callable=AsyncMock,
                 return_value=[
                     {"integration_id": "db_int", "status": "connected"},
@@ -2378,7 +2378,7 @@ class TestMCPClientFindIntegrationIdByServerUrl:
         client = MCPClient(user_id=USER_ID)
         with (
             patch(
-                "app.services.mcp.mcp_client.get_user_connected_integrations",
+                "app.services.mcp.mcp_client.get_user_integration_records",
                 new_callable=AsyncMock,
                 return_value=[],
             ),
@@ -2390,7 +2390,7 @@ class TestMCPClientFindIntegrationIdByServerUrl:
         client = MCPClient(user_id=USER_ID)
         with (
             patch(
-                "app.services.mcp.mcp_client.get_user_connected_integrations",
+                "app.services.mcp.mcp_client.get_user_integration_records",
                 new_callable=AsyncMock,
                 return_value=[
                     {"integration_id": "pending_int", "status": "created"},
@@ -2404,7 +2404,7 @@ class TestMCPClientFindIntegrationIdByServerUrl:
         client = MCPClient(user_id=USER_ID)
         with (
             patch(
-                "app.services.mcp.mcp_client.get_user_connected_integrations",
+                "app.services.mcp.mcp_client.get_user_integration_records",
                 new_callable=AsyncMock,
                 side_effect=Exception("DB error"),
             ),
@@ -2418,7 +2418,7 @@ class TestMCPClientFindIntegrationIdByServerUrl:
         with (
             patch("app.services.mcp.mcp_client.IntegrationResolver") as mock_resolver,
             patch(
-                "app.services.mcp.mcp_client.get_user_connected_integrations",
+                "app.services.mcp.mcp_client.get_user_integration_records",
                 new_callable=AsyncMock,
                 return_value=[
                     {"integration_id": "err_int", "status": "connected"},


### PR DESCRIPTION
Moves per-user workspace (JuiceFS VFS) materialization off the chat hot path and onto the events that actually change it — user registration, integration connect/disconnect, conversation creation, and app startup — instead of running the full bootstrap on every chat turn (todos/tasks already self-heal via their existing mutation schedulers). Also fixes the auto-generated conversation title reverting to "New Chat" after a refresh: the title-update task was racing the conversation-row insert, so the `$set` matched zero rows and the title only ever lived in the SSE stream.

Adds a developer CLI (`app.scripts.sync_user_workspaces`) for backfill/skill re-sync and a `dev:vm` mise task, removes now-dead code (`bootstrap_user_session`, `write_user_root_docs` — INDEX/GUIDE are symlinks into `_system`), and renames the misleading `get_user_connected_integrations` → `get_user_integration_records`. Verified end-to-end against the dockered backend — registration provisioning, session creation, and integration/todos/gaia-tasks sync all materialize correctly on disk — plus a 24-case unit suite; lint and type-check are clean.