### PR TITLE
refactor(skills): resolve subagent skill targets via registry, add docgen handoff

### DIFF
--- a/apps/api/app/agents/core/subagents/registry.py
+++ b/apps/api/app/agents/core/subagents/registry.py
@@ -62,3 +62,27 @@ def get_subagent_by_id(subagent_id: str) -> Subagent | None:
         if sa.id.lower() == s or (sa.short_name and sa.short_name.lower() == s):
             return sa
     return None
+
+
+@cache
+def _subagent_id_by_agent_name() -> dict[str, str]:
+    """Map each subagent's `agent_name` to its canonical `id`.
+
+    `agent_name` is the one handle the skill catalog is keyed on: a skill's
+    frontmatter `target` is the owning subagent's `agent_name`, and the handoff
+    path passes that same `agent_name` when surfacing a subagent's skills. Built
+    from `all_subagents()`, so it is the authoritative `agent_name -> id` table
+    covering OAuth-derived AND builtin subagents. (`agent_name` is also the
+    LangGraph graph-registration key, so it is unique by construction.)
+    """
+    return {sa.config.agent_name: sa.id for sa in all_subagents()}
+
+
+def resolve_subagent_id(agent_name: str) -> str | None:
+    """Resolve a subagent `agent_name` to its canonical `id`, or `None` if no
+    registered subagent uses that `agent_name`.
+
+    `None` is the correct answer for the general `executor` bucket and for
+    custom/public MCP subagents that aren't in the registry.
+    """
+    return _subagent_id_by_agent_name().get(agent_name.strip())

--- a/apps/api/app/agents/core/subagents/subagent_helpers.py
+++ b/apps/api/app/agents/core/subagents/subagent_helpers.py
@@ -16,7 +16,9 @@ from langchain_core.messages import SystemMessage
 from app.agents.core.subagents.registry import get_subagent_by_id
 from app.agents.prompts.custom_mcp_prompts import CUSTOM_MCP_SUBAGENT_PROMPT
 from app.agents.skills.discovery import get_available_skills_text
+from app.agents.workspace.skill_loader import target_to_subagent
 from app.config.oauth_config import get_integration_by_id
+from app.constants.skills import EXECUTOR_SUBAGENT_ID
 from app.helpers.message_helpers import (
     BACKGROUND_EXECUTION_BANNER,
     DYNAMIC_CONTEXT_MARKER,
@@ -204,7 +206,7 @@ async def create_agent_context_message(
             block = skills_text or ""
         elif user_id:
             try:
-                agent_for_skills = subagent_id or "executor"
+                agent_for_skills = subagent_id or EXECUTOR_SUBAGENT_ID
                 text = await get_available_skills_text(user_id=user_id, agent_name=agent_for_skills)
                 if text:
                     log.info(f"Injected installable skills for {agent_for_skills}")
@@ -213,7 +215,11 @@ async def create_agent_context_message(
                 log.warning(f"Error injecting installable skills: {e}")
 
         if subagent_id:
-            integration_block = integration_skills_block(subagent_id)
+            # `subagent_id` carries the agent_name ("docgen_agent"), but
+            # skills_by_subagent is keyed by the subagent id ("docgen"). Map it the
+            # same way the loader builds those keys, or integration_skills_block
+            # silently finds nothing and the subagent runs with no skills.
+            integration_block = integration_skills_block(target_to_subagent(subagent_id))
             if integration_block:
                 block = f"{block}\n\n{integration_block}" if block else integration_block
 

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -740,6 +740,10 @@ GAIA SELF-KNOWLEDGE (MANDATORY)
 - Do NOT use web_search_tool, deep_research, or perplexity for GAIA questions: multiple unrelated "Gaia" projects exist; only gaia_knowledge_guide grounds answers in heygaia.io docs.
 - Pass the user's exact question through unchanged.
 
+DOCUMENT GENERATION (MANDATORY)
+- Downloadable document file (PDF, .docx, .pptx, .xlsx, CSV) → handoff to subagent:docgen. Always available, no retrieve_tools needed.
+- Not for inline chat cards (use create-artifacts) or docs inside a connected app (Google Docs/Sheets/Slides, Notion → their own subagents).
+
 Handoff contract (strict)
 - Send: objective + constraints + success criteria + key IDs/context.
 - Preserve user objective as-is.

--- a/apps/api/app/agents/skills/builtin/googlesheets-analyze-data/SKILL.md
+++ b/apps/api/app/agents/skills/builtin/googlesheets-analyze-data/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: googlesheets-analyze-data
 description: Analyze spreadsheet data intelligently - understand structure, choose right analysis tool (SQL/pivot/chart), apply formatting, present insights.
-target: googlesheets_agent
+target: google_sheets_agent
 ---
 
 # Google Sheets Analyze Data

--- a/apps/api/app/agents/skills/builtin/googlesheets-charts-graphs/SKILL.md
+++ b/apps/api/app/agents/skills/builtin/googlesheets-charts-graphs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: googlesheets-charts-graphs
 description: Create charts and visualizations in Google Sheets — detect data structure, select chart type, format for clarity, present insights
-target: googlesheets_agent
+target: google_sheets_agent
 ---
 
 # Google Sheets: Charts & Graphs

--- a/apps/api/app/agents/skills/discovery.py
+++ b/apps/api/app/agents/skills/discovery.py
@@ -32,12 +32,9 @@ from app.constants.cache import (
     SKILLS_TEXT_CACHE_KEY,
     SKILLS_TEXT_CACHE_TTL,
 )
+from app.constants.skills import EXECUTOR_SUBAGENT_ID
 from app.decorators.caching import Cacheable
 from shared.py.wide_events import log
-
-# Subagent id for executor-target builtins (matches skill_loader's mapping and
-# the `subagent_id or "executor"` fallback in subagent_helpers).
-_EXECUTOR_AGENT_NAME = "executor"
 
 
 def _builtin_entries(agent_name: str) -> list[tuple[str, str, str]]:
@@ -85,7 +82,7 @@ async def get_available_skills_text(
     # executor needs them merged here: integration subagents already get their
     # builtins via system_docs.integration_skills_block, so merging there too
     # would list them twice. Fetch first so a Mongo hiccup can't hide them.
-    builtins = _builtin_entries(agent_name) if agent_name == _EXECUTOR_AGENT_NAME else []
+    builtins = _builtin_entries(agent_name) if agent_name == EXECUTOR_SUBAGENT_ID else []
     try:
         user_skills = await get_skills_for_agent(user_id, agent_name)
     except Exception as e:

--- a/apps/api/app/agents/workspace/operational_docs.py
+++ b/apps/api/app/agents/workspace/operational_docs.py
@@ -429,6 +429,7 @@ these.
 | "Track this / follow up later / what are you tracking?" | tracked-todo tools | `tracked-todos` |
 | "Add to my todo list / what are my tasks?" | the user's todo provider | `user-todos` |
 | "Notify / remind me on WhatsApp/Telegram/email" | see the notifications doc | `notifications` |
+| "Make / export a downloadable file (PDF, Word, slides, spreadsheet, CSV)" | `handoff("docgen", ...)` | docgen subagent |
 | "How do you work / how do I configure you?" | answer from this core + the doc | (this core) |
 
 Persist a preference only when it is DURABLE, not a one-off for this turn.

--- a/apps/api/app/agents/workspace/skill_loader.py
+++ b/apps/api/app/agents/workspace/skill_loader.py
@@ -62,7 +62,8 @@ def target_to_subagent(agent_name: str) -> str:
         return EXECUTOR_SUBAGENT_ID
     resolved = resolve_subagent_id(agent_name)
     if resolved is None:
-        log.warning(f"skill_loader: skill target {agent_name!r} matches no subagent agent_name")
+        log.set(skill_target=agent_name, component="skill_loader")
+        log.warning("skill target matches no subagent agent_name")
         return agent_name
     return resolved
 

--- a/apps/api/app/agents/workspace/skill_loader.py
+++ b/apps/api/app/agents/workspace/skill_loader.py
@@ -24,36 +24,47 @@ from dataclasses import dataclass
 from functools import lru_cache
 import hashlib
 from pathlib import Path
-import re
 
+from app.agents.core.subagents.registry import resolve_subagent_id
+from app.constants.skills import (
+    BUILTIN_SKILLS_DIRNAME,
+    EXECUTOR_SUBAGENT_ID,
+    SKILL_FRONTMATTER_KV_RE,
+    SKILL_FRONTMATTER_RE,
+    SKILL_SOURCE_FILENAME,
+    SKILLS_PACKAGE_DIRNAME,
+)
 from shared.py.wide_events import log
 
 # Skills live as siblings in source: apps/api/app/agents/skills/builtin/<slug>/SKILL.md.
 # Resolved relative to this file so prod (the docker image), tests, and the dev
 # server all pick up the same library.
-_BUILTIN_ROOT = Path(__file__).resolve().parent.parent / "skills" / "builtin"
-
-# Filename of the materialized skill body inside each slug dir. Shared by the
-# materializer (storage.sessions.skills) and the index (skills.discovery) so the
-# path the agent is told to read always matches the file actually on disk.
-SKILL_BODY_FILENAME = "skill.md"
-
-# Frontmatter `target` values use a `<provider>_agent` convention plus the
-# special "executor" target for general-purpose skills. Map them to the
-# subagent id used by the registry/integrations service so the FS layout
-# (`integrations/<id>/...`) matches the runtime identifier.
-_TARGET_ALIASES = {
-    # Special "general" bucket — not tied to a single integration.
-    "executor": "executor",
-}
+_BUILTIN_ROOT = (
+    Path(__file__).resolve().parent.parent / SKILLS_PACKAGE_DIRNAME / BUILTIN_SKILLS_DIRNAME
+)
 
 
-def _target_to_subagent(target: str) -> str:
-    if target in _TARGET_ALIASES:
-        return _TARGET_ALIASES[target]
-    if target.endswith("_agent"):
-        return target[: -len("_agent")]
-    return target
+def target_to_subagent(agent_name: str) -> str:
+    """Resolve a subagent ``agent_name`` to the canonical subagent ``id`` used as
+    the ``skills_by_subagent`` key.
+
+    ``agent_name`` is the single handle the skill catalog is keyed on: every
+    builtin skill's frontmatter ``target`` is the owning subagent's ``agent_name``
+    (e.g. ``google_sheets_agent``), and the handoff path passes that same
+    ``agent_name`` when surfacing a subagent's skills. Resolution goes through the
+    subagent registry, the single source of truth for ``agent_name -> id``.
+    ``executor`` is the general bucket for skills not owned by a subagent and maps
+    to itself. An unknown ``agent_name`` is returned unchanged and logged so a
+    mis-targeted skill surfaces instead of being silently misfiled.
+    """
+    agent_name = agent_name.strip()
+    if agent_name == EXECUTOR_SUBAGENT_ID:
+        return EXECUTOR_SUBAGENT_ID
+    resolved = resolve_subagent_id(agent_name)
+    if resolved is None:
+        log.warning(f"skill_loader: skill target {agent_name!r} matches no subagent agent_name")
+        return agent_name
+    return resolved
 
 
 @dataclass(frozen=True)
@@ -73,26 +84,15 @@ class BuiltinSkill:
     resources: tuple[tuple[str, str], ...] = ()
 
 
-# Input is a trusted, bounded builtin SKILL.md frontmatter block bundled in the
-# repo — never user-supplied — so the lazy `.*?` cannot be driven into pathological
-# backtracking by an adversary.
-_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)  # NOSONAR python:S5852
-# Forgiving YAML reader: builtins only ever use scalar key: value pairs and we
-# don't want to depend on PyYAML in this hot path. The leading-whitespace gap is
-# matched possessively (`\s*+`) so it never backtracks into the value group,
-# keeping the match linear. Trailing whitespace is stripped by the caller.
-_KV_RE = re.compile(r"^([A-Za-z_]\w*):\s*+(.+)$")
-
-
 def _parse_frontmatter(raw: str) -> tuple[dict[str, str], str]:
-    match = _FRONTMATTER_RE.match(raw)
+    match = SKILL_FRONTMATTER_RE.match(raw)
     if not match:
         return {}, raw
     meta: dict[str, str] = {}
     for line in match.group(1).splitlines():
         if not line.strip() or line.lstrip().startswith("#"):
             continue
-        kv = _KV_RE.match(line)
+        kv = SKILL_FRONTMATTER_KV_RE.match(line)
         if kv:
             meta[kv.group(1)] = kv.group(2).strip().strip('"').strip("'")
     body = raw[match.end() :]
@@ -106,7 +106,7 @@ def _load_resources(skill_dir: Path) -> tuple[tuple[str, str], ...]:
     system-file model is text only)."""
     resources: list[tuple[str, str]] = []
     for path in sorted(skill_dir.rglob("*")):
-        if not path.is_file() or path.name == "SKILL.md":
+        if not path.is_file() or path.name == SKILL_SOURCE_FILENAME:
             continue
         # Skip build/junk artifacts (e.g. __pycache__/*.pyc, dotfiles) so a stray
         # local file never gets materialized + symlinked as a skill "resource".
@@ -130,19 +130,19 @@ def _load_resources(skill_dir: Path) -> tuple[tuple[str, str], ...]:
 
 
 def _load_one(skill_dir: Path) -> BuiltinSkill | None:
-    skill_path = skill_dir / "SKILL.md"
+    skill_path = skill_dir / SKILL_SOURCE_FILENAME
     if not skill_path.is_file():
         return None
     raw = skill_path.read_text(encoding="utf-8")
     meta, body = _parse_frontmatter(raw)
     name = meta.get("name", skill_dir.name)
-    target = meta.get("target", "executor")
+    target = meta.get("target", EXECUTOR_SUBAGENT_ID)
     return BuiltinSkill(
         slug=skill_dir.name,
         name=name,
         description=meta.get("description", ""),
         target=target,
-        subagent_id=_target_to_subagent(target),
+        subagent_id=target_to_subagent(target),
         body=body,
         resources=_load_resources(skill_dir),
     )
@@ -188,7 +188,7 @@ def skills_by_subagent() -> dict[str, list[BuiltinSkill]]:
 
 def integration_subagent_ids() -> Iterable[str]:
     """Subagent ids that own at least one skill (excluding executor)."""
-    return tuple(sa for sa in sorted(skills_by_subagent()) if sa != "executor")
+    return tuple(sa for sa in sorted(skills_by_subagent()) if sa != EXECUTOR_SUBAGENT_ID)
 
 
 @lru_cache(maxsize=1)
@@ -219,10 +219,10 @@ def library_hash() -> str:
 
 
 __all__ = [
-    "SKILL_BODY_FILENAME",
     "BuiltinSkill",
     "integration_subagent_ids",
     "library_hash",
     "load_builtin_skills",
     "skills_by_subagent",
+    "target_to_subagent",
 ]

--- a/apps/api/app/agents/workspace/system_files.py
+++ b/apps/api/app/agents/workspace/system_files.py
@@ -20,7 +20,6 @@ from functools import lru_cache
 from typing import NamedTuple
 
 from app.agents.workspace.skill_loader import (
-    SKILL_BODY_FILENAME,
     BuiltinSkill,
     load_builtin_skills,
 )
@@ -32,9 +31,7 @@ from app.agents.workspace.system_docs import (
     SESSIONS_GUIDE_MD,
     USER_TODOS_GUIDE_MD,
 )
-
-# Subagent id for general (non-integration) builtin skills.
-_EXECUTOR_SUBAGENT = "executor"
+from app.constants.skills import EXECUTOR_SUBAGENT_ID, SKILL_BODY_FILENAME
 
 
 class SystemFile(NamedTuple):
@@ -58,7 +55,7 @@ _STATIC_DOCS: list[tuple[str, str]] = [
 
 def builtin_skill_root_rel(skill: BuiltinSkill) -> str:
     """``/workspace``-relative directory of a builtin skill — matches materialize_skills."""
-    if skill.subagent_id == _EXECUTOR_SUBAGENT:
+    if skill.subagent_id == EXECUTOR_SUBAGENT_ID:
         return f"skills/{skill.slug}"
     return f"integrations/{skill.subagent_id}/agent/skills/{skill.slug}"
 

--- a/apps/api/app/constants/skills.py
+++ b/apps/api/app/constants/skills.py
@@ -1,0 +1,40 @@
+"""Skills domain constants.
+
+Single source of truth for the skill catalog's on-disk filenames, the special
+"executor" bucket id, the builtin library location, and the SKILL.md frontmatter
+parsers. Imported by the skill loader, the workspace materializers, the system-
+file index, and the discovery service so these values can never drift apart.
+"""
+
+import re
+
+# Source filename authored in the repo for each builtin skill
+# (apps/api/app/agents/skills/builtin/<slug>/SKILL.md).
+SKILL_SOURCE_FILENAME = "SKILL.md"
+
+# Filename of the materialized skill body inside each slug dir on the workspace
+# (e.g. integrations/<id>/agent/skills/<slug>/skill.md). Shared by the
+# materializer (storage.sessions.skills), the system-file index, and discovery
+# so the path the agent is told to read always matches the file on disk.
+SKILL_BODY_FILENAME = "skill.md"
+
+# Bucket id for general builtin skills not owned by an integration subagent
+# (create-artifacts, task-management, …). It is NOT a registered subagent: it
+# maps to itself and its skills materialize under /workspace/skills/ rather than
+# /workspace/integrations/<id>/.
+EXECUTOR_SUBAGENT_ID = "executor"
+
+# Builtin SKILL.md library location, relative to the app/agents/ package dir.
+SKILLS_PACKAGE_DIRNAME = "skills"
+BUILTIN_SKILLS_DIRNAME = "builtin"
+
+# --- SKILL.md frontmatter parsing -------------------------------------------
+# Input is a trusted, bounded builtin SKILL.md frontmatter block bundled in the
+# repo — never user-supplied — so the lazy `.*?` cannot be driven into pathological
+# backtracking by an adversary.
+SKILL_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)  # NOSONAR python:S5852
+# Forgiving YAML reader: builtins only ever use scalar key: value pairs and we
+# don't want to depend on PyYAML in this hot path. The leading-whitespace gap is
+# matched possessively (`\s*+`) so it never backtracks into the value group,
+# keeping the match linear. Trailing whitespace is stripped by the caller.
+SKILL_FRONTMATTER_KV_RE = re.compile(r"^([A-Za-z_]\w*):\s*+(.+)$")

--- a/apps/api/app/services/storage/sessions/skills.py
+++ b/apps/api/app/services/storage/sessions/skills.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from app.agents.workspace.skill_loader import (
-    SKILL_BODY_FILENAME,
     BuiltinSkill,
     skills_by_subagent,
 )
 from app.agents.workspace.system_docs import (
     INTEGRATIONS_GUIDE_MD,
 )
+from app.constants.skills import EXECUTOR_SUBAGENT_ID, SKILL_BODY_FILENAME
 from app.services.storage._vfs_common import matches_text
 from app.services.storage.juicefs import ensure_safe_path_id
 from shared.py.wide_events import log
@@ -118,7 +118,7 @@ def materialize_skills(user_root: Path, connected_ids: set[str]) -> int:
 
     grouped = skills_by_subagent()
     for iid, skills in grouped.items():
-        if iid == "executor" or not skills:
+        if iid == EXECUTOR_SUBAGENT_ID or not skills:
             continue
         agent_dir = integrations_root / iid / "agent"
         skills_dir = agent_dir / "skills"

--- a/apps/api/app/services/workflow/context_extractor.py
+++ b/apps/api/app/services/workflow/context_extractor.py
@@ -10,7 +10,9 @@ This module provides functionality to:
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.agents.core.subagents.registry import get_subagent_by_id
 from app.config.oauth_config import get_toolkit_to_integration_map
+from app.utils.agent_utils import parse_subagent_id
 from shared.py.wide_events import log
 
 
@@ -146,18 +148,22 @@ class WorkflowContextExtractor:
                 tool_args = tc.get("args", {})
                 tool_id = tc.get("id", "")
 
-                # Track agent transitions via handoff
+                # Track agent transitions via handoff. The handoff arg is a
+                # subagent reference ("subagent:gmail", "gmail", …); resolve it to
+                # the canonical integration id so following steps are attributed to it.
                 if tool_name == "handoff":
-                    subagent_id = tool_args.get("subagent_id", "")
-                    current_agent = f"{subagent_id}_agent"
-                    integrations.add(subagent_id)
+                    clean_id, _ = parse_subagent_id(tool_args.get("subagent_id", ""))
+                    sa = get_subagent_by_id(clean_id)
+                    current_agent = sa.id if sa else clean_id
+                    if current_agent:
+                        integrations.add(current_agent)
                     continue
 
                 # Skip internal tools
                 if tool_name in cls.SKIP_TOOLS:
                     continue
 
-                # Infer category from agent or tool name
+                # Infer category from the active subagent or the tool name
                 category = cls._infer_category(current_agent, tool_name)
                 if category != "general":
                     integrations.add(category)
@@ -207,13 +213,15 @@ class WorkflowContextExtractor:
 
     @classmethod
     def _infer_category(cls, agent: str, tool_name: str) -> str:
-        """Infer category from agent name or tool prefix.
+        """Infer the integration category for a step.
 
-        Uses oauth_config.get_toolkit_to_integration_map() as the single source of truth.
+        A step run inside a subagent inherits that subagent's integration id;
+        otherwise the category comes from the tool name's toolkit prefix, using
+        oauth_config.get_toolkit_to_integration_map() as the single source of truth.
         """
-        # From agent name: gmail_agent -> gmail
-        if agent and agent.endswith("_agent") and agent != "executor":
-            return agent.replace("_agent", "")
+        # A subagent handoff already pins the integration for its steps.
+        if agent and agent != "executor":
+            return agent
 
         # From tool name prefix using oauth_config as source of truth
         tool_upper = tool_name.upper()

--- a/apps/api/app/services/workflow/context_extractor.py
+++ b/apps/api/app/services/workflow/context_extractor.py
@@ -10,7 +10,7 @@ This module provides functionality to:
 from dataclasses import dataclass, field
 from typing import Any
 
-from app.agents.core.subagents.registry import get_subagent_by_id
+from app.agents.core.subagents.registry import get_subagent_by_id, resolve_subagent_id
 from app.config.oauth_config import get_toolkit_to_integration_map
 from app.utils.agent_utils import parse_subagent_id
 from shared.py.wide_events import log
@@ -154,7 +154,11 @@ class WorkflowContextExtractor:
                 if tool_name == "handoff":
                     clean_id, _ = parse_subagent_id(tool_args.get("subagent_id", ""))
                     sa = get_subagent_by_id(clean_id)
-                    current_agent = sa.id if sa else clean_id
+                    # `get_subagent_by_id` resolves id/short_name only; if the
+                    # handoff arg carried an `agent_name` ("docgen_agent"), fall back
+                    # to the registry's agent_name -> id map so steps are attributed
+                    # to the canonical subagent id rather than a raw name.
+                    current_agent = sa.id if sa else (resolve_subagent_id(clean_id) or clean_id)
                     if current_agent:
                         integrations.add(current_agent)
                     continue


### PR DESCRIPTION
Centralizes the skill catalog's filenames, frontmatter parsers, and the `executor` bucket id into `app/constants/skills.py` as a single source of truth shared by the loader, materializers, system-file index, and discovery service. Skill frontmatter `target`s now resolve through the subagent registry (`agent_name -> id`) instead of brittle string stripping, fixing the googlesheets target and the handoff path that previously surfaced no skills for subagents like docgen. Surfaces docgen as the document-generation handoff in agent prompts and operational docs, and attributes workflow steps to the resolved subagent integration id.