### PR TITLE
fix(infra): stop embedding-sidecar OOM-loop killing prod memory engine

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -225,12 +225,20 @@ services:
       restart_policy:
         condition: any
         delay: 5s
-        max_attempts: 3
+        # No max_attempts: an OOM or crash must always self-heal. Previously
+        # capped at 3 — under real traffic the sidecar OOM-looped, exhausted
+        # the 3 retries, and Swarm parked the service at 0/1 for hours (DNS
+        # for `embedding-sidecar` then drops, so every embed call fails).
       resources:
         limits:
-          memory: 2560M
+          # Working set under production load is ~3.0-3.1 GiB (two ONNX models
+          # — mxbai embedder + jina reranker — plus per-batch arenas that grow
+          # with batch_size, up to 40). The old 2560M cap sat below that, so
+          # the kernel OOM-killed it (exit 137) on first real traffic. 5G gives
+          # headroom; host has 15 GiB total / ~10 GiB free.
+          memory: 5120M
         reservations:
-          memory: 2G
+          memory: 3G
 
   # ---------------------------------------------------------------------------
   # Bots


### PR DESCRIPTION
## What broke

Production memory engine was fully down for ~9h (2026-06-14, ~00:35–09:40 UTC). All memory writes (`memory_retain`) and semantic memory search failed across `gaia-backend` and `arq_worker` with:

```
ConnectError: [Errno -2] Name or service not known   (backend="sidecar")
```

## Root cause (confirmed on the prod swarm, not inferred)

`docker inspect` on the dead `embedding-sidecar` containers:

```
OOMKilled=true   ExitCode=137   mem_limit=2684354560 (2560M)
```

`docker service ps gaia-prod_embedding-sidecar` — 4 tasks, all `task: non-zero exit (137)`.

The sidecar loads **two** ONNX models (mxbai-embed-large embedder + jina reranker) and fastembed/ONNX-Runtime allocates per-batch memory arenas that grow with `batch_size` (worker sends up to 40) and don't shrink. Measured working set under live traffic after restore: **~3.0–3.1 GiB** (cgroup `memory.peak`), above the **2560M** cap → kernel OOM-kill on first real traffic (~5 min after each start).

Then `restart_policy.max_attempts: 3` did the rest: Swarm restarted it 3×, each OOM'd, the cap was reached, and the service was **parked at 0/1**. With zero running tasks, `embedding-sidecar` drops out of swarm's internal DNS — hence the `[Errno -2]` on every embed call. A cap meant to stop crash-loop spam converted a transient OOM into a multi-hour outage.

## Fix

- **`limits.memory` 2560M → 5120M**, **`reservations.memory` 2G → 3G** — sized from the measured ~3.1 GiB peak; the host has 15 GiB total / ~10 GiB free, so this is comfortable.
- **Remove `restart_policy.max_attempts`** so an OOM/crash always self-heals instead of permanently parking the service at 0/1.

## Prod state

Already hot-restored live (`docker service update --limit-memory 4G`) — service is **1/1 healthy**, both models loaded, serving. This PR makes the fix durable so the next deploy doesn't revert to 2560M. **Re-deploy will move the live limit from the interim 4G to 5G.**

## Follow-up (not in this PR — needs design)

A single sidecar outage takes out 100% of the memory engine. A graceful-degradation path is worth discussing, but the obvious options each have a real downside: a local in-process fallback would load ~1.8 GB into every `arq_worker` (2 GB limit → worker OOM), and a Google-embeddings fallback produces vectors in a different space than the mxbai index (corrupts ANN retrieval). Deferred deliberately rather than shipped as a band-aid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)