### PR TITLE
feat(api): rate limit E2B sandbox creation

### DIFF
--- a/apps/api/app/config/rate_limits.py
+++ b/apps/api/app/config/rate_limits.py
@@ -189,6 +189,14 @@ FEATURE_LIMITS: dict[str, TieredRateLimits] = {
         info=FeatureInfo(title="Memory Operations", description="Store and retrieve memories"),
     ),
     # Coding tools (persistent E2B workspace)
+    "sandbox_creation": TieredRateLimits(
+        free=RateLimitConfig(day=3, month=20),  # Each create provisions a fresh E2B VM
+        pro=RateLimitConfig(day=150, month=3000),
+        info=FeatureInfo(
+            title="Sandbox Creation",
+            description="Provision a fresh coding sandbox for shell and workspace tools",
+        ),
+    ),
     "bash_execution": TieredRateLimits(
         free=RateLimitConfig(day=20, month=200),  # Restrictive: sandbox cost
         pro=RateLimitConfig(day=1500, month=45000),

--- a/apps/api/app/decorators/__init__.py
+++ b/apps/api/app/decorators/__init__.py
@@ -8,6 +8,7 @@ from .integration import require_integration
 from .rate_limiting import (
     LangChainRateLimitException,
     clear_user_context,
+    enforce_rate_limit,
     get_current_rate_limit_info,
     set_user_context,
     tiered_rate_limit,
@@ -20,6 +21,7 @@ __all__ = [
     # Rate limiting
     "with_rate_limiting",
     "tiered_rate_limit",
+    "enforce_rate_limit",
     "LangChainRateLimitException",
     "set_user_context",
     "clear_user_context",

--- a/apps/api/app/decorators/rate_limiting.py
+++ b/apps/api/app/decorators/rate_limiting.py
@@ -17,6 +17,7 @@ from app.api.v1.middleware.tiered_rate_limiter import (
 )
 from app.db.redis import redis_cache
 from app.models.payment_models import PlanType
+from app.models.usage_models import UsageInfo
 from app.services.payments.payment_service import payment_service
 from shared.py.wide_events import log
 
@@ -284,6 +285,23 @@ class LangChainRateLimitException(Exception):
             message += f" Upgrade to {detail['plan_required'].upper()} for higher limits."
 
         super().__init__(message)
+
+
+async def enforce_rate_limit(user_id: str, feature_key: str) -> dict[str, UsageInfo]:
+    """Check-and-increment a feature's tiered rate limit from service-layer code.
+
+    For call sites that are neither FastAPI endpoints nor LangChain tools
+    (e.g. sandbox lifecycle), where the decorator forms don't apply.
+
+    Raises RateLimitExceededException when the limit is exceeded.
+    """
+    subscription = await _get_cached_subscription(user_id)
+    user_plan = subscription.plan_type or PlanType.FREE
+    return await tiered_limiter.check_and_increment(
+        user_id=user_id,
+        feature_key=feature_key,
+        user_plan=user_plan,
+    )
 
 
 async def _get_cached_subscription(user_id: str):

--- a/apps/api/app/services/sandbox/lifecycle.py
+++ b/apps/api/app/services/sandbox/lifecycle.py
@@ -27,8 +27,10 @@ from urllib.parse import urlsplit, urlunsplit
 
 from e2b import AsyncSandbox
 
+from app.api.v1.middleware.tiered_rate_limiter import RateLimitExceededException
 from app.config.settings import settings
 from app.db.mongodb.collections import e2b_sandboxes_collection
+from app.decorators import enforce_rate_limit
 from app.services.sandbox.artifact_watcher import start_watcher_for
 from app.services.sandbox.pool import PooledSandbox, get_sandbox_pool
 from app.services.sandbox.shard_router import shard_for, shard_meta_url
@@ -43,10 +45,15 @@ from shared.py.wide_events import log
 
 CANARY_PATH = "/workspace/.gaia/canary.txt"
 MOUNT_SCRIPT_PATH = "/etc/gaia/mount.sh"
+SANDBOX_CREATION_FEATURE_KEY = "sandbox_creation"
 
 
 class SandboxAcquisitionError(RuntimeError):
     """Raised when a usable sandbox cannot be obtained for a user."""
+
+
+class SandboxRateLimitError(SandboxAcquisitionError):
+    """Raised when the user has exhausted their sandbox-creation rate limit."""
 
 
 def _now() -> datetime:
@@ -114,6 +121,25 @@ def _mount_env(user_id: str, shard_id: int) -> dict[str, str]:
         "JFS_R2_BUCKET": (settings.R2_BUCKET or "").strip(),
         "JFS_R2_ACCOUNT": (settings.R2_ACCOUNT_ID or "").strip(),
     }
+
+
+async def _enforce_creation_limit(user_id: str) -> None:
+    """Gate fresh sandbox provisioning behind the tiered rate limiter.
+
+    Only the create path is gated — reusing or resuming an existing sandbox
+    stays unlimited; provisioning a new E2B VM is the cost driver.
+    """
+    try:
+        await enforce_rate_limit(user_id, SANDBOX_CREATION_FEATURE_KEY)
+    except RateLimitExceededException as e:
+        log.warning(f"[sandbox] creation rate limit hit for user {user_id}")
+        detail: dict[str, Any] = e.detail if isinstance(e.detail, dict) else {}
+        message = "sandbox creation limit reached"
+        if detail.get("reset_time"):
+            message += f"; resets at {detail['reset_time']}"
+        if detail.get("plan_required"):
+            message += f" (upgrade to {detail['plan_required'].upper()} for higher limits)"
+        raise SandboxRateLimitError(message) from e
 
 
 async def _create_fresh_sandbox(user_id: str, shard_id: int) -> Any:
@@ -385,6 +411,7 @@ async def _acquire_or_create(user_id: str) -> PooledSandbox:
         workspace_version = doc.get("workspace_version", 0)
 
     if sbx is None:
+        await _enforce_creation_limit(user_id)
         # Pre-create the per-user subtrees host-side so the sandbox's
         # ``--subdir`` mounts find them ready. Doing this on the host (which
         # holds the full JuiceFS mount) avoids ever exposing the full

--- a/apps/api/app/services/sandbox/lifecycle.py
+++ b/apps/api/app/services/sandbox/lifecycle.py
@@ -140,6 +140,9 @@ async def _enforce_creation_limit(user_id: str) -> None:
         if detail.get("plan_required"):
             message += f" (upgrade to {detail['plan_required'].upper()} for higher limits)"
         raise SandboxRateLimitError(message) from e
+    except Exception as e:
+        log.error(f"[sandbox] creation limit check failed for user {user_id}: {e}")
+        raise SandboxAcquisitionError(f"sandbox creation limit check failed: {e}") from e
 
 
 async def _create_fresh_sandbox(user_id: str, shard_id: int) -> Any:


### PR DESCRIPTION
## Summary

Tool-call rate limits (`bash_execution`, `workspace_read/write/edit`) already gate per-call sandbox usage, but **fresh E2B sandbox provisioning — the actual cost driver — was unlimited**. A user whose sandbox keeps dying or getting evicted (stale canary, health-probe failure, sweeper eviction) could trigger unbounded E2B VM creates.

## Changes

- **`config/rate_limits.py`** — new `sandbox_creation` feature key: free `3/day, 20/month`, pro `150/day, 3000/month`. Flows into the usage dashboard automatically via `FEATURE_LIMITS` enumeration.
- **`decorators/rate_limiting.py`** — new `enforce_rate_limit(user_id, feature_key)` service-layer entry point. The existing decorator forms can't be used here: `@tiered_rate_limit` needs a FastAPI user dependency and `@with_rate_limiting` needs a `config: RunnableConfig` parameter (validated at decoration time) — the sandbox lifecycle context manager has neither. The helper is a thin composition of the existing cached subscription lookup + `tiered_limiter.check_and_increment`; no limiter logic is duplicated.
- **`services/sandbox/lifecycle.py`** — `_acquire_or_create` enforces the limit **only on the fresh-create path**; reuse and pause/resume stay unlimited. On exceed it raises `SandboxRateLimitError` (subclass of `SandboxAcquisitionError`), so all coding tools degrade gracefully into their existing `sandbox unavailable` error string, including the reset time and a PRO upgrade hint.

## Verification

- `nx lint api` ✅
- `nx type-check api` ✅ (mypy, 623 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)