### PR TITLE
feat(skills): user skills management in settings

### DIFF
--- a/apps/api/app/agents/skills/installer.py
+++ b/apps/api/app/agents/skills/installer.py
@@ -19,7 +19,13 @@ from app.agents.skills.parser import (
     parse_skill_md,
     validate_skill_content,
 )
-from app.agents.skills.registry import get_skill, install_skill, uninstall_skill
+from app.agents.skills.registry import (
+    get_skill,
+    get_skill_by_name,
+    install_skill,
+    uninstall_skill,
+    update_skill,
+)
 from app.agents.skills.utils import GITHUB_API_BASE, get_github_headers
 from app.services.storage import (
     JuiceFSUnavailable,
@@ -348,6 +354,78 @@ async def install_from_inline(
 
     log.info(f"[skills] Created inline skill '{name}' (target={target})")
     return installed
+
+
+async def update_skill_inline(
+    user_id: str,
+    skill_id: str,
+    *,
+    description: str | None = None,
+    instructions: str | None = None,
+    target: str | None = None,
+) -> Skill | None:
+    """Edit an existing skill's description, instructions (body), and/or target.
+
+    Only provided fields change; the rest are preserved. The skill ``name`` is
+    immutable (it keys the VFS directory), so the storage path never moves. The
+    VFS SKILL.md is rewritten only when the body actually changes; description
+    and target are metadata and live only in MongoDB.
+
+    Returns the updated skill, or None if it does not exist for this user.
+
+    Raises:
+        ValueError: If the new values are invalid, or retargeting would collide
+            with an existing skill of the same name on that target.
+    """
+    skill = await get_skill(user_id, skill_id)
+    if not skill:
+        return None
+
+    new_description = description if description is not None else skill.description
+    new_target = target if target is not None else skill.target
+    new_body = instructions if instructions is not None else (skill.body_content or "")
+
+    # Round-trip through the SKILL.md generator/parser so the same validation
+    # that guards creation guards edits (name format, required fields, length).
+    skill_md_content = generate_skill_md(
+        name=skill.name,
+        description=new_description,
+        instructions=new_body,
+        target=new_target,
+        metadata=skill.metadata or None,
+    )
+    errors = validate_skill_content(skill_md_content)
+    if errors:
+        raise ValueError(f"Invalid skill: {'; '.join(errors)}")
+    metadata, body = parse_skill_md(skill_md_content)
+
+    # Retargeting must respect the (user_id, name, target) uniqueness invariant.
+    if metadata.target != skill.target:
+        clash = await get_skill_by_name(user_id, skill.name, metadata.target)
+        if clash and clash.id != skill.id:
+            raise ValueError(
+                f"A skill named '{skill.name}' already targets '{metadata.target}'. "
+                "Rename or remove it first."
+            )
+
+    # Persist the body to VFS only when it changed — description/target are
+    # metadata-only and never touch the filesystem.
+    if body != (skill.body_content or ""):
+        await ensure_user_skills_dir(user_id)
+        await write_skill_file(user_id, skill.name, "SKILL.md", body)
+
+    updated = await update_skill(
+        user_id,
+        skill_id,
+        {
+            "description": metadata.description,
+            "target": metadata.target,
+            "body_content": body,
+        },
+    )
+
+    log.info(f"[skills] Updated inline skill '{skill.name}' (target={metadata.target})")
+    return updated
 
 
 async def uninstall_skill_full(user_id: str, skill_id: str) -> bool:

--- a/apps/api/app/agents/skills/installer.py
+++ b/apps/api/app/agents/skills/installer.py
@@ -126,6 +126,7 @@ async def install_from_github(
     repo_url: str,
     skill_path: str | None = None,
     target_override: str | None = None,
+    allowed_targets: set[str] | None = None,
 ) -> Skill:
     """Install a skill from a GitHub repository.
 
@@ -137,12 +138,17 @@ async def install_from_github(
         repo_url: GitHub repo reference (owner/repo, full URL, etc.)
         skill_path: Optional path within repo to skill folder
         target_override: Override target from SKILL.md frontmatter
+        allowed_targets: If provided, the effective target (override or the
+            repo's frontmatter target) must be in this set, else ValueError.
+            Used by the REST endpoint to block scoping a skill to an
+            integration the user hasn't connected; left None for agent tools.
 
     Returns:
         The installed skill
 
     Raises:
-        ValueError: If skill is invalid or already installed
+        ValueError: If skill is invalid, already installed, or its effective
+            target is not in ``allowed_targets``.
     """
     owner, repo, url_path = _parse_github_url(repo_url)
 
@@ -197,8 +203,14 @@ async def install_from_github(
         # Parse frontmatter → metadata + body
         metadata, body = parse_skill_md(skill_md_content)
 
-        # Apply target override
+        # Apply target override, then validate the effective target so a repo's
+        # frontmatter can't scope a skill to an unconnected/invalid agent.
         target = target_override if target_override else metadata.target
+        if allowed_targets is not None and target not in allowed_targets:
+            raise ValueError(
+                f"Target '{target}' is not available. "
+                "Connect the integration before installing a skill scoped to it."
+            )
 
         # Determine logical storage path (used by the Skill record)
         storage_path = _skill_storage_path(user_id, metadata.name)

--- a/apps/api/app/agents/skills/models.py
+++ b/apps/api/app/agents/skills/models.py
@@ -207,8 +207,70 @@ class SkillInlineCreateRequest(BaseModel):
     )
 
 
+class SkillUpdateRequest(BaseModel):
+    """Request to edit an existing skill. Only provided fields are changed.
+
+    The skill ``name`` is its identity (and the key of its VFS directory), so it
+    is immutable after creation — rename is delete + recreate, not an edit.
+    """
+
+    description: str | None = Field(
+        default=None, max_length=1024, description="What it does and when to use it"
+    )
+    instructions: str | None = Field(
+        default=None, description="Markdown instructions (body of SKILL.md)"
+    )
+    target: str | None = Field(
+        default=None,
+        description="Target agent: 'executor' or a connected subagent agent_name (unchanged if omitted)",
+    )
+
+
 class SkillListResponse(BaseModel):
     """Response for listing installed skills."""
 
     skills: list[Skill] = Field(default_factory=list)
+    total: int = Field(default=0)
+
+
+class SkillTarget(BaseModel):
+    """A place a skill can run: the executor, or a connected integration subagent.
+
+    ``value`` is the subagent ``agent_name`` written to a skill's ``target``;
+    ``icon`` is the integration id (``executor`` for the general bucket) so the
+    UI can reuse the integration logo set.
+    """
+
+    value: str = Field(..., description="Skill target value (agent_name)")
+    label: str = Field(..., description="Human-readable display name")
+    icon: str = Field(..., description="Icon key (integration id, or 'executor')")
+    connected: bool = Field(default=True, description="Whether the target is available")
+
+
+class SkillTargetsResponse(BaseModel):
+    """Available skill targets for the current user."""
+
+    targets: list[SkillTarget] = Field(default_factory=list)
+
+
+class BuiltinSkillInfo(BaseModel):
+    """A read-only built-in skill shipped with GAIA, for display in settings."""
+
+    slug: str = Field(..., description="Skill directory slug")
+    name: str = Field(..., description="Skill name")
+    description: str = Field(..., description="What the skill does")
+    target: str = Field(..., description="Target agent_name (executor or a subagent)")
+    group_label: str = Field(..., description="Display name of the owning agent")
+    icon: str = Field(..., description="Icon key (owning subagent id, or 'executor')")
+    connected: bool = Field(
+        default=True,
+        description="Whether the owning agent is available to the user (always-on, or a connected integration)",
+    )
+    body: str = Field(default="", description="SKILL.md markdown body (for read-only preview)")
+
+
+class BuiltinSkillsResponse(BaseModel):
+    """Response for listing built-in skills."""
+
+    skills: list[BuiltinSkillInfo] = Field(default_factory=list)
     total: int = Field(default=0)

--- a/apps/api/app/agents/skills/registry.py
+++ b/apps/api/app/agents/skills/registry.py
@@ -14,6 +14,7 @@ both the per-agent user skills cache and the composed skills text cache.
 """
 
 from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 from pymongo import ReturnDocument
@@ -289,7 +290,7 @@ async def disable_skill(user_id: str, skill_id: str) -> bool:
 
 
 @CacheInvalidator(key_patterns=_SKILLS_INVALIDATION_PATTERNS)
-async def update_skill(user_id: str, skill_id: str, fields: dict) -> Skill | None:
+async def update_skill(user_id: str, skill_id: str, fields: dict[str, Any]) -> Skill | None:
     """Patch metadata fields on an existing skill and return the updated record.
 
     Always stamps ``updated_at``. Scoped to ``{_id, user_id}`` so a user can only

--- a/apps/api/app/agents/skills/registry.py
+++ b/apps/api/app/agents/skills/registry.py
@@ -16,6 +16,8 @@ both the per-agent user skills cache and the composed skills text cache.
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from pymongo import ReturnDocument
+
 from app.agents.skills.models import Skill, SkillSource
 from app.constants.cache import (
     USER_SKILLS_CACHE_KEY,
@@ -284,3 +286,24 @@ async def disable_skill(user_id: str, skill_id: str) -> bool:
         },
     )
     return result.modified_count > 0
+
+
+@CacheInvalidator(key_patterns=_SKILLS_INVALIDATION_PATTERNS)
+async def update_skill(user_id: str, skill_id: str, fields: dict) -> Skill | None:
+    """Patch metadata fields on an existing skill and return the updated record.
+
+    Always stamps ``updated_at``. Scoped to ``{_id, user_id}`` so a user can only
+    edit their own skills. Returns None if no matching skill exists.
+    """
+    log.set(user_id=user_id, skill_id=skill_id, skill_op="update_skill")
+    collection = _get_collection()
+    updates = {**fields, "updated_at": datetime.now(UTC).isoformat()}
+    doc = await collection.find_one_and_update(
+        {"_id": skill_id, "user_id": user_id},
+        {"$set": updates},
+        return_document=ReturnDocument.AFTER,
+    )
+    if not doc:
+        return None
+    log.info(f"[skills] Updated skill {skill_id} for user {user_id}")
+    return _doc_to_skill(doc)

--- a/apps/api/app/agents/skills/targets.py
+++ b/apps/api/app/agents/skills/targets.py
@@ -1,0 +1,45 @@
+"""Skill targets - the places a skill can run.
+
+A skill's ``target`` is either the general ``executor`` or a connected
+integration subagent's ``agent_name``. The settings UI offers exactly these as
+options, and the REST endpoints validate writes against them so a skill can
+never be scoped to an integration the user hasn't connected.
+"""
+
+from app.agents.core.subagents.registry import get_subagent_by_id
+from app.agents.skills.models import SkillTarget
+from app.constants.skills import EXECUTOR_SUBAGENT_ID, EXECUTOR_TARGET_LABEL
+from app.services.integrations.user_integrations import get_connected_integration_ids
+
+
+async def get_skill_targets(user_id: str) -> list[SkillTarget]:
+    """Return the skill targets available to a user.
+
+    Always includes the executor (the general assistant). Adds one entry per
+    connected integration that exposes a subagent, using the subagent registry
+    as the single source of truth for its ``agent_name`` and display name.
+    """
+    targets: list[SkillTarget] = [
+        SkillTarget(
+            value=EXECUTOR_SUBAGENT_ID,
+            label=EXECUTOR_TARGET_LABEL,
+            icon=EXECUTOR_SUBAGENT_ID,
+            connected=True,
+        )
+    ]
+
+    connected_ids = await get_connected_integration_ids(user_id)
+    for integration_id in sorted(connected_ids):
+        subagent = get_subagent_by_id(integration_id)
+        if not subagent or not subagent.config.has_subagent:
+            continue
+        targets.append(
+            SkillTarget(
+                value=subagent.config.agent_name,
+                label=subagent.name,
+                icon=subagent.id,
+                connected=True,
+            )
+        )
+
+    return targets

--- a/apps/api/app/api/v1/endpoints/skills.py
+++ b/apps/api/app/api/v1/endpoints/skills.py
@@ -190,8 +190,9 @@ async def install_skill_with_auto_discover(
         skill={"repo": repo_url, "name": skill_name, "path": skill_path},
     )
     try:
-        if target:
-            await _validate_target(user_id, target)
+        # The effective target (override or the repo's frontmatter target) is
+        # validated inside install_from_github against the user's allowed set.
+        allowed_targets = {t.value for t in await get_skill_targets(user_id)}
 
         install_path = skill_path
 
@@ -215,6 +216,7 @@ async def install_skill_with_auto_discover(
             repo_url=repo_url,
             skill_path=install_path,
             target_override=target,
+            allowed_targets=allowed_targets,
         )
         log.set(skill_id=installed.id if hasattr(installed, "id") else None)
         log.set(outcome="success")

--- a/apps/api/app/api/v1/endpoints/skills.py
+++ b/apps/api/app/api/v1/endpoints/skills.py
@@ -7,6 +7,7 @@ installable agent skills (Agent Skills open standard).
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status as http_status
 
+from app.agents.core.subagents.registry import get_subagent_by_id
 from app.agents.skills.github_discovery import (
     discover_skills_from_repo,
     get_skill_from_repo,
@@ -15,11 +16,16 @@ from app.agents.skills.installer import (
     install_from_github,
     install_from_inline,
     uninstall_skill_full,
+    update_skill_inline,
 )
 from app.agents.skills.models import (
+    BuiltinSkillInfo,
+    BuiltinSkillsResponse,
     Skill,
     SkillInlineCreateRequest,
     SkillListResponse,
+    SkillTargetsResponse,
+    SkillUpdateRequest,
 )
 from app.agents.skills.registry import (
     disable_skill,
@@ -27,8 +33,13 @@ from app.agents.skills.registry import (
     get_skill,
     list_skills,
 )
+from app.agents.skills.targets import get_skill_targets
+from app.agents.workspace.skill_loader import load_builtin_skills
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.config.oauth_config import get_integration_by_id
+from app.constants.skills import EXECUTOR_SUBAGENT_ID, EXECUTOR_TARGET_LABEL
 from app.decorators import tiered_rate_limit
+from app.services.integrations.user_integrations import get_connected_integration_ids
 from shared.py.wide_events import log
 
 router = APIRouter(prefix="/skills", tags=["skills"])
@@ -42,6 +53,74 @@ def _get_user_id(user: dict = Depends(get_current_user)) -> str:
             detail="User not authenticated",
         )
     return user_id
+
+
+async def _validate_target(user_id: str, target: str) -> None:
+    """Reject a target that isn't the executor or one of the user's connected
+    integration subagents. Keeps the UI from scoping a skill to something the
+    agent can never run."""
+    targets = await get_skill_targets(user_id)
+    allowed = {t.value for t in targets}
+    if target not in allowed:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Target '{target}' is not available. "
+                "Connect the integration before scoping a skill to it."
+            ),
+        )
+
+
+@router.get("/targets", response_model=SkillTargetsResponse)
+async def list_skill_targets_endpoint(
+    user_id: str = Depends(_get_user_id),
+):
+    """List the targets a skill can run in: the executor plus the user's
+    connected integration subagents."""
+    log.set(operation="list_skill_targets")
+    targets = await get_skill_targets(user_id)
+    log.set(result_count=len(targets), outcome="success")
+    return SkillTargetsResponse(targets=targets)
+
+
+@router.get("/builtin", response_model=BuiltinSkillsResponse)
+async def list_builtin_skills_endpoint(
+    user_id: str = Depends(_get_user_id),
+):
+    """List the read-only built-in skills shipped with GAIA, grouped by the
+    agent they run in. Each carries a `connected` flag so the UI can deactivate
+    skills whose owning integration the user hasn't connected."""
+    log.set(operation="list_builtin_skills")
+    connected_ids = await get_connected_integration_ids(user_id)
+
+    def _is_available(subagent_id: str) -> bool:
+        # The executor and non-integration builtin subagents (docgen, knowledge
+        # guide) are always available; integration-backed ones need a connection.
+        if subagent_id == EXECUTOR_SUBAGENT_ID:
+            return True
+        if get_integration_by_id(subagent_id) is None:
+            return True
+        return subagent_id in connected_ids
+
+    skills = [
+        BuiltinSkillInfo(
+            slug=s.slug,
+            name=s.name,
+            description=s.description,
+            target=s.target,
+            group_label=(
+                EXECUTOR_TARGET_LABEL
+                if s.subagent_id == EXECUTOR_SUBAGENT_ID
+                else (sa.name if (sa := get_subagent_by_id(s.subagent_id)) else s.subagent_id)
+            ),
+            icon=s.subagent_id,
+            connected=_is_available(s.subagent_id),
+            body=s.body,
+        )
+        for s in load_builtin_skills()
+    ]
+    log.set(result_count=len(skills), outcome="success")
+    return BuiltinSkillsResponse(skills=skills, total=len(skills))
 
 
 @router.get("/discover")
@@ -111,6 +190,9 @@ async def install_skill_with_auto_discover(
         skill={"repo": repo_url, "name": skill_name, "path": skill_path},
     )
     try:
+        if target:
+            await _validate_target(user_id, target)
+
         install_path = skill_path
 
         if skill_name and not install_path:
@@ -165,6 +247,7 @@ async def create_inline_skill_endpoint(
     """Create a skill from inline components."""
     log.set(user={"id": user_id}, skill={"name": request.name, "target": request.target})
     try:
+        await _validate_target(user_id, request.target)
         installed = await install_from_inline(
             user_id=user_id,
             name=request.name,
@@ -175,6 +258,8 @@ async def create_inline_skill_endpoint(
         log.set(skill_id=installed.id if hasattr(installed, "id") else None)
         log.set(outcome="success")
         return installed
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(
             status_code=http_status.HTTP_400_BAD_REQUEST,
@@ -185,6 +270,52 @@ async def create_inline_skill_endpoint(
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create skill",
+        ) from e
+
+
+@router.put("/{skill_id}", response_model=Skill)
+@tiered_rate_limit("skill_operations")
+async def update_skill_endpoint(
+    skill_id: str,
+    request: SkillUpdateRequest,
+    user_id: str = Depends(_get_user_id),
+):
+    """Edit an existing skill's description, instructions, and/or target.
+
+    The skill name is immutable. Only the fields present in the request body are
+    changed; omitting a field leaves it untouched.
+    """
+    log.set(operation="update_skill", skill_id=skill_id, skill={"target": request.target})
+    try:
+        if request.target is not None:
+            await _validate_target(user_id, request.target)
+
+        updated = await update_skill_inline(
+            user_id=user_id,
+            skill_id=skill_id,
+            description=request.description,
+            instructions=request.instructions,
+            target=request.target,
+        )
+        if not updated:
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND,
+                detail=f"Skill {skill_id} not found",
+            )
+        log.set(skill_name=updated.name, outcome="success")
+        return updated
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except Exception as e:
+        log.error(f"Error updating skill {skill_id}: {e}")
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update skill",
         ) from e
 
 

--- a/apps/api/app/api/v1/endpoints/skills.py
+++ b/apps/api/app/api/v1/endpoints/skills.py
@@ -74,7 +74,7 @@ async def _validate_target(user_id: str, target: str) -> None:
 @router.get("/targets", response_model=SkillTargetsResponse)
 async def list_skill_targets_endpoint(
     user_id: str = Depends(_get_user_id),
-):
+) -> SkillTargetsResponse:
     """List the targets a skill can run in: the executor plus the user's
     connected integration subagents."""
     log.set(operation="list_skill_targets")
@@ -86,7 +86,7 @@ async def list_skill_targets_endpoint(
 @router.get("/builtin", response_model=BuiltinSkillsResponse)
 async def list_builtin_skills_endpoint(
     user_id: str = Depends(_get_user_id),
-):
+) -> BuiltinSkillsResponse:
     """List the read-only built-in skills shipped with GAIA, grouped by the
     agent they run in. Each carries a `connected` flag so the UI can deactivate
     skills whose owning integration the user hasn't connected."""
@@ -281,7 +281,7 @@ async def update_skill_endpoint(
     skill_id: str,
     request: SkillUpdateRequest,
     user_id: str = Depends(_get_user_id),
-):
+) -> Skill:
     """Edit an existing skill's description, instructions, and/or target.
 
     The skill name is immutable. Only the fields present in the request body are

--- a/apps/api/app/constants/skills.py
+++ b/apps/api/app/constants/skills.py
@@ -24,6 +24,11 @@ SKILL_BODY_FILENAME = "skill.md"
 # /workspace/integrations/<id>/.
 EXECUTOR_SUBAGENT_ID = "executor"
 
+# User-facing label for the executor target in the skills UI. The executor is
+# the general assistant (not a registered integration subagent), so it needs an
+# explicit display name where subagents get theirs from the subagent registry.
+EXECUTOR_TARGET_LABEL = "General assistant"
+
 # Builtin SKILL.md library location, relative to the app/agents/ package dir.
 SKILLS_PACKAGE_DIRNAME = "skills"
 BUILTIN_SKILLS_DIRNAME = "builtin"

--- a/apps/web/src/features/settings/components/SkillsSettings.tsx
+++ b/apps/web/src/features/settings/components/SkillsSettings.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import SkillsManagement from "@/features/skills/components/SkillsManagement";
+
+export default function SkillsSettings() {
+  return (
+    <div className="h-full w-full">
+      <SkillsManagement />
+    </div>
+  );
+}

--- a/apps/web/src/features/settings/config/sectionComponents.tsx
+++ b/apps/web/src/features/settings/config/sectionComponents.tsx
@@ -10,6 +10,7 @@ import NotificationSettings from "@/features/settings/components/NotificationSet
 import PreferencesSettings from "@/features/settings/components/PreferencesSettings";
 import ProfileCardSettings from "@/features/settings/components/ProfileCardSettings";
 import type { ModalAction } from "@/features/settings/components/SettingsMenu";
+import SkillsSettings from "@/features/settings/components/SkillsSettings";
 import { SubscriptionSettings } from "@/features/settings/components/SubscriptionSettings";
 import UsageSettings from "@/features/settings/components/UsageSettings";
 import VoiceSettings from "@/features/settings/components/VoiceSettings";
@@ -45,6 +46,8 @@ export function SectionComponent({
       return <IntegrationInstructionsSettings />;
     case "memory":
       return <MemorySettings />;
+    case "skills":
+      return <SkillsSettings />;
     case "notifications":
       return <NotificationSettings />;
     case "desktop":

--- a/apps/web/src/features/settings/config/sectionKeys.ts
+++ b/apps/web/src/features/settings/config/sectionKeys.ts
@@ -10,6 +10,7 @@ export const VALID_SECTIONS = [
   "voice",
   "instructions",
   "memory",
+  "skills",
   "notifications",
   "desktop",
 ] as const;

--- a/apps/web/src/features/settings/config/settingsConfig.tsx
+++ b/apps/web/src/features/settings/config/settingsConfig.tsx
@@ -8,6 +8,7 @@ import {
   MessageMultiple02Icon,
   NoteEditIcon,
   NotificationIcon,
+  PuzzleIcon,
   UserCircleIcon,
   VoiceIdIcon,
   WhatsappIcon,
@@ -85,6 +86,12 @@ export const settingsPageItems: SettingsMenuItem[] = [
     label: "Memories",
     icon: Brain02Icon,
     href: "/settings/memory",
+  },
+  {
+    key: "skills",
+    label: "Skills",
+    icon: PuzzleIcon,
+    href: "/settings/skills",
   },
   // Only rendered inside the Electron app (filtered in SettingsSidebar).
   {

--- a/apps/web/src/features/skills/api/skillsApi.ts
+++ b/apps/web/src/features/skills/api/skillsApi.ts
@@ -67,15 +67,18 @@ export const skillsApi = {
     );
   },
 
-  /** Install a skill from a GitHub repo by name (auto-discovers its path). */
+  /** Install a skill from a GitHub repo using its exact discovered path
+   * (avoids picking the wrong skill when a repo has duplicate names). */
   installFromGithub: async (
     repoUrl: string,
     skillName: string,
+    skillPath: string,
     target?: string,
   ): Promise<Skill> => {
     const params = new URLSearchParams({
       repo_url: repoUrl,
       skill_name: skillName,
+      skill_path: skillPath,
     });
     if (target) params.set("target", target);
     return await apiService.post<Skill>(

--- a/apps/web/src/features/skills/api/skillsApi.ts
+++ b/apps/web/src/features/skills/api/skillsApi.ts
@@ -1,0 +1,86 @@
+import { apiService } from "@/lib/api/service";
+import type {
+  BuiltinSkillsResponse,
+  DiscoverSkillsResponse,
+  Skill,
+  SkillInlineCreateRequest,
+  SkillListResponse,
+  SkillTargetsResponse,
+  SkillUpdateRequest,
+} from "./types";
+
+export const skillsApi = {
+  /** List the current user's installed skills. */
+  listSkills: async (): Promise<SkillListResponse> => {
+    return await apiService.get<SkillListResponse>("/skills");
+  },
+
+  /** List the targets a skill can run in (executor + connected subagents). */
+  listTargets: async (): Promise<SkillTargetsResponse> => {
+    return await apiService.get<SkillTargetsResponse>("/skills/targets", {
+      silent: true,
+    });
+  },
+
+  /** List the read-only built-in skills shipped with GAIA. */
+  listBuiltinSkills: async (): Promise<BuiltinSkillsResponse> => {
+    return await apiService.get<BuiltinSkillsResponse>("/skills/builtin", {
+      silent: true,
+    });
+  },
+
+  /** Create a skill from inline components. */
+  createSkill: async (body: SkillInlineCreateRequest): Promise<Skill> => {
+    return await apiService.post<Skill>("/skills/install/inline", body);
+  },
+
+  /** Edit an existing skill (description / instructions / target). */
+  updateSkill: async (
+    skillId: string,
+    body: SkillUpdateRequest,
+  ): Promise<Skill> => {
+    return await apiService.put<Skill>(`/skills/${skillId}`, body);
+  },
+
+  /** Uninstall a skill and delete its files. */
+  deleteSkill: async (skillId: string): Promise<void> => {
+    await apiService.delete(`/skills/${skillId}`);
+  },
+
+  /** Enable a disabled skill. */
+  enableSkill: async (skillId: string): Promise<void> => {
+    await apiService.patch(`/skills/${skillId}/enable`, {}, { silent: true });
+  },
+
+  /** Disable a skill without uninstalling it. */
+  disableSkill: async (skillId: string): Promise<void> => {
+    await apiService.patch(`/skills/${skillId}/disable`, {}, { silent: true });
+  },
+
+  /** Preview the skills available in a GitHub repo without installing. */
+  discoverSkills: async (
+    repo: string,
+    branch = "main",
+  ): Promise<DiscoverSkillsResponse> => {
+    return await apiService.get<DiscoverSkillsResponse>(
+      `/skills/discover?repo=${encodeURIComponent(repo)}&branch=${encodeURIComponent(branch)}`,
+    );
+  },
+
+  /** Install a skill from a GitHub repo by name (auto-discovers its path). */
+  installFromGithub: async (
+    repoUrl: string,
+    skillName: string,
+    target?: string,
+  ): Promise<Skill> => {
+    const params = new URLSearchParams({
+      repo_url: repoUrl,
+      skill_name: skillName,
+    });
+    if (target) params.set("target", target);
+    return await apiService.post<Skill>(
+      `/skills/install/github?${params.toString()}`,
+      {},
+    );
+  },
+};

--- a/apps/web/src/features/skills/api/types.ts
+++ b/apps/web/src/features/skills/api/types.ts
@@ -1,0 +1,92 @@
+// Skill types mirror the backend's flat snake_case schema
+// (apps/api/app/agents/skills/models.py). Responses are not camelized.
+
+export type SkillSource = "github" | "url" | "upload" | "inline";
+
+export interface Skill {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string;
+  /** Target agent: "executor" or a subagent agent_name (e.g. gmail_agent). */
+  target: string;
+  license: string | null;
+  compatibility: string | null;
+  metadata: Record<string, string>;
+  allowed_tools: string[];
+  body_content: string | null;
+  vfs_path: string;
+  enabled: boolean;
+  source: SkillSource;
+  source_url: string | null;
+  installed_at: string;
+  updated_at: string | null;
+  files: string[];
+}
+
+export interface SkillListResponse {
+  skills: Skill[];
+  total: number;
+}
+
+/** A place a skill can run: the executor or a connected integration subagent. */
+export interface SkillTarget {
+  /** agent_name written to a skill's `target`. */
+  value: string;
+  label: string;
+  /** Integration id used to resolve a logo (or "executor"). */
+  icon: string;
+  connected: boolean;
+}
+
+export interface SkillTargetsResponse {
+  targets: SkillTarget[];
+}
+
+export interface BuiltinSkillInfo {
+  slug: string;
+  name: string;
+  description: string;
+  target: string;
+  /** Display name of the owning agent. */
+  group_label: string;
+  /** Owning subagent id (or "executor") for logo resolution. */
+  icon: string;
+  /** Whether the owning agent is available (always-on or connected integration). */
+  connected: boolean;
+  /** SKILL.md markdown body, for the read-only preview modal. */
+  body: string;
+}
+
+export interface BuiltinSkillsResponse {
+  skills: BuiltinSkillInfo[];
+  total: number;
+}
+
+export interface SkillInlineCreateRequest {
+  name: string;
+  description: string;
+  instructions: string;
+  target: string;
+}
+
+export interface SkillUpdateRequest {
+  description?: string;
+  instructions?: string;
+  target?: string;
+}
+
+export interface DiscoveredSkill {
+  name: string;
+  description: string;
+  path: string;
+  repo_url: string;
+  subagent_id: string;
+}
+
+export interface DiscoverSkillsResponse {
+  repo: string;
+  branch: string;
+  skills: DiscoveredSkill[];
+  count: number;
+}

--- a/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
+++ b/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
@@ -2,12 +2,13 @@
 
 import { Button } from "@heroui/button";
 import { Chip } from "@heroui/chip";
-import { Skeleton } from "@heroui/skeleton";
 import NextLink from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { skillsApi } from "../api/skillsApi";
 import type { BuiltinSkillInfo } from "../api/types";
+import { skillMatchesQuery } from "../utils";
 import { SkillGroup } from "./SkillGroup";
+import { SkillListSkeleton } from "./SkillListSkeleton";
 import { SkillPreviewModal } from "./SkillPreviewModal";
 import { SkillTargetIcon } from "./SkillTargetIcon";
 
@@ -24,29 +25,29 @@ interface Group {
 
 export function BuiltinSkillsList({ query }: BuiltinSkillsListProps) {
   const [skills, setSkills] = useState<BuiltinSkillInfo[] | null>(null);
+  const [error, setError] = useState(false);
   const [selected, setSelected] = useState<BuiltinSkillInfo | null>(null);
 
-  useEffect(() => {
-    let active = true;
-    skillsApi
-      .listBuiltinSkills()
-      .then((res) => active && setSkills(res.skills))
-      .catch(() => active && setSkills([]));
-    return () => {
-      active = false;
-    };
+  const load = useCallback(async () => {
+    setError(false);
+    setSkills(null);
+    try {
+      const res = await skillsApi.listBuiltinSkills();
+      setSkills(res.skills);
+    } catch {
+      setError(true);
+    }
   }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   const groups = useMemo<Group[]>(() => {
     if (!skills) return [];
-    const q = query.trim().toLowerCase();
-    const filtered = q
-      ? skills.filter(
-          (s) =>
-            s.name.toLowerCase().includes(q) ||
-            s.description.toLowerCase().includes(q),
-        )
-      : skills;
+    const filtered = skills.filter((s) =>
+      skillMatchesQuery(s.name, s.description, query),
+    );
 
     const byLabel = new Map<string, Group>();
     for (const skill of filtered) {
@@ -67,14 +68,24 @@ export function BuiltinSkillsList({ query }: BuiltinSkillsListProps) {
     });
   }, [skills, query]);
 
-  if (skills === null) {
+  if (error) {
     return (
-      <div className="space-y-2">
-        <Skeleton className="h-16 w-full rounded-2xl" />
-        <Skeleton className="h-16 w-full rounded-2xl" />
-        <Skeleton className="h-16 w-full rounded-2xl" />
+      <div className="flex flex-col items-center gap-3 rounded-2xl bg-zinc-900/60 px-6 py-12 text-center">
+        <p className="text-sm text-zinc-400">Couldn't load built-in skills.</p>
+        <Button
+          size="sm"
+          variant="flat"
+          className="rounded-xl"
+          onPress={() => load()}
+        >
+          Retry
+        </Button>
       </div>
     );
+  }
+
+  if (skills === null) {
+    return <SkillListSkeleton />;
   }
 
   return (

--- a/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
+++ b/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
@@ -122,7 +122,7 @@ export function BuiltinSkillsList({ query }: BuiltinSkillsListProps) {
                   </Chip>
                   <Button
                     as={NextLink}
-                    href={`/integrations?id=${group.icon}`}
+                    href={`/integrations?id=${encodeURIComponent(group.icon)}`}
                     size="sm"
                     color="primary"
                     variant="flat"

--- a/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
+++ b/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Chip } from "@heroui/chip";
+import { Skeleton } from "@heroui/skeleton";
+import NextLink from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { skillsApi } from "../api/skillsApi";
+import type { BuiltinSkillInfo } from "../api/types";
+import { SkillGroup } from "./SkillGroup";
+import { SkillPreviewModal } from "./SkillPreviewModal";
+import { SkillTargetIcon } from "./SkillTargetIcon";
+
+interface BuiltinSkillsListProps {
+  query: string;
+}
+
+interface Group {
+  label: string;
+  icon: string;
+  connected: boolean;
+  skills: BuiltinSkillInfo[];
+}
+
+export function BuiltinSkillsList({ query }: BuiltinSkillsListProps) {
+  const [skills, setSkills] = useState<BuiltinSkillInfo[] | null>(null);
+  const [selected, setSelected] = useState<BuiltinSkillInfo | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    skillsApi
+      .listBuiltinSkills()
+      .then((res) => active && setSkills(res.skills))
+      .catch(() => active && setSkills([]));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const groups = useMemo<Group[]>(() => {
+    if (!skills) return [];
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? skills.filter(
+          (s) =>
+            s.name.toLowerCase().includes(q) ||
+            s.description.toLowerCase().includes(q),
+        )
+      : skills;
+
+    const byLabel = new Map<string, Group>();
+    for (const skill of filtered) {
+      const existing = byLabel.get(skill.group_label);
+      if (existing) existing.skills.push(skill);
+      else
+        byLabel.set(skill.group_label, {
+          label: skill.group_label,
+          icon: skill.icon,
+          connected: skill.connected,
+          skills: [skill],
+        });
+    }
+    // Connected groups first, then deactivated; alphabetical within each.
+    return [...byLabel.values()].sort((a, b) => {
+      if (a.connected !== b.connected) return a.connected ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
+  }, [skills, query]);
+
+  if (skills === null) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-16 w-full rounded-2xl" />
+        <Skeleton className="h-16 w-full rounded-2xl" />
+        <Skeleton className="h-16 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {groups.length === 0 ? (
+        <p className="py-8 text-center text-xs text-zinc-500">
+          No built-in skills match your search.
+        </p>
+      ) : (
+        groups.map((group) => (
+          <SkillGroup
+            // Key includes search state so toggling search remounts folders open/closed.
+            key={`${group.label}${query.trim() ? "-q" : ""}`}
+            icon={
+              <SkillTargetIcon value={group.icon} icon={group.icon} size={20} />
+            }
+            label={group.label}
+            count={group.skills.length}
+            deactivated={!group.connected}
+            defaultOpen={query.trim().length > 0}
+            trailing={
+              group.connected ? undefined : (
+                <div className="flex shrink-0 items-center gap-2">
+                  <Chip
+                    size="sm"
+                    variant="flat"
+                    color="warning"
+                    classNames={{
+                      base: "bg-warning/15",
+                      content: "text-xs font-medium",
+                    }}
+                  >
+                    Not connected
+                  </Chip>
+                  <Button
+                    as={NextLink}
+                    href={`/integrations?id=${group.icon}`}
+                    size="sm"
+                    color="primary"
+                    variant="flat"
+                    className="rounded-lg"
+                  >
+                    Connect
+                  </Button>
+                </div>
+              )
+            }
+          >
+            {group.skills.map((skill) => (
+              <button
+                key={skill.slug}
+                type="button"
+                onClick={() => setSelected(skill)}
+                className="flex w-full cursor-pointer flex-col px-4 py-3 text-left transition-colors hover:bg-white/5"
+              >
+                <span className="text-sm text-zinc-100">{skill.name}</span>
+                {skill.description && (
+                  <span className="mt-0.5 line-clamp-2 text-xs text-zinc-400">
+                    {skill.description}
+                  </span>
+                )}
+              </button>
+            ))}
+          </SkillGroup>
+        ))
+      )}
+
+      <SkillPreviewModal
+        skill={
+          selected
+            ? {
+                name: selected.name,
+                description: selected.description,
+                body: selected.body,
+                groupLabel: selected.group_label,
+                icon: selected.icon,
+                badge: "Built-in",
+              }
+            : null
+        }
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillEditorModal.tsx
+++ b/apps/web/src/features/skills/components/SkillEditorModal.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Input, Textarea } from "@heroui/input";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { Select, SelectItem } from "@heroui/select";
+import { Tab, Tabs } from "@heroui/tabs";
+import { Github01Icon, PlusSignIcon } from "@icons";
+import { useEffect, useMemo, useState } from "react";
+import MarkdownRenderer from "@/features/chat/components/interface/MarkdownRenderer";
+import { toast } from "@/lib/toast";
+import { skillsApi } from "../api/skillsApi";
+import type { DiscoveredSkill, Skill, SkillTarget } from "../api/types";
+import {
+  EXECUTOR_TARGET,
+  GITHUB_REPO_PATTERN,
+  MAX_SKILL_DESCRIPTION_LENGTH,
+  MAX_SKILL_NAME_LENGTH,
+  SKILL_NAME_PATTERN,
+} from "../constants";
+import { SkillTargetIcon } from "./SkillTargetIcon";
+
+interface SkillEditorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  targets: SkillTarget[];
+  /** The skill being edited, or null when creating. */
+  skill: Skill | null;
+}
+
+export function SkillEditorModal({
+  isOpen,
+  onClose,
+  onSaved,
+  targets,
+  skill,
+}: SkillEditorModalProps) {
+  const isEdit = skill !== null;
+
+  const [mode, setMode] = useState<"write" | "import">("write");
+  const [instructionsTab, setInstructionsTab] = useState<"write" | "preview">(
+    "write",
+  );
+  const [name, setName] = useState("");
+  const [target, setTarget] = useState(EXECUTOR_TARGET);
+  const [description, setDescription] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Import-from-GitHub state.
+  const [repoUrl, setRepoUrl] = useState("");
+  const [discovering, setDiscovering] = useState(false);
+  const [discovered, setDiscovered] = useState<DiscoveredSkill[] | null>(null);
+  const [installingName, setInstallingName] = useState<string | null>(null);
+  const [installingAll, setInstallingAll] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setMode("write");
+    setInstructionsTab("write");
+    setName(skill?.name ?? "");
+    setTarget(skill?.target ?? EXECUTOR_TARGET);
+    setDescription(skill?.description ?? "");
+    setInstructions(skill?.body_content ?? "");
+    setRepoUrl("");
+    setDiscovered(null);
+    setInstallingName(null);
+    setInstallingAll(false);
+  }, [isOpen, skill]);
+
+  const nameError = useMemo(() => {
+    if (!name) return undefined;
+    if (name.length > MAX_SKILL_NAME_LENGTH)
+      return `Keep it under ${MAX_SKILL_NAME_LENGTH} characters`;
+    if (!SKILL_NAME_PATTERN.test(name))
+      return "Use lowercase letters, numbers, and single hyphens";
+    return undefined;
+  }, [name]);
+
+  const repoError = useMemo(() => {
+    const repo = repoUrl.trim();
+    if (!repo) return undefined;
+    if (!GITHUB_REPO_PATTERN.test(repo))
+      return "Use owner/repo or a full github.com URL";
+    return undefined;
+  }, [repoUrl]);
+
+  const repoValid = repoUrl.trim().length > 0 && !repoError;
+
+  const isValid =
+    name.length > 0 &&
+    !nameError &&
+    description.trim().length > 0 &&
+    description.length <= MAX_SKILL_DESCRIPTION_LENGTH &&
+    instructions.trim().length > 0;
+
+  const handleSave = async () => {
+    if (!isValid) return;
+    setSaving(true);
+    try {
+      if (isEdit) {
+        await skillsApi.updateSkill(skill.id, {
+          description: description.trim(),
+          instructions,
+          target,
+        });
+        toast.success(`Saved "${name}"`);
+      } else {
+        await skillsApi.createSkill({
+          name,
+          description: description.trim(),
+          instructions,
+          target,
+        });
+        toast.success(`Created "${name}"`);
+      }
+      onSaved();
+      onClose();
+    } catch {
+      // The API interceptor surfaces the server's error message.
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDiscover = async () => {
+    const repo = repoUrl.trim();
+    if (!repo) return;
+    setDiscovering(true);
+    setDiscovered(null);
+    try {
+      const result = await skillsApi.discoverSkills(repo);
+      setDiscovered(result.skills);
+      if (result.skills.length === 0)
+        toast.info("No skills found in that repo");
+    } catch {
+      setDiscovered([]);
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
+  const handleInstall = async (discoveredSkill: DiscoveredSkill) => {
+    setInstallingName(discoveredSkill.name);
+    try {
+      await skillsApi.installFromGithub(
+        discoveredSkill.repo_url,
+        discoveredSkill.name,
+        target,
+      );
+      toast.success(`Installed "${discoveredSkill.name}"`);
+      onSaved();
+    } catch {
+      // Interceptor surfaces the error (e.g. already installed).
+    } finally {
+      setInstallingName(null);
+    }
+  };
+
+  const handleInstallAll = async () => {
+    if (!discovered?.length) return;
+    setInstallingAll(true);
+    let installed = 0;
+    // Sequential to stay friendly to GitHub rate limits and keep order stable.
+    for (const d of discovered) {
+      try {
+        await skillsApi.installFromGithub(d.repo_url, d.name, target);
+        installed += 1;
+      } catch {
+        // Skip ones that fail (e.g. already installed); keep going.
+      }
+    }
+    setInstallingAll(false);
+    if (installed > 0) {
+      toast.success(
+        `Installed ${installed} skill${installed === 1 ? "" : "s"}`,
+      );
+      onSaved();
+    }
+  };
+
+  const targetSelect = (
+    <Select
+      label="Runs in"
+      selectedKeys={[target]}
+      onChange={(e) => e.target.value && setTarget(e.target.value)}
+      classNames={{ trigger: "rounded-xl bg-zinc-800" }}
+      renderValue={(items) => {
+        const value = items[0]?.key as string | undefined;
+        const meta = targets.find((t) => t.value === value);
+        if (!meta) return null;
+        return (
+          <div className="flex items-center gap-2">
+            <SkillTargetIcon value={meta.value} icon={meta.icon} size={16} />
+            <span>{meta.label}</span>
+          </div>
+        );
+      }}
+    >
+      {targets.map((t) => (
+        <SelectItem
+          key={t.value}
+          startContent={
+            <SkillTargetIcon value={t.value} icon={t.icon} size={16} />
+          }
+        >
+          {t.label}
+        </SelectItem>
+      ))}
+    </Select>
+  );
+
+  const writeForm = (
+    <div className="flex flex-col gap-4">
+      <Input
+        label="Name"
+        placeholder="triage-inbox"
+        value={name}
+        onValueChange={setName}
+        isDisabled={isEdit}
+        description={
+          isEdit
+            ? "The name is the skill's identity and can't be changed."
+            : "Lowercase, hyphenated. This is how the agent refers to it."
+        }
+        isInvalid={!!nameError}
+        errorMessage={nameError}
+      />
+      <Input
+        label="Description"
+        placeholder="Sort, label, and draft replies for new mail"
+        value={description}
+        onValueChange={setDescription}
+        description="What it does and when to use it — the agent sees this at all times."
+      />
+      {targetSelect}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-zinc-300">Instructions</span>
+          <Tabs
+            size="sm"
+            radius="full"
+            selectedKey={instructionsTab}
+            onSelectionChange={(key) =>
+              setInstructionsTab(key as "write" | "preview")
+            }
+          >
+            <Tab key="write" title="Write" />
+            <Tab key="preview" title="Preview" />
+          </Tabs>
+        </div>
+        {instructionsTab === "write" ? (
+          <Textarea
+            aria-label="Instructions"
+            placeholder={"# Triage inbox\n\n1. Fetch unread mail\n2. ..."}
+            value={instructions}
+            onValueChange={setInstructions}
+            minRows={8}
+            maxRows={18}
+            classNames={{ input: "font-mono text-xs" }}
+          />
+        ) : (
+          <div className="min-h-44 rounded-xl bg-zinc-900/60 p-4">
+            {instructions.trim() ? (
+              <MarkdownRenderer
+                content={instructions}
+                hideCodeToolbar
+                className="prose-sm prose-p:text-zinc-300 prose-li:text-zinc-300"
+              />
+            ) : (
+              <p className="text-xs text-zinc-500">Nothing to preview yet.</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const importForm = (
+    <div className="flex flex-col gap-4">
+      {targetSelect}
+      <Input
+        label="GitHub repository"
+        placeholder="owner/repo or a full GitHub URL"
+        value={repoUrl}
+        onValueChange={setRepoUrl}
+        isInvalid={!!repoError}
+        errorMessage={repoError}
+        startContent={<Github01Icon className="size-4 text-white" />}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && repoValid) handleDiscover();
+        }}
+        endContent={
+          <Button
+            size="sm"
+            color="primary"
+            variant="flat"
+            className="-mr-1 shrink-0 rounded-lg"
+            isLoading={discovering}
+            isDisabled={!repoValid}
+            onPress={handleDiscover}
+          >
+            Find skills
+          </Button>
+        }
+      />
+
+      {discovered !== null && discovered.length > 0 && (
+        <>
+          <div className="flex items-center justify-between px-1">
+            <span className="text-xs text-zinc-500">
+              Found {discovered.length} skill
+              {discovered.length === 1 ? "" : "s"}
+            </span>
+            <Button
+              size="sm"
+              color="primary"
+              variant="flat"
+              className="rounded-xl"
+              isLoading={installingAll}
+              startContent={
+                installingAll ? undefined : <PlusSignIcon className="size-4" />
+              }
+              onPress={handleInstallAll}
+            >
+              Add all
+            </Button>
+          </div>
+          <div className="divide-y divide-zinc-800/60 overflow-hidden rounded-xl bg-zinc-800/60">
+            {discovered.map((d) => (
+              <div
+                key={`${d.repo_url}/${d.path}`}
+                className="flex items-center gap-3 px-3 py-2.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm text-zinc-100">{d.name}</p>
+                  <p className="line-clamp-1 text-xs text-zinc-500">
+                    {d.description}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  color="primary"
+                  variant="flat"
+                  className="rounded-xl"
+                  isLoading={installingName === d.name}
+                  startContent={
+                    installingName === d.name ? undefined : (
+                      <PlusSignIcon className="size-4" />
+                    )
+                  }
+                  onPress={() => handleInstall(d)}
+                >
+                  Add
+                </Button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+      {discovered !== null && discovered.length === 0 && !discovering && (
+        <p className="text-center text-xs text-zinc-500">
+          No skills found in that repository.
+        </p>
+      )}
+    </div>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="2xl" scrollBehavior="inside">
+      <ModalContent>
+        <ModalHeader className="flex-col items-start gap-1">
+          <span>{isEdit ? "Edit skill" : "New skill"}</span>
+          <span className="text-xs font-normal text-zinc-500">
+            {isEdit
+              ? "Update what this skill does and where it runs."
+              : "Teach your assistant a reusable workflow it can follow."}
+          </span>
+        </ModalHeader>
+        <ModalBody>
+          {isEdit ? (
+            writeForm
+          ) : (
+            <Tabs
+              radius="full"
+              variant="solid"
+              color="primary"
+              selectedKey={mode}
+              onSelectionChange={(key) => setMode(key as "write" | "import")}
+              classNames={{ base: "mb-1" }}
+            >
+              <Tab key="write" title="Write your own">
+                {writeForm}
+              </Tab>
+              <Tab
+                key="import"
+                title={
+                  <div className="flex items-center gap-1.5">
+                    <Github01Icon className="size-4" />
+                    <span>Import from GitHub</span>
+                  </div>
+                }
+              >
+                {importForm}
+              </Tab>
+            </Tabs>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="light" className="rounded-xl" onPress={onClose}>
+            {isEdit || mode === "write" ? "Cancel" : "Done"}
+          </Button>
+          {(isEdit || mode === "write") && (
+            <Button
+              color="primary"
+              className="rounded-xl"
+              onPress={handleSave}
+              isLoading={saving}
+              isDisabled={!isValid}
+            >
+              {isEdit ? "Save changes" : "Create skill"}
+            </Button>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillEditorModal.tsx
+++ b/apps/web/src/features/skills/components/SkillEditorModal.tsx
@@ -79,9 +79,11 @@ export function SkillEditorModal({
     return undefined;
   }, [description]);
 
+  // Name is immutable while editing, so its validity can't block a save
+  // (legacy skills may predate stricter name rules).
+  const nameValid = isEdit || (name.length > 0 && !nameError);
   const isValid =
-    name.length > 0 &&
-    !nameError &&
+    nameValid &&
     description.trim().length > 0 &&
     !descriptionError &&
     instructions.trim().length > 0;

--- a/apps/web/src/features/skills/components/SkillEditorModal.tsx
+++ b/apps/web/src/features/skills/components/SkillEditorModal.tsx
@@ -9,22 +9,22 @@ import {
   ModalFooter,
   ModalHeader,
 } from "@heroui/modal";
-import { Select, SelectItem } from "@heroui/select";
 import { Tab, Tabs } from "@heroui/tabs";
-import { Github01Icon, PlusSignIcon } from "@icons";
+import { Github01Icon } from "@icons";
 import { useEffect, useMemo, useState } from "react";
 import MarkdownRenderer from "@/features/chat/components/interface/MarkdownRenderer";
 import { toast } from "@/lib/toast";
 import { skillsApi } from "../api/skillsApi";
-import type { DiscoveredSkill, Skill, SkillTarget } from "../api/types";
+import type { Skill, SkillTarget } from "../api/types";
 import {
+  CONSECUTIVE_HYPHENS,
   EXECUTOR_TARGET,
-  GITHUB_REPO_PATTERN,
   MAX_SKILL_DESCRIPTION_LENGTH,
   MAX_SKILL_NAME_LENGTH,
   SKILL_NAME_PATTERN,
 } from "../constants";
-import { SkillTargetIcon } from "./SkillTargetIcon";
+import { SkillImportForm } from "./SkillImportForm";
+import { SkillTargetSelect } from "./SkillTargetSelect";
 
 interface SkillEditorModalProps {
   isOpen: boolean;
@@ -54,13 +54,6 @@ export function SkillEditorModal({
   const [instructions, setInstructions] = useState("");
   const [saving, setSaving] = useState(false);
 
-  // Import-from-GitHub state.
-  const [repoUrl, setRepoUrl] = useState("");
-  const [discovering, setDiscovering] = useState(false);
-  const [discovered, setDiscovered] = useState<DiscoveredSkill[] | null>(null);
-  const [installingName, setInstallingName] = useState<string | null>(null);
-  const [installingAll, setInstallingAll] = useState(false);
-
   useEffect(() => {
     if (!isOpen) return;
     setMode("write");
@@ -69,36 +62,28 @@ export function SkillEditorModal({
     setTarget(skill?.target ?? EXECUTOR_TARGET);
     setDescription(skill?.description ?? "");
     setInstructions(skill?.body_content ?? "");
-    setRepoUrl("");
-    setDiscovered(null);
-    setInstallingName(null);
-    setInstallingAll(false);
   }, [isOpen, skill]);
 
   const nameError = useMemo(() => {
     if (!name) return undefined;
     if (name.length > MAX_SKILL_NAME_LENGTH)
       return `Keep it under ${MAX_SKILL_NAME_LENGTH} characters`;
-    if (!SKILL_NAME_PATTERN.test(name))
-      return "Use lowercase letters, numbers, and single hyphens";
+    if (!SKILL_NAME_PATTERN.test(name) || CONSECUTIVE_HYPHENS.test(name))
+      return "Lowercase letters, numbers, and single hyphens only";
     return undefined;
   }, [name]);
 
-  const repoError = useMemo(() => {
-    const repo = repoUrl.trim();
-    if (!repo) return undefined;
-    if (!GITHUB_REPO_PATTERN.test(repo))
-      return "Use owner/repo or a full github.com URL";
+  const descriptionError = useMemo(() => {
+    if (description.length > MAX_SKILL_DESCRIPTION_LENGTH)
+      return `Keep it under ${MAX_SKILL_DESCRIPTION_LENGTH} characters`;
     return undefined;
-  }, [repoUrl]);
-
-  const repoValid = repoUrl.trim().length > 0 && !repoError;
+  }, [description]);
 
   const isValid =
     name.length > 0 &&
     !nameError &&
     description.trim().length > 0 &&
-    description.length <= MAX_SKILL_DESCRIPTION_LENGTH &&
+    !descriptionError &&
     instructions.trim().length > 0;
 
   const handleSave = async () => {
@@ -130,93 +115,6 @@ export function SkillEditorModal({
     }
   };
 
-  const handleDiscover = async () => {
-    const repo = repoUrl.trim();
-    if (!repo) return;
-    setDiscovering(true);
-    setDiscovered(null);
-    try {
-      const result = await skillsApi.discoverSkills(repo);
-      setDiscovered(result.skills);
-      if (result.skills.length === 0)
-        toast.info("No skills found in that repo");
-    } catch {
-      setDiscovered([]);
-    } finally {
-      setDiscovering(false);
-    }
-  };
-
-  const handleInstall = async (discoveredSkill: DiscoveredSkill) => {
-    setInstallingName(discoveredSkill.name);
-    try {
-      await skillsApi.installFromGithub(
-        discoveredSkill.repo_url,
-        discoveredSkill.name,
-        target,
-      );
-      toast.success(`Installed "${discoveredSkill.name}"`);
-      onSaved();
-    } catch {
-      // Interceptor surfaces the error (e.g. already installed).
-    } finally {
-      setInstallingName(null);
-    }
-  };
-
-  const handleInstallAll = async () => {
-    if (!discovered?.length) return;
-    setInstallingAll(true);
-    let installed = 0;
-    // Sequential to stay friendly to GitHub rate limits and keep order stable.
-    for (const d of discovered) {
-      try {
-        await skillsApi.installFromGithub(d.repo_url, d.name, target);
-        installed += 1;
-      } catch {
-        // Skip ones that fail (e.g. already installed); keep going.
-      }
-    }
-    setInstallingAll(false);
-    if (installed > 0) {
-      toast.success(
-        `Installed ${installed} skill${installed === 1 ? "" : "s"}`,
-      );
-      onSaved();
-    }
-  };
-
-  const targetSelect = (
-    <Select
-      label="Runs in"
-      selectedKeys={[target]}
-      onChange={(e) => e.target.value && setTarget(e.target.value)}
-      classNames={{ trigger: "rounded-xl bg-zinc-800" }}
-      renderValue={(items) => {
-        const value = items[0]?.key as string | undefined;
-        const meta = targets.find((t) => t.value === value);
-        if (!meta) return null;
-        return (
-          <div className="flex items-center gap-2">
-            <SkillTargetIcon value={meta.value} icon={meta.icon} size={16} />
-            <span>{meta.label}</span>
-          </div>
-        );
-      }}
-    >
-      {targets.map((t) => (
-        <SelectItem
-          key={t.value}
-          startContent={
-            <SkillTargetIcon value={t.value} icon={t.icon} size={16} />
-          }
-        >
-          {t.label}
-        </SelectItem>
-      ))}
-    </Select>
-  );
-
   const writeForm = (
     <div className="flex flex-col gap-4">
       <Input
@@ -239,8 +137,14 @@ export function SkillEditorModal({
         value={description}
         onValueChange={setDescription}
         description="What it does and when to use it — the agent sees this at all times."
+        isInvalid={!!descriptionError}
+        errorMessage={descriptionError}
       />
-      {targetSelect}
+      <SkillTargetSelect
+        targets={targets}
+        value={target}
+        onChange={setTarget}
+      />
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <span className="text-sm text-zinc-300">Instructions</span>
@@ -283,96 +187,6 @@ export function SkillEditorModal({
     </div>
   );
 
-  const importForm = (
-    <div className="flex flex-col gap-4">
-      {targetSelect}
-      <Input
-        label="GitHub repository"
-        placeholder="owner/repo or a full GitHub URL"
-        value={repoUrl}
-        onValueChange={setRepoUrl}
-        isInvalid={!!repoError}
-        errorMessage={repoError}
-        startContent={<Github01Icon className="size-4 text-white" />}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && repoValid) handleDiscover();
-        }}
-        endContent={
-          <Button
-            size="sm"
-            color="primary"
-            variant="flat"
-            className="-mr-1 shrink-0 rounded-lg"
-            isLoading={discovering}
-            isDisabled={!repoValid}
-            onPress={handleDiscover}
-          >
-            Find skills
-          </Button>
-        }
-      />
-
-      {discovered !== null && discovered.length > 0 && (
-        <>
-          <div className="flex items-center justify-between px-1">
-            <span className="text-xs text-zinc-500">
-              Found {discovered.length} skill
-              {discovered.length === 1 ? "" : "s"}
-            </span>
-            <Button
-              size="sm"
-              color="primary"
-              variant="flat"
-              className="rounded-xl"
-              isLoading={installingAll}
-              startContent={
-                installingAll ? undefined : <PlusSignIcon className="size-4" />
-              }
-              onPress={handleInstallAll}
-            >
-              Add all
-            </Button>
-          </div>
-          <div className="divide-y divide-zinc-800/60 overflow-hidden rounded-xl bg-zinc-800/60">
-            {discovered.map((d) => (
-              <div
-                key={`${d.repo_url}/${d.path}`}
-                className="flex items-center gap-3 px-3 py-2.5"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm text-zinc-100">{d.name}</p>
-                  <p className="line-clamp-1 text-xs text-zinc-500">
-                    {d.description}
-                  </p>
-                </div>
-                <Button
-                  size="sm"
-                  color="primary"
-                  variant="flat"
-                  className="rounded-xl"
-                  isLoading={installingName === d.name}
-                  startContent={
-                    installingName === d.name ? undefined : (
-                      <PlusSignIcon className="size-4" />
-                    )
-                  }
-                  onPress={() => handleInstall(d)}
-                >
-                  Add
-                </Button>
-              </div>
-            ))}
-          </div>
-        </>
-      )}
-      {discovered !== null && discovered.length === 0 && !discovering && (
-        <p className="text-center text-xs text-zinc-500">
-          No skills found in that repository.
-        </p>
-      )}
-    </div>
-  );
-
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="2xl" scrollBehavior="inside">
       <ModalContent>
@@ -408,7 +222,7 @@ export function SkillEditorModal({
                   </div>
                 }
               >
-                {importForm}
+                <SkillImportForm targets={targets} onInstalled={onSaved} />
               </Tab>
             </Tabs>
           )}

--- a/apps/web/src/features/skills/components/SkillGroup.tsx
+++ b/apps/web/src/features/skills/components/SkillGroup.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { ChevronRight } from "@/components/shared/icons";
+import { cn } from "@/lib/utils";
+
+interface SkillGroupProps {
+  /** Prominent leading glyph (integration logo or agent icon). */
+  icon: ReactNode;
+  label: string;
+  count: number;
+  /** Greyed out — e.g. a built-in group whose integration isn't connected. */
+  deactivated?: boolean;
+  defaultOpen?: boolean;
+  /** Trailing header content (e.g. a status chip + Connect button). */
+  trailing?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * A collapsible folder grouping skills under an agent — folders are agents,
+ * files are skills. The leading icon is a prominent tile so each group reads
+ * at a glance.
+ */
+export function SkillGroup({
+  icon,
+  label,
+  count,
+  deactivated = false,
+  defaultOpen = true,
+  trailing,
+  children,
+}: SkillGroupProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const toggle = () => setOpen((v) => !v);
+
+  return (
+    <div className="overflow-hidden rounded-2xl bg-zinc-900/60">
+      <div className="relative flex items-center gap-2 px-3 py-2.5 transition-colors hover:bg-white/5">
+        {/* Full-row toggle: the whole padded header is the touch target. */}
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={`${open ? "Collapse" : "Expand"} ${label}`}
+          className="absolute inset-0 cursor-pointer"
+        />
+        <div
+          className={cn(
+            "pointer-events-none flex min-w-0 flex-1 items-center gap-3",
+            deactivated && "opacity-60",
+          )}
+        >
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-zinc-800">
+            {icon}
+          </div>
+          <span className="truncate text-sm font-medium text-zinc-100">
+            {label}
+          </span>
+          <span className="shrink-0 text-xs text-zinc-500">{count}</span>
+        </div>
+        {/* Interactive actions sit above the overlay so they stay clickable. */}
+        {trailing && <div className="relative z-10 shrink-0">{trailing}</div>}
+        <ChevronRight
+          className={cn(
+            "pointer-events-none relative size-4 shrink-0 text-zinc-500 transition-transform",
+            open && "rotate-90",
+          )}
+        />
+      </div>
+      {open && (
+        <div className="divide-y divide-zinc-800/60 pb-1">{children}</div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillGroup.tsx
+++ b/apps/web/src/features/skills/components/SkillGroup.tsx
@@ -43,6 +43,7 @@ export function SkillGroup({
           type="button"
           onClick={toggle}
           aria-label={`${open ? "Collapse" : "Expand"} ${label}`}
+          aria-expanded={open}
           className="absolute inset-0 cursor-pointer"
         />
         <div

--- a/apps/web/src/features/skills/components/SkillImportForm.tsx
+++ b/apps/web/src/features/skills/components/SkillImportForm.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Input } from "@heroui/input";
+import { Github01Icon, PlusSignIcon } from "@icons";
+import { useMemo, useState } from "react";
+import { toast } from "@/lib/toast";
+import { skillsApi } from "../api/skillsApi";
+import type { DiscoveredSkill, SkillTarget } from "../api/types";
+import { EXECUTOR_TARGET, GITHUB_REPO_PATTERN } from "../constants";
+import { SkillTargetSelect } from "./SkillTargetSelect";
+
+interface SkillImportFormProps {
+  targets: SkillTarget[];
+  /** Called after each successful install so the caller can refetch. */
+  onInstalled: () => void;
+}
+
+/** The "Import from GitHub" tab: discover a repo's skills and install them. */
+export function SkillImportForm({
+  targets,
+  onInstalled,
+}: SkillImportFormProps) {
+  const [target, setTarget] = useState(EXECUTOR_TARGET);
+  const [repoUrl, setRepoUrl] = useState("");
+  const [discovering, setDiscovering] = useState(false);
+  const [discovered, setDiscovered] = useState<DiscoveredSkill[] | null>(null);
+  const [installingPath, setInstallingPath] = useState<string | null>(null);
+  const [installingAll, setInstallingAll] = useState(false);
+
+  const repoError = useMemo(() => {
+    const repo = repoUrl.trim();
+    if (!repo) return undefined;
+    if (!GITHUB_REPO_PATTERN.test(repo))
+      return "Use owner/repo or a full github.com URL";
+    return undefined;
+  }, [repoUrl]);
+  const repoValid = repoUrl.trim().length > 0 && !repoError;
+
+  const handleDiscover = async () => {
+    const repo = repoUrl.trim();
+    if (!repo) return;
+    setDiscovering(true);
+    setDiscovered(null);
+    try {
+      const result = await skillsApi.discoverSkills(repo);
+      setDiscovered(result.skills);
+      if (result.skills.length === 0)
+        toast.info("No skills found in that repo");
+    } catch {
+      setDiscovered([]);
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
+  const handleInstall = async (skill: DiscoveredSkill) => {
+    setInstallingPath(skill.path);
+    try {
+      await skillsApi.installFromGithub(skill.repo_url, skill.name, target);
+      toast.success(`Installed "${skill.name}"`);
+      onInstalled();
+    } catch {
+      // Interceptor surfaces the error (e.g. already installed).
+    } finally {
+      setInstallingPath(null);
+    }
+  };
+
+  const handleInstallAll = async () => {
+    if (!discovered?.length) return;
+    setInstallingAll(true);
+    let installed = 0;
+    // Sequential to stay friendly to GitHub rate limits and keep order stable.
+    for (const skill of discovered) {
+      try {
+        await skillsApi.installFromGithub(skill.repo_url, skill.name, target);
+        installed += 1;
+      } catch {
+        // Skip ones that fail (e.g. already installed); keep going.
+      }
+    }
+    setInstallingAll(false);
+    if (installed > 0) {
+      toast.success(
+        `Installed ${installed} skill${installed === 1 ? "" : "s"}`,
+      );
+      onInstalled();
+    } else {
+      toast.error("Couldn't add any skills");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SkillTargetSelect
+        targets={targets}
+        value={target}
+        onChange={setTarget}
+      />
+      <Input
+        label="GitHub repository"
+        placeholder="owner/repo or a full GitHub URL"
+        value={repoUrl}
+        onValueChange={setRepoUrl}
+        isInvalid={!!repoError}
+        errorMessage={repoError}
+        startContent={<Github01Icon className="size-4 text-white" />}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && repoValid) handleDiscover();
+        }}
+        endContent={
+          <Button
+            size="sm"
+            color="primary"
+            variant="flat"
+            className="-mr-1 shrink-0 rounded-lg"
+            isLoading={discovering}
+            isDisabled={!repoValid}
+            onPress={handleDiscover}
+          >
+            Find skills
+          </Button>
+        }
+      />
+
+      {discovered !== null && discovered.length > 0 && (
+        <>
+          <div className="flex items-center justify-between px-1">
+            <span className="text-xs text-zinc-500">
+              Found {discovered.length} skill
+              {discovered.length === 1 ? "" : "s"}
+            </span>
+            <Button
+              size="sm"
+              color="primary"
+              variant="flat"
+              className="rounded-xl"
+              isLoading={installingAll}
+              startContent={
+                installingAll ? undefined : <PlusSignIcon className="size-4" />
+              }
+              onPress={handleInstallAll}
+            >
+              Add all
+            </Button>
+          </div>
+          <div className="divide-y divide-zinc-800/60 overflow-hidden rounded-xl bg-zinc-800/60">
+            {discovered.map((skill) => (
+              <div
+                key={`${skill.repo_url}/${skill.path}`}
+                className="flex items-center gap-3 px-3 py-2.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm text-zinc-100">{skill.name}</p>
+                  <p className="line-clamp-1 text-xs text-zinc-500">
+                    {skill.description}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  color="primary"
+                  variant="flat"
+                  className="rounded-xl"
+                  isLoading={installingPath === skill.path}
+                  startContent={
+                    installingPath === skill.path ? undefined : (
+                      <PlusSignIcon className="size-4" />
+                    )
+                  }
+                  onPress={() => handleInstall(skill)}
+                >
+                  Add
+                </Button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+      {discovered !== null && discovered.length === 0 && !discovering && (
+        <p className="text-center text-xs text-zinc-500">
+          No skills found in that repository.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillImportForm.tsx
+++ b/apps/web/src/features/skills/components/SkillImportForm.tsx
@@ -25,8 +25,12 @@ export function SkillImportForm({
   const [repoUrl, setRepoUrl] = useState("");
   const [discovering, setDiscovering] = useState(false);
   const [discovered, setDiscovered] = useState<DiscoveredSkill[] | null>(null);
+  const [discoverError, setDiscoverError] = useState(false);
   const [installingPath, setInstallingPath] = useState<string | null>(null);
   const [installingAll, setInstallingAll] = useState(false);
+
+  // No install (single or "Add all") may overlap another.
+  const installBusy = installingAll || installingPath !== null;
 
   const repoError = useMemo(() => {
     const repo = repoUrl.trim();
@@ -42,22 +46,29 @@ export function SkillImportForm({
     if (!repo) return;
     setDiscovering(true);
     setDiscovered(null);
+    setDiscoverError(false);
     try {
       const result = await skillsApi.discoverSkills(repo);
       setDiscovered(result.skills);
       if (result.skills.length === 0)
         toast.info("No skills found in that repo");
     } catch {
-      setDiscovered([]);
+      setDiscoverError(true);
     } finally {
       setDiscovering(false);
     }
   };
 
   const handleInstall = async (skill: DiscoveredSkill) => {
+    if (installBusy) return;
     setInstallingPath(skill.path);
     try {
-      await skillsApi.installFromGithub(skill.repo_url, skill.name, target);
+      await skillsApi.installFromGithub(
+        skill.repo_url,
+        skill.name,
+        skill.path,
+        target,
+      );
       toast.success(`Installed "${skill.name}"`);
       onInstalled();
     } catch {
@@ -68,13 +79,18 @@ export function SkillImportForm({
   };
 
   const handleInstallAll = async () => {
-    if (!discovered?.length) return;
+    if (installBusy || !discovered?.length) return;
     setInstallingAll(true);
     let installed = 0;
     // Sequential to stay friendly to GitHub rate limits and keep order stable.
     for (const skill of discovered) {
       try {
-        await skillsApi.installFromGithub(skill.repo_url, skill.name, target);
+        await skillsApi.installFromGithub(
+          skill.repo_url,
+          skill.name,
+          skill.path,
+          target,
+        );
         installed += 1;
       } catch {
         // Skip ones that fail (e.g. already installed); keep going.
@@ -137,6 +153,7 @@ export function SkillImportForm({
               variant="flat"
               className="rounded-xl"
               isLoading={installingAll}
+              isDisabled={installBusy && !installingAll}
               startContent={
                 installingAll ? undefined : <PlusSignIcon className="size-4" />
               }
@@ -163,6 +180,7 @@ export function SkillImportForm({
                   variant="flat"
                   className="rounded-xl"
                   isLoading={installingPath === skill.path}
+                  isDisabled={installBusy && installingPath !== skill.path}
                   startContent={
                     installingPath === skill.path ? undefined : (
                       <PlusSignIcon className="size-4" />
@@ -177,11 +195,19 @@ export function SkillImportForm({
           </div>
         </>
       )}
-      {discovered !== null && discovered.length === 0 && !discovering && (
+      {discoverError && (
         <p className="text-center text-xs text-zinc-500">
-          No skills found in that repository.
+          Couldn't reach that repository. Check the name and try again.
         </p>
       )}
+      {!discoverError &&
+        discovered !== null &&
+        discovered.length === 0 &&
+        !discovering && (
+          <p className="text-center text-xs text-zinc-500">
+            No skills found in that repository.
+          </p>
+        )}
     </div>
   );
 }

--- a/apps/web/src/features/skills/components/SkillListSkeleton.tsx
+++ b/apps/web/src/features/skills/components/SkillListSkeleton.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@heroui/skeleton";
+
+/** Loading placeholder for a skills list / folder list. */
+export function SkillListSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-16 w-full rounded-2xl" />
+      <Skeleton className="h-16 w-full rounded-2xl" />
+      <Skeleton className="h-16 w-full rounded-2xl" />
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillPreviewModal.tsx
+++ b/apps/web/src/features/skills/components/SkillPreviewModal.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import MarkdownRenderer from "@/features/chat/components/interface/MarkdownRenderer";
+import { SkillTargetIcon } from "./SkillTargetIcon";
+
+/** Normalized shape for the shared read-only preview (built-in or user skill). */
+export interface SkillPreview {
+  name: string;
+  description: string;
+  /** SKILL.md markdown body. */
+  body: string;
+  /** Display name of the owning agent (e.g. "General assistant", "Gmail"). */
+  groupLabel: string;
+  /** Icon key for SkillTargetIcon (subagent/integration id, or "executor"). */
+  icon: string;
+  /** Optional prefix tag, e.g. "Built-in". */
+  badge?: string;
+}
+
+interface SkillPreviewModalProps {
+  skill: SkillPreview | null;
+  onClose: () => void;
+}
+
+/** Read-only preview of a skill's SKILL.md — shared by Your Skills and Built-in. */
+export function SkillPreviewModal({ skill, onClose }: SkillPreviewModalProps) {
+  return (
+    <Modal
+      isOpen={skill !== null}
+      onClose={onClose}
+      size="2xl"
+      scrollBehavior="inside"
+    >
+      <ModalContent>
+        {skill && (
+          <>
+            <ModalHeader className="flex items-center gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-zinc-800">
+                <SkillTargetIcon
+                  value={skill.icon}
+                  icon={skill.icon}
+                  size={20}
+                />
+              </div>
+              <div className="min-w-0">
+                <p className="truncate text-base font-medium text-white">
+                  {skill.name}
+                </p>
+                <p className="text-xs font-normal text-zinc-500">
+                  {skill.badge
+                    ? `${skill.badge} · ${skill.groupLabel}`
+                    : skill.groupLabel}
+                </p>
+              </div>
+            </ModalHeader>
+            <ModalBody>
+              {skill.description && (
+                <p className="text-sm text-zinc-400">{skill.description}</p>
+              )}
+              {skill.body && (
+                <div className="rounded-xl bg-zinc-900/60 p-4">
+                  <MarkdownRenderer
+                    content={skill.body}
+                    hideCodeToolbar
+                    className="prose-sm prose-p:text-zinc-300 prose-li:text-zinc-300"
+                  />
+                </div>
+              )}
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="light" className="rounded-xl" onPress={onClose}>
+                Close
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillRow.tsx
+++ b/apps/web/src/features/skills/components/SkillRow.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Chip } from "@heroui/chip";
+import { Switch } from "@heroui/switch";
+import { Delete02Icon, Link04Icon, PencilEdit02Icon } from "@icons";
+import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
+import type { Skill, SkillTarget } from "../api/types";
+import { EXECUTOR_TARGET } from "../constants";
+import { SkillTargetIcon } from "./SkillTargetIcon";
+
+interface SkillRowProps {
+  skill: Skill;
+  /** Resolved metadata for the skill's target, if known. */
+  targetMeta?: SkillTarget;
+  /** Show the target chip inline (used in flat/search views, hidden in groups). */
+  showTarget?: boolean;
+  isDeleting?: boolean;
+  onView: (skill: Skill) => void;
+  onEdit: (skill: Skill) => void;
+  onToggle: (skill: Skill, enabled: boolean) => void;
+  onDelete: (skill: Skill) => void;
+}
+
+export function SkillRow({
+  skill,
+  targetMeta,
+  showTarget = false,
+  isDeleting = false,
+  onView,
+  onEdit,
+  onToggle,
+  onDelete,
+}: SkillRowProps) {
+  const isScoped = skill.target !== EXECUTOR_TARGET;
+
+  return (
+    <div className="group flex items-center gap-3 px-4 py-3 transition-colors hover:bg-white/5">
+      <button
+        type="button"
+        onClick={() => onView(skill)}
+        className="min-w-0 flex-1 cursor-pointer text-left"
+      >
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm text-zinc-100">{skill.name}</p>
+          {showTarget && isScoped && targetMeta && (
+            <Chip
+              size="sm"
+              variant="flat"
+              startContent={
+                <SkillTargetIcon
+                  value={targetMeta.value}
+                  icon={targetMeta.icon}
+                  size={12}
+                />
+              }
+              classNames={{
+                base: "h-5 shrink-0 gap-1 bg-zinc-800 pl-1.5",
+                content: "px-1 text-xs text-zinc-400",
+              }}
+            >
+              {targetMeta.label}
+            </Chip>
+          )}
+        </div>
+        {skill.description && (
+          <p className="mt-0.5 line-clamp-2 text-xs text-zinc-400">
+            {skill.description}
+          </p>
+        )}
+      </button>
+
+      {skill.source_url &&
+        (skill.source === "github" || skill.source === "url") && (
+          <Chip
+            as="a"
+            href={skill.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+            variant="flat"
+            startContent={
+              skill.source === "github" ? (
+                getToolCategoryIcon("github", {
+                  size: 14,
+                  width: 14,
+                  height: 14,
+                  showBackground: false,
+                })
+              ) : (
+                <Link04Icon className="size-3.5 text-zinc-300" />
+              )
+            }
+            classNames={{
+              base: "h-6 shrink-0 cursor-pointer gap-1 bg-zinc-800 pl-2 data-[hover=true]:bg-zinc-700",
+              content: "px-1 text-xs text-zinc-400",
+            }}
+          >
+            {skill.source === "github" ? "GitHub" : "Source"}
+          </Chip>
+        )}
+
+      <div className="flex shrink-0 items-center gap-1">
+        <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <Button
+            isIconOnly
+            size="sm"
+            variant="light"
+            aria-label={`Edit ${skill.name}`}
+            onPress={() => onEdit(skill)}
+          >
+            <PencilEdit02Icon className="size-4 text-zinc-400" />
+          </Button>
+          <Button
+            isIconOnly
+            size="sm"
+            variant="light"
+            color="danger"
+            aria-label={`Delete ${skill.name}`}
+            isLoading={isDeleting}
+            onPress={() => onDelete(skill)}
+          >
+            <Delete02Icon className="size-4" />
+          </Button>
+        </div>
+        <Switch
+          size="sm"
+          isSelected={skill.enabled}
+          onValueChange={(enabled) => onToggle(skill, enabled)}
+          aria-label={`${skill.enabled ? "Disable" : "Enable"} ${skill.name}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillTargetIcon.tsx
+++ b/apps/web/src/features/skills/components/SkillTargetIcon.tsx
@@ -1,0 +1,59 @@
+import { AiMagicIcon, BookOpen01Icon, Note01Icon } from "@icons";
+import type { ComponentType, SVGProps } from "react";
+import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
+import { EXECUTOR_TARGET } from "../constants";
+
+interface SkillTargetIconProps {
+  /** Target value (executor or a subagent agent_name). */
+  value: string;
+  /** Icon key (integration id, or "executor"). */
+  icon: string;
+  size?: number;
+}
+
+/** Built-in (non-integration) subagents have no logo — give them a proper glyph. */
+const BUILTIN_ICONS: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
+  docgen: Note01Icon,
+  gaia_knowledge_guide: BookOpen01Icon,
+};
+
+/**
+ * Renders the logo for a skill target: a magic-wand glyph for the general
+ * assistant, a proper glyph for built-in subagents, otherwise the owning
+ * integration's logo (resolved by id).
+ */
+export function SkillTargetIcon({
+  value,
+  icon,
+  size = 16,
+}: SkillTargetIconProps) {
+  if (value === EXECUTOR_TARGET || icon === EXECUTOR_TARGET) {
+    return (
+      <AiMagicIcon
+        className="text-primary"
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
+  const Builtin = BUILTIN_ICONS[icon] ?? BUILTIN_ICONS[value];
+  if (Builtin) {
+    return (
+      <Builtin
+        className="text-zinc-300"
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
+  return (
+    <>
+      {getToolCategoryIcon(icon, {
+        size,
+        width: size,
+        height: size,
+        showBackground: false,
+      })}
+    </>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillTargetIcon.tsx
+++ b/apps/web/src/features/skills/components/SkillTargetIcon.tsx
@@ -46,14 +46,10 @@ export function SkillTargetIcon({
     );
   }
 
-  return (
-    <>
-      {getToolCategoryIcon(icon, {
-        size,
-        width: size,
-        height: size,
-        showBackground: false,
-      })}
-    </>
-  );
+  return getToolCategoryIcon(icon, {
+    size,
+    width: size,
+    height: size,
+    showBackground: false,
+  });
 }

--- a/apps/web/src/features/skills/components/SkillTargetSelect.tsx
+++ b/apps/web/src/features/skills/components/SkillTargetSelect.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Select, SelectItem } from "@heroui/select";
+import type { SkillTarget } from "../api/types";
+import { SkillTargetIcon } from "./SkillTargetIcon";
+
+interface SkillTargetSelectProps {
+  targets: SkillTarget[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/** "Runs in" picker — executor + the user's connected integration subagents. */
+export function SkillTargetSelect({
+  targets,
+  value,
+  onChange,
+}: SkillTargetSelectProps) {
+  return (
+    <Select
+      label="Runs in"
+      selectedKeys={[value]}
+      onChange={(e) => e.target.value && onChange(e.target.value)}
+      classNames={{ trigger: "rounded-xl bg-zinc-800" }}
+      renderValue={(items) => {
+        const selected = items[0]?.key as string | undefined;
+        const meta = targets.find((t) => t.value === selected);
+        if (!meta) return null;
+        return (
+          <div className="flex items-center gap-2">
+            <SkillTargetIcon value={meta.value} icon={meta.icon} size={16} />
+            <span>{meta.label}</span>
+          </div>
+        );
+      }}
+    >
+      {targets.map((t) => (
+        <SelectItem
+          key={t.value}
+          startContent={
+            <SkillTargetIcon value={t.value} icon={t.icon} size={16} />
+          }
+        >
+          {t.label}
+        </SelectItem>
+      ))}
+    </Select>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillsList.tsx
+++ b/apps/web/src/features/skills/components/SkillsList.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { Button } from "@heroui/button";
-import { Skeleton } from "@heroui/skeleton";
 import { PlusSignIcon, PuzzleIcon } from "@icons";
 import { useMemo } from "react";
 import type { Skill, SkillTarget } from "../api/types";
 import { EXECUTOR_TARGET } from "../constants";
+import { skillMatchesQuery } from "../utils";
 import { SkillGroup } from "./SkillGroup";
+import { SkillListSkeleton } from "./SkillListSkeleton";
 import { SkillRow } from "./SkillRow";
 import { SkillTargetIcon } from "./SkillTargetIcon";
 
 interface SkillsListProps {
   skills: Skill[];
-  targets: SkillTarget[];
+  /** value → target lookup, built once by the parent. */
+  targetByValue: Map<string, SkillTarget>;
   loading: boolean;
   query: string;
   deletingId: string | null;
@@ -23,17 +25,9 @@ interface SkillsListProps {
   onDelete: (skill: Skill) => void;
 }
 
-function matches(skill: Skill, query: string): boolean {
-  const q = query.toLowerCase();
-  return (
-    skill.name.toLowerCase().includes(q) ||
-    skill.description.toLowerCase().includes(q)
-  );
-}
-
 export function SkillsList({
   skills,
-  targets,
+  targetByValue,
   loading,
   query,
   deletingId,
@@ -43,15 +37,9 @@ export function SkillsList({
   onToggle,
   onDelete,
 }: SkillsListProps) {
-  const targetByValue = useMemo(() => {
-    const map = new Map<string, SkillTarget>();
-    for (const t of targets) map.set(t.value, t);
-    return map;
-  }, [targets]);
-
   const isSearching = query.trim().length > 0;
   const visible = isSearching
-    ? skills.filter((s) => matches(s, query))
+    ? skills.filter((s) => skillMatchesQuery(s.name, s.description, query))
     : skills;
 
   const active = visible.filter((s) => targetByValue.has(s.target));
@@ -88,13 +76,7 @@ export function SkillsList({
   );
 
   if (loading) {
-    return (
-      <div className="space-y-2">
-        <Skeleton className="h-16 w-full rounded-2xl" />
-        <Skeleton className="h-16 w-full rounded-2xl" />
-        <Skeleton className="h-16 w-full rounded-2xl" />
-      </div>
-    );
+    return <SkillListSkeleton />;
   }
 
   if (visible.length === 0) {

--- a/apps/web/src/features/skills/components/SkillsList.tsx
+++ b/apps/web/src/features/skills/components/SkillsList.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Skeleton } from "@heroui/skeleton";
+import { PlusSignIcon, PuzzleIcon } from "@icons";
+import { useMemo } from "react";
+import type { Skill, SkillTarget } from "../api/types";
+import { EXECUTOR_TARGET } from "../constants";
+import { SkillGroup } from "./SkillGroup";
+import { SkillRow } from "./SkillRow";
+import { SkillTargetIcon } from "./SkillTargetIcon";
+
+interface SkillsListProps {
+  skills: Skill[];
+  targets: SkillTarget[];
+  loading: boolean;
+  query: string;
+  deletingId: string | null;
+  onCreate: () => void;
+  onView: (skill: Skill) => void;
+  onEdit: (skill: Skill) => void;
+  onToggle: (skill: Skill, enabled: boolean) => void;
+  onDelete: (skill: Skill) => void;
+}
+
+function matches(skill: Skill, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    skill.name.toLowerCase().includes(q) ||
+    skill.description.toLowerCase().includes(q)
+  );
+}
+
+export function SkillsList({
+  skills,
+  targets,
+  loading,
+  query,
+  deletingId,
+  onCreate,
+  onView,
+  onEdit,
+  onToggle,
+  onDelete,
+}: SkillsListProps) {
+  const targetByValue = useMemo(() => {
+    const map = new Map<string, SkillTarget>();
+    for (const t of targets) map.set(t.value, t);
+    return map;
+  }, [targets]);
+
+  const isSearching = query.trim().length > 0;
+  const visible = isSearching
+    ? skills.filter((s) => matches(s, query))
+    : skills;
+
+  const active = visible.filter((s) => targetByValue.has(s.target));
+  const inactive = visible.filter((s) => !targetByValue.has(s.target));
+
+  const activeTargets = useMemo(() => {
+    const present = [...new Set(active.map((s) => s.target))];
+    return present.sort((a, b) => {
+      if (a === EXECUTOR_TARGET) return -1;
+      if (b === EXECUTOR_TARGET) return 1;
+      const la = targetByValue.get(a)?.label ?? a;
+      const lb = targetByValue.get(b)?.label ?? b;
+      return la.localeCompare(lb);
+    });
+  }, [active, targetByValue]);
+
+  // Folders only when scoping varies; a pure executor list stays flat.
+  const grouped =
+    !isSearching &&
+    (activeTargets.length > 1 || activeTargets[0] !== EXECUTOR_TARGET);
+
+  const row = (skill: Skill, showTarget: boolean) => (
+    <SkillRow
+      key={skill.id}
+      skill={skill}
+      targetMeta={targetByValue.get(skill.target)}
+      showTarget={showTarget}
+      isDeleting={deletingId === skill.id}
+      onView={onView}
+      onEdit={onEdit}
+      onToggle={onToggle}
+      onDelete={onDelete}
+    />
+  );
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-16 w-full rounded-2xl" />
+        <Skeleton className="h-16 w-full rounded-2xl" />
+        <Skeleton className="h-16 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (visible.length === 0) {
+    return <EmptyState searching={isSearching} onCreate={onCreate} />;
+  }
+
+  return (
+    <div className="space-y-3">
+      {grouped ? (
+        activeTargets.map((targetValue) => {
+          const meta = targetByValue.get(targetValue);
+          const rows = active.filter((s) => s.target === targetValue);
+          return (
+            <SkillGroup
+              key={targetValue}
+              icon={
+                meta ? (
+                  <SkillTargetIcon
+                    value={meta.value}
+                    icon={meta.icon}
+                    size={20}
+                  />
+                ) : (
+                  <PuzzleIcon className="size-5 text-zinc-400" />
+                )
+              }
+              label={meta?.label ?? targetValue}
+              count={rows.length}
+            >
+              {rows.map((s) => row(s, false))}
+            </SkillGroup>
+          );
+        })
+      ) : (
+        <div className="divide-y divide-zinc-800/60 overflow-hidden rounded-2xl bg-zinc-900/60">
+          {active.map((s) => row(s, isSearching))}
+        </div>
+      )}
+
+      {inactive.length > 0 && (
+        <SkillGroup
+          icon={<PuzzleIcon className="size-5 text-zinc-500" />}
+          label="Inactive"
+          count={inactive.length}
+          deactivated
+          defaultOpen={false}
+        >
+          {inactive.map((s) => row(s, true))}
+        </SkillGroup>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({
+  searching,
+  onCreate,
+}: {
+  searching: boolean;
+  onCreate: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl bg-zinc-900/60 px-6 py-14 text-center">
+      <div className="mb-3 flex size-12 items-center justify-center rounded-2xl bg-zinc-800">
+        <PuzzleIcon className="size-6 text-zinc-500" />
+      </div>
+      <p className="text-sm text-zinc-300">
+        {searching ? "No skills match your search" : "No skills yet"}
+      </p>
+      {!searching && (
+        <>
+          <p className="mt-1 max-w-sm text-xs text-zinc-500">
+            Skills are reusable workflows your assistant can follow — like
+            triaging your inbox or planning your day.
+          </p>
+          <Button
+            size="sm"
+            color="primary"
+            className="mt-4 rounded-xl"
+            startContent={<PlusSignIcon className="size-4" />}
+            onPress={onCreate}
+          >
+            New skill
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/components/SkillsManagement.tsx
+++ b/apps/web/src/features/skills/components/SkillsManagement.tsx
@@ -13,8 +13,9 @@ import type { ComponentType } from "react";
 import { useMemo, useState } from "react";
 import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
 import { useConfirmation } from "@/hooks/useConfirmation";
-import type { Skill, SkillTarget } from "../api/types";
+import type { Skill } from "../api/types";
 import { useSkills } from "../hooks/useSkills";
+import { buildTargetMap } from "../utils";
 import { BuiltinSkillsList } from "./BuiltinSkillsList";
 import { SkillEditorModal } from "./SkillEditorModal";
 import type { SkillPreview } from "./SkillPreviewModal";
@@ -32,11 +33,7 @@ export default function SkillsManagement() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const { confirm, confirmationProps } = useConfirmation();
 
-  const targetByValue = useMemo(() => {
-    const map = new Map<string, SkillTarget>();
-    for (const t of targets) map.set(t.value, t);
-    return map;
-  }, [targets]);
+  const targetByValue = useMemo(() => buildTargetMap(targets), [targets]);
 
   const openCreate = () => {
     setEditingSkill(null);
@@ -128,7 +125,7 @@ export default function SkillsManagement() {
         {tab === "yours" ? (
           <SkillsList
             skills={skills}
-            targets={targets}
+            targetByValue={targetByValue}
             loading={loading}
             query={query}
             deletingId={deletingId}

--- a/apps/web/src/features/skills/components/SkillsManagement.tsx
+++ b/apps/web/src/features/skills/components/SkillsManagement.tsx
@@ -159,13 +159,12 @@ export default function SkillsManagement() {
   );
 }
 
-function TabTitle({
-  icon: Icon,
-  label,
-}: {
+interface TabTitleProps {
   icon: ComponentType<{ className?: string }>;
   label: string;
-}) {
+}
+
+function TabTitle({ icon: Icon, label }: TabTitleProps) {
   return (
     <div className="flex items-center gap-2">
       <Icon className="size-4" />

--- a/apps/web/src/features/skills/components/SkillsManagement.tsx
+++ b/apps/web/src/features/skills/components/SkillsManagement.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Input } from "@heroui/input";
+import { Tab, Tabs } from "@heroui/tabs";
+import {
+  FolderLibraryIcon,
+  PlusSignIcon,
+  PuzzleIcon,
+  Search01Icon,
+} from "@icons";
+import type { ComponentType } from "react";
+import { useMemo, useState } from "react";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+import { useConfirmation } from "@/hooks/useConfirmation";
+import type { Skill, SkillTarget } from "../api/types";
+import { useSkills } from "../hooks/useSkills";
+import { BuiltinSkillsList } from "./BuiltinSkillsList";
+import { SkillEditorModal } from "./SkillEditorModal";
+import type { SkillPreview } from "./SkillPreviewModal";
+import { SkillPreviewModal } from "./SkillPreviewModal";
+import { SkillsList } from "./SkillsList";
+
+export default function SkillsManagement() {
+  const { skills, targets, loading, refetch, setEnabled, removeSkill } =
+    useSkills();
+  const [tab, setTab] = useState("yours");
+  const [query, setQuery] = useState("");
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+  const [previewSkill, setPreviewSkill] = useState<SkillPreview | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const { confirm, confirmationProps } = useConfirmation();
+
+  const targetByValue = useMemo(() => {
+    const map = new Map<string, SkillTarget>();
+    for (const t of targets) map.set(t.value, t);
+    return map;
+  }, [targets]);
+
+  const openCreate = () => {
+    setEditingSkill(null);
+    setEditorOpen(true);
+  };
+  const openEdit = (skill: Skill) => {
+    setEditingSkill(skill);
+    setEditorOpen(true);
+  };
+  const openView = (skill: Skill) => {
+    const meta = targetByValue.get(skill.target);
+    setPreviewSkill({
+      name: skill.name,
+      description: skill.description,
+      body: skill.body_content ?? "",
+      groupLabel: meta?.label ?? skill.target,
+      icon: meta?.icon ?? skill.target,
+    });
+  };
+
+  const handleDelete = async (skill: Skill) => {
+    const confirmed = await confirm({
+      title: `Delete "${skill.name}"?`,
+      message:
+        "This permanently removes the skill and its files. This can't be undone.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      variant: "destructive",
+    });
+    if (!confirmed) return;
+    setDeletingId(skill.id);
+    await removeSkill(skill);
+    setDeletingId(null);
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div>
+        <h2 className="text-xl font-medium text-white">Skills</h2>
+        <p className="mt-1 text-sm text-zinc-400">
+          Reusable workflows your assistant can follow, scoped to where they
+          run.
+        </p>
+      </div>
+
+      {/* Tabs, search, and New skill share one row. */}
+      <div className="flex items-center gap-3">
+        <Tabs
+          variant="solid"
+          color="primary"
+          radius="full"
+          selectedKey={tab}
+          onSelectionChange={(key) => setTab(key as string)}
+        >
+          <Tab
+            key="yours"
+            title={<TabTitle icon={PuzzleIcon} label="Your Skills" />}
+          />
+          <Tab
+            key="builtin"
+            title={<TabTitle icon={FolderLibraryIcon} label="Built-in" />}
+          />
+        </Tabs>
+        <div className="flex-1" />
+        <Input
+          size="sm"
+          variant="flat"
+          radius="lg"
+          placeholder="Search skills"
+          value={query}
+          onValueChange={setQuery}
+          startContent={<Search01Icon className="size-4 text-zinc-500" />}
+          className="max-w-56"
+          isClearable
+          onClear={() => setQuery("")}
+        />
+        <Button
+          size="sm"
+          color="primary"
+          className="shrink-0 rounded-xl"
+          startContent={<PlusSignIcon className="size-4" />}
+          onPress={openCreate}
+        >
+          New skill
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {tab === "yours" ? (
+          <SkillsList
+            skills={skills}
+            targets={targets}
+            loading={loading}
+            query={query}
+            deletingId={deletingId}
+            onCreate={openCreate}
+            onView={openView}
+            onEdit={openEdit}
+            onToggle={setEnabled}
+            onDelete={handleDelete}
+          />
+        ) : (
+          <BuiltinSkillsList query={query} />
+        )}
+      </div>
+
+      <SkillEditorModal
+        isOpen={editorOpen}
+        onClose={() => setEditorOpen(false)}
+        onSaved={() => {
+          refetch();
+          setTab("yours");
+        }}
+        targets={targets}
+        skill={editingSkill}
+      />
+      <SkillPreviewModal
+        skill={previewSkill}
+        onClose={() => setPreviewSkill(null)}
+      />
+      <ConfirmationDialog {...confirmationProps} />
+    </div>
+  );
+}
+
+function TabTitle({
+  icon: Icon,
+  label,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="size-4" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/features/skills/constants.ts
+++ b/apps/web/src/features/skills/constants.ts
@@ -5,6 +5,8 @@ export const EXECUTOR_TARGET = "executor";
 export const MAX_SKILL_NAME_LENGTH = 64;
 export const MAX_SKILL_DESCRIPTION_LENGTH = 1024;
 export const SKILL_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+/** The backend rejects consecutive hyphens separately from the pattern. */
+export const CONSECUTIVE_HYPHENS = /--/;
 
 /**
  * Accepts a GitHub repo reference: `owner/repo` (optionally with a sub-path) or

--- a/apps/web/src/features/skills/constants.ts
+++ b/apps/web/src/features/skills/constants.ts
@@ -1,0 +1,14 @@
+/** The general-assistant target value (matches backend EXECUTOR_SUBAGENT_ID). */
+export const EXECUTOR_TARGET = "executor";
+
+/** Mirrors the backend validators in app/agents/skills/models.py. */
+export const MAX_SKILL_NAME_LENGTH = 64;
+export const MAX_SKILL_DESCRIPTION_LENGTH = 1024;
+export const SKILL_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Accepts a GitHub repo reference: `owner/repo` (optionally with a sub-path) or
+ * a full github.com URL. Mirrors what the backend's _parse_github_url handles.
+ */
+export const GITHUB_REPO_PATTERN =
+  /^(https?:\/\/(www\.)?github\.com\/[\w.-]+\/[\w.-]+(\/.*)?|[\w.-]+\/[\w.-]+(\/.*)?)$/;

--- a/apps/web/src/features/skills/hooks/useSkills.ts
+++ b/apps/web/src/features/skills/hooks/useSkills.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "@/lib/toast";
+import { skillsApi } from "../api/skillsApi";
+import type { Skill, SkillTarget } from "../api/types";
+
+export interface UseSkillsResult {
+  skills: Skill[];
+  targets: SkillTarget[];
+  loading: boolean;
+  refetch: () => Promise<void>;
+  setEnabled: (skill: Skill, enabled: boolean) => Promise<void>;
+  removeSkill: (skill: Skill) => Promise<boolean>;
+}
+
+/**
+ * Loads the user's installed skills plus the targets they can run in, and
+ * exposes enable/disable/delete actions with optimistic local updates.
+ */
+export function useSkills(): UseSkillsResult {
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [targets, setTargets] = useState<SkillTarget[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    try {
+      const [list, targetsResponse] = await Promise.all([
+        skillsApi.listSkills(),
+        skillsApi.listTargets(),
+      ]);
+      setSkills(list.skills);
+      setTargets(targetsResponse.targets);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  const setEnabled = useCallback(async (skill: Skill, enabled: boolean) => {
+    setSkills((prev) =>
+      prev.map((s) => (s.id === skill.id ? { ...s, enabled } : s)),
+    );
+    try {
+      if (enabled) await skillsApi.enableSkill(skill.id);
+      else await skillsApi.disableSkill(skill.id);
+    } catch {
+      setSkills((prev) =>
+        prev.map((s) => (s.id === skill.id ? { ...s, enabled: !enabled } : s)),
+      );
+      toast.error(
+        `Failed to ${enabled ? "enable" : "disable"} "${skill.name}"`,
+      );
+    }
+  }, []);
+
+  const removeSkill = useCallback(async (skill: Skill) => {
+    try {
+      await skillsApi.deleteSkill(skill.id);
+      setSkills((prev) => prev.filter((s) => s.id !== skill.id));
+      toast.success(`Deleted "${skill.name}"`);
+      return true;
+    } catch {
+      toast.error(`Failed to delete "${skill.name}"`);
+      return false;
+    }
+  }, []);
+
+  return { skills, targets, loading, refetch, setEnabled, removeSkill };
+}

--- a/apps/web/src/features/skills/hooks/useSkills.ts
+++ b/apps/web/src/features/skills/hooks/useSkills.ts
@@ -31,6 +31,9 @@ export function useSkills(): UseSkillsResult {
       ]);
       setSkills(list.skills);
       setTargets(targetsResponse.targets);
+    } catch {
+      // listSkills isn't silent, so the API interceptor already surfaces a
+      // toast; swallow here so the mount effect can't reject unhandled.
     } finally {
       setLoading(false);
     }

--- a/apps/web/src/features/skills/utils.ts
+++ b/apps/web/src/features/skills/utils.ts
@@ -1,0 +1,21 @@
+import type { SkillTarget } from "./api/types";
+
+/** Case-insensitive match of a query against a skill's name + description. */
+export function skillMatchesQuery(
+  name: string,
+  description: string,
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    name.toLowerCase().includes(q) || description.toLowerCase().includes(q)
+  );
+}
+
+/** Build a value→target lookup from the targets list. */
+export function buildTargetMap(
+  targets: SkillTarget[],
+): Map<string, SkillTarget> {
+  return new Map(targets.map((t) => [t.value, t]));
+}


### PR DESCRIPTION
## Summary

Adds a **Skills** section to settings so users can manage their agent skills, with two tabs:

**Your Skills**
- Create / edit (name immutable) / delete / enable-disable user skills
- Collapsible folders grouped by target (executor + connected integration subagents); flat when all executor-scoped; an "Inactive" group for skills whose integration was disconnected
- **GitHub import**: discover skills from a repo (`owner/repo` or full URL, validated), install individually or **Add all**
- Read-only **preview modal** with rendered markdown; a **GitHub source chip** linking to the repo
- Editor modal: **Write/Preview** markdown tabs, connected-only "Runs in" target picker

**Built-in**
- Read-only catalog grouped by owning agent as collapsible folders with prominent icons; unconnected-integration groups are **deactivated** with a "Not connected" chip + **Connect** deep-link

## Backend
- `PUT /skills/{id}` edit endpoint (`update_skill_inline` + registry `update_skill`) — rewrites the VFS `SKILL.md` only when the body changes, re-checks `(user_id, name, target)` uniqueness, validates target
- `GET /skills/targets` — executor + the user's connected integration subagents
- `GET /skills/builtin` — built-in catalog with a server-computed `connected` flag and body for the preview
- Target validation on inline/github install and edit (can't scope to a disconnected/invalid agent)

Honors the existing **target-scoping** model: the executor only ingests `target=executor` skills; subagent-scoped skills are injected only when that subagent runs.

## Test plan
- Backend: 22-check service-level integration test against real Mongo + Redis + VFS — create, **ingestion** (the skill's name + full description appear in the exact text injected into the executor prompt), scoping, edit, retarget, uniqueness, validation, targets, built-ins, delete
- Skill **agent tools** (`create_skill` / `list_installed_skills` / `manage_skill`) invoked directly — create, list, uninstall all verified
- Browser E2E (logged-in session): full CRUD, folder grouping + scoping, GitHub import (discovered 17 from `anthropics/skills`, installed 2), built-in preview with rendered markdown, deactivated groups + Connect, validation, source chip
- `nx type-check web`, `nx type-check api` (mypy), Biome, Ruff — all green

## Notes
- Featured / Browse (skills.sh) tabs intentionally deferred (skills.sh API is Vercel-OIDC gated)
- Local JuiceFS isn't mounted in dev; the skills VFS needs a real mountpoint to exercise install/edit locally