### PR TITLE
fix(agents): restore subagent conversation history persistence

### DIFF
--- a/apps/api/app/agents/core/subagents/handoff_tools.py
+++ b/apps/api/app/agents/core/subagents/handoff_tools.py
@@ -315,7 +315,7 @@ async def _resolve_subagent(
     # Platform/builtin subagent (Subagent object)
     subagent = resolved
     agent_name = subagent.config.agent_name
-    int_id = subagent.id
+    integration_id = subagent.id
 
     # Handle auth-required MCP integrations specially
     if subagent.managed_by == "mcp" and subagent.mcp_config and subagent.mcp_config.requires_auth:
@@ -329,9 +329,9 @@ async def _resolve_subagent(
 
         # Check if user has connected this MCP integration
         token_store = MCPTokenStore(user_id=user_id)
-        is_connected = await token_store.is_connected(int_id)
+        is_connected = await token_store.is_connected(integration_id)
         if not is_connected:
-            connect_url = build_connect_link_url(user_id, int_id)
+            connect_url = build_connect_link_url(user_id, integration_id)
             return (
                 None,
                 None,
@@ -340,7 +340,7 @@ async def _resolve_subagent(
             )
 
         # Create subagent on-the-fly with user's tokens
-        subagent_graph = await create_subagent_for_user(int_id, user_id)
+        subagent_graph = await create_subagent_for_user(integration_id, user_id)
         if not subagent_graph:
             return (
                 None,
@@ -352,7 +352,7 @@ async def _resolve_subagent(
         # Non-MCP or non-auth-required MCP integrations
         # Skip connection check for internal integrations (always available)
         if subagent.managed_by not in ("mcp", "internal") and user_id:
-            error_message = await check_integration_connection(int_id, user_id)
+            error_message = await check_integration_connection(integration_id, user_id)
             if error_message:
                 return None, None, error_message, False
 
@@ -363,28 +363,28 @@ async def _resolve_subagent(
         if not subagent_graph:
             return None, None, f"Error: {agent_name} not available", False
 
-    return subagent_graph, agent_name, int_id, False
+    return subagent_graph, agent_name, integration_id, False
 
 
 _background_subagent_tasks: set[asyncio.Task[None]] = set()
 
 
-async def _build_integration_metadata(is_custom: bool, int_id: str) -> IntegrationMetadata | None:
+async def _build_integration_metadata(is_custom: bool, integration_id: str) -> IntegrationMetadata | None:
     """Build display metadata for a resolved subagent integration."""
     if is_custom:
-        integration = await _get_subagent_by_id(int_id)
+        integration = await _get_subagent_by_id(integration_id)
         if isinstance(integration, dict):
             return IntegrationMetadata(
                 icon_url=integration.get("icon_url"),
-                integration_id=int_id,
-                name=str(integration.get("name") or int_id),
+                integration_id=integration_id,
+                name=str(integration.get("name") or integration_id),
             )
         return None
-    platform_integ = get_subagent_by_id(int_id)
+    platform_integ = get_subagent_by_id(integration_id)
     if platform_integ:
         return IntegrationMetadata(
             icon_url=getattr(platform_integ, "icon_url", None),
-            integration_id=int_id,
+            integration_id=integration_id,
             name=platform_integ.name,
         )
     return None
@@ -409,12 +409,12 @@ async def _run_blocking_handoff(
     ctx: SubagentExecutionContext,
     metadata: IntegrationMetadata | None,
     agent_name: str,
-    int_id: str,
+    integration_id: str,
 ) -> str:
     """Run a handoff subagent synchronously, emitting lifecycle SSE events."""
     writer = get_stream_writer()
     sa_id = str(uuid4())
-    display, icon_url, tool_category = _resolve_display_metadata(metadata, agent_name, int_id)
+    display, icon_url, tool_category = _resolve_display_metadata(metadata, agent_name, integration_id)
 
     # Propagate this subagent's UUID into config so nested spawned subagents
     # can reference it as parent_subagent_id.
@@ -512,11 +512,11 @@ async def handoff(
             return int_id_or_error or "Unknown error resolving subagent"
 
         agent_name: str = resolved_agent_name
-        int_id: str = int_id_or_error
+        integration_id: str = int_id_or_error
         log.set(
             subagent={
                 "name": agent_name,
-                "provider": int_id,
+                "provider": integration_id,
                 "is_custom": is_custom,
                 "task_length": len(task),
             }
@@ -524,7 +524,7 @@ async def handoff(
 
         # Build config
         thread_id = configurable.get("thread_id", "")
-        subagent_thread_id = f"{int_id}_{thread_id}"
+        subagent_thread_id = f"{integration_id}_{thread_id}"
 
         user = {
             "user_id": user_id,
@@ -544,7 +544,7 @@ async def handoff(
 
         # Create system message
         system_message = await create_subagent_system_message(
-            integration_id=int_id,
+            integration_id=integration_id,
             agent_name=agent_name,
             user_id=user_id,
         )
@@ -552,7 +552,7 @@ async def handoff(
         # Avoid passing Gaia display name as a service username
         provider_meta = None
         provider_name = None
-        platform_subagent = get_subagent_by_id(int_id)
+        platform_subagent = get_subagent_by_id(integration_id)
         if platform_subagent and platform_subagent.provider and user_id:
             provider_name = platform_subagent.provider
             provider_meta = await get_provider_metadata(user_id, platform_subagent.provider)
@@ -563,7 +563,7 @@ async def handoff(
         sanitized_task = _sanitize_task_user_reference(
             task=task,
             gaia_name=user.get("name"),
-            provider_hint=(provider_name or int_id),
+            provider_hint=(provider_name or integration_id),
             service_username=service_username,
         )
 
@@ -578,7 +578,7 @@ async def handoff(
             # Without this the custom-instructions/provider-metadata lookup falls
             # back to agent_name ("gmail_agent"), which never matches the stored
             # integration id ("gmail"), so the user's instructions are dropped.
-            integration_id=int_id,
+            integration_id=integration_id,
         )
 
         # Create execution context with stream_id for cancellation
@@ -587,7 +587,7 @@ async def handoff(
             agent_name=agent_name,
             config=subagent_config,
             configurable=new_configurable,
-            integration_id=int_id,
+            integration_id=integration_id,
             initial_state={
                 "messages": messages,
                 "todos": [],
@@ -598,7 +598,7 @@ async def handoff(
             stream_id=stream_id,
         )
 
-        integration_metadata = await _build_integration_metadata(is_custom, int_id)
+        integration_metadata = await _build_integration_metadata(is_custom, integration_id)
 
         # Background mode: spawn subagent as asyncio task and return immediately.
         # Caller must use wait_for_subagents() to collect results.
@@ -612,7 +612,7 @@ async def handoff(
                     "falling back to blocking execution"
                 )
                 blocking_result = await _run_blocking_handoff(
-                    ctx, integration_metadata, agent_name, int_id
+                    ctx, integration_metadata, agent_name, integration_id
                 )
                 return (
                     "[WARNING: background handoff fell back to blocking — "
@@ -622,7 +622,7 @@ async def handoff(
             sid: str = str(stream_id)
             bg_sa_id = str(uuid4())
             bg_display, bg_icon, bg_cat = _resolve_display_metadata(
-                integration_metadata, agent_name, int_id
+                integration_metadata, agent_name, integration_id
             )
             increment_pending_subagents(sid)
             bg_task = asyncio.create_task(
@@ -645,7 +645,7 @@ async def handoff(
             )
 
         # Blocking (default): execute synchronously and return result.
-        return await _run_blocking_handoff(ctx, integration_metadata, agent_name, int_id)
+        return await _run_blocking_handoff(ctx, integration_metadata, agent_name, integration_id)
 
     except Exception as e:
         log.error(

--- a/apps/api/app/agents/core/subagents/handoff_tools.py
+++ b/apps/api/app/agents/core/subagents/handoff_tools.py
@@ -369,7 +369,9 @@ async def _resolve_subagent(
 _background_subagent_tasks: set[asyncio.Task[None]] = set()
 
 
-async def _build_integration_metadata(is_custom: bool, integration_id: str) -> IntegrationMetadata | None:
+async def _build_integration_metadata(
+    is_custom: bool, integration_id: str
+) -> IntegrationMetadata | None:
     """Build display metadata for a resolved subagent integration."""
     if is_custom:
         integration = await _get_subagent_by_id(integration_id)
@@ -414,7 +416,9 @@ async def _run_blocking_handoff(
     """Run a handoff subagent synchronously, emitting lifecycle SSE events."""
     writer = get_stream_writer()
     sa_id = str(uuid4())
-    display, icon_url, tool_category = _resolve_display_metadata(metadata, agent_name, integration_id)
+    display, icon_url, tool_category = _resolve_display_metadata(
+        metadata, agent_name, integration_id
+    )
 
     # Propagate this subagent's UUID into config so nested spawned subagents
     # can reference it as parent_subagent_id.

--- a/apps/api/app/agents/core/subagents/subagent_helpers.py
+++ b/apps/api/app/agents/core/subagents/subagent_helpers.py
@@ -23,6 +23,7 @@ from app.helpers.message_helpers import (
     BACKGROUND_EXECUTION_BANNER,
     DYNAMIC_CONTEXT_MARKER,
     _build_active_todo_banner,
+    build_workspace_session_banner,
 )
 from app.memory.engine import memory_engine
 from app.services.integration_instructions_service import get_instructions
@@ -172,6 +173,7 @@ async def create_agent_context_message(
         if banner:
             parts.append(banner)
 
+    # User identity.
     if user_name:
         parts.append(f"User Name: {user_name}")
 
@@ -181,6 +183,15 @@ async def create_agent_context_message(
     # (byte-stable across turns) stays in system_instruction.
     if user_timezone:
         parts.append(f"User Timezone: {user_timezone}")
+
+    # Session directory — stated so the agent never guesses a
+    # `/workspace/sessions/<id>/` id when reporting or delivering artifacts (a
+    # wrong id lands files outside the session the artifact watcher scans). The
+    # executor pins `vfs_session_id` to the conversation thread and subagents
+    # inherit it (mirrors `get_session_id`, which the coding tools key on).
+    session_id = configurable.get("vfs_session_id") or configurable.get("thread_id")
+    if session_id:
+        parts.append(build_workspace_session_banner(session_id))
 
     async def _fetch_memories() -> str:
         if memories_text is not None:

--- a/apps/api/app/agents/core/subagents/subagent_helpers.py
+++ b/apps/api/app/agents/core/subagents/subagent_helpers.py
@@ -186,10 +186,12 @@ async def create_agent_context_message(
 
     # Session directory — stated so the agent never guesses a
     # `/workspace/sessions/<id>/` id when reporting or delivering artifacts (a
-    # wrong id lands files outside the session the artifact watcher scans). The
-    # executor pins `vfs_session_id` to the conversation thread and subagents
-    # inherit it (mirrors `get_session_id`, which the coding tools key on).
-    session_id = configurable.get("vfs_session_id") or configurable.get("thread_id")
+    # wrong id lands files outside the session the artifact watcher scans). Only
+    # `vfs_session_id` is trusted: the executor pins it to the conversation
+    # thread and subagents inherit it. We deliberately do NOT fall back to
+    # `thread_id` — that is the `executor_<conv>` wrapper, which would yield
+    # `/workspace/sessions/executor_<conv>/` and recreate the wrong-dir bug.
+    session_id = configurable.get("vfs_session_id")
     if session_id:
         parts.append(build_workspace_session_banner(session_id))
 

--- a/apps/api/app/agents/core/subagents/subagent_runner.py
+++ b/apps/api/app/agents/core/subagents/subagent_runner.py
@@ -5,8 +5,6 @@ Lives here (rather than in handoff_tools.py) so those modules import from it,
 avoiding a cyclic dependency.
 """
 
-import uuid
-
 from langchain_core.messages import (
     AIMessageChunk,
     HumanMessage,
@@ -276,19 +274,15 @@ async def prepare_executor_execution(
     user_id = configurable.get("user_id")
     thread_id = configurable.get("thread_id", "")
 
-    # Fresh executor thread per call_executor invocation. Architecturally the
-    # comms agent owns the conversation thread; the executor is a subroutine
-    # invoked with a task description + the last user message. Giving it its
-    # own ephemeral thread keeps its context small and prevents stale tool
-    # observations from one task bleeding into the next. If a later user turn
-    # needs prior context, comms passes it explicitly in the new task
-    # description.
-    call_scope = uuid.uuid4().hex[:12]
-    executor_thread_id = f"executor_{thread_id}_{call_scope}"
+    # Deterministic executor thread, derived purely from the conversation
+    # thread so it can be reconstructed from the conversation id alone. The
+    # executor (and the subagents it spawns, whose threads are derived from
+    # this one) retains its history across call_executor invocations within
+    # the same conversation.
+    executor_thread_id = f"executor_{thread_id}"
 
-    # VFS session stays pinned to the PARENT conversation thread so files
-    # written by one executor call are visible to the next — the ephemeral
-    # thread only scopes agent reasoning, not persisted artefacts.
+    # VFS session stays pinned to the conversation thread so files written by
+    # one executor call are visible to the next.
     vfs_session_id = configurable.get("vfs_session_id") or thread_id
 
     # Load executor graph

--- a/apps/api/app/agents/prompts/subagent_prompts.py
+++ b/apps/api/app/agents/prompts/subagent_prompts.py
@@ -2359,9 +2359,13 @@ the very first document; subsequent runs are fast.
 — DELIVERY (how the user actually receives the file)
 When the document is finished, move it into `./artifacts/`. That makes it appear
 automatically in the web frontend AND, for messaging users (WhatsApp, etc.), be
-sent to them as a file. Then your activity report MUST state the file's full
-workspace path (e.g. `/workspace/sessions/<conv>/artifacts/<name>.pdf`). Keep
-all intermediates in `./scratch/` — only the deliverable goes to `./artifacts/`.
+sent to them as a file. Always deliver via the relative `./artifacts/` path (or
+the absolute artifacts path given in the WORKSPACE SESSION block of your
+context) — never type out a `/workspace/sessions/<id>/` path with an id you
+guessed; writing to a wrong id drops the file where the frontend never finds it.
+Then your activity report MUST state the file's full workspace path, copied
+exactly from the WORKSPACE SESSION block in your context. Keep all intermediates
+in `./scratch/` — only the deliverable goes to `./artifacts/`.
 """,
 )
 

--- a/apps/api/app/agents/prompts/subagent_prompts.py
+++ b/apps/api/app/agents/prompts/subagent_prompts.py
@@ -2360,12 +2360,12 @@ the very first document; subsequent runs are fast.
 When the document is finished, move it into `./artifacts/`. That makes it appear
 automatically in the web frontend AND, for messaging users (WhatsApp, etc.), be
 sent to them as a file. Always deliver via the relative `./artifacts/` path (or
-the absolute artifacts path given in the WORKSPACE SESSION block of your
+the absolute artifacts path under the `Session directory` given in your
 context) — never type out a `/workspace/sessions/<id>/` path with an id you
 guessed; writing to a wrong id drops the file where the frontend never finds it.
-Then your activity report MUST state the file's full workspace path, copied
-exactly from the WORKSPACE SESSION block in your context. Keep all intermediates
-in `./scratch/` — only the deliverable goes to `./artifacts/`.
+Then your activity report MUST state the file's full workspace path, built from
+the `Session directory` given in your context (append `/artifacts/<name>`). Keep
+all intermediates in `./scratch/` — only the deliverable goes to `./artifacts/`.
 """,
 )
 

--- a/apps/api/app/agents/tools/coding/_context.py
+++ b/apps/api/app/agents/tools/coding/_context.py
@@ -47,8 +47,8 @@ def get_session_id(config: RunnableConfig) -> str | None:
 
     Prefer `vfs_session_id`: subagent_runner pins it to the *parent*
     conversation thread so artifacts written by one executor call are visible
-    to the next (`thread_id` is the ephemeral `executor_<conv>_<hex>` wrapper
-    and differs from the conversation_id that `ensure_session_dirs` and the
+    to the next (`thread_id` is the `executor_<conv>` wrapper and differs from
+    the conversation_id that `ensure_session_dirs` and the
     chat artifact forwarder key on — using it would split the session dir and
     drop every artifact event). May be None for non-chat invocations
     (workflows, background tasks)."""

--- a/apps/api/app/constants/chat.py
+++ b/apps/api/app/constants/chat.py
@@ -4,11 +4,13 @@ import re
 
 # Matches bot-emitted artifact references in three shapes — ``./artifacts/x``,
 # ``/artifacts/x``, and plain ``artifacts/x`` — so each can be rewritten to an
-# absolute backend URL. Allows a quote, paren or whitespace right before
-# (markdown image links, OpenUI string args, plain prose) but requires no
-# leading "word" character so ``myartifacts/`` is never mangled.
+# absolute backend URL. The reference must sit at the start of the string or
+# right after whitespace, a quote, or an opening paren (markdown image links,
+# OpenUI string args, plain prose). Anchoring on those delimiters — rather than
+# "any non-word char" — keeps ``myartifacts/`` AND query strings like
+# ``?file=artifacts/report.pdf`` from being mangled.
 ARTIFACT_REF_RE = re.compile(
-    r"""(?P<lead>(?<![A-Za-z0-9_/])|(?<=['"`(\s]))(?P<prefix>\.\/|\/)?artifacts\/(?P<path>[A-Za-z0-9._\-/]+)""",
+    r"""(?P<lead>^|[\s'"`(])(?P<prefix>\.\/|\/)?artifacts\/(?P<path>[A-Za-z0-9._\-/]+)""",
     re.VERBOSE,
 )
 

--- a/apps/api/app/constants/chat.py
+++ b/apps/api/app/constants/chat.py
@@ -1,0 +1,22 @@
+"""Chat persistence constants."""
+
+import re
+
+# Matches bot-emitted artifact references in three shapes — ``./artifacts/x``,
+# ``/artifacts/x``, and plain ``artifacts/x`` — so each can be rewritten to an
+# absolute backend URL. Allows a quote, paren or whitespace right before
+# (markdown image links, OpenUI string args, plain prose) but requires no
+# leading "word" character so ``myartifacts/`` is never mangled.
+ARTIFACT_REF_RE = re.compile(
+    r"""(?P<lead>(?<![A-Za-z0-9_/])|(?<=['"`(\s]))(?P<prefix>\.\/|\/)?artifacts\/(?P<path>[A-Za-z0-9._\-/]+)""",
+    re.VERBOSE,
+)
+
+# Matches a fully-qualified in-sandbox artifact path
+# (``/workspace/sessions/<id>/artifacts/<name>``). An agent that reports an
+# absolute path can only mean THIS conversation's artifact, so it is rewritten
+# to the current conversation's backend URL regardless of the ``<id>`` written —
+# which also self-heals a fabricated/mismatched session id.
+WORKSPACE_ARTIFACT_RE = re.compile(
+    r"/workspace/sessions/[A-Za-z0-9._-]+/artifacts/(?P<path>[A-Za-z0-9._\-/]+)"
+)

--- a/apps/api/app/helpers/message_helpers.py
+++ b/apps/api/app/helpers/message_helpers.py
@@ -19,7 +19,10 @@ from app.agents.templates.agent_template import (
     EXECUTOR_PROMPT_TEMPLATE,
     get_comms_static_prompt,
 )
-from app.agents.workspace.paths import safe_upload_filename
+from app.agents.workspace.paths import (
+    safe_upload_filename,
+    session_dir,
+)
 from app.config.oauth_config import get_integration_by_id
 from app.db.mongodb.collections import (
     conversations_collection,
@@ -218,6 +221,18 @@ BACKGROUND_EXECUTION_BANNER = (
     "the active todo's canvas (Context section) and stop.\n"
     "   - Your output is consumed by the system, not a human. Be terse and action-only."
 )
+
+
+def build_workspace_session_banner(session_id: str) -> str:
+    """State the absolute path of the agent's own session directory.
+
+    The agent never otherwise learns its conversation/session id, so a prompt
+    that asks it to report an absolute ``/workspace/sessions/<id>/...`` path
+    forces it to guess — and a weak model fabricates one, writing the
+    deliverable outside the session the artifact watcher scans, where it is
+    silently lost. Stating the real path removes the guess.
+    """
+    return f"Session directory: {session_dir(session_id)}"
 
 
 def _format_active_todo_banner(todo: dict) -> str:

--- a/apps/api/app/services/chat/persistence.py
+++ b/apps/api/app/services/chat/persistence.py
@@ -20,6 +20,7 @@ from typing import Any
 from app.api.v1.middleware.tiered_rate_limiter import tiered_limiter
 from app.config.model_pricing import calculate_token_cost
 from app.config.settings import settings
+from app.constants.chat import ARTIFACT_REF_RE, WORKSPACE_ARTIFACT_RE
 from app.models.chat_models import MessageModel, UpdateMessagesRequest
 from app.models.message_models import MessageRequestWithHistory
 from app.models.payment_models import PlanType
@@ -28,16 +29,6 @@ from app.services.payments.payment_service import payment_service
 from app.services.storage import JuiceFSUnavailable, ensure_session_dirs
 from app.utils.chat_utils import create_conversation
 from shared.py.wide_events import log
-
-# Matches bot-emitted artifact references in three shapes — ``./artifacts/x``,
-# ``/artifacts/x``, and plain ``artifacts/x`` — so we can rewrite each to an
-# absolute backend URL. Allows quotes, parens or whitespace right before
-# (markdown image links, OpenUI string args, plain prose) but requires no
-# leading "word" character so we don't mangle ``myartifacts/``.
-_ARTIFACT_REF_RE = re.compile(
-    r"""(?P<lead>(?<![A-Za-z0-9_/])|(?<=['"`(\s]))(?P<prefix>\.\/|\/)?artifacts\/(?P<path>[A-Za-z0-9._\-/]+)""",
-    re.VERBOSE,
-)
 
 
 async def initialize_new_conversation(
@@ -103,7 +94,8 @@ def absolutize_artifact_urls(message: str, conversation_id: str) -> str:
         lead = m.group("lead") or ""
         return f"{lead}{base}/{m.group('path')}"
 
-    return _ARTIFACT_REF_RE.sub(_sub, message)
+    message = WORKSPACE_ARTIFACT_RE.sub(lambda m: f"{base}/{m.group('path')}", message)
+    return ARTIFACT_REF_RE.sub(_sub, message)
 
 
 async def save_conversation_async(


### PR DESCRIPTION
PR #651 made the executor thread ephemeral by appending a random `call_scope` (`executor_<conv>_<hex>`) on every `call_executor` invocation; because subagent threads derive from the executor thread, every new turn produced a fresh subagent thread and specialists (gmail, github, linear, slack) lost their checkpointed history within a conversation. This restores the deterministic executor thread (`executor_<conv>`) so the executor and the subagents it spawns retain history across `call_executor` calls and every thread is reconstructible from the conversation id alone. Also renames the local `int_id` to `integration_id` in `handoff_tools.py` for clarity. Lint and mypy pass on both files.