### PR TITLE
fix(api): settle/re-arm overdue reminders in schedule-type backfill migration

### DIFF
--- a/apps/api/scripts/migrate_workflow_schedule_types.py
+++ b/apps/api/scripts/migrate_workflow_schedule_types.py
@@ -16,9 +16,17 @@ For workflows this script converts the scheduling/audit timestamps to datetimes 
 for every active recurring workflow, recomputes the next *future* run, marks it
 scheduled, and enqueues it in ARQ. It advances from now (never replays missed runs)
 and honours ``max_occurrences`` / ``stop_after``. Cancelled, paused and one-time
-workflows are left untouched. For reminders it converts the same string timestamps to
-datetimes — no re-arm is needed, the (now ``$lte``) recovery scan recovers overdue
-reminders once their dates are native.
+workflows are left untouched.
+
+For reminders it converts the same string timestamps to datetimes. A reminder whose
+``scheduled_at`` lands in the past once it is a native datetime would be fired
+immediately by the startup recovery scan (``status=scheduled`` + ``scheduled_at <=
+now``) — replaying a long-missed reminder at the user. The scheduler's own policy is to
+advance from now and never replay a missed run, so this migration settles overdue
+reminders the same way: a one-time overdue reminder is marked ``completed`` and a
+recurring overdue reminder is re-armed to its next *future* occurrence (and re-enqueued
+in ARQ), honouring ``max_occurrences`` / ``stop_after``. Future-dated reminders are only
+type-fixed and left scheduled, so a legitimately upcoming reminder still fires.
 
 Idempotent: re-running recomputes a future run and the deterministic ARQ job id dedupes
 the enqueue, so it is safe to run repeatedly.
@@ -41,6 +49,7 @@ from app.db.mongodb.collections import (  # noqa: E402
     workflows_collection,
 )
 from app.models.scheduler_models import ScheduledTaskStatus  # noqa: E402
+from app.services.reminder_service import ReminderScheduler  # noqa: E402
 from app.services.workflow.scheduler import WorkflowScheduler  # noqa: E402
 from app.utils.cron_utils import get_next_run_time  # noqa: E402
 
@@ -86,21 +95,70 @@ def _build_type_fixes(doc: dict) -> dict:
     return fixes
 
 
-async def _migrate_reminder_types(apply: bool) -> int:
-    """Type-repair reminder scheduling/audit datetimes.
+def _plan_reminder_recovery(
+    doc: dict, now: datetime
+) -> tuple[dict[str, object], str, datetime | None] | None:
+    """Decide how to stop an overdue reminder from replaying on the next scan.
 
-    No re-arm is needed: once the dates are native, the recovery scan
-    (``scheduled_at: {"$lte": now}``) recovers any overdue reminder.
+    Returns ``(set_fields, outcome, enqueue_at)`` where outcome is ``"settled"`` or
+    ``"rearmed"``, or ``None`` when the reminder is future-dated or not in the resting
+    scheduled state (type-fix only — leave its run-state alone). A re-armed reminder
+    carries ``enqueue_at`` so the caller re-adds its deferred ARQ job; the startup scan
+    only re-enqueues overdue tasks, so a future-armed reminder would otherwise be
+    orphaned once its original (long-expired) job is gone.
     """
-    fixed = 0
+    if doc.get("status") != ScheduledTaskStatus.SCHEDULED.value:
+        return None
+    scheduled_at = _to_datetime(doc.get("scheduled_at"))
+    if scheduled_at is None or scheduled_at > now:
+        return None
+
+    if not doc.get("repeat"):
+        return ({"status": ScheduledTaskStatus.COMPLETED.value}, "settled", None)
+
+    # Reminders carry no per-task timezone; recurrence is computed in UTC, matching
+    # ReminderScheduler's runtime path (handle_recurring_task passes timezone=None).
+    next_run = get_next_run_time(doc["repeat"], now, None)
+    if next_run is None or _recurrence_limit_reached(doc, next_run):
+        return ({"status": ScheduledTaskStatus.COMPLETED.value}, "settled", None)
+
+    return (
+        {"scheduled_at": next_run, "status": ScheduledTaskStatus.SCHEDULED.value},
+        "rearmed",
+        next_run,
+    )
+
+
+async def _migrate_reminders(
+    scheduler: ReminderScheduler, now: datetime, apply: bool
+) -> dict[str, int]:
+    """Type-repair reminder datetimes, then settle/re-arm any overdue reminder so the
+    startup recovery scan never replays a long-missed fire."""
+    counts = {"type_fixed": 0, "rearmed": 0, "settled": 0}
     async for doc in reminders_collection.find({}):
-        fixes = _build_type_fixes(doc)
-        if fixes:
-            fixed += 1
-            print(f"  reminder {doc.get('_id')}: type-fix {sorted(fixes)}")
-            if apply:
-                await reminders_collection.update_one({"_id": doc["_id"]}, {"$set": fixes})
-    return fixed
+        set_fields: dict[str, object] = dict(_build_type_fixes(doc))
+        if set_fields:
+            counts["type_fixed"] += 1
+
+        plan = _plan_reminder_recovery(doc, now)
+        enqueue_at: datetime | None = None
+        if plan is not None:
+            delta, outcome, enqueue_at = plan
+            set_fields.update(delta)
+            counts[outcome] += 1
+            print(f"  reminder {doc.get('_id')}: {outcome} {sorted(delta)}")
+        elif set_fields:
+            print(f"  reminder {doc.get('_id')}: type-fix {sorted(set_fields)}")
+
+        if not set_fields:
+            continue
+        if apply:
+            if plan is not None:
+                set_fields["updated_at"] = now
+            await reminders_collection.update_one({"_id": doc["_id"]}, {"$set": set_fields})
+            if enqueue_at is not None:
+                await scheduler.reschedule_task(str(doc["_id"]), enqueue_at)
+    return counts
 
 
 async def _apply_type_fixes(doc: dict, apply: bool) -> bool:
@@ -180,11 +238,13 @@ async def migrate(apply: bool) -> None:
     print(f"[{mode}] Repairing workflow + reminder scheduling state...\n")
 
     scheduler = WorkflowScheduler()
+    reminder_scheduler = ReminderScheduler()
     if apply:
         await scheduler.initialize()
+        await reminder_scheduler.initialize()
 
     counts = {"type_fixed": 0, "rearmed": 0, "completed": 0, "skipped": 0}
-    reminder_fixed = 0
+    reminder_counts = {"type_fixed": 0, "rearmed": 0, "settled": 0}
 
     try:
         async for doc in workflows_collection.find({}):
@@ -199,16 +259,19 @@ async def migrate(apply: bool) -> None:
             outcome = await _rearm_workflow(doc, scheduler, now, apply)
             counts[outcome] += 1
 
-        # 3. Type repair for reminders (same string->datetime defect, no re-arm).
-        reminder_fixed = await _migrate_reminder_types(apply)
+        # 3. Type repair + settle/re-arm for reminders (same string->datetime defect;
+        #    overdue reminders are settled/re-armed so the scan never replays them).
+        reminder_counts = await _migrate_reminders(reminder_scheduler, datetime.now(UTC), apply)
     finally:
         if apply:
             await scheduler.close()
+            await reminder_scheduler.close()
 
     print(
         f"\n[{mode}] Done. workflow type-fixed={counts['type_fixed']} "
         f"re-armed={counts['rearmed']} completed={counts['completed']} "
-        f"skipped={counts['skipped']} | reminder type-fixed={reminder_fixed}"
+        f"skipped={counts['skipped']} | reminder type-fixed={reminder_counts['type_fixed']} "
+        f"re-armed={reminder_counts['rearmed']} settled={reminder_counts['settled']}"
     )
     if not apply:
         print("Re-run with --apply to write these changes.")


### PR DESCRIPTION
## Problem

`scripts/migrate_workflow_schedule_types.py` (added in #736) repairs the string→datetime defect for reminders, but its reminder path **only type-fixed timestamps** and relied on the startup recovery scan to deliver overdue reminders.

The recovery scan (`scheduler_service.py` `_query_pending_tasks`) selects `status=scheduled` + `scheduled_at <= now` with **no age guard**. So once a stuck reminder's date becomes native, it becomes immediately due and the worker fires it on the next scan — replaying long-missed reminders at users.

Measured on prod before this fix: **32 reminders 7–312 days overdue** (29 of them >30 days) would have been delivered on the next worker restart.

## Fix

Mirror the workflow re-arm logic and the scheduler's own policy ("advance from now, never replay a missed run", `scheduler_service.py:189-190`) for reminders:

- **one-time overdue** reminder → settled to `completed` (does not fire)
- **recurring overdue** reminder → re-armed to its next *future* occurrence and re-enqueued in ARQ (honouring `max_occurrences` / `stop_after`)
- **future-dated** reminders → only type-fixed, still fire on schedule

The re-arm re-enqueues a deferred ARQ job because the startup scan only re-enqueues *overdue* tasks; a future-armed reminder whose original (long-expired) job is gone would otherwise be orphaned.

## Verification

Ran against **production** (dry run → apply with the ARQ worker scaled to 0 → worker restarted):

- `reminder type-fixed=65, settled=21, re-armed=11`
- post-apply idempotency dry run: `type-fixed=0, settled=0, re-armed=0`
- worker startup recovery scan then found **1** genuinely-due task — **not** a stale burst
- worker healthy afterward (`j_failed=0`)

Idempotent and safe to re-run. `nx lint api` / `nx type-check api` clean (pre-commit ruff/bandit/pip-audit/mypy passed on push).