### PR TITLE
fix(download): resolve desktop release via API so buttons download directly

### DIFF
--- a/apps/api/app/api/v1/endpoints/desktop.py
+++ b/apps/api/app/api/v1/endpoints/desktop.py
@@ -1,8 +1,11 @@
-"""Desktop tool bridge endpoints.
+"""Desktop app endpoints.
 
-The Electron app POSTs results of desktop-executed tool actions here; the
-endpoint validates ownership against the pending-request key and relays the
-payload to the awaiting agent tool over Redis.
+Two concerns share the ``/desktop`` prefix:
+
+- the tool bridge (authed): the Electron app POSTs results of desktop-executed
+  tool actions here, and the endpoint relays them to the awaiting agent tool;
+- release distribution (public): the marketing download page resolves the latest
+  desktop binary so its buttons link straight to the right platform/arch asset.
 """
 
 from typing import Annotated
@@ -10,11 +13,29 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
-from app.schemas.desktop_schemas import DesktopToolResultRequest, DesktopToolResultResponse
+from app.schemas.desktop_schemas import (
+    DesktopReleaseResponse,
+    DesktopToolResultRequest,
+    DesktopToolResultResponse,
+)
 from app.services.desktop.bridge import relay_desktop_result
+from app.services.desktop.releases import get_latest_desktop_release
 from shared.py.wide_events import log
 
 router = APIRouter(prefix="/desktop", tags=["desktop"])
+
+
+@router.get("/releases/latest")
+async def latest_desktop_release() -> DesktopReleaseResponse:
+    """Return the newest published desktop release and its per-platform binaries.
+
+    Public (no auth) — the download page links straight to the correct
+    platform/arch asset instead of falling back to the GitHub releases list.
+    """
+    log.set(desktop_release={"operation": "resolve_latest"})
+    release = await get_latest_desktop_release()
+    log.set(desktop_release={"tag": release.tag, "asset_count": len(release.assets)})
+    return release
 
 
 @router.post("/tool-result")

--- a/apps/api/app/api/v1/middleware/auth.py
+++ b/apps/api/app/api/v1/middleware/auth.py
@@ -53,6 +53,10 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
             "/api/v1/bot",
             "/api/v1/webhook",
             "/metrics",
+            # Public desktop release lookup for the marketing download page.
+            # Scoped to /releases so the authed /desktop/tool-result bridge stays
+            # protected.
+            "/api/v1/desktop/releases",
             # Login-free connect link — self-authenticates via a signed,
             # single-use, connect-scoped token (see connect_link_service).
             "/api/v1/integrations/connect-link",

--- a/apps/api/app/constants/cache.py
+++ b/apps/api/app/constants/cache.py
@@ -85,6 +85,10 @@ PLATFORM_LINK_TOKEN_TTL = TEN_MINUTES_TTL
 # rejects late POSTs whose key is gone.
 DESKTOP_REQUEST_PREFIX = "desktop:request:"
 DESKTOP_RESULT_CHANNEL_PREFIX = "desktop:result:"
+# Latest desktop (Electron) release resolved from GitHub for the download page.
+# Infrequent releases, so 30 min keeps the page fresh without hammering GitHub.
+DESKTOP_RELEASE_CACHE_KEY = "desktop:release:latest"
+DESKTOP_RELEASE_CACHE_TTL = THIRTY_MINUTES_TTL
 # The ownership key's TTL is derived per-call from the awaiting tool's timeout
 # plus this grace, so the key always outlives the wait (a fixed TTL could be
 # outrun by a longer custom timeout, expiring mid-wait and dropping a valid

--- a/apps/api/app/constants/desktop.py
+++ b/apps/api/app/constants/desktop.py
@@ -1,0 +1,19 @@
+"""Desktop app constants.
+
+Release distribution for the marketing download page — see
+``app.services.desktop.releases``.
+"""
+
+# GAIA's monorepo. Desktop builds are tagged ``desktop-<version>`` and share the
+# repo's single GitHub Releases feed with every other app.
+GAIA_GITHUB_REPO = "theexperiencecompany/gaia"
+DESKTOP_RELEASE_TAG_PREFIX = "desktop-"
+
+# GitHub's max page size. Desktop releases recur often enough that the newest one
+# always lands within the first page even interleaved with the far more frequent
+# web/api/cli/bots/mobile releases — a smaller page silently hid it and forced
+# every download button to fall back to the raw releases list.
+DESKTOP_RELEASES_PAGE_SIZE = 100
+
+# Upper bound on the GitHub releases fetch.
+GITHUB_RELEASES_TIMEOUT_SECONDS = 15.0

--- a/apps/api/app/schemas/desktop_schemas.py
+++ b/apps/api/app/schemas/desktop_schemas.py
@@ -50,3 +50,26 @@ class DesktopToolResultResponse(BaseModel):
     """Acknowledgement that a desktop tool result was relayed."""
 
     success: bool
+
+
+class DesktopReleaseAsset(BaseModel):
+    """One downloadable binary attached to a desktop release."""
+
+    name: str = Field(description="Asset filename, e.g. GAIA-x64.exe")
+    download_url: str = Field(description="Direct browser download URL for the asset")
+    size: int = Field(description="Asset size in bytes")
+    content_type: str | None = Field(
+        default=None, description="Asset MIME type as reported by GitHub"
+    )
+
+
+class DesktopReleaseResponse(BaseModel):
+    """Latest published desktop (Electron) release and its per-platform binaries."""
+
+    tag: str = Field(description="Release tag, e.g. desktop-v0.3.0")
+    name: str | None = Field(default=None, description="Human-readable release name")
+    html_url: str = Field(description="GitHub release page URL")
+    published_at: str | None = Field(default=None, description="ISO 8601 publish timestamp")
+    assets: list[DesktopReleaseAsset] = Field(
+        description="Downloadable binaries for every platform/arch in this release"
+    )

--- a/apps/api/app/services/desktop/releases.py
+++ b/apps/api/app/services/desktop/releases.py
@@ -10,26 +10,17 @@ releases list.
 import httpx
 
 from app.agents.skills.utils import GITHUB_API_BASE, get_github_headers
+from app.constants.cache import DESKTOP_RELEASE_CACHE_KEY, DESKTOP_RELEASE_CACHE_TTL
+from app.constants.desktop import (
+    DESKTOP_RELEASE_TAG_PREFIX,
+    DESKTOP_RELEASES_PAGE_SIZE,
+    GAIA_GITHUB_REPO,
+    GITHUB_RELEASES_TIMEOUT_SECONDS,
+)
 from app.decorators.caching import Cacheable
 from app.schemas.desktop_schemas import DesktopReleaseAsset, DesktopReleaseResponse
 from app.utils.errors import create_error
 from shared.py.wide_events import log
-
-# GAIA's own monorepo. Desktop builds are tagged ``desktop-<version>``.
-GAIA_GITHUB_REPO = "theexperiencecompany/gaia"
-DESKTOP_TAG_PREFIX = "desktop-"
-
-# GitHub's max page size. Desktop releases recur often enough that the newest one
-# always lands within the first page even when interleaved with the far more
-# frequent web/api/cli/bots/mobile releases — a smaller page silently hid it and
-# forced every download button to fall back to the releases list.
-_RELEASES_PAGE_SIZE = 100
-_GITHUB_TIMEOUT_SECONDS = 15.0
-
-DESKTOP_RELEASE_CACHE_KEY = "desktop:release:latest"
-# Desktop releases are infrequent; 30 min keeps the page fresh without hammering
-# GitHub's API (and staying well inside its rate limits).
-DESKTOP_RELEASE_CACHE_TTL = 1800
 
 
 @Cacheable(
@@ -46,10 +37,10 @@ async def get_latest_desktop_release() -> DesktopReleaseResponse:
     url = f"{GITHUB_API_BASE}/repos/{GAIA_GITHUB_REPO}/releases"
 
     try:
-        async with httpx.AsyncClient(timeout=_GITHUB_TIMEOUT_SECONDS) as client:
+        async with httpx.AsyncClient(timeout=GITHUB_RELEASES_TIMEOUT_SECONDS) as client:
             response = await client.get(
                 url,
-                params={"per_page": _RELEASES_PAGE_SIZE},
+                params={"per_page": DESKTOP_RELEASES_PAGE_SIZE},
                 headers=get_github_headers(),
             )
             response.raise_for_status()
@@ -66,7 +57,7 @@ async def get_latest_desktop_release() -> DesktopReleaseResponse:
         (
             release
             for release in releases
-            if release.get("tag_name", "").startswith(DESKTOP_TAG_PREFIX)
+            if release.get("tag_name", "").startswith(DESKTOP_RELEASE_TAG_PREFIX)
             and not release.get("draft")
             and not release.get("prerelease")
         ),
@@ -76,7 +67,10 @@ async def get_latest_desktop_release() -> DesktopReleaseResponse:
     if latest is None:
         raise create_error(
             message="No published desktop release was found",
-            why=f"No '{DESKTOP_TAG_PREFIX}*' tag in the {_RELEASES_PAGE_SIZE} most recent releases",
+            why=(
+                f"No '{DESKTOP_RELEASE_TAG_PREFIX}*' tag in the "
+                f"{DESKTOP_RELEASES_PAGE_SIZE} most recent releases"
+            ),
             status_code=404,
         )
 

--- a/apps/api/app/services/desktop/releases.py
+++ b/apps/api/app/services/desktop/releases.py
@@ -1,0 +1,101 @@
+"""Resolve the latest published GAIA desktop release from GitHub Releases.
+
+Every app in the monorepo publishes into one GitHub Releases feed, so the newest
+``desktop-*`` tag is usually buried several entries below the most recent web/api
+releases. The web download page calls this (cached) so its buttons can link
+straight to the right platform binary instead of dumping users on the raw GitHub
+releases list.
+"""
+
+import httpx
+
+from app.agents.skills.utils import GITHUB_API_BASE, get_github_headers
+from app.decorators.caching import Cacheable
+from app.schemas.desktop_schemas import DesktopReleaseAsset, DesktopReleaseResponse
+from app.utils.errors import create_error
+from shared.py.wide_events import log
+
+# GAIA's own monorepo. Desktop builds are tagged ``desktop-<version>``.
+GAIA_GITHUB_REPO = "theexperiencecompany/gaia"
+DESKTOP_TAG_PREFIX = "desktop-"
+
+# GitHub's max page size. Desktop releases recur often enough that the newest one
+# always lands within the first page even when interleaved with the far more
+# frequent web/api/cli/bots/mobile releases — a smaller page silently hid it and
+# forced every download button to fall back to the releases list.
+_RELEASES_PAGE_SIZE = 100
+_GITHUB_TIMEOUT_SECONDS = 15.0
+
+DESKTOP_RELEASE_CACHE_KEY = "desktop:release:latest"
+# Desktop releases are infrequent; 30 min keeps the page fresh without hammering
+# GitHub's API (and staying well inside its rate limits).
+DESKTOP_RELEASE_CACHE_TTL = 1800
+
+
+@Cacheable(
+    key=DESKTOP_RELEASE_CACHE_KEY,
+    ttl=DESKTOP_RELEASE_CACHE_TTL,
+    model=DesktopReleaseResponse,
+)
+async def get_latest_desktop_release() -> DesktopReleaseResponse:
+    """Return the newest non-draft ``desktop-*`` release and its assets.
+
+    Raises ``AppError`` 502 if GitHub is unreachable, or 404 if no desktop
+    release has been published yet.
+    """
+    url = f"{GITHUB_API_BASE}/repos/{GAIA_GITHUB_REPO}/releases"
+
+    try:
+        async with httpx.AsyncClient(timeout=_GITHUB_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                url,
+                params={"per_page": _RELEASES_PAGE_SIZE},
+                headers=get_github_headers(),
+            )
+            response.raise_for_status()
+            releases = response.json()
+    except httpx.HTTPError as exc:
+        raise create_error(
+            message="Could not reach GitHub to resolve the latest desktop release",
+            why=str(exc),
+            fix="Retry shortly; the download page falls back to the GitHub releases list",
+            status_code=502,
+        ) from exc
+
+    latest = next(
+        (
+            release
+            for release in releases
+            if release.get("tag_name", "").startswith(DESKTOP_TAG_PREFIX)
+            and not release.get("draft")
+            and not release.get("prerelease")
+        ),
+        None,
+    )
+
+    if latest is None:
+        raise create_error(
+            message="No published desktop release was found",
+            why=f"No '{DESKTOP_TAG_PREFIX}*' tag in the {_RELEASES_PAGE_SIZE} most recent releases",
+            status_code=404,
+        )
+
+    assets = [
+        DesktopReleaseAsset(
+            name=asset["name"],
+            download_url=asset["browser_download_url"],
+            size=asset.get("size", 0),
+            content_type=asset.get("content_type"),
+        )
+        for asset in latest.get("assets", [])
+    ]
+
+    log.set(desktop_release={"tag": latest["tag_name"], "asset_count": len(assets)})
+
+    return DesktopReleaseResponse(
+        tag=latest["tag_name"],
+        name=latest.get("name"),
+        html_url=latest["html_url"],
+        published_at=latest.get("published_at"),
+        assets=assets,
+    )

--- a/apps/web/src/features/download/api/desktopApi.ts
+++ b/apps/web/src/features/download/api/desktopApi.ts
@@ -1,0 +1,9 @@
+import { api } from "@/lib/api/client";
+import type { DesktopRelease } from "../types";
+
+export const desktopApi = {
+  getLatestRelease: async (): Promise<DesktopRelease> => {
+    const response = await api.get<DesktopRelease>("/desktop/releases/latest");
+    return response.data;
+  },
+};

--- a/apps/web/src/features/download/components/DownloadPage.tsx
+++ b/apps/web/src/features/download/components/DownloadPage.tsx
@@ -18,11 +18,19 @@ import ProgressiveImage from "@/components/ui/ProgressiveImage";
 import { appConfig } from "@/config/appConfig";
 import GetStartedButton from "@/features/landing/components/shared/GetStartedButton";
 import {
+  type DesktopArch,
+  type DesktopOS,
   GITHUB_RELEASES_BASE,
   usePlatformDetection,
 } from "@/hooks/ui/usePlatformDetection";
 
-type MacChipOption = "intel" | "m-series";
+const DESKTOP_OSES: DesktopOS[] = ["mac", "windows", "linux"];
+
+const OS_META: Record<DesktopOS, { name: string; icon: string }> = {
+  mac: { name: "macOS", icon: "/images/icons/apple.svg" },
+  windows: { name: "Windows", icon: "/images/icons/windows.svg" },
+  linux: { name: "Linux", icon: "/images/icons/linux.svg" },
+};
 
 // Reusable section layout component
 interface DownloadSectionLayoutProps {
@@ -94,123 +102,121 @@ function DownloadSectionLayout({
   );
 }
 
-function MacDownloadButton({ isPrimary = false }: { isPrimary?: boolean }) {
-  const { platformConfigs } = usePlatformDetection();
-  const [selectedOption, setSelectedOption] = useState<Set<MacChipOption>>(
-    new Set(["intel"]),
+// One download control for a desktop OS. Renders an arch chooser (x64 / ARM)
+// when more than one binary is published, a single button when only one is, a
+// loading state while the release resolves, and a releases-page fallback if the
+// lookup failed entirely — so a click always does something sensible.
+function DesktopDownloadButton({
+  os,
+  isPrimary = false,
+}: {
+  os: DesktopOS;
+  isPrimary?: boolean;
+}) {
+  const { desktopDownloads, detectedDesktop, isDesktopReleaseLoading } =
+    usePlatformDetection();
+  const [overrideArch, setOverrideArch] = useState<DesktopArch | null>(null);
+
+  const meta = OS_META[os];
+  const available = desktopDownloads[os].filter((v) => v.downloadUrl);
+  const buttonVariant = isPrimary ? undefined : ("flat" as const);
+  // Mac's apple.svg is dark; invert it on the light "flat" (secondary) buttons.
+  const invertIcon = os === "mac" && !isPrimary;
+
+  const icon = (
+    <div className="relative h-4 w-4">
+      <Image
+        src={meta.icon}
+        alt={meta.name}
+        fill
+        className={
+          invertIcon ? "object-contain filter invert" : "object-contain"
+        }
+      />
+    </div>
   );
 
-  const labelsMap: Record<MacChipOption, string> = {
-    intel: "Download for macOS Intel",
-    "m-series": "Download for M-series",
-  };
+  const baseLabel = isPrimary ? `Download for ${meta.name}` : meta.name;
 
-  const downloadUrlMap: Record<MacChipOption, string> = {
-    intel: platformConfigs["mac-intel"].downloadUrl || "#",
-    "m-series": platformConfigs["mac-arm"].downloadUrl || "#",
-  };
-
-  const selectedOptionValue = Array.from(selectedOption)[0] as MacChipOption;
-
-  if (!isPrimary) {
+  if (isDesktopReleaseLoading) {
     return (
-      <ButtonGroup>
-        <Button
-          as={Link}
-          href={downloadUrlMap[selectedOptionValue]}
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="flat"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/apple.svg"
-                alt="Apple"
-                fill
-                className="object-contain filter invert"
-              />
-            </div>
-          }
-        >
-          {selectedOptionValue === "intel" ? "macOS Intel" : "macOS M-series"}
-        </Button>
-        <Dropdown placement="bottom-end">
-          <DropdownTrigger>
-            <Button isIconOnly variant="flat">
-              <ChevronDown width={17} height={17} />
-            </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            disallowEmptySelection
-            aria-label="Mac chip options"
-            selectedKeys={selectedOption}
-            selectionMode="single"
-            onSelectionChange={(keys) =>
-              setSelectedOption(keys as Set<MacChipOption>)
-            }
-          >
-            <DropdownItem
-              key="intel"
-              description="For Macs with Intel processor"
-            >
-              Intel
-            </DropdownItem>
-            <DropdownItem
-              key="m-series"
-              description="For Macs with M1, M2, M3, or M4 chip"
-            >
-              Apple Silicon (M-series)
-            </DropdownItem>
-          </DropdownMenu>
-        </Dropdown>
-      </ButtonGroup>
+      <Button variant={buttonVariant} isLoading startContent={icon}>
+        {baseLabel}
+      </Button>
     );
+  }
+
+  if (available.length === 0) {
+    return (
+      <Button
+        as={Link}
+        href={GITHUB_RELEASES_BASE}
+        target="_blank"
+        rel="noopener noreferrer"
+        variant={buttonVariant}
+        startContent={icon}
+      >
+        {baseLabel}
+      </Button>
+    );
+  }
+
+  const defaultArch =
+    detectedDesktop?.os === os &&
+    available.some((v) => v.arch === detectedDesktop.arch)
+      ? detectedDesktop.arch
+      : available[0].arch;
+  const effectiveArch =
+    overrideArch && available.some((v) => v.arch === overrideArch)
+      ? overrideArch
+      : defaultArch;
+  const selected =
+    available.find((v) => v.arch === effectiveArch) ?? available[0];
+
+  // Surface the selected arch only when there's a real choice to make.
+  const label =
+    available.length > 1 ? `${baseLabel} (${selected.label})` : baseLabel;
+
+  const mainButton = (
+    <Button
+      as={Link}
+      href={selected.downloadUrl ?? "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant={buttonVariant}
+      startContent={icon}
+    >
+      {label}
+    </Button>
+  );
+
+  if (available.length === 1) {
+    return mainButton;
   }
 
   return (
     <ButtonGroup>
-      <Button
-        as={Link}
-        href={downloadUrlMap[selectedOptionValue]}
-        target="_blank"
-        rel="noopener noreferrer"
-        startContent={
-          <div className="relative h-4 w-4">
-            <Image
-              src="/images/icons/apple.svg"
-              alt="Apple"
-              fill
-              className="object-contain"
-            />
-          </div>
-        }
-      >
-        {labelsMap[selectedOptionValue]}
-      </Button>
+      {mainButton}
       <Dropdown placement="bottom-end">
         <DropdownTrigger>
-          <Button isIconOnly>
+          <Button isIconOnly variant={buttonVariant}>
             <ChevronDown width={17} height={17} />
           </Button>
         </DropdownTrigger>
         <DropdownMenu
           disallowEmptySelection
-          aria-label="Mac chip options"
-          selectedKeys={selectedOption}
+          aria-label={`${meta.name} architecture options`}
+          selectedKeys={new Set([effectiveArch])}
           selectionMode="single"
           onSelectionChange={(keys) =>
-            setSelectedOption(keys as Set<MacChipOption>)
+            setOverrideArch(Array.from(keys)[0] as DesktopArch)
           }
         >
-          <DropdownItem key="intel" description="For Macs with Intel processor">
-            Intel
-          </DropdownItem>
-          <DropdownItem
-            key="m-series"
-            description="For Macs with M1, M2, M3, or M4 chip"
-          >
-            Apple Silicon (M-series)
-          </DropdownItem>
+          {available.map((variant) => (
+            <DropdownItem key={variant.arch} description={variant.description}>
+              {variant.label}
+            </DropdownItem>
+          ))}
         </DropdownMenu>
       </Dropdown>
     </ButtonGroup>
@@ -218,114 +224,9 @@ function MacDownloadButton({ isPrimary = false }: { isPrimary?: boolean }) {
 }
 
 function DesktopSection() {
-  const { isMac, isWindows, isLinux, platformConfigs } = usePlatformDetection();
-
-  const renderPrimaryButton = () => {
-    if (isMac) return <MacDownloadButton isPrimary />;
-
-    if (isWindows) {
-      return (
-        <Button
-          as={Link}
-          href={platformConfigs["windows"].downloadUrl || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/windows.svg"
-                alt="Windows"
-                fill
-                className="object-contain"
-              />
-            </div>
-          }
-        >
-          Download for Windows
-        </Button>
-      );
-    }
-
-    if (isLinux)
-      return (
-        <Button
-          as={Link}
-          href={platformConfigs["linux"].downloadUrl || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/linux.svg"
-                alt="Linux"
-                fill
-                className="object-contain"
-              />
-            </div>
-          }
-        >
-          Download for Linux
-        </Button>
-      );
-
-    return <MacDownloadButton isPrimary />;
-  };
-
-  const renderSecondaryButtons = () => {
-    const buttons: ReactNode[] = [];
-
-    if (!isMac) buttons.push(<MacDownloadButton key="mac" />);
-
-    if (!isWindows)
-      buttons.push(
-        <Button
-          key="windows"
-          as={Link}
-          href={platformConfigs["windows"].downloadUrl || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="flat"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/windows.svg"
-                alt="Windows"
-                fill
-                className="object-contain"
-              />
-            </div>
-          }
-        >
-          Windows
-        </Button>,
-      );
-
-    if (!isLinux)
-      buttons.push(
-        <Button
-          key="linux"
-          as={Link}
-          href={platformConfigs["linux"].downloadUrl || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="flat"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/linux.svg"
-                alt="Linux"
-                fill
-                className="object-contain"
-              />
-            </div>
-          }
-        >
-          Linux
-        </Button>,
-      );
-
-    return buttons;
-  };
+  const { detectedDesktop } = usePlatformDetection();
+  const primaryOs: DesktopOS = detectedDesktop?.os ?? "mac";
+  const secondaryOses = DESKTOP_OSES.filter((os) => os !== primaryOs);
 
   return (
     <DownloadSectionLayout
@@ -343,9 +244,11 @@ function DesktopSection() {
       description="Get the native desktop experience with enhanced performance."
       actions={
         <div className="flex flex-col gap-3 justify-center items-center">
-          {renderPrimaryButton()}
+          <DesktopDownloadButton os={primaryOs} isPrimary />
           <div className="flex flex-wrap justify-center gap-2 md:justify-end">
-            {renderSecondaryButtons()}
+            {secondaryOses.map((os) => (
+              <DesktopDownloadButton key={os} os={os} />
+            ))}
           </div>
         </div>
       }
@@ -530,61 +433,10 @@ function DownloadCard({
   );
 }
 
-// Landing page variant - 2 column grid with Desktop and Mobile side by side
+// Landing page variant - 3 column grid with Desktop, Web and Mobile
 export function LandingDownloadSection() {
-  const { isMac, isWindows, isLinux, platformConfigs } = usePlatformDetection();
-
-  const renderPrimaryButton = () => {
-    if (isMac) return <MacDownloadButton isPrimary />;
-
-    if (isWindows) {
-      return (
-        <Button
-          as={Link}
-          href={platformConfigs["windows"].downloadUrl || "#"}
-          target="_blank"
-          rel="noopener noreferrer"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/windows.svg"
-                alt="Windows"
-                fill
-                className="object-contain"
-              />
-            </div>
-          }
-        >
-          Download for Windows
-        </Button>
-      );
-    }
-
-    if (isLinux)
-      return (
-        <Button
-          as={Link}
-          href={platformConfigs["linux"].downloadUrl || "#"}
-          target="_blank"
-          color="primary"
-          rel="noopener noreferrer"
-          startContent={
-            <div className="relative h-4 w-4">
-              <Image
-                src="/images/icons/linux.svg"
-                alt="Linux"
-                fill
-                className="object-contain"
-              />
-            </div>
-          }
-        >
-          Download for Linux
-        </Button>
-      );
-
-    return <MacDownloadButton isPrimary />;
-  };
+  const { detectedDesktop } = usePlatformDetection();
+  const primaryOs: DesktopOS = detectedDesktop?.os ?? "mac";
 
   return (
     <section className="relative z-10 mx-auto w-full px-4 sm:px-6 py-16 sm:py-24">
@@ -610,7 +462,7 @@ export function LandingDownloadSection() {
                 All platforms
                 <ArrowRight02Icon className="h-3 w-3" />
               </Link>
-              {renderPrimaryButton()}
+              <DesktopDownloadButton os={primaryOs} isPrimary />
             </>
           }
         />

--- a/apps/web/src/features/download/types.ts
+++ b/apps/web/src/features/download/types.ts
@@ -1,0 +1,14 @@
+export interface DesktopReleaseAsset {
+  name: string;
+  download_url: string;
+  size: number;
+  content_type: string | null;
+}
+
+export interface DesktopRelease {
+  tag: string;
+  name: string | null;
+  html_url: string;
+  published_at: string | null;
+  assets: DesktopReleaseAsset[];
+}

--- a/apps/web/src/hooks/ui/usePlatformDetection.ts
+++ b/apps/web/src/hooks/ui/usePlatformDetection.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { desktopApi } from "@/features/download/api/desktopApi";
+import type { DesktopRelease } from "@/features/download/types";
 
 export type Platform =
   | "mac-arm"
@@ -10,6 +12,9 @@ export type Platform =
   | "ios"
   | "android"
   | "unknown";
+
+export type DesktopOS = "mac" | "windows" | "linux";
+export type DesktopArch = "x64" | "arm64";
 
 export interface PlatformInfo {
   platform: Platform;
@@ -21,30 +26,97 @@ export interface PlatformInfo {
   isMobile: boolean;
 }
 
+export interface DesktopVariant {
+  os: DesktopOS;
+  arch: DesktopArch;
+  label: string;
+  description: string;
+  /** Direct asset URL, or null when this binary isn't published in the release. */
+  downloadUrl: string | null;
+}
+
 const GITHUB_RELEASES_BASE =
   "https://github.com/theexperiencecompany/gaia/releases";
-const GITHUB_RELEASES_API =
-  "https://api.github.com/repos/theexperiencecompany/gaia/releases?per_page=10";
 
-// GitHub's global "latest" release tracks the web app, not desktop, so we
-// resolve the newest tag starting with `desktop-` at runtime. If that fetch
-// fails, buttons fall back to this filtered releases page.
-const DESKTOP_RELEASES_FALLBACK = `${GITHUB_RELEASES_BASE}?q=desktop&expanded=true`;
+// Expected asset filename per (OS, arch). Mirrors apps/desktop/electron-builder.yml
+// `artifactName: "${productName}-${arch}.${ext}"`. Linux x64 ships as the x86_64
+// AppImage. Download URLs are resolved by matching these names against the real
+// published assets, so a missing binary (e.g. Windows arm64, not yet built)
+// resolves to null and is simply not offered — never a 404.
+const DESKTOP_ASSET_NAMES: Record<DesktopOS, Record<DesktopArch, string>> = {
+  mac: { x64: "GAIA-x64.dmg", arm64: "GAIA-arm64.dmg" },
+  windows: { x64: "GAIA-x64.exe", arm64: "GAIA-arm64.exe" },
+  linux: { x64: "GAIA-x86_64.AppImage", arm64: "GAIA-arm64.AppImage" },
+};
 
+const DESKTOP_VARIANT_META: Record<
+  DesktopOS,
+  Record<DesktopArch, { label: string; description: string }>
+> = {
+  mac: {
+    x64: { label: "Intel", description: "For Macs with an Intel processor" },
+    arm64: {
+      label: "Apple Silicon",
+      description: "For Macs with M1, M2, M3, or M4 chips",
+    },
+  },
+  windows: {
+    x64: { label: "x64", description: "For 64-bit Intel or AMD processors" },
+    arm64: { label: "ARM64", description: "For Windows on ARM devices" },
+  },
+  linux: {
+    x64: { label: "x64", description: "For 64-bit Intel or AMD processors" },
+    arm64: { label: "ARM64", description: "For 64-bit ARM processors" },
+  },
+};
+
+const DESKTOP_OS_ORDER: DesktopArch[] = ["x64", "arm64"];
+
+function resolveAssetUrl(
+  release: DesktopRelease | null,
+  assetName: string,
+): string | null {
+  if (!release) return null;
+  return (
+    release.assets.find((asset) => asset.name === assetName)?.download_url ??
+    null
+  );
+}
+
+function buildDesktopDownloads(
+  release: DesktopRelease | null,
+): Record<DesktopOS, DesktopVariant[]> {
+  const forOs = (os: DesktopOS): DesktopVariant[] =>
+    DESKTOP_OS_ORDER.map((arch) => ({
+      os,
+      arch,
+      label: DESKTOP_VARIANT_META[os][arch].label,
+      description: DESKTOP_VARIANT_META[os][arch].description,
+      downloadUrl: resolveAssetUrl(release, DESKTOP_ASSET_NAMES[os][arch]),
+    }));
+
+  return {
+    mac: forOs("mac"),
+    windows: forOs("windows"),
+    linux: forOs("linux"),
+  };
+}
+
+// Legacy PlatformInfo map kept for consumers that key off a single Platform
+// (e.g. the settings download submenu). Mac keeps its two arch entries; Windows
+// and Linux expose their x64 build as the default single-click download.
 function buildPlatformConfigs(
-  tag: string | null,
+  downloads: Record<DesktopOS, DesktopVariant[]>,
 ): Record<Platform, Omit<PlatformInfo, "platform">> {
-  const desktopUrl = (asset: string) =>
-    tag
-      ? `${GITHUB_RELEASES_BASE}/download/${tag}/${asset}`
-      : DESKTOP_RELEASES_FALLBACK;
+  const url = (os: DesktopOS, arch: DesktopArch): string | null =>
+    downloads[os].find((v) => v.arch === arch)?.downloadUrl ?? null;
 
   return {
     "mac-arm": {
       displayName: "macOS (Apple Silicon)",
       shortName: "Mac (M-series)",
       iconPath: "/images/icons/apple.svg",
-      downloadUrl: desktopUrl("GAIA-arm64.dmg"),
+      downloadUrl: url("mac", "arm64"),
       isDesktop: true,
       isMobile: false,
     },
@@ -52,7 +124,7 @@ function buildPlatformConfigs(
       displayName: "macOS (Intel)",
       shortName: "Mac (Intel)",
       iconPath: "/images/icons/apple.svg",
-      downloadUrl: desktopUrl("GAIA-x64.dmg"),
+      downloadUrl: url("mac", "x64"),
       isDesktop: true,
       isMobile: false,
     },
@@ -60,7 +132,7 @@ function buildPlatformConfigs(
       displayName: "Windows",
       shortName: "Windows",
       iconPath: "/images/icons/windows.svg",
-      downloadUrl: desktopUrl("GAIA-x64.exe"),
+      downloadUrl: url("windows", "x64"),
       isDesktop: true,
       isMobile: false,
     },
@@ -68,7 +140,7 @@ function buildPlatformConfigs(
       displayName: "Linux",
       shortName: "Linux",
       iconPath: "/images/icons/linux.svg",
-      downloadUrl: desktopUrl("GAIA-x86_64.AppImage"),
+      downloadUrl: url("linux", "x64"),
       isDesktop: true,
       isMobile: false,
     },
@@ -92,44 +164,58 @@ function buildPlatformConfigs(
       displayName: "Desktop",
       shortName: "Desktop",
       iconPath: "/images/icons/apple.svg",
-      downloadUrl: tag
-        ? `${GITHUB_RELEASES_BASE}/tag/${tag}`
-        : DESKTOP_RELEASES_FALLBACK,
+      downloadUrl: null,
       isDesktop: true,
       isMobile: false,
     },
   };
 }
 
-interface GithubRelease {
-  tag_name: string;
-  draft: boolean;
-  prerelease: boolean;
+function detectedDesktopOf(
+  platform: Platform,
+): { os: DesktopOS; arch: DesktopArch } | null {
+  switch (platform) {
+    case "mac-arm":
+      return { os: "mac", arch: "arm64" };
+    case "mac-intel":
+      return { os: "mac", arch: "x64" };
+    case "windows":
+      return { os: "windows", arch: "x64" };
+    case "linux":
+      return { os: "linux", arch: "x64" };
+    default:
+      return null;
+  }
 }
 
-function useLatestDesktopTag(): string | null {
-  const [tag, setTag] = useState<string | null>(null);
+function useLatestDesktopRelease(): {
+  release: DesktopRelease | null;
+  isLoading: boolean;
+} {
+  const [release, setRelease] = useState<DesktopRelease | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const controller = new AbortController();
-    fetch(GITHUB_RELEASES_API, {
-      headers: { Accept: "application/vnd.github+json" },
-      signal: controller.signal,
-    })
-      .then((r) => (r.ok ? (r.json() as Promise<GithubRelease[]>) : null))
-      .then((releases) => {
-        if (!releases) return;
-        const desktop = releases.find(
-          (r) => r.tag_name.startsWith("desktop-") && !r.draft && !r.prerelease,
-        );
-        if (desktop) setTag(desktop.tag_name);
+    let active = true;
+    desktopApi
+      .getLatestRelease()
+      .then((data) => {
+        if (active) setRelease(data);
       })
-      .catch(() => {});
-
-    return () => controller.abort();
+      .catch((error) => {
+        // Degrade gracefully: buttons fall back to the GitHub releases page.
+        // Logged (console.error survives prod stripping) so an outage is visible.
+        console.error("Failed to resolve latest desktop release", error);
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
   }, []);
 
-  return tag;
+  return { release, isLoading };
 }
 
 function detectPlatform(): Platform {
@@ -184,16 +270,21 @@ function detectPlatform(): Platform {
 export function usePlatformDetection() {
   const [platform, setPlatform] = useState<Platform>("unknown");
   const [isLoading, setIsLoading] = useState(true);
-  const desktopTag = useLatestDesktopTag();
+  const { release, isLoading: isDesktopReleaseLoading } =
+    useLatestDesktopRelease();
 
   useEffect(() => {
     setPlatform(detectPlatform());
     setIsLoading(false);
   }, []);
 
+  const desktopDownloads = useMemo(
+    () => buildDesktopDownloads(release),
+    [release],
+  );
   const platformConfigs = useMemo(
-    () => buildPlatformConfigs(desktopTag),
-    [desktopTag],
+    () => buildPlatformConfigs(desktopDownloads),
+    [desktopDownloads],
   );
 
   const currentPlatform: PlatformInfo = {
@@ -201,37 +292,21 @@ export function usePlatformDetection() {
     ...platformConfigs[platform],
   };
 
-  const allPlatforms: PlatformInfo[] = Object.entries(platformConfigs)
+  const desktopPlatforms: PlatformInfo[] = Object.entries(platformConfigs)
     .filter(([key]) => key !== "unknown")
-    .map(([key, config]) => ({
-      platform: key as Platform,
-      ...config,
-    }));
-
-  const desktopPlatforms = allPlatforms.filter((p) => p.isDesktop);
-  const mobilePlatforms = allPlatforms.filter((p) => p.isMobile);
-
-  // Get platforms sorted with current platform first (for desktop)
-  const sortedDesktopPlatforms = [
-    ...desktopPlatforms.filter((p) => p.platform === platform),
-    ...desktopPlatforms.filter((p) => p.platform !== platform),
-  ];
+    .map(([key, config]) => ({ platform: key as Platform, ...config }))
+    .filter((p) => p.isDesktop);
 
   return {
     platform,
-    platformConfigs,
     currentPlatform,
-    allPlatforms,
     desktopPlatforms,
-    mobilePlatforms,
-    sortedDesktopPlatforms,
+    desktopDownloads,
+    detectedDesktop: detectedDesktopOf(platform),
     isLoading,
-    isMac: platform === "mac-arm" || platform === "mac-intel",
-    isWindows: platform === "windows",
-    isLinux: platform === "linux",
-    isMobile: platform === "ios" || platform === "android",
+    isDesktopReleaseLoading,
   };
 }
 
-// Export platform configs for use in server components
+// Exposed for the download page's SEO schema and the "All releases" link.
 export { GITHUB_RELEASES_BASE };

--- a/apps/web/src/hooks/ui/usePlatformDetection.ts
+++ b/apps/web/src/hooks/ui/usePlatformDetection.ts
@@ -3,37 +3,21 @@
 import { useEffect, useMemo, useState } from "react";
 import { desktopApi } from "@/features/download/api/desktopApi";
 import type { DesktopRelease } from "@/features/download/types";
+import type {
+  DesktopArch,
+  DesktopOS,
+  DesktopVariant,
+  Platform,
+  PlatformInfo,
+} from "./usePlatformDetection.types";
 
-export type Platform =
-  | "mac-arm"
-  | "mac-intel"
-  | "windows"
-  | "linux"
-  | "ios"
-  | "android"
-  | "unknown";
-
-export type DesktopOS = "mac" | "windows" | "linux";
-export type DesktopArch = "x64" | "arm64";
-
-export interface PlatformInfo {
-  platform: Platform;
-  displayName: string;
-  shortName: string;
-  iconPath: string;
-  downloadUrl: string | null;
-  isDesktop: boolean;
-  isMobile: boolean;
-}
-
-export interface DesktopVariant {
-  os: DesktopOS;
-  arch: DesktopArch;
-  label: string;
-  description: string;
-  /** Direct asset URL, or null when this binary isn't published in the release. */
-  downloadUrl: string | null;
-}
+export type {
+  DesktopArch,
+  DesktopOS,
+  DesktopVariant,
+  Platform,
+  PlatformInfo,
+} from "./usePlatformDetection.types";
 
 const GITHUB_RELEASES_BASE =
   "https://github.com/theexperiencecompany/gaia/releases";

--- a/apps/web/src/hooks/ui/usePlatformDetection.types.ts
+++ b/apps/web/src/hooks/ui/usePlatformDetection.types.ts
@@ -1,0 +1,30 @@
+export type Platform =
+  | "mac-arm"
+  | "mac-intel"
+  | "windows"
+  | "linux"
+  | "ios"
+  | "android"
+  | "unknown";
+
+export type DesktopOS = "mac" | "windows" | "linux";
+export type DesktopArch = "x64" | "arm64";
+
+export interface PlatformInfo {
+  platform: Platform;
+  displayName: string;
+  shortName: string;
+  iconPath: string;
+  downloadUrl: string | null;
+  isDesktop: boolean;
+  isMobile: boolean;
+}
+
+export interface DesktopVariant {
+  os: DesktopOS;
+  arch: DesktopArch;
+  label: string;
+  description: string;
+  /** Direct asset URL, or null when this binary isn't published in the release. */
+  downloadUrl: string | null;
+}


### PR DESCRIPTION
## Problem

Going to `/download` and clicking **Download for Windows** (or Mac/Linux) dumps the user on the raw GitHub releases page instead of downloading the binary — surfaced by a user on a university network.

**Root cause (deterministic, not flaky):** the buttons resolve the latest desktop release client-side from the GitHub API with `?per_page=10`. Every monorepo app publishes into one releases feed, so the 10 most recent releases are all `web`/`api`/`cli`/`bots`/`mobile` and the newest `desktop-*` tag sits at index **[10]** — just past the cutoff. Resolution returns `null` and every button falls back to `releases?q=desktop&expanded=true`.

```
[0] web-v0.20.0 ... [9] mobile-v0.5.0   ← per_page=10 sees only these
[10] desktop-v0.3.0                       ← the desktop release, out of reach
```

A second latent failure: the client hits GitHub **unauthenticated** (60 req/hr **per IP**), so a shared/NAT'd network (office, university) can exhaust it and break downloads for everyone behind it.

## Fix

Move release resolution into our API and drive the UI from the **real** published assets.

### Backend (`apps/api`)
- New public `GET /desktop/releases/latest` — fetches GitHub with `per_page=100`, returns the newest non-draft `desktop-*` tag + its asset list.
- Cached in Redis (30 min) via `@Cacheable`; uses `GITHUB_TOKEN` (5000/hr) so shared IPs can't exhaust the limit.
- Added `/api/v1/desktop/releases` to the WorkOS auth allowlist — scoped so the authed `/desktop/tool-result` bridge stays protected.

### Frontend (`apps/web`)
- `usePlatformDetection` now calls our API and resolves each platform/arch URL by **matching real asset names**. A missing binary resolves to `null` and is simply not offered — never a 404. Falls back to the GitHub releases page if the lookup fails.
- Replaced the Mac-only chip chooser + separate Windows/Linux buttons with **one** arch-aware `DesktopDownloadButton(os)` that shows an x64/ARM picker when >1 binary is published and a single button otherwise. `SettingsMenu`'s hook API is unchanged.

## Result (verified against the live `desktop-v0.3.0` release)

| Platform | Behaviour |
|---|---|
| macOS | Chooser: Intel + Apple Silicon |
| Linux | Chooser: x64 + ARM64 _(previously x64-only)_ |
| Windows | Single x64 button — ARM64 hidden (not published), auto-becomes a chooser once built |

## Out of scope (separate follow-up)
`electron-builder.yml` lists Windows arm64 as a target, but `desktop-v0.3.0` ships no `GAIA-arm64.exe`. The UI auto-shows the Windows chooser the moment that artifact is published — but the desktop **build/CI** needs to actually produce & upload it.

## Verification
- `nx lint api` ✓, mypy on changed files ✓
- `nx run web:type-check` ✓, biome on changed files clean ✓
- Simulated full resolution (backend selection + frontend asset mapping) against the live GitHub release — all targets resolve correctly, Windows ARM correctly hidden.

## Testing notes
No tests added (per repo convention). To verify manually: load `/download` and confirm each platform downloads the binary directly; check `GET /api/v1/desktop/releases/latest` returns `desktop-v0.3.0` + assets without auth.