### PR TITLE
fix(web): stop routing remote images through Cloudflare cdn-cgi resizer

### DIFF
--- a/apps/web/image-loader.ts
+++ b/apps/web/image-loader.ts
@@ -3,31 +3,40 @@ import type { ImageLoaderProps } from "next/image";
 /**
  * Cloudflare Image Resizing loader for next/image.
  *
- * Routes optimization to Cloudflare's image CDN via the `/cdn-cgi/image/`
- * endpoint instead of Next.js' default optimizer (which, on OpenNext/Workers,
- * runs uncached in the worker and is slow). Cloudflare transforms on the fly at
- * the edge and caches each (source, params, format) variant, so repeat hits are
- * free CDN cache hits and never touch the worker.
+ * Routes optimization for SAME-ORIGIN images to Cloudflare's image CDN via the
+ * `/cdn-cgi/image/` endpoint instead of Next.js' default optimizer (which, on
+ * OpenNext/Workers, runs uncached in the worker and is slow). Cloudflare
+ * transforms on the fly at the edge and caches each (source, params, format)
+ * variant, so repeat hits are free CDN cache hits and never touch the worker.
  *
- * Requires "Transformations" (Image Resizing) enabled on the zone, plus
- * "resize images from any origin" if remote sources are transformed.
+ * Remote images (favicons, external logos) are returned untouched so the
+ * browser loads them straight from their own CDN. This zone does not enable
+ * "resize images from any origin", so `/cdn-cgi/image/` answers 403 for any
+ * off-origin source; routing remote URLs through it is what broke them. It also
+ * would not help even if enabled — sources like Google's `s2/favicons`
+ * 301-redirect to gstatic, and the resizer does not follow redirects. These
+ * favicons are already tiny and CDN-cached at the source, so there is nothing
+ * to gain from edge-resizing them.
+ *
+ * Requires "Transformations" (Image Resizing) enabled on the zone.
  */
 const normalizeSrc = (src: string) =>
   src.startsWith("/") ? src.slice(1) : src;
 
-// Cloudflare treats everything after the options segment as the source, so a
-// `?` or `#` in the source (e.g. signed image URLs) would otherwise be parsed
-// as the loader URL's own query/fragment and truncate the path. Escape them.
-const escapeSrcForPath = (src: string) =>
-  normalizeSrc(src).replaceAll("?", "%3F").replaceAll("#", "%23");
+const isRemoteSource = (src: string) => /^https?:\/\//i.test(src);
 
 export default function cloudflareLoader({
   src,
   width,
   quality,
 }: ImageLoaderProps): string {
-  // Data URIs and already-transformed URLs pass through untouched.
-  if (src.startsWith("data:") || src.includes("/cdn-cgi/image/")) {
+  // Data URIs, already-transformed URLs, and any off-origin source bypass the
+  // edge resizer and load directly.
+  if (
+    src.startsWith("data:") ||
+    src.includes("/cdn-cgi/image/") ||
+    isRemoteSource(src)
+  ) {
     return src;
   }
 
@@ -37,5 +46,5 @@ export default function cloudflareLoader({
   }
 
   const params = [`width=${width}`, `quality=${quality || 75}`, "format=auto"];
-  return `/cdn-cgi/image/${params.join(",")}/${escapeSrcForPath(src)}`;
+  return `/cdn-cgi/image/${params.join(",")}/${normalizeSrc(src)}`;
 }


### PR DESCRIPTION
## Problem

The Cloudflare image loader (\`apps/web/image-loader.ts\`, active on edge builds via \`IMAGE_LOADER=cloudflare\`) routed **every** \`next/image\` source through \`/cdn-cgi/image/…\` — including remote favicon/logo URLs. Result: broken external favicons in production, e.g. the browserbase logo rendered from:

\`\`\`
https://heygaia.io/cdn-cgi/image/width=32,quality=75,format=auto/https://www.google.com/s2/favicons%3Fdomain=browserbase.com&sz=128
\`\`\`

## Root cause (verified against the live `heygaia.io` zone with curl)

| Source through cdn-cgi | Result |
|---|---|
| Local `images/icons/slack.svg` | `200 image/svg+xml` |
| Remote (Google favicon, gstatic, GitHub — any origin) | `403 Forbidden` for **all** encodings |
| Google `s2/favicons?domain=…` direct | `301 redirect` → gstatic |

Three independent failures, none fixable by tweaking encoding:

1. This zone does not enable **"resize images from any origin"**, so the edge resizer 403s every off-origin source.
2. `s2/favicons` **301-redirects** to gstatic, and the resizer does not follow redirects.
3. The old `escapeSrcForPath` escaped only `?`→`%3F` and left `&`, corrupting the nested query string (`favicons%3Fdomain=…&sz=128`) — the visible symptom.

## Fix

Bypass the edge transform for `data:` URIs and any `http(s)://` (remote) source — return them untouched so the browser loads them directly from their own CDN (already `200`, already tiny + CDN-cached). Same-origin images still get edge-optimized and cached. Removed the now-dead `escapeSrcForPath` helper (only same-origin paths reach the transform now, and those carry no query string).

## Verification

- Local images → edge-optimized via cdn-cgi (confirmed `200`).
- Remote URLs (favicons, external logos) → loaded directly (confirmed `200` at source).
- `biome check` clean; file only imports a type, so type-check is unaffected.

## Note

If external favicons should ever be edge-resized, the real levers are enabling "resize images from any origin" on the Cloudflare zone **and** switching the favicon source off the redirecting `s2/favicons` endpoint to the direct `gstatic.com/faviconV2` form. Not worth it for tiny favicons — bypassing is the correct call.