### PR TITLE
fix(bots): copy pnpm patches into Docker build context

### DIFF
--- a/apps/bots/Dockerfile
+++ b/apps/bots/Dockerfile
@@ -9,8 +9,12 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10.17.1 --activate
 
-# Copy workspace config
+# Copy workspace config + pnpm patch files. The patch sources must travel
+# with the patchedDependencies declared in package.json/pnpm-lock.yaml —
+# pnpm hashes every patch during --frozen-lockfile, even for deps this bot
+# doesn't use. Copying the whole dir auto-includes any future patch.
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY patches ./patches
 
 # Copy shared lib (bundled into output by tsup) and the target bot
 COPY libs/shared/ts ./libs/shared/ts


### PR DESCRIPTION
## Problem

The `bots` release group's `docker:build` fails for all four bots (discord, slack, telegram, whatsapp), which breaks the `trigger-build / docker-release` CI job:

```
ENOENT: no such file or directory, open '/app/patches/sileo@0.1.4.patch'
... process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 254
```

## Root cause

`apps/bots/Dockerfile` copies the root `package.json` / `pnpm-lock.yaml`, which declare `patchedDependencies` (`sileo@0.1.4` → `patches/sileo@0.1.4.patch`), but it never copied the `patches/` directory into the build context. During `pnpm install --frozen-lockfile`, pnpm hashes **every** declared patch — even deps the bots don't use — so the install aborts when the patch file is absent.

Only the bots image is affected. `apps/web/Dockerfile` uses `COPY . .` (and the root `.dockerignore` doesn't exclude `patches/`), so it already includes patches. No Python image is affected.

## Fix

Add `COPY patches ./patches` right after the workspace manifests in the builder stage:

- Copies the **whole** `patches/` dir, so any current or future patch is included automatically — the patch *files* now always travel with the patch *declarations*.
- Positioned above the more frequently-changing `libs/shared/ts` and bot source for optimal layer caching (patches change rarely).

## Verification

Ran the exact failing command locally:

```
docker build --platform linux/amd64 -f apps/bots/Dockerfile --build-arg BOT_NAME=telegram .
```

Build now completes end-to-end — `pnpm install --frozen-lockfile` → tsup bundle → runner stage — confirming the ENOENT is resolved.