### PR TITLE
fix(landing): truncate memory bento caption to one line

### DIFF
--- a/apps/web/src/features/landing/components/demo/memory-bento/MemoryFoldersCard.tsx
+++ b/apps/web/src/features/landing/components/demo/memory-bento/MemoryFoldersCard.tsx
@@ -102,7 +102,7 @@ export default function MemoryFoldersCard() {
         <AnimatePresence mode="wait" initial={false}>
           <m.span
             key={caption}
-            className="text-xs text-zinc-300"
+            className="min-w-0 flex-1 truncate text-xs text-zinc-300"
             initial={{ opacity: 0, y: 4 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}


### PR DESCRIPTION
## Problem

In the **"An assistant that actually knows you"** (MEMORY) section, the first bento's **"Noted from your chat:"** caption swaps on hover. The variants differ in length (e.g. `Noted from your chat: you love the window table there` is much longer than the default), so longer captions wrapped to two lines, growing the row and **shifting the folder rows below** on every hover.

## Fix

Constrain the caption to a single line with an ellipsis — `min-w-0 flex-1 truncate` on the caption span (`MemoryFoldersCard.tsx`).

## Verified (Chrome DevTools)

With the longest caption hovered: span height stays **16px (1 line)**, the caption row stays **40px** (unchanged), and the text ellipsizes (`scrollWidth 308 > clientWidth 293`). The folder rows below no longer move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)