### PR TITLE
feat(agent): add wait tool so the executor can pause instead of polling

### DIFF
--- a/apps/api/app/agents/core/graph_builder/build_graph.py
+++ b/apps/api/app/agents/core/graph_builder/build_graph.py
@@ -30,6 +30,7 @@ from app.agents.tools.core.tool_runtime_config import (
 from app.agents.tools.executor_tool import call_executor, cancel_executor
 from app.agents.tools.todo_tools import create_todo_pre_model_hook, create_todo_tools
 from app.agents.tools.wait_for_subagents_tool import wait_for_subagents as wait_for_subagents_tool
+from app.agents.tools.wait_tool import wait as wait_tool
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider
 from app.override.langgraph_bigtool.create_agent import create_agent
 from app.override.langgraph_bigtool.hooks import HookType
@@ -56,6 +57,7 @@ async def build_executor_graph(
     tool_dict.update({"handoff": handoff_tool})
     tool_dict.update({t.name: t for t in todo_tools})
     tool_dict.update({"wait_for_subagents": wait_for_subagents_tool})
+    tool_dict.update({"wait": wait_tool})
 
     todo_hook = create_todo_pre_model_hook(source="executor")
 
@@ -100,6 +102,7 @@ async def build_executor_graph(
             "bash",
             "deep_research",
             "wait_for_subagents",
+            "wait",
             "read_manual",
             "create_tracked_todo",
             "update_tracked_todo",

--- a/apps/api/app/agents/core/subagents/base_subagent.py
+++ b/apps/api/app/agents/core/subagents/base_subagent.py
@@ -34,6 +34,7 @@ from app.agents.tools.integration_instructions_tools import update_integration_i
 from app.agents.tools.memory_tools import search_memory
 from app.agents.tools.research_tool import deep_research
 from app.agents.tools.todo_tools import create_todo_pre_model_hook, create_todo_tools
+from app.agents.tools.wait_tool import wait
 from app.agents.tools.webpage_tool import fetch_webpages, web_search_tool
 from app.constants.general import FINISH_TASK_NAME
 from app.override.langgraph_bigtool.create_agent import create_agent
@@ -79,6 +80,11 @@ def _build_scoped_tool_dict(
     scoped_tool_dict[web_search_tool.name] = web_search_tool
     scoped_tool_dict[fetch_webpages.name] = fetch_webpages
     scoped_tool_dict[deep_research.name] = deep_research
+    # Always-bound so a subagent can pause on a long-running tool (e.g. an MCP
+    # render/export job) instead of polling its status in a tight loop until it
+    # exhausts the recursion limit.
+    scoped_tool_dict[wait.name] = wait
+    initial_tool_ids.append(wait.name)
     # Always-on so a subagent can persist a user's durable preference for its
     # own integration the moment it hears one (its instructions are already in
     # context, so it can rewrite the full block without a separate read).

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -856,10 +856,14 @@ WAITING ON LONG-RUNNING TASKS (wait, always available)
   call it again immediately in a loop. That burns the step budget and gets you nothing.
 - Instead call wait(seconds=<estimate>, reason="...") once to pause, then re-check.
   Pick seconds from any estimate the task gives you; otherwise start small and increase.
+- After waiting, re-check the task. If it is still not done, call wait again with a
+  longer duration and re-check. Repeat until it completes (subject to the limit below).
 - Pattern:
   render(...)            # returns "rendering, ~60s"
   wait(seconds=60, reason="waiting for the render")
-  get_status(...)        # check again; wait again only if still not done
+  get_status(...)        # still rendering?
+  wait(seconds=120, reason="still rendering")
+  get_status(...)        # done -> continue
 - wait is for short pauses only (a single call caps at 5 minutes). Do NOT loop wait
   to babysit a task that takes many minutes: that holds the turn open and drains the
   step budget. If a task will take more than a few minutes, do not block. Finish the

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -850,6 +850,17 @@ spawn_subagent (lightweight focused execution)
 - Preferred for large workspace-file outputs and expensive extraction/summarization.
 - Do not use spawn_subagent for provider-owned actions when a provider subagent is available.
 
+WAITING ON LONG-RUNNING TASKS (wait, always available)
+- When a tool or process reports it is still in progress (a render, build, export,
+  upload, async job, anything that returns "not ready / processing / queued"), do NOT
+  call it again immediately in a loop. That burns the step budget and gets you nothing.
+- Instead call wait(seconds=<estimate>, reason="...") once to pause, then re-check.
+  Pick seconds from any estimate the task gives you; otherwise start small and increase.
+- Pattern:
+  render(...)            # returns "rendering, ~60s"
+  wait(seconds=60, reason="waiting for the render")
+  get_status(...)        # check again; wait again only if still not done
+
 YOUR OUTPUT (INTERNAL — read by comms, not the user)
 - Your final message is NOT shown to the user as-is; it is handed to the comms
   agent as ground-truth facts, and comms re-voices it for the user. Write for

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -860,6 +860,11 @@ WAITING ON LONG-RUNNING TASKS (wait, always available)
   render(...)            # returns "rendering, ~60s"
   wait(seconds=60, reason="waiting for the render")
   get_status(...)        # check again; wait again only if still not done
+- wait is for short pauses only (a single call caps at 5 minutes). Do NOT loop wait
+  to babysit a task that takes many minutes: that holds the turn open and drains the
+  step budget. If a task will take more than a few minutes, do not block. Finish the
+  turn, tell the user it is in progress, and resume later with a scheduled tracked todo
+  or a workflow.
 
 YOUR OUTPUT (INTERNAL — read by comms, not the user)
 - Your final message is NOT shown to the user as-is; it is handed to the comms

--- a/apps/api/app/agents/prompts/custom_mcp_prompts.py
+++ b/apps/api/app/agents/prompts/custom_mcp_prompts.py
@@ -42,6 +42,23 @@ It is YOUR responsibility to resolve uncertainty and complete the task.
 - **Search then act**: Search/query first → Use results to inform action
 - **Batch operations**: Gather all needed data → Execute in logical order
 
+### Long-Running Operations (use the `wait` tool, always available)
+- When a tool reports work is still in progress (rendering, building, exporting,
+  uploading, processing, queued, "not ready"), do NOT call its status tool again
+  immediately in a loop. That wastes your step budget and the task never finishes.
+- Call `wait(seconds=<estimate>, reason="...")` once to pause, then re-check. Use
+  any estimate the tool gives you; otherwise start small and increase.
+- After waiting, re-check. If still not done, `wait` again with a longer duration
+  and re-check. Repeat until complete.
+- A single `wait` caps at 5 minutes. If the job will take much longer than a few
+  minutes, do not block: report back to the main agent that it is still in progress.
+- Pattern:
+  render(...) returns "rendering, ~60s"
+  wait(seconds=60, reason="waiting for the render")
+  get_status(...) still rendering?
+  wait(seconds=120, reason="still rendering")
+  get_status(...) done, continue
+
 ## FAILURE HANDLING
 
 If an attempt fails:

--- a/apps/api/app/agents/tools/wait_tool.py
+++ b/apps/api/app/agents/tools/wait_tool.py
@@ -1,0 +1,65 @@
+"""Generic self-pause tool: lets the agent wait out a long-running task instead
+of polling the same call in a tight loop and exhausting the recursion limit."""
+
+import asyncio
+from typing import Annotated
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langgraph.config import get_stream_writer
+
+from app.constants.general import MAX_WAIT_SECONDS, WAIT_POLL_INTERVAL_SECONDS
+from app.core.stream_manager import stream_manager
+from shared.py.wide_events import log
+
+
+@tool
+async def wait(
+    config: RunnableConfig,
+    # NOSONAR python:S7483 — `seconds` is part of this tool's LLM-facing input
+    # schema (the model chooses how long to pause); it is not an internal call
+    # timeout that an asyncio.timeout() context manager could replace.
+    seconds: Annotated[  # NOSONAR python:S7483
+        float,
+        "How long to pause before continuing, in seconds. Pick a value that "
+        "matches how long the in-progress task realistically needs (e.g. 60 "
+        f"for a ~1 minute render). Capped at {MAX_WAIT_SECONDS}s per call.",
+    ],
+    reason: Annotated[
+        str | None,
+        'Short reason shown to the user while waiting (e.g. "waiting for the '
+        'render to finish"). Optional.',
+    ] = None,
+) -> str:
+    """Pause execution for a set duration, then resume.
+
+    Use this when a task is genuinely in progress and you must wait before
+    checking it again: a long render/build/export, an async job that reports
+    progress, a background process. Pausing once and re-checking afterwards is
+    far better than calling the same tool repeatedly in a tight loop.
+
+    Returns once the wait elapses (or immediately if the user cancels the turn).
+    """
+    seconds = max(0.0, min(seconds, MAX_WAIT_SECONDS))
+
+    writer = get_stream_writer()
+    writer({"progress": f"Waiting {seconds:.0f}s" + (f" ({reason})" if reason else "") + "..."})
+
+    stream_id = config.get("configurable", {}).get("stream_id")
+    log.info(f"wait: pausing {seconds:.1f}s (reason={reason!r}, stream={stream_id})")
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + seconds
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        if stream_id and await stream_manager.is_cancelled(stream_id):
+            log.info(f"wait: cancelled by user mid-wait (stream={stream_id})")
+            return "Wait cancelled by user."
+        await asyncio.sleep(min(WAIT_POLL_INTERVAL_SECONDS, remaining))
+
+    return f"Waited {seconds:.0f}s. Resume and re-check the task."
+
+
+tools = [wait]

--- a/apps/api/app/constants/general.py
+++ b/apps/api/app/constants/general.py
@@ -18,6 +18,12 @@ FINISH_TASK_NAME = "finish_task"
 # generated in the executor path rather than the current turn.
 CALL_EXECUTOR_NAME = "call_executor"
 
+# Agent self-pause ("wait" tool). MAX_WAIT_SECONDS is an upper safety bound on a
+# single pause (the agent picks the actual duration per task); the poll interval
+# is how often we re-check for stream cancellation while paused.
+MAX_WAIT_SECONDS = 300
+WAIT_POLL_INTERVAL_SECONDS = 1.0
+
 MAX_EMAILS_PER_PLATFORM = 20
 DEDUPLICATION_SIMILARITY_THRESHOLD = 0.9
 PROFILE_EXTRACTION_LLM_PROVIDER = "gemini"


### PR DESCRIPTION
## What

Adds a generic `wait` tool that lets the executor agent pause itself on long-running tasks instead of polling the same call in a tight loop.

## Why

The executor had no way to wait. When a tool reports work still in progress (a render, build, export, upload, async job, anything returning "not ready / processing / queued"), the model would re-call it immediately, step after step, and exhaust `AGENT_RECURSION_LIMIT` (40) long before the task actually finished. This is transport-agnostic: it applies to any user-connected MCP tool or background process, not a specific integration.

## How

- **`app/agents/tools/wait_tool.py`** (new) — `wait(seconds, reason=None)`:
  - Streams a `"Waiting Ns..."` progress chunk so the live chat UI isn't silent.
  - Sleeps in `WAIT_POLL_INTERVAL_SECONDS` ticks, re-checking `StreamManager.is_cancelled(stream_id)` each tick, so a user-initiated cancel aborts within ~1s instead of blocking the full duration.
  - Clamps `seconds` to `MAX_WAIT_SECONDS` (upper safety bound; the agent still chooses the actual duration per task).
- **`app/constants/general.py`** — `MAX_WAIT_SECONDS` and `WAIT_POLL_INTERVAL_SECONDS`.
- **`app/agents/core/graph_builder/build_graph.py`** — register in `tool_dict` and add to `initial_tool_ids` so it is always bound on the executor (a control primitive the agent reaches for mid-loop must be reliably present, not semantically retrieved). Left available to spawned subagents.
- **`app/agents/prompts/comms_prompts.py`** — a short executor-prompt section: when a task reports it is in progress, call `wait` once then re-check instead of re-calling immediately.

## Behavior

```
render(...)            # returns "rendering, ~60s"
wait(seconds=60, reason="waiting for the render")
get_status(...)        # check again; wait again only if still not done
```

A ~20-poll loop (~40 steps, hits the recursion limit) collapses into `wait → check` (a handful of steps).

## Verification

- `nx type-check api` — passes (no issues in 674 files)
- `nx lint api` — passes