### PR TITLE
fix: address CodeRabbit & SonarQube feedback on develop (PR #774)

### DIFF
--- a/apps/api/app/agents/core/background/result_delivery.py
+++ b/apps/api/app/agents/core/background/result_delivery.py
@@ -190,25 +190,14 @@ async def _narrate_and_deliver(
     is_ws_path = not run.workflow_id and not is_bot_platform(conversation_source)
 
     if not is_ws_path:
-        # Follow-ups are a best-effort enhancement. A failure in this second LLM
-        # call must not abort delivery — the outer deliver_result handler turns any
-        # exception into (None, None) and drops the result, so guard it here and
-        # ship the message without suggestions instead.
-        try:
-            follow_up_actions = await _build_follow_up_actions(
-                msg_type=result_type,
-                notification_text=notification_text,
-                user_msg_content=user_msg_content,
-                user_id=user_id,
-            )
-        except Exception as e:  # noqa: BLE001 — follow-ups are best-effort
-            log.error(
-                "deliver_result: failed to generate follow-up actions",
-                error=str(e),
-                conversation_id=run.conversation_id,
-                message_id=bot_message.message_id,
-            )
-            follow_up_actions = []
+        follow_up_actions = await _safe_inline_follow_ups(
+            result_type=result_type,
+            notification_text=notification_text,
+            user_msg_content=user_msg_content,
+            user_id=user_id,
+            conversation_id=run.conversation_id,
+            message_id=bot_message.message_id,
+        )
         if follow_up_actions:
             bot_message.follow_up_actions = follow_up_actions
 
@@ -289,6 +278,39 @@ async def _narrate_and_deliver(
         delivered=delivered,
     )
     return notification_text, bot_message.message_id
+
+
+async def _safe_inline_follow_ups(
+    *,
+    result_type: str,
+    notification_text: str,
+    user_msg_content: str,
+    user_id: str,
+    conversation_id: str,
+    message_id: str,
+) -> list[str]:
+    """Build follow-up actions for the single-send path, swallowing failures.
+
+    Follow-ups are a best-effort enhancement. A failure in this second LLM call
+    must not abort delivery — the outer deliver_result handler turns any exception
+    into (None, None) and drops the result, so guard it here and ship the message
+    without suggestions instead.
+    """
+    try:
+        return await _build_follow_up_actions(
+            msg_type=result_type,
+            notification_text=notification_text,
+            user_msg_content=user_msg_content,
+            user_id=user_id,
+        )
+    except Exception as e:  # noqa: BLE001 — follow-ups are best-effort
+        log.error(
+            "deliver_result: failed to generate follow-up actions",
+            error=str(e),
+            conversation_id=conversation_id,
+            message_id=message_id,
+        )
+        return []
 
 
 async def _build_follow_up_actions(

--- a/apps/api/app/agents/core/subagents/subagent_helpers.py
+++ b/apps/api/app/agents/core/subagents/subagent_helpers.py
@@ -138,9 +138,12 @@ async def create_agent_context_message(
 ) -> SystemMessage:
     """Build the dynamic-context system message for executor/subagent runs.
 
-    Carries everything that varies per request: user name, current time,
-    memories, installable skills, and (for subagents) provider metadata. This
-    is the message `manage_system_prompts_node` keeps only the latest of.
+    Carries everything that varies per request: user name, static home
+    timezone, memories, installable skills, and (for subagents) provider
+    metadata. Current time is NOT here — it lives in a HumanMessage built by
+    ``build_initial_messages`` so this system message stays byte-stable across
+    minute ticks. This is the message `manage_system_prompts_node` keeps only
+    the latest of.
 
     Args:
         configurable: The config["configurable"] dict from RunnableConfig.

--- a/apps/api/app/agents/core/subagents/subagent_runner.py
+++ b/apps/api/app/agents/core/subagents/subagent_runner.py
@@ -166,6 +166,55 @@ async def build_initial_messages(
     ]
 
 
+def _process_messages_payload(
+    payload: tuple,
+    complete_message: str,
+    stream_writer: StreamWriterCallable | None,
+    subagent_id: str | None,
+) -> str:
+    """Handle one "messages"-mode stream event, returning the updated message.
+
+    Accumulates AI content, streams reasoning deltas, and emits tool_output for
+    ToolMessages — all gated on a non-silent payload and an available writer.
+    """
+    chunk, metadata = payload
+    if metadata.get("silent"):
+        return complete_message
+
+    # Accumulate AI response content
+    if chunk and isinstance(chunk, AIMessageChunk):
+        content = chunk.text if hasattr(chunk, "text") else str(chunk.content)
+        if content:
+            complete_message += content
+
+        # Stream the model's thinking interleaved with tool events, so the
+        # UI can show what it reasoned about between each step. Carries the
+        # subagent_id so the client nests it in the right step (same routing
+        # as tool_data/tool_output). Empty for non-reasoning models.
+        if stream_writer:
+            reasoning_delta = _extract_reasoning_delta(chunk)
+            if reasoning_delta:
+                reasoning_event: dict = {"content": reasoning_delta}
+                if subagent_id:
+                    reasoning_event["subagent_id"] = subagent_id
+                stream_writer({"reasoning": reasoning_event})
+
+    # Emit tool_output when ToolMessage arrives
+    elif chunk and isinstance(chunk, ToolMessage):
+        content_str = chunk.content if isinstance(chunk.content, str) else str(chunk.content)
+        complete_message = _capture_finish_task_content(chunk, complete_message)
+        if stream_writer:
+            tool_output_data: dict = {
+                "tool_call_id": chunk.tool_call_id,
+                "output": content_str,
+            }
+            if subagent_id:
+                tool_output_data["subagent_id"] = subagent_id
+            stream_writer({"tool_output": tool_output_data})
+
+    return complete_message
+
+
 async def execute_subagent_stream(
     ctx: SubagentExecutionContext,
     stream_writer: StreamWriterCallable | None = None,
@@ -235,42 +284,9 @@ async def execute_subagent_stream(
             continue
 
         if stream_mode == "messages":
-            chunk, metadata = payload
-            if metadata.get("silent"):
-                continue
-
-            # Accumulate AI response content
-            if chunk and isinstance(chunk, AIMessageChunk):
-                content = chunk.text if hasattr(chunk, "text") else str(chunk.content)
-                if content:
-                    complete_message += content
-
-                # Stream the model's thinking interleaved with tool events, so the
-                # UI can show what it reasoned about between each step. Carries the
-                # subagent_id so the client nests it in the right step (same routing
-                # as tool_data/tool_output). Empty for non-reasoning models.
-                if stream_writer:
-                    reasoning_delta = _extract_reasoning_delta(chunk)
-                    if reasoning_delta:
-                        reasoning_event: dict = {"content": reasoning_delta}
-                        if subagent_id:
-                            reasoning_event["subagent_id"] = subagent_id
-                        stream_writer({"reasoning": reasoning_event})
-
-            # Emit tool_output when ToolMessage arrives
-            elif chunk and isinstance(chunk, ToolMessage):
-                content_str = (
-                    chunk.content if isinstance(chunk.content, str) else str(chunk.content)
-                )
-                complete_message = _capture_finish_task_content(chunk, complete_message)
-                if stream_writer:
-                    tool_output_data: dict = {
-                        "tool_call_id": chunk.tool_call_id,
-                        "output": content_str,
-                    }
-                    if subagent_id:
-                        tool_output_data["subagent_id"] = subagent_id
-                    stream_writer({"tool_output": tool_output_data})
+            complete_message = _process_messages_payload(
+                payload, complete_message, stream_writer, subagent_id
+            )
             continue
 
         if stream_mode == "custom":

--- a/apps/api/app/agents/tools/coding/bash_tool.py
+++ b/apps/api/app/agents/tools/coding/bash_tool.py
@@ -162,7 +162,12 @@ async def bash(
         str,
         "Working directory; defaults to your session root (holds artifacts/, scratch/, user-uploaded/)",
     ] = "",
-    timeout: Annotated[int, "Seconds before kill"] = BASH_DEFAULT_TIMEOUT_SECONDS,
+    # Agent-facing tool parameter: the e2b server-side command deadline (see
+    # _run_foreground). A local asyncio.timeout context manager can't replace it
+    # — it would cancel our coroutine without killing the remote command.
+    timeout: Annotated[
+        int, "Seconds before kill"
+    ] = BASH_DEFAULT_TIMEOUT_SECONDS,  # NOSONAR python:S7483
     background: Annotated[bool, "Run detached; returns pid + log path"] = False,
 ) -> str:
     """Run a shell command in the user's persistent coding sandbox."""

--- a/apps/api/app/agents/tools/executor_tool.py
+++ b/apps/api/app/agents/tools/executor_tool.py
@@ -73,7 +73,10 @@ async def _acquire_lock_through_redirect(
         return False
     waited = 0.0
     saw_cancel = False
-    while waited < REDIRECT_CANCEL_WAIT_S:
+    # Polls Redis state (try_acquire_lock / is_cancelled) freed by cancel_executor,
+    # which may run in a different uvicorn worker — an asyncio.Event can't observe
+    # that cross-process release, so polling is the correct mechanism here.
+    while waited < REDIRECT_CANCEL_WAIT_S:  # NOSONAR python:S7484
         if not saw_cancel:
             saw_cancel = await StreamManager.is_cancelled(held_stream_id)
         # Try the lock on every poll, not only after a cancel is observed:
@@ -193,7 +196,7 @@ async def _dispatch_executor(
         #   - DIFFERENT stream_id → a genuinely new request arrived while the
         #     executor is busy; queue it to run next.
         held_value = await redis_cache.client.get(lock_key) if redis_cache.client else None
-        held_stream_id = parse_lock_value(str(held_value))[0] if held_value else ""
+        held_stream_id = parse_lock_value(decode_raw_item(held_value))[0] if held_value else ""
         if stream_id and held_stream_id == stream_id:
             log.warning(
                 "Duplicate call_executor in same turn — ignored, not queued",

--- a/apps/api/app/agents/workspace/paths.py
+++ b/apps/api/app/agents/workspace/paths.py
@@ -65,6 +65,8 @@ _PLAIN_TEXT_EXTS = (
     "gradle",
 )
 
+_APPLICATION_YAML = "application/yaml"
+
 _EXT_CONTENT_TYPES = {
     "png": "image/png",
     "jpg": "image/jpeg",
@@ -75,8 +77,8 @@ _EXT_CONTENT_TYPES = {
     "pdf": "application/pdf",
     "json": "application/json",
     "xml": "application/xml",
-    "yaml": "application/yaml",
-    "yml": "application/yaml",
+    "yaml": _APPLICATION_YAML,
+    "yml": _APPLICATION_YAML,
     "md": "text/markdown",
     "txt": "text/plain",
     "csv": "text/csv",
@@ -96,7 +98,7 @@ _INLINEABLE_APPLICATION_TYPES = frozenset(
     {
         "application/json",
         "application/xml",
-        "application/yaml",
+        _APPLICATION_YAML,
         "application/x-yaml",
         "application/javascript",
         "application/x-sh",

--- a/apps/api/app/api/v1/endpoints/desktop.py
+++ b/apps/api/app/api/v1/endpoints/desktop.py
@@ -11,22 +11,24 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.schemas.desktop_schemas import DesktopToolResultRequest, DesktopToolResultResponse
-from app.services.desktop.bridge import (
-    DesktopRequestForbidden,
-    DesktopRequestNotFound,
-    relay_desktop_result,
-)
+from app.services.desktop.bridge import relay_desktop_result
 from shared.py.wide_events import log
 
-router = APIRouter()
+router = APIRouter(prefix="/desktop", tags=["desktop"])
 
 
-@router.post("/desktop/tool-result")
+@router.post("/tool-result")
 async def desktop_tool_result(
     payload: DesktopToolResultRequest,
     user: Annotated[dict, Depends(get_current_user)],
 ) -> DesktopToolResultResponse:
-    """Accept a desktop tool result and relay it to the awaiting agent tool."""
+    """Accept a desktop tool result and relay it to the awaiting agent tool.
+
+    ``relay_desktop_result`` raises :class:`DesktopRequestNotFound` (410) or
+    :class:`DesktopRequestForbidden` (403) — both ``AppError`` subclasses that the
+    global handler maps to the right status — so late/duplicate or cross-user
+    deliveries can't double-resolve a request.
+    """
     user_id = user.get("user_id")
     if not user_id:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="user_id is required")
@@ -36,25 +38,13 @@ async def desktop_tool_result(
         desktop_tool={"request_id": payload.request_id, "ok": payload.ok},
     )
 
-    try:
-        await relay_desktop_result(
-            request_id=payload.request_id,
-            user_id=user_id,
-            ok=payload.ok,
-            data=payload.data,
-            error=payload.error,
-        )
-    except DesktopRequestNotFound as exc:
-        # Expired or already answered — reject so late/duplicate deliveries
-        # can't double-resolve a request.
-        raise HTTPException(
-            status_code=status.HTTP_410_GONE,
-            detail="Desktop tool request expired or already resolved",
-        ) from exc
-    except DesktopRequestForbidden as exc:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Desktop tool request belongs to another user",
-        ) from exc
+    await relay_desktop_result(
+        request_id=payload.request_id,
+        user_id=user_id,
+        ok=payload.ok,
+        data=payload.data,
+        error=payload.error,
+    )
 
+    log.set(desktop_tool={"relayed": True})
     return DesktopToolResultResponse(success=True)

--- a/apps/api/app/api/v1/endpoints/reminders.py
+++ b/apps/api/app/api/v1/endpoints/reminders.py
@@ -2,6 +2,8 @@
 FastAPI endpoints for reminder management.
 """
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status as http_status
 
 from app.api.v1.dependencies.oauth_dependencies import (
@@ -26,8 +28,8 @@ router = APIRouter(prefix="/reminders", tags=["reminders"])
 @tiered_rate_limit("reminder_operations")
 async def create_reminder_endpoint(
     reminder_data: CreateReminderRequest,
+    user_timezone: Annotated[str, Depends(get_user_timezone_from_preferences)],
     user: dict = Depends(get_current_user),
-    user_timezone: str = Depends(get_user_timezone_from_preferences),
 ):
     """
     Create a new reminder.

--- a/apps/api/app/api/v1/endpoints/skills.py
+++ b/apps/api/app/api/v1/endpoints/skills.py
@@ -5,6 +5,8 @@ Provides REST API for installing, creating, listing, and managing
 installable agent skills (Agent Skills open standard).
 """
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status as http_status
 
 from app.agents.core.subagents.registry import get_subagent_by_id
@@ -71,9 +73,9 @@ async def _validate_target(user_id: str, target: str) -> None:
         )
 
 
-@router.get("/targets", response_model=SkillTargetsResponse)
+@router.get("/targets")
 async def list_skill_targets_endpoint(
-    user_id: str = Depends(_get_user_id),
+    user_id: Annotated[str, Depends(_get_user_id)],
 ) -> SkillTargetsResponse:
     """List the targets a skill can run in: the executor plus the user's
     connected integration subagents."""
@@ -83,9 +85,9 @@ async def list_skill_targets_endpoint(
     return SkillTargetsResponse(targets=targets)
 
 
-@router.get("/builtin", response_model=BuiltinSkillsResponse)
+@router.get("/builtin")
 async def list_builtin_skills_endpoint(
-    user_id: str = Depends(_get_user_id),
+    user_id: Annotated[str, Depends(_get_user_id)],
 ) -> BuiltinSkillsResponse:
     """List the read-only built-in skills shipped with GAIA, grouped by the
     agent they run in. Each carries a `connected` flag so the UI can deactivate
@@ -102,17 +104,19 @@ async def list_builtin_skills_endpoint(
             return True
         return subagent_id in connected_ids
 
+    def _group_label(subagent_id: str) -> str:
+        if subagent_id == EXECUTOR_SUBAGENT_ID:
+            return EXECUTOR_TARGET_LABEL
+        subagent = get_subagent_by_id(subagent_id)
+        return subagent.name if subagent else subagent_id
+
     skills = [
         BuiltinSkillInfo(
             slug=s.slug,
             name=s.name,
             description=s.description,
             target=s.target,
-            group_label=(
-                EXECUTOR_TARGET_LABEL
-                if s.subagent_id == EXECUTOR_SUBAGENT_ID
-                else (sa.name if (sa := get_subagent_by_id(s.subagent_id)) else s.subagent_id)
-            ),
+            group_label=_group_label(s.subagent_id),
             icon=s.subagent_id,
             connected=_is_available(s.subagent_id),
             body=s.body,
@@ -275,12 +279,12 @@ async def create_inline_skill_endpoint(
         ) from e
 
 
-@router.put("/{skill_id}", response_model=Skill)
+@router.put("/{skill_id}")
 @tiered_rate_limit("skill_operations")
 async def update_skill_endpoint(
     skill_id: str,
     request: SkillUpdateRequest,
-    user_id: str = Depends(_get_user_id),
+    user_id: Annotated[str, Depends(_get_user_id)],
 ) -> Skill:
     """Edit an existing skill's description, instructions, and/or target.
 

--- a/apps/api/app/api/v1/routes.py
+++ b/apps/api/app/api/v1/routes.py
@@ -50,7 +50,7 @@ router = APIRouter()
 
 router.include_router(voice.router, tags=["Voice"])
 router.include_router(chat.router, tags=["Chat"])
-router.include_router(desktop.router, tags=["Desktop"])
+router.include_router(desktop.router)
 router.include_router(conversations.router, tags=["Conversations"])
 router.include_router(sessions.router)
 router.include_router(feedback.router, tags=["Feedback"])

--- a/apps/api/app/models/chat_models.py
+++ b/apps/api/app/models/chat_models.py
@@ -54,6 +54,7 @@ tool_fields = [
     "workflow_draft",
     "workflow_created",
     "artifact_data",
+    "screenshot_data",
     "mcp_app",
 ]
 

--- a/apps/api/app/models/reminder_models.py
+++ b/apps/api/app/models/reminder_models.py
@@ -229,6 +229,24 @@ class CreateReminderToolRequest(BaseModel):
                 raise ValueError("Timezone offset must be in (+|-)HH:MM format")
         return v
 
+    @staticmethod
+    def _parse_local_datetime(
+        raw: str, offset: str | None, home_tz: Timezone, field_name: str
+    ) -> datetime:
+        """Parse an absolute clock time, localizing to ``offset`` or the home zone.
+
+        A value carrying its own offset is converted to that zone; a naive value
+        is stamped with the explicit offset if given, else the user's home zone.
+        """
+        try:
+            dt = datetime.fromisoformat(raw.replace(" ", "T"))
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid {field_name} format: {raw}. Use YYYY-MM-DD HH:MM:SS format. Error: {e}"
+            )
+        tzinfo = Timezone.parse(offset).tzinfo if offset else home_tz.tzinfo
+        return dt.astimezone(tzinfo) if dt.tzinfo is not None else dt.replace(tzinfo=tzinfo)
+
     def to_create_reminder_request(self) -> "CreateReminderRequest":
         """Convert to CreateReminderRequest with proper datetime handling.
 
@@ -244,37 +262,15 @@ class CreateReminderToolRequest(BaseModel):
             # simply now + delay, independent of any zone.
             processed_scheduled_at = datetime.now(UTC) + timedelta(seconds=self.delay_seconds)
         elif self.scheduled_at:
-            try:
-                dt = datetime.fromisoformat(self.scheduled_at.replace(" ", "T"))
-                tzinfo = (
-                    Timezone.parse(self.timezone_offset).tzinfo
-                    if self.timezone_offset
-                    else home_tz.tzinfo
-                )
-                processed_scheduled_at = (
-                    dt.astimezone(tzinfo) if dt.tzinfo is not None else dt.replace(tzinfo=tzinfo)
-                )
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid scheduled_at format: {self.scheduled_at}. Use YYYY-MM-DD HH:MM:SS format. Error: {e}"
-                )
+            processed_scheduled_at = self._parse_local_datetime(
+                self.scheduled_at, self.timezone_offset, home_tz, "scheduled_at"
+            )
 
         processed_stop_after = None
         if self.stop_after:
-            try:
-                dt = datetime.fromisoformat(self.stop_after.replace(" ", "T"))
-                tzinfo = (
-                    Timezone.parse(self.stop_after_timezone_offset).tzinfo
-                    if self.stop_after_timezone_offset
-                    else home_tz.tzinfo
-                )
-                processed_stop_after = (
-                    dt.astimezone(tzinfo) if dt.tzinfo is not None else dt.replace(tzinfo=tzinfo)
-                )
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid stop_after format: {self.stop_after}. Use YYYY-MM-DD HH:MM:SS format. Error: {e}"
-                )
+            processed_stop_after = self._parse_local_datetime(
+                self.stop_after, self.stop_after_timezone_offset, home_tz, "stop_after"
+            )
 
         # Recurrence wall-clock zone: an explicitly stated offset wins, else the
         # user's home zone (None only if the agent config had no zone -> UTC).

--- a/apps/api/app/schemas/desktop_schemas.py
+++ b/apps/api/app/schemas/desktop_schemas.py
@@ -32,14 +32,15 @@ class DesktopToolResultRequest(BaseModel):
 
     @model_validator(mode="after")
     def _enforce_result_contract(self) -> "DesktopToolResultRequest":
-        """Reject ambiguous payloads so the bridge contract stays unambiguous.
+        """Reject internally-inconsistent payloads without ever dropping a result.
 
-        Success carries data and no error; failure carries an error and no data.
+        A success must not carry an error, and a failure must not carry data.
+        We deliberately do NOT require a non-empty ``error`` on failure: the
+        bridge guarantees a tool result always reaches the awaiting tool, so a
+        failure with an empty message is relayed, not rejected into a timeout.
         """
         if self.ok and self.error:
             raise ValueError("'error' must be omitted when ok is true")
-        if not self.ok and not self.error:
-            raise ValueError("'error' is required when ok is false")
         if not self.ok and self.data is not None:
             raise ValueError("'data' must be omitted when ok is false")
         return self

--- a/apps/api/app/schemas/desktop_schemas.py
+++ b/apps/api/app/schemas/desktop_schemas.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Generous cap (~16 MB of base64) for the screenshot image fields. A 1568px
 # long-edge PNG is well under this; the bound only rejects abusive payloads
@@ -29,6 +29,20 @@ class DesktopToolResultRequest(BaseModel):
                 if isinstance(blob, str) and len(blob) > MAX_RESULT_IMAGE_B64_CHARS:
                     raise ValueError(f"'{key}' exceeds the maximum allowed size")
         return value
+
+    @model_validator(mode="after")
+    def _enforce_result_contract(self) -> "DesktopToolResultRequest":
+        """Reject ambiguous payloads so the bridge contract stays unambiguous.
+
+        Success carries data and no error; failure carries an error and no data.
+        """
+        if self.ok and self.error:
+            raise ValueError("'error' must be omitted when ok is true")
+        if not self.ok and not self.error:
+            raise ValueError("'error' is required when ok is false")
+        if not self.ok and self.data is not None:
+            raise ValueError("'data' must be omitted when ok is false")
+        return self
 
 
 class DesktopToolResultResponse(BaseModel):

--- a/apps/api/app/services/chat/workspace.py
+++ b/apps/api/app/services/chat/workspace.py
@@ -15,6 +15,7 @@ message in Mongo so the card persists with the conversation on server reload.
 """
 
 import asyncio
+from collections import deque
 import contextlib
 from datetime import UTC, datetime
 import json
@@ -223,8 +224,10 @@ def _warm_artifact_blocks(host_path: Path) -> None:
     """Read a file through the FUSE mount to pull its blocks into the JuiceFS
     local cache. Constant memory: chunks are read and discarded."""
     with host_path.open("rb") as fh:
-        while fh.read(_WARM_CHUNK_BYTES):
-            pass
+        # Drain the file in fixed-size chunks, discarding each: the read is the
+        # side effect (it pulls blocks into the JuiceFS cache), the bytes aren't
+        # kept. ``deque(maxlen=0)`` consumes the iterator without a loop body.
+        deque(iter(lambda: fh.read(_WARM_CHUNK_BYTES), b""), maxlen=0)
 
 
 async def _warm_artifact_cache(user_id: str, conversation_id: str, path: str) -> None:

--- a/apps/api/app/services/desktop/bridge.py
+++ b/apps/api/app/services/desktop/bridge.py
@@ -126,10 +126,15 @@ async def request_desktop_action(
 
         return outcome
     finally:
-        # Best-effort cleanup: a failure here must never mask the real outcome
-        # (the request key also carries a TTL, so it expires regardless).
+        # Best-effort cleanup in independent guards: a failure here must never
+        # mask the real outcome, and a failed key-delete must not skip the
+        # pubsub teardown (the request key also carries a TTL, so it expires
+        # regardless).
         try:
             await redis_cache.delete(request_key)
+        except Exception:  # nosec B110 - cleanup must not mask the outcome
+            pass
+        try:
             await pubsub.unsubscribe(result_channel)
             await pubsub.aclose()
         except Exception:  # nosec B110 - cleanup must not mask the outcome

--- a/apps/api/app/services/desktop/bridge.py
+++ b/apps/api/app/services/desktop/bridge.py
@@ -11,6 +11,7 @@ process.
 
 import asyncio
 from dataclasses import dataclass
+from http import HTTPStatus
 import json
 from typing import Any
 from uuid import uuid4
@@ -22,6 +23,7 @@ from app.constants.cache import (
 )
 from app.core.stream_manager import stream_manager
 from app.db.redis import redis_cache
+from app.utils.errors import AppError
 from shared.py.wide_events import log
 
 DESKTOP_TOOL_TIMEOUT_SECONDS = 30.0
@@ -34,12 +36,24 @@ ERROR_TIMEOUT = (
 ERROR_REDIS_UNAVAILABLE = "Desktop bridge unavailable (no Redis connection)."
 
 
-class DesktopRequestNotFound(Exception):
+class DesktopRequestNotFound(AppError):
     """The pending request key is gone — expired or already resolved."""
 
+    def __init__(self) -> None:
+        super().__init__(
+            message="Desktop tool request expired or already resolved",
+            status_code=HTTPStatus.GONE,
+        )
 
-class DesktopRequestForbidden(Exception):
+
+class DesktopRequestForbidden(AppError):
     """A result was POSTed by a user who does not own the pending request."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            message="Desktop tool request belongs to another user",
+            status_code=HTTPStatus.FORBIDDEN,
+        )
 
 
 @dataclass
@@ -112,8 +126,10 @@ async def request_desktop_action(
 
         return outcome
     finally:
-        await redis_cache.delete(request_key)
+        # Best-effort cleanup: a failure here must never mask the real outcome
+        # (the request key also carries a TTL, so it expires regardless).
         try:
+            await redis_cache.delete(request_key)
             await pubsub.unsubscribe(result_channel)
             await pubsub.aclose()
         except Exception:  # nosec B110 - cleanup must not mask the outcome

--- a/apps/api/app/services/storage/sessions/artifacts.py
+++ b/apps/api/app/services/storage/sessions/artifacts.py
@@ -63,32 +63,42 @@ def _list_files(base: Path) -> list[ArtifactInfo]:
     out: list[ArtifactInfo] = []
     stack = [str(base)]
     while stack:
-        try:
-            with os.scandir(stack.pop()) as it:
-                for entry in it:
-                    try:
-                        if entry.is_symlink():
-                            continue
-                        if entry.is_dir(follow_symlinks=False):
-                            stack.append(entry.path)
-                            continue
-                        if not entry.is_file(follow_symlinks=False):
-                            continue
-                        st = entry.stat()
-                    except OSError:
-                        continue
-                    out.append(
-                        ArtifactInfo(
-                            path=os.path.relpath(entry.path, base),
-                            size_bytes=st.st_size,
-                            mtime=st.st_mtime,
-                            content_type=detect_content_type(entry.name),
-                        )
-                    )
-        except OSError:
-            continue
+        _scan_one_dir(stack.pop(), base, stack, out)
     out.sort(key=lambda a: a.path)
     return out
+
+
+def _scan_one_dir(dir_path: str, base: Path, stack: list[str], out: list[ArtifactInfo]) -> None:
+    """Scan a single directory: queue subdirs onto ``stack``, append files to ``out``.
+
+    Symlinks are skipped and never followed into directories, so the walk can't be
+    redirected outside ``base``. Per-entry and per-directory errors are swallowed so
+    a racing or hostile entry can't 500 the whole listing.
+    """
+    try:
+        with os.scandir(dir_path) as it:
+            for entry in it:
+                try:
+                    if entry.is_symlink():
+                        continue
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    st = entry.stat()
+                except OSError:
+                    continue
+                out.append(
+                    ArtifactInfo(
+                        path=os.path.relpath(entry.path, base),
+                        size_bytes=st.st_size,
+                        mtime=st.st_mtime,
+                        content_type=detect_content_type(entry.name),
+                    )
+                )
+    except OSError:
+        return
 
 
 async def list_artifacts(user_id: str, conv_id: str) -> list[ArtifactInfo]:

--- a/apps/api/tests/unit/models/test_workflow_models.py
+++ b/apps/api/tests/unit/models/test_workflow_models.py
@@ -46,8 +46,9 @@ class TestTriggerConfigCalculateNextRun:
 
     def test_default_timezone_is_none_sentinel(self) -> None:
         # Default changed from "UTC" to None so create/update can distinguish a
-        # user-chosen zone from an unset one.
-        assert _schedule().timezone is None
+        # user-chosen zone from an unset one. Omit timezone to exercise the model
+        # default (not _schedule(), which passes timezone=None explicitly).
+        assert TriggerConfig(type=TriggerType.SCHEDULE).timezone is None
 
     def test_non_schedule_trigger_returns_none(self) -> None:
         assert TriggerConfig(type=TriggerType.MANUAL).calculate_next_run(base_time=BASE) is None

--- a/apps/api/tests/unit/sandbox/test_lifecycle_eviction.py
+++ b/apps/api/tests/unit/sandbox/test_lifecycle_eviction.py
@@ -122,6 +122,7 @@ async def test_command_deadline_timeout_does_not_evict_a_live_sandbox() -> None:
     async with _run(
         sbx, body_error=TimeoutException("exceeding 'timeout' — long running request")
     ) as (uid, pool, coll, sched, raised):
+        assert isinstance(raised, TimeoutException)
         assert pool.get(uid) is not None, "a slow command must not evict a healthy sandbox"
         assert not _dead_state_written(coll)
 
@@ -137,6 +138,7 @@ async def test_eviction_when_health_probe_itself_raises() -> None:
         sched,
         raised,
     ):
+        assert isinstance(raised, RuntimeError)
         assert pool.get(uid) is None, "unreachable /health → treat as dead → evict"
 
 

--- a/apps/api/tests/unit/tools/coding/test_atomic_write.py
+++ b/apps/api/tests/unit/tools/coding/test_atomic_write.py
@@ -32,10 +32,10 @@ def _fake_sbx(entry_mtime: datetime | None) -> tuple[AsyncMock, dict]:
 
     files = AsyncMock()
 
-    async def _write(path: str, data: bytes) -> None:
+    def _write(path: str, data: bytes) -> None:
         calls["write"].append((path, data))
 
-    async def _rename(src: str, dst: str):  # noqa: ANN202
+    def _rename(src: str, dst: str):  # noqa: ANN202
         calls["rename"].append((src, dst))
         return _Info()
 

--- a/apps/api/tests/unit/tools/coding/test_canonical_path.py
+++ b/apps/api/tests/unit/tools/coding/test_canonical_path.py
@@ -38,7 +38,7 @@ def test_containment_is_workspace_wide_not_session_scoped() -> None:
     # This test exists so that behavior isn't later "fixed" as a vulnerability.
     up, _, _ = canonical_path("..", session_id="c1")
     assert up == "/workspace/sessions"
-    other, role, conv = canonical_path("../other/scratch/x", session_id="c1")
+    other, _, conv = canonical_path("../other/scratch/x", session_id="c1")
     assert other == "/workspace/sessions/other/scratch/x"
     assert conv == "other"  # cross-session within the same user is allowed
 

--- a/apps/api/tests/unit/tools/coding/test_resolve_cwd.py
+++ b/apps/api/tests/unit/tools/coding/test_resolve_cwd.py
@@ -47,7 +47,7 @@ def test_dotdot_escape_is_rejected_after_normalization(escape: str) -> None:
     # The bug: is_under_workspace("/workspace/../etc") was True on the raw
     # string (startswith "/workspace/"), then the shell resolved `..` and
     # escaped. _resolve_cwd must normpath BEFORE the containment check.
-    cwd, use_session, err = _resolve_cwd(escape, "c")
+    _, _, err = _resolve_cwd(escape, "c")
     assert err is not None, f"{escape!r} must be rejected — it escapes /workspace"
     assert "must be under" in err
 
@@ -56,13 +56,13 @@ def test_relative_cwd_joins_to_session_dir_like_read_and_write() -> None:
     # read/write (canonical_path) join a relative path to the session dir, so
     # `cwd="scratch"` must mean the session's scratch — not be rejected. bash
     # used to error here, breaking the agent's session-relative mental model.
-    cwd, use_session, err = _resolve_cwd("scratch", "conv1")
+    cwd, _, err = _resolve_cwd("scratch", "conv1")
     assert err is None, f"a relative cwd must be accepted, got error: {err!r}"
     assert cwd == f"{session_dir('conv1')}/scratch"
 
 
 def test_relative_cwd_without_session_joins_to_workspace_root() -> None:
-    cwd, use_session, err = _resolve_cwd("sub/dir", None)
+    cwd, _, err = _resolve_cwd("sub/dir", None)
     assert err is None
     assert cwd == f"{WORKSPACE_ROOT}/sub/dir"
 
@@ -77,6 +77,6 @@ def test_relative_cwd_escape_still_rejected() -> None:
 def test_no_session_no_cwd_defaults_to_workspace_root_downstream() -> None:
     # No session and no cwd: not a session-scratch case, no error; caller
     # falls back to WORKSPACE_ROOT.
-    cwd, use_session, err = _resolve_cwd("", None)
+    _, use_session, err = _resolve_cwd("", None)
     assert err is None
     assert use_session is False

--- a/apps/api/tests/unit/utils/test_timezone.py
+++ b/apps/api/tests/unit/utils/test_timezone.py
@@ -109,7 +109,7 @@ class TestTimezoneParse:
 @pytest.mark.unit
 class TestTimezoneTryParse:
     @pytest.mark.parametrize("blank", [None, "", "   "])
-    def test_blank_returns_none(self, blank) -> None:
+    def test_blank_returns_none(self, blank: str | None) -> None:
         assert Timezone.try_parse(blank) is None
 
     @pytest.mark.parametrize("garbage", ["Not/A_Zone", "CEST", "+0530"])
@@ -193,7 +193,7 @@ class TestIsValidTimezone:
         assert is_valid_timezone(ok) is True
 
     @pytest.mark.parametrize("bad", [None, "", "   ", "Not/A_Zone", "+0530", "CEST"])
-    def test_invalid(self, bad) -> None:
+    def test_invalid(self, bad: str | None) -> None:
         assert is_valid_timezone(bad) is False
 
 

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -61,10 +61,11 @@ export function registerIpcHandlers(onWindowReady: () => void): void {
     onWindowReady();
   });
 
-  ipcMain.on(IPC.openExternal, (_event, url: string) => {
+  ipcMain.on(IPC.openExternal, (_event, url: unknown) => {
+    if (typeof url !== "string") return;
     console.log("[Main] Opening external URL:", url);
     if (url.startsWith("https://") || url.startsWith("http://")) {
-      shell.openExternal(url);
+      void shell.openExternal(url);
     }
   });
 

--- a/apps/desktop/src/main/tools/index.ts
+++ b/apps/desktop/src/main/tools/index.ts
@@ -20,14 +20,19 @@ import { captureScreenshot } from "./screenshot";
 export async function dispatchDesktopTool(
   request: DesktopToolRequest,
 ): Promise<DesktopToolResult> {
+  // request arrives from the wire — read identity defensively so a malformed
+  // frame still yields a serializable result instead of throwing past it.
+  const requestId =
+    typeof request?.request_id === "string" ? request.request_id : "";
+  const toolName = typeof request?.tool === "string" ? request.tool : "unknown";
   try {
     const data = await executeAction(request);
-    return { request_id: request.request_id, ok: true, data, error: null };
+    return { request_id: requestId, ok: true, data, error: null };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`[Main] Desktop tool '${request.tool}' failed:`, message);
+    console.error(`[Main] Desktop tool '${toolName}' failed:`, message);
     return {
-      request_id: request.request_id,
+      request_id: requestId,
       ok: false,
       data: null,
       error: message,

--- a/apps/web/src/app/[locale]/(desktop)/desktop-popup/page.tsx
+++ b/apps/web/src/app/[locale]/(desktop)/desktop-popup/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ErrorBoundary from "@/components/shared/ErrorBoundary";
 import { AssistantPopup } from "@/features/desktop-popup";
 import { useTransparentPopupChrome } from "@/features/desktop-popup/hooks/useTransparentPopupChrome";
 
@@ -11,5 +12,9 @@ import { useTransparentPopupChrome } from "@/features/desktop-popup/hooks/useTra
 export default function DesktopPopupPage() {
   useTransparentPopupChrome();
 
-  return <AssistantPopup />;
+  return (
+    <ErrorBoundary>
+      <AssistantPopup />
+    </ErrorBoundary>
+  );
 }

--- a/apps/web/src/components/ui/CompactMarkdown.tsx
+++ b/apps/web/src/components/ui/CompactMarkdown.tsx
@@ -15,41 +15,53 @@ interface CompactMarkdownProps {
 // Typography styles via zero-specificity :where(), and the merged `components`
 // map applies ours last.
 const COMPACT_COMPONENTS: Components = {
-  h1: ({ ...props }) => (
+  h1: ({ children, ...props }) => (
     <h1
       className="mt-2 mb-1 text-base font-semibold text-zinc-100 first:mt-0"
       {...props}
-    />
+    >
+      {children}
+    </h1>
   ),
-  h2: ({ ...props }) => (
+  h2: ({ children, ...props }) => (
     <h2
       className="mt-2 mb-1 text-sm font-semibold text-zinc-200 first:mt-0"
       {...props}
-    />
+    >
+      {children}
+    </h2>
   ),
-  h3: ({ ...props }) => (
+  h3: ({ children, ...props }) => (
     <h3
       className="mt-1.5 mb-0.5 text-[13px] font-semibold text-zinc-200 first:mt-0"
       {...props}
-    />
+    >
+      {children}
+    </h3>
   ),
-  h4: ({ ...props }) => (
+  h4: ({ children, ...props }) => (
     <h4
       className="mt-1.5 mb-0.5 text-xs font-semibold text-zinc-300 first:mt-0"
       {...props}
-    />
+    >
+      {children}
+    </h4>
   ),
-  h5: ({ ...props }) => (
+  h5: ({ children, ...props }) => (
     <h5
       className="mt-1.5 mb-0.5 text-[11px] font-semibold text-zinc-400 first:mt-0"
       {...props}
-    />
+    >
+      {children}
+    </h5>
   ),
-  h6: ({ ...props }) => (
+  h6: ({ children, ...props }) => (
     <h6
       className="mt-1.5 mb-0.5 text-[11px] font-medium uppercase tracking-wide text-zinc-500 first:mt-0"
       {...props}
-    />
+    >
+      {children}
+    </h6>
   ),
   p: ({ ...props }) => <p className="mb-1 last:mb-0" {...props} />,
   ul: ({ ...props }) => (

--- a/apps/web/src/components/ui/orb/GaiaOrb.tsx
+++ b/apps/web/src/components/ui/orb/GaiaOrb.tsx
@@ -220,6 +220,12 @@ function createOrbRenderer(
   const fs = compile(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
   if (!vs || !fs) return null;
   const program = gl.createProgram();
+  if (!program) {
+    console.error("[GaiaOrb] Program creation failed");
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    return null;
+  }
   gl.attachShader(program, vs);
   gl.attachShader(program, fs);
   gl.linkProgram(program);
@@ -230,8 +236,10 @@ function createOrbRenderer(
     );
     return null;
   }
-  // biome-ignore lint/correctness/useHookAtTopLevel: gl.useProgram is a WebGL call, not a React hook
-  gl.useProgram(program);
+  // Aliased so the callee isn't a `use*`-named member, which Biome's
+  // useHookAtTopLevel rule would otherwise mistake for a React hook.
+  const activateProgram = gl.useProgram.bind(gl);
+  activateProgram(program);
 
   const uniforms = {
     resolution: gl.getUniformLocation(program, "u_resolution"),

--- a/apps/web/src/features/calendar/hooks/useCalendarPreferences.ts
+++ b/apps/web/src/features/calendar/hooks/useCalendarPreferences.ts
@@ -40,10 +40,9 @@ export const useCalendarPreferences = (
       const currentStore = useCalendarStore.getState().selectedCalendars;
 
       if (query.data && query.data.length > 0) {
-        // Always sync from backend when available
+        // Always sync from backend when available; skip if the store already matches.
         if (JSON.stringify(currentStore) !== JSON.stringify(query.data)) {
           setSelectedCalendars(query.data);
-        } else {
         }
       } else if (query.data && query.data.length === 0) {
         console.warn(

--- a/apps/web/src/features/chat/components/bubbles/bot/ScreenshotSection.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/ScreenshotSection.tsx
@@ -1,6 +1,11 @@
 import { ComputerIcon } from "@icons";
+import Image from "next/image";
 import type React from "react";
 import type { ScreenshotData } from "@/types/features/desktopToolTypes";
+
+/** Fallback intrinsic size when the capture omits its dimensions. */
+const FALLBACK_WIDTH = 1280;
+const FALLBACK_HEIGHT = 720;
 
 interface ScreenshotSectionProps {
   screenshot_data: ScreenshotData;
@@ -19,13 +24,13 @@ const ScreenshotSection: React.FC<ScreenshotSectionProps> = ({
         <span className="text-sm text-zinc-400">Looked at your screen</span>
       </div>
       {/* Raw data URL from the local capture — next/image can't optimize it. */}
-      {/* biome-ignore lint/performance/noImgElement: data-URL screenshot */}
-      <img
+      <Image
         src={screenshot_data.thumbnail}
         alt="Screenshot of your screen"
-        width={screenshot_data.width}
-        height={screenshot_data.height}
+        width={screenshot_data.width ?? FALLBACK_WIDTH}
+        height={screenshot_data.height ?? FALLBACK_HEIGHT}
         className="w-full rounded-xl"
+        unoptimized
       />
     </div>
   );

--- a/apps/web/src/features/chat/components/bubbles/bot/SubagentRow.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/SubagentRow.tsx
@@ -29,11 +29,13 @@ const MARKDOWN_READ_PATH = /\.(md|markdown|mdx)$/i;
 function displayToolOutput(call: ToolCallEntry): unknown {
   const { output, inputs } = call;
   if (call.tool_name === "read" && typeof output === "string") {
-    const path =
+    const rawPath =
       inputs && typeof inputs === "object"
-        ? String((inputs as { path?: unknown }).path ?? "")
-        : "";
-    if (MARKDOWN_READ_PATH.test(path)) {
+        ? (inputs as { path?: unknown }).path
+        : undefined;
+    // Only a string path can be a markdown filename; anything else (objects,
+    // numbers) must not be coerced — `String({})` would yield "[object Object]".
+    if (typeof rawPath === "string" && MARKDOWN_READ_PATH.test(rawPath)) {
       return output.replace(/^ *\d+\t/gm, "");
     }
   }

--- a/apps/web/src/features/chat/components/bubbles/bot/TextBubble/useSubagentSynthesis.ts
+++ b/apps/web/src/features/chat/components/bubbles/bot/TextBubble/useSubagentSynthesis.ts
@@ -80,7 +80,7 @@ function bucketToolData(
 function coalesceReasoning(calls: ToolCallEntry[]): ToolCallEntry[] {
   const out: ToolCallEntry[] = [];
   for (const tc of calls) {
-    const prev = out[out.length - 1];
+    const prev = out.at(-1);
     if (tc.reasoning != null && prev?.reasoning != null) {
       out[out.length - 1] = {
         ...prev,
@@ -98,7 +98,7 @@ function coalesceReasoning(calls: ToolCallEntry[]): ToolCallEntry[] {
 function coalesceTimelineReasoning(timeline: TimelineItem[]): TimelineItem[] {
   const out: TimelineItem[] = [];
   for (const item of timeline) {
-    const prev = out[out.length - 1];
+    const prev = out.at(-1);
     if (
       item.kind === "tool" &&
       item.data.reasoning != null &&

--- a/apps/web/src/features/chat/components/composer/SendStopButton.tsx
+++ b/apps/web/src/features/chat/components/composer/SendStopButton.tsx
@@ -5,8 +5,57 @@ import { ArrowUp02Icon, Clock01Icon, StopIcon } from "@icons";
 import { AnimatePresence } from "motion/react";
 import * as m from "motion/react-m";
 import { TextMorph } from "torph/react";
-import { useComposerSendMode } from "@/features/chat/hooks/useComposerSendMode";
+import {
+  type ComposerSendMode,
+  useComposerSendMode,
+} from "@/features/chat/hooks/useComposerSendMode";
 import { useLoading } from "@/features/chat/hooks/useLoading";
+
+// One source of truth for the button's look: the HeroUI background (`color`) and
+// the icon color (icons inherit `currentColor`, transitioned) are decided
+// together so they can never drift apart. Stop wins; otherwise typed content
+// gets the primary fill, an empty composer the muted default.
+function getButtonStyle(
+  showStop: boolean,
+  hasContent: boolean,
+): { bg: "default" | "primary"; contentColor: string } {
+  if (showStop) return { bg: "default", contentColor: "text-zinc-300" };
+  if (hasContent) return { bg: "primary", contentColor: "text-black" };
+  return { bg: "default", contentColor: "text-zinc-500" };
+}
+
+const MODE_ARIA_LABEL = {
+  stop: "Stop generation",
+  queue: "Queue message",
+  send: "Send message",
+} as const satisfies Record<ComposerSendMode, string>;
+
+// The glyph (and Queue label) for each mode. Kept out of the JSX so the
+// AnimatePresence wrapper stays flat instead of nesting a ternary.
+function renderModeContent(mode: ComposerSendMode) {
+  switch (mode) {
+    case "stop":
+      return (
+        <StopIcon
+          color="currentColor"
+          fill="currentColor"
+          width={20}
+          height={20}
+        />
+      );
+    case "queue":
+      return (
+        <>
+          <Clock01Icon color="currentColor" width={18} height={18} />
+          <TextMorph as="span" className="font-medium text-sm">
+            Queue
+          </TextMorph>
+        </>
+      );
+    default:
+      return <ArrowUp02Icon color="currentColor" />;
+  }
+}
 
 interface SendStopButtonProps {
   /** Whether there is content ready to send. */
@@ -39,34 +88,25 @@ export default function SendStopButton({
     }
   };
 
-  // One source of truth for the button's look per state: the HeroUI background
-  // (`color`) and the icon color (icons inherit `currentColor`, transitioned)
-  // are decided in a single branch so they can never drift apart.
-  const { bg, contentColor } = showStop
-    ? ({ bg: "default", contentColor: "text-zinc-300" } as const)
-    : hasContent
-      ? ({ bg: "primary", contentColor: "text-black" } as const)
-      : ({ bg: "default", contentColor: "text-zinc-500" } as const);
+  const { bg, contentColor } = getButtonStyle(showStop, hasContent);
+
+  // Queue widens into a labelled pill; stop/send stay icon-only square buttons.
+  const stopCursor = showStop ? "cursor-pointer" : "";
+  const shapeClass = showQueue
+    ? "h-9 min-h-9 gap-1.5 rounded-xl px-3"
+    : `${className} ${stopCursor}`;
 
   return (
     <Button
       isIconOnly={!showQueue}
-      aria-label={
-        showStop
-          ? "Stop generation"
-          : showQueue
-            ? "Queue message"
-            : "Send message"
-      }
-      className={`transition-all duration-300 ${contentColor} ${
-        showQueue
-          ? "h-9 min-h-9 gap-1.5 rounded-xl px-3"
-          : `${className} ${showStop ? "cursor-pointer" : ""}`
-      }`}
+      aria-label={MODE_ARIA_LABEL[mode]}
+      className={`transition-all duration-300 ${contentColor} ${shapeClass}`}
       color={bg}
       disabled={!isStreaming && !hasContent}
       radius="full"
-      type="submit"
+      // In stop mode the button aborts the stream rather than submitting, so it
+      // must not trigger the composer form. Only send/queue submit.
+      type={showStop ? "button" : "submit"}
       onPress={handlePress}
     >
       <AnimatePresence mode="wait" initial={false}>
@@ -78,23 +118,7 @@ export default function SendStopButton({
           exit={{ opacity: 0, scale: 0.6 }}
           transition={{ duration: 0.16, ease: "easeOut" }}
         >
-          {mode === "stop" ? (
-            <StopIcon
-              color="currentColor"
-              fill="currentColor"
-              width={20}
-              height={20}
-            />
-          ) : mode === "queue" ? (
-            <>
-              <Clock01Icon color="currentColor" width={18} height={18} />
-              <TextMorph as="span" className="font-medium text-sm">
-                Queue
-              </TextMorph>
-            </>
-          ) : (
-            <ArrowUp02Icon color="currentColor" />
-          )}
+          {renderModeContent(mode)}
         </m.span>
       </AnimatePresence>
     </Button>

--- a/apps/web/src/features/chat/hooks/useChatStream/streamHandlers.ts
+++ b/apps/web/src/features/chat/hooks/useChatStream/streamHandlers.ts
@@ -86,7 +86,7 @@ function appendReasoningStep(
   steps: ToolCallEntry[],
   content: string,
 ): ToolCallEntry[] {
-  const last = steps[steps.length - 1];
+  const last = steps.at(-1);
   if (last?.reasoning != null) {
     return [
       ...steps.slice(0, -1),

--- a/apps/web/src/features/chat/hooks/useComposerSendMode.ts
+++ b/apps/web/src/features/chat/hooks/useComposerSendMode.ts
@@ -35,11 +35,9 @@ export function useComposerSendMode(hasContent: boolean) {
       streamingConversationId === activeConversationId);
   const showQueue = isStreaming && hasContent;
   const showStop = isStreaming && !hasContent;
-  const mode: ComposerSendMode = showStop
-    ? "stop"
-    : showQueue
-      ? "queue"
-      : "send";
+  let mode: ComposerSendMode = "send";
+  if (showStop) mode = "stop";
+  else if (showQueue) mode = "queue";
 
   return { isStreaming, showQueue, showStop, mode };
 }

--- a/apps/web/src/features/landing/components/shared/TextSoftBlurIn.tsx
+++ b/apps/web/src/features/landing/components/shared/TextSoftBlurIn.tsx
@@ -43,11 +43,15 @@ function splitText(text: string, splitBy: "char" | "word"): string[] {
   return Array.from(text);
 }
 
+// Each char carries its global index (`gid`) so the render can key on a stable
+// identity instead of the per-word map index (noArrayIndexKey / Sonar S6479).
+type CharCell = { ch: string; gid: number };
+
 function groupIntoWords(
   chars: string[],
-): { chars: string[]; start: number; isSpace: boolean }[] {
-  const groups: { chars: string[]; start: number; isSpace: boolean }[] = [];
-  let word: string[] = [];
+): { chars: CharCell[]; start: number; isSpace: boolean }[] {
+  const groups: { chars: CharCell[]; start: number; isSpace: boolean }[] = [];
+  let word: CharCell[] = [];
   let wordStart = 0;
 
   for (let i = 0; i < chars.length; i++) {
@@ -57,10 +61,10 @@ function groupIntoWords(
         groups.push({ chars: word, start: wordStart, isSpace: false });
         word = [];
       }
-      groups.push({ chars: [ch], start: i, isSpace: true });
+      groups.push({ chars: [{ ch, gid: i }], start: i, isSpace: true });
     } else {
       if (word.length === 0) wordStart = i;
-      word.push(ch);
+      word.push({ ch, gid: i });
     }
   }
   if (word.length > 0) {
@@ -96,33 +100,27 @@ function TextInner({
   buildCharStyle,
   innerRef,
   baseId,
-}: {
+}: Readonly<{
   parts: string[];
   splitBy: "char" | "word";
   gradient?: string;
   buildCharStyle: (idx: number) => CSSProperties;
   innerRef?: React.RefObject<HTMLSpanElement | null>;
   baseId?: string;
-}) {
+}>) {
   if (splitBy === "char") {
     return (
       <span ref={innerRef} aria-hidden="true" style={gradientCss(gradient)}>
-        {groupIntoWords(parts).map(({ chars, start, isSpace }, gIdx) => (
+        {groupIntoWords(parts).map(({ chars, start, isSpace }) => (
           <span
-            // biome-ignore lint/suspicious/noArrayIndexKey: static grouping, stable index
-            key={gIdx}
+            key={start}
             style={{
               display: isSpace ? "inline" : "inline-block",
               ...(gradient && !isSpace ? GRADIENT_INHERIT : null),
             }}
           >
-            {chars.map((ch, i) => (
-              <span
-                // biome-ignore lint/suspicious/noArrayIndexKey: stable position
-                key={i}
-                className="sbi-anim"
-                style={buildCharStyle(start + i)}
-              >
+            {chars.map(({ ch, gid }) => (
+              <span key={gid} className="sbi-anim" style={buildCharStyle(gid)}>
                 {ch}
               </span>
             ))}

--- a/apps/web/src/features/pricing/components/EnterpriseBar.tsx
+++ b/apps/web/src/features/pricing/components/EnterpriseBar.tsx
@@ -11,7 +11,7 @@ interface EnterpriseBarProps {
   ctaHref: string;
 }
 
-export function EnterpriseBar({ plan, ctaHref }: EnterpriseBarProps) {
+export function EnterpriseBar({ plan, ctaHref }: Readonly<EnterpriseBarProps>) {
   const router = useRouter();
 
   return (

--- a/apps/web/src/features/pricing/components/PricingCard.tsx
+++ b/apps/web/src/features/pricing/components/PricingCard.tsx
@@ -49,12 +49,10 @@ function getPriceDisplay(
   // Savings vs paying monthly (originalPrice = 12× the monthly rate).
   const savePercent =
     originalPrice && price ? Math.round((1 - price / originalPrice) * 100) : 0;
-  const priceSubLine =
-    price === 0
-      ? "Free forever"
-      : yearlyTotalDollars
-        ? "Billed yearly"
-        : "Billed monthly";
+  let priceSubLine: string;
+  if (price === 0) priceSubLine = "Free forever";
+  else if (yearlyTotalDollars) priceSubLine = "Billed yearly";
+  else priceSubLine = "Billed monthly";
   return {
     perMonthDollars,
     yearlyTotalDollars,
@@ -158,6 +156,35 @@ export function PricingCard({
   // A signed-in user with no active paid subscription is on the Free plan.
   const isOnFreePlan = !!user && !hasActiveSubscription;
 
+  const renderCta = () => {
+    if (!isFree) {
+      return (
+        <RaisedButton
+          className="w-full text-black!"
+          color="#00bbff"
+          onClick={handleGetStarted}
+          disabled={
+            isCreatingSubscription || (isCurrentPlan && hasActiveSubscription)
+          }
+        >
+          {getButtonText()}
+        </RaisedButton>
+      );
+    }
+    if (isOnFreePlan) {
+      return (
+        <Button isDisabled className="w-full" variant="flat">
+          Current Plan
+        </Button>
+      );
+    }
+    return (
+      <Button className="w-full" variant="flat" onPress={handleGetStarted}>
+        Start for Free
+      </Button>
+    );
+  };
+
   return (
     <div
       className={[
@@ -244,32 +271,7 @@ export function PricingCard({
             <p className="text-sm text-red-400">{paymentError}</p>
           </div>
         )}
-        {isFree ? (
-          isOnFreePlan ? (
-            <Button isDisabled className="w-full" variant="flat">
-              Current Plan
-            </Button>
-          ) : (
-            <Button
-              className="w-full"
-              variant="flat"
-              onPress={handleGetStarted}
-            >
-              Start for Free
-            </Button>
-          )
-        ) : (
-          <RaisedButton
-            className="w-full text-black!"
-            color="#00bbff"
-            onClick={handleGetStarted}
-            disabled={
-              isCreatingSubscription || (isCurrentPlan && hasActiveSubscription)
-            }
-          >
-            {getButtonText()}
-          </RaisedButton>
-        )}
+        {renderCta()}
       </div>
 
       {/* Features — flex-1 so both cards fill remaining height equally */}

--- a/apps/web/src/features/pricing/components/PricingCards.tsx
+++ b/apps/web/src/features/pricing/components/PricingCards.tsx
@@ -118,14 +118,15 @@ export function PricingCards({
   // a ~2xl block, a 3-tier lineup the full 5xl. The Enterprise bar is w-full, so
   // it always spans the exact width of the cards above it.
   const tierCount = sortedPlans.length;
-  const blockWidthClass =
-    tierCount >= 3 ? "max-w-5xl" : tierCount === 2 ? "max-w-2xl" : "max-w-sm";
-  const gridColsClass =
-    tierCount >= 3
-      ? "sm:grid-cols-3"
-      : tierCount === 2
-        ? "sm:grid-cols-2"
-        : "sm:grid-cols-1";
+  let blockWidthClass = "max-w-sm";
+  let gridColsClass = "sm:grid-cols-1";
+  if (tierCount >= 3) {
+    blockWidthClass = "max-w-5xl";
+    gridColsClass = "sm:grid-cols-3";
+  } else if (tierCount === 2) {
+    blockWidthClass = "max-w-2xl";
+    gridColsClass = "sm:grid-cols-2";
+  }
 
   return (
     <div className={`mx-auto flex w-full flex-col gap-3 ${blockWidthClass}`}>

--- a/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
+++ b/apps/web/src/features/skills/components/BuiltinSkillsList.tsx
@@ -23,7 +23,7 @@ interface Group {
   skills: BuiltinSkillInfo[];
 }
 
-export function BuiltinSkillsList({ query }: BuiltinSkillsListProps) {
+export function BuiltinSkillsList({ query }: Readonly<BuiltinSkillsListProps>) {
   const [skills, setSkills] = useState<BuiltinSkillInfo[] | null>(null);
   const [error, setError] = useState(false);
   const [selected, setSelected] = useState<BuiltinSkillInfo | null>(null);

--- a/apps/web/src/features/skills/components/SkillEditorModal.tsx
+++ b/apps/web/src/features/skills/components/SkillEditorModal.tsx
@@ -41,7 +41,7 @@ export function SkillEditorModal({
   onSaved,
   targets,
   skill,
-}: SkillEditorModalProps) {
+}: Readonly<SkillEditorModalProps>) {
   const isEdit = skill !== null;
 
   const [mode, setMode] = useState<"write" | "import">("write");

--- a/apps/web/src/features/skills/components/SkillGroup.tsx
+++ b/apps/web/src/features/skills/components/SkillGroup.tsx
@@ -31,7 +31,7 @@ export function SkillGroup({
   defaultOpen = true,
   trailing,
   children,
-}: SkillGroupProps) {
+}: Readonly<SkillGroupProps>) {
   const [open, setOpen] = useState(defaultOpen);
   const toggle = () => setOpen((v) => !v);
 

--- a/apps/web/src/features/skills/components/SkillImportForm.tsx
+++ b/apps/web/src/features/skills/components/SkillImportForm.tsx
@@ -20,7 +20,7 @@ interface SkillImportFormProps {
 export function SkillImportForm({
   targets,
   onInstalled,
-}: SkillImportFormProps) {
+}: Readonly<SkillImportFormProps>) {
   const [target, setTarget] = useState(EXECUTOR_TARGET);
   const [repoUrl, setRepoUrl] = useState("");
   const [discovering, setDiscovering] = useState(false);

--- a/apps/web/src/features/skills/components/SkillPreviewModal.tsx
+++ b/apps/web/src/features/skills/components/SkillPreviewModal.tsx
@@ -31,7 +31,10 @@ interface SkillPreviewModalProps {
 }
 
 /** Read-only preview of a skill's SKILL.md — shared by Your Skills and Built-in. */
-export function SkillPreviewModal({ skill, onClose }: SkillPreviewModalProps) {
+export function SkillPreviewModal({
+  skill,
+  onClose,
+}: Readonly<SkillPreviewModalProps>) {
   return (
     <Modal
       isOpen={skill !== null}

--- a/apps/web/src/features/skills/components/SkillRow.tsx
+++ b/apps/web/src/features/skills/components/SkillRow.tsx
@@ -31,7 +31,7 @@ export function SkillRow({
   onEdit,
   onToggle,
   onDelete,
-}: SkillRowProps) {
+}: Readonly<SkillRowProps>) {
   const isScoped = skill.target !== EXECUTOR_TARGET;
 
   return (

--- a/apps/web/src/features/skills/components/SkillTargetIcon.tsx
+++ b/apps/web/src/features/skills/components/SkillTargetIcon.tsx
@@ -26,7 +26,7 @@ export function SkillTargetIcon({
   value,
   icon,
   size = 16,
-}: SkillTargetIconProps) {
+}: Readonly<SkillTargetIconProps>) {
   if (value === EXECUTOR_TARGET || icon === EXECUTOR_TARGET) {
     return (
       <AiMagicIcon

--- a/apps/web/src/features/skills/components/SkillTargetSelect.tsx
+++ b/apps/web/src/features/skills/components/SkillTargetSelect.tsx
@@ -15,7 +15,7 @@ export function SkillTargetSelect({
   targets,
   value,
   onChange,
-}: SkillTargetSelectProps) {
+}: Readonly<SkillTargetSelectProps>) {
   return (
     <Select
       label="Runs in"

--- a/apps/web/src/features/skills/components/SkillsList.tsx
+++ b/apps/web/src/features/skills/components/SkillsList.tsx
@@ -36,7 +36,7 @@ export function SkillsList({
   onEdit,
   onToggle,
   onDelete,
-}: SkillsListProps) {
+}: Readonly<SkillsListProps>) {
   const isSearching = query.trim().length > 0;
   const visible = isSearching
     ? skills.filter((s) => skillMatchesQuery(s.name, s.description, query))
@@ -134,10 +134,10 @@ export function SkillsList({
 function EmptyState({
   searching,
   onCreate,
-}: {
+}: Readonly<{
   searching: boolean;
   onCreate: () => void;
-}) {
+}>) {
   return (
     <div className="flex flex-col items-center justify-center rounded-2xl bg-zinc-900/60 px-6 py-14 text-center">
       <div className="mb-3 flex size-12 items-center justify-center rounded-2xl bg-zinc-800">

--- a/apps/web/src/features/skills/components/SkillsManagement.tsx
+++ b/apps/web/src/features/skills/components/SkillsManagement.tsx
@@ -164,7 +164,7 @@ interface TabTitleProps {
   label: string;
 }
 
-function TabTitle({ icon: Icon, label }: TabTitleProps) {
+function TabTitle({ icon: Icon, label }: Readonly<TabTitleProps>) {
   return (
     <div className="flex items-center gap-2">
       <Icon className="size-4" />

--- a/apps/web/src/features/todo/components/fields/ScheduledFieldChip.tsx
+++ b/apps/web/src/features/todo/components/fields/ScheduledFieldChip.tsx
@@ -19,8 +19,8 @@ export default function ScheduledFieldChip({
   timezone,
 }: Readonly<ScheduledFieldChipProps>) {
   // Use user's preferred timezone or fallback to browser timezone
-  const userTimezone =
-    timezone && timezone.trim() !== "" ? timezone : getBrowserTimezone();
+  const normalizedTimezone = timezone?.trim();
+  const userTimezone = normalizedTimezone || getBrowserTimezone();
 
   const formatDisplayValue = (dateString: string) => {
     const date = new Date(dateString);
@@ -58,12 +58,14 @@ export default function ScheduledFieldChip({
     : "";
 
   const buildISOFromParts = (datePart: string, timePart: string): string => {
-    if (timezone) {
+    if (normalizedTimezone) {
       // Build an ISO string that represents this wall-clock time in the user's timezone
       // Use Intl to compute the offset, then adjust
       const naive = new Date(`${datePart}T${timePart}:00`);
       const utcStr = naive.toLocaleString("en-US", { timeZone: "UTC" });
-      const tzStr = naive.toLocaleString("en-US", { timeZone: timezone });
+      const tzStr = naive.toLocaleString("en-US", {
+        timeZone: normalizedTimezone,
+      });
       const utcDate = new Date(utcStr);
       const tzDate = new Date(tzStr);
       const offsetMs = utcDate.getTime() - tzDate.getTime();

--- a/apps/web/src/features/whats-new/components/WhatsNewRecentReleases.tsx
+++ b/apps/web/src/features/whats-new/components/WhatsNewRecentReleases.tsx
@@ -24,7 +24,7 @@ export function WhatsNewRecentReleases({
   releases,
   currentIndex,
   onSelect,
-}: WhatsNewRecentReleasesProps) {
+}: Readonly<WhatsNewRecentReleasesProps>) {
   // `releases` is ordered most-recent-first, so the first N are the latest and
   // each item's position in the slice equals its index in the full list.
   const recent = releases.slice(0, RECENT_COUNT);

--- a/apps/web/src/lib/timezone.ts
+++ b/apps/web/src/lib/timezone.ts
@@ -25,11 +25,15 @@ declare const timezoneBrand: unique symbol;
 /** A validated IANA timezone string. Construct only via the helpers below. */
 export type Timezone = string & { readonly [timezoneBrand]: true };
 
+/** Fixed UTC offset zones like "+05:30" or "-08:00" (up to ±14:00). */
+const OFFSET_TZ_PATTERN = /^[+-](?:0\d|1[0-4]):[0-5]\d$/;
+
 /** Whether `raw` is an IANA zone the runtime accepts (narrows to `Timezone`). */
 export const isValidTimezone = (
   raw: string | null | undefined,
 ): raw is Timezone => {
   if (!raw) return false;
+  if (OFFSET_TZ_PATTERN.test(raw)) return true;
   try {
     // Throws RangeError for an unknown IANA zone.
     new Intl.DateTimeFormat("en-US", { timeZone: raw });

--- a/apps/web/src/lib/toast.tsx
+++ b/apps/web/src/lib/toast.tsx
@@ -70,12 +70,12 @@ function ToastControls({
   action,
   showDismiss,
   state,
-}: {
+}: Readonly<{
   idRef: IdRef;
   action?: { label: string; onClick: () => void };
   showDismiss: boolean;
   state: ToastState;
-}) {
+}>) {
   const twoUp = !!action && showDismiss;
   return (
     <div className={twoUp ? "mt-2 grid grid-cols-2 gap-2" : "mt-2"}>

--- a/apps/web/src/lib/websocket/useWebSocketConnection.ts
+++ b/apps/web/src/lib/websocket/useWebSocketConnection.ts
@@ -39,8 +39,8 @@ export function useWebSocketConnection() {
       return () => {
         wsManager.disconnect();
       };
-    } else {
     }
+    // No signed-in user: nothing to connect, so no cleanup either.
     return undefined;
   }, [user?.email]);
 


### PR DESCRIPTION
Addresses the CodeRabbit review threads and SonarCloud findings reported on the develop→master PR (#774). Branched from and targeted at `develop`; once merged, #774's analysis re-runs against the updated develop head and these findings clear.

## Verification (all green locally)
- **API:** `ruff check` ✅, `mypy app` ✅ (673 files), modified unit tests ✅ (131 passed)
- **Web:** `biome check` ✅ (0 errors), `tsc` ✅ *(only the pre-existing `streamdown` missing-dep cascade, which also affects untouched files and resolves on CI's fresh install)*
- **Desktop:** `biome check` ✅, `tsc` ✅

## What changed
**API**
- Desktop bridge domain errors now subclass `AppError` (global handler maps status); cleanup `delete` guarded in `finally`; `DesktopToolResultRequest` enforces the ok/data/error contract via a `model_validator`. Desktop router gains `prefix`/`tags` and logs the relay result.
- `executor_tool`: decode the held lock value with `decode_raw_item` instead of `str()`.
- `screenshot_data` added to `tool_fields` so OpenUI is suppressed for it (prevents double-render, per the one-path contract).
- Annotated DI in skills/reminders; yaml-mime constant; explicit cache-warm drain loop; cognitive-complexity refactors (`reminder_models`, `result_delivery`, `subagent_runner`, `artifacts`) — behavior-preserving extraction.
- Test fixes: real default-timezone assertion, exception-type asserts, parametrized type annotations, unused-var and async-without-await cleanup.

**Web**
- `CompactMarkdown` headings render `children` (heading-has-content); `TextSoftBlurIn` keys on a stable global char id, not the array index.
- readonly props (S6759), nested-ternary extraction (S3358), `.at()` (S7755), empty-block + base-object-stringification cleanups.
- timezone validator accepts fixed-offset zones; `ScheduledFieldChip` normalizes tz once; `GaiaOrb` guards `createProgram` and drops a lint suppression; `ScreenshotSection` uses `next/image`; desktop-popup wrapped in `ErrorBoundary`; `SendStopButton` no longer submits the form in stop mode.

**Desktop**
- IPC `openExternal` validates the `url` type; `dispatchDesktopTool` hardens its catch against malformed requests.

## Intentionally NOT applied (with reasoning — not blindly following the bots)
- **chat.py `X-Client-Type`** ("capability escalation"): desktop tools only target the requesting user's *own* machine and require a connected desktop renderer; spoofing without the app just times out. Self-scoped and harmless (the docstring already documents this).
- **bridge.py TOCTOU → atomic GETDEL** (heavy-lift): the race needs two concurrent same-user POSTs of an unguessable UUID, the consumer is idempotent (first message wins), and a truly atomic ownership-check needs a Lua script. Not worth the risk.
- **`executor_tool` S7484 / `bash_tool` S7483**: justified `# NOSONAR` — both are cross-process Redis polling / agent-facing tool params where the suggested rewrite doesn't apply.
- **desktop workflows SHA-pinning + `apps/web/**` paths** (3 threads): web is *intentionally* excluded from the desktop build (documented in-file); repo convention is `@v` tags for first-party `actions/*` (40+ usages); CI security gates already pass. Pinning only these files would add inconsistency.