### PR TITLE
fix: ARQ worker JuiceFS-wedge resilience + cut embedding-sidecar memory

### DIFF
--- a/apps/api/app/constants/memory.py
+++ b/apps/api/app/constants/memory.py
@@ -25,7 +25,10 @@ RERANKER_MODEL_NAME = "jinaai/jina-reranker-v1-turbo-en"
 # ONNX CPU mem arena retains buffers to fill RAM (~5GB for ~2GB of weights); off
 # keeps RSS near model size. Thread cap bounds per-thread arenas. Vectors unchanged.
 ONNX_ENABLE_CPU_MEM_ARENA = os.getenv("MEMORY_ONNX_CPU_MEM_ARENA", "0") == "1"
-ONNX_INTRA_OP_THREADS = int(os.getenv("MEMORY_ONNX_THREADS", "4"))
+try:
+    ONNX_INTRA_OP_THREADS = max(1, int(os.getenv("MEMORY_ONNX_THREADS", "4")))
+except ValueError:
+    ONNX_INTRA_OP_THREADS = 4
 
 # Optional embedding/reranking sidecar. When this env var holds the sidecar's
 # base URL, embed/rerank become HTTP calls so the ~1.8GB of model weights load

--- a/apps/api/app/constants/memory.py
+++ b/apps/api/app/constants/memory.py
@@ -22,6 +22,11 @@ _COLLECTION_SUFFIX = os.getenv("GAIA_CHROMA_COLLECTION_SUFFIX", "")
 # fact): top-3 gold rank 4/6 vs 2/6 on our probe set at the same ~30ms.
 RERANKER_MODEL_NAME = "jinaai/jina-reranker-v1-turbo-en"
 
+# ONNX CPU mem arena retains buffers to fill RAM (~5GB for ~2GB of weights); off
+# keeps RSS near model size. Thread cap bounds per-thread arenas. Vectors unchanged.
+ONNX_ENABLE_CPU_MEM_ARENA = os.getenv("MEMORY_ONNX_CPU_MEM_ARENA", "0") == "1"
+ONNX_INTRA_OP_THREADS = int(os.getenv("MEMORY_ONNX_THREADS", "4"))
+
 # Optional embedding/reranking sidecar. When this env var holds the sidecar's
 # base URL, embed/rerank become HTTP calls so the ~1.8GB of model weights load
 # ONCE for the deployment instead of in every process. Unset = load locally.

--- a/apps/api/app/memory/embeddings.py
+++ b/apps/api/app/memory/embeddings.py
@@ -35,6 +35,8 @@ from app.constants.memory import (
     EMBEDDING_SIDECAR_TIMEOUT_SECONDS,
     EMBEDDING_SIDECAR_URL_ENV,
     MODEL_CACHE_DIR,
+    ONNX_ENABLE_CPU_MEM_ARENA,
+    ONNX_INTRA_OP_THREADS,
     RERANKER_MODEL_NAME,
 )
 from shared.py.wide_events import log
@@ -80,7 +82,10 @@ def _get_embedding_model() -> TextEmbedding:
             if _embedding_model is None:
                 started = time.perf_counter()
                 _embedding_model = TextEmbedding(
-                    model_name=EMBEDDING_MODEL_NAME, cache_dir=MODEL_CACHE_DIR
+                    model_name=EMBEDDING_MODEL_NAME,
+                    cache_dir=MODEL_CACHE_DIR,
+                    threads=ONNX_INTRA_OP_THREADS,
+                    enable_cpu_mem_arena=ONNX_ENABLE_CPU_MEM_ARENA,
                 )
                 log.info(
                     f"Loaded memory embedding model {EMBEDDING_MODEL_NAME} "
@@ -97,7 +102,10 @@ def _get_reranker_model() -> TextCrossEncoder:
             if _reranker_model is None:
                 started = time.perf_counter()
                 _reranker_model = TextCrossEncoder(
-                    model_name=RERANKER_MODEL_NAME, cache_dir=MODEL_CACHE_DIR
+                    model_name=RERANKER_MODEL_NAME,
+                    cache_dir=MODEL_CACHE_DIR,
+                    threads=ONNX_INTRA_OP_THREADS,
+                    enable_cpu_mem_arena=ONNX_ENABLE_CPU_MEM_ARENA,
                 )
                 log.info(
                     f"Loaded memory reranker model {RERANKER_MODEL_NAME} "

--- a/apps/api/app/services/storage/bootstrap.py
+++ b/apps/api/app/services/storage/bootstrap.py
@@ -44,6 +44,8 @@ from shared.py.wide_events import log
 
 _ENCRYPTION_KEY_FILE = Path("/etc/gaia/jfs-master.pem")
 _CACHE_DIR = Path("/var/cache/juicefs")
+# A stat on an unresponsive FUSE mount blocks forever; bound the startup probe.
+_MOUNT_PROBE_TIMEOUT_SECONDS = 10
 _CACHE_SIZE_MB = 4096
 _BUFFER_SIZE_MB = 600
 _MAX_UPLOADS = 20
@@ -381,11 +383,28 @@ async def init_juicefs_mount() -> str:
         log.info("[juicefs] skipping bootstrap; missing settings: " + ", ".join(missing))
         return settings.JUICEFS_HOST_MOUNT_PATH
 
+    # Probe off the event loop with a timeout — a wedged FUSE mount blocks forever
+    # and running this inline previously froze the worker before it consumed jobs.
+    mount_path = Path(settings.JUICEFS_HOST_MOUNT_PATH)
+    try:
+        already_mounted = await asyncio.wait_for(
+            asyncio.to_thread(_is_mounted, mount_path),
+            timeout=_MOUNT_PROBE_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        log.warning(
+            "[juicefs] mount probe timed out after %ss — mount likely unresponsive; "
+            "(re)starting bootstrap",
+            _MOUNT_PROBE_TIMEOUT_SECONDS,
+        )
+        already_mounted = False
+
+    if already_mounted:
+        log.info("[juicefs] mount already healthy")
+        return settings.JUICEFS_HOST_MOUNT_PATH
+
     with _bootstrap_lock:
         if _bootstrap_thread is not None and _bootstrap_thread.is_alive():
-            return settings.JUICEFS_HOST_MOUNT_PATH
-        if _is_mounted(Path(settings.JUICEFS_HOST_MOUNT_PATH)):
-            log.info("[juicefs] mount already healthy")
             return settings.JUICEFS_HOST_MOUNT_PATH
         _bootstrap_thread = threading.Thread(
             target=_bootstrap_loop,

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -102,7 +102,7 @@ services:
       restart_policy:
         condition: any
         delay: 5s
-        max_attempts: 3
+        # No max_attempts: a crash/OOM loop must self-heal, not park at 0/N.
       resources:
         limits:
           memory: 4G
@@ -146,10 +146,13 @@ services:
         aliases:
           - arq_worker
     healthcheck:
-      test: ["CMD", "python", "-c", "import socket; socket.create_connection(('redis', 6379), timeout=5)"]
+      # arq --check fails when the poll loop stops refreshing its health key (a
+      # wedged worker); the old Redis-socket probe passed even when frozen.
+      test: ["CMD", "arq", "app.worker.WorkerSettings", "--check"]
       interval: 30s
       timeout: 10s
-      retries: 5
+      retries: 3
+      start_period: 120s
     deploy:
       replicas: 1
       update_config:
@@ -165,7 +168,7 @@ services:
       restart_policy:
         condition: any
         delay: 5s
-        max_attempts: 3
+        # No max_attempts: a wedged/crashed worker must self-heal, not park at 0/1.
       resources:
         limits:
           memory: 2G
@@ -884,7 +887,7 @@ services:
       restart_policy:
         condition: any
         delay: 5s
-        max_attempts: 3
+        # No max_attempts: a crash/OOM loop must self-heal, not park at 0/N.
       resources:
         limits:
           # VAD + turn-detector models live in each forked job process.

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -176,13 +176,10 @@ services:
   # ---------------------------------------------------------------------------
   # Embedding + reranking sidecar
   # ---------------------------------------------------------------------------
-  # Loads the fastembed models (mxbai embedder + jina reranker, ~1.85GB) ONCE
-  # so gaia-backend and arq_worker share a single copy over HTTP instead of each
-  # loading their own. Without this, the worker alone (2G limit) would OOM just
-  # loading the models. Memory limit is 2.5G: the footprint is ~1.85GB and stays
-  # flat under batched load (measured +24MB for a 25-text batch), so 2.5G is a
-  # runaway ceiling with real headroom — capping below 2G would OOM-kill it
-  # since the model can't even load in under ~1.85GB.
+  # Loads the fastembed models (mxbai embedder + jina reranker, ~2GB) ONCE so
+  # gaia-backend and arq_worker share one copy over HTTP instead of each loading
+  # their own. Memory: with the ONNX CPU mem arena OFF (see embeddings.py) RSS
+  # settles near the ~2GB weights; 3G limit leaves headroom over the ~2.4GB peak.
   embedding-sidecar:
     image: ghcr.io/theexperiencecompany/gaia:latest
     working_dir: /app/apps/api
@@ -197,6 +194,8 @@ services:
       # Persist the ~1.85GB fastembed weights so they download ONCE, not on every
       # restart/redeploy (measured ~148s cold-load). Mounted volume below.
       MEMORY_MODEL_CACHE_DIR: /models
+      # Cap glibc malloc arenas (complements the ONNX arena being off).
+      MALLOC_ARENA_MAX: "2"
       # MEMORY_EMBEDDING_SIDECAR_URL MUST stay unset here so the sidecar serves
       # from its own local models rather than calling itself.
     secrets:
@@ -239,9 +238,9 @@ services:
           # with batch_size, up to 40). The old 2560M cap sat below that, so
           # the kernel OOM-killed it (exit 137) on first real traffic. 5G gives
           # headroom; host has 15 GiB total / ~10 GiB free.
-          memory: 5120M
+          memory: 3072M
         reservations:
-          memory: 3G
+          memory: 2G
 
   # ---------------------------------------------------------------------------
   # Bots


### PR DESCRIPTION
Two prod-resilience fixes (folded together — both touch `docker-compose.prod.yml`).

## 1. ARQ worker freeze on unresponsive JuiceFS + self-heal

The worker silently stopped processing **all** scheduled workflows/reminders for ~6 days (88 users, 251+ tasks). `unified_startup` eagerly inits the JuiceFS mount provider, which calls `_is_mounted()` **synchronously on the event loop**; on an unresponsive FUSE mount that `stat()` blocks forever (`request_wait_answer`), freezing the loop before the worker consumes anything — while the Redis-socket healthcheck still reported `Up (healthy)`.

- **`bootstrap.py`** — run the startup mount probe off the event loop with a 10s timeout.
- **compose** — `arq_worker` healthcheck → `arq app.worker.WorkerSettings --check` (fails when the poll loop stops refreshing its health key) + `start_period: 120s`. Verified in OrbStack: passes when consuming, fails when dead/frozen.
- **compose** — drop `restart_policy.max_attempts` on `arq_worker`, `gaia-backend`, `voice-agent-worker` (a crash/OOM loop should self-heal, not park at 0/N).

## 2. Embedding-sidecar memory ~5GB → ~2GB

The fastembed models are ~2GB but the sidecar pegged at its 5GB limit: ONNX's CPU memory arena grows to the peak activation size and never returns it to the OS, so RSS ratchets up to fill available memory.

- **`embeddings.py` / `constants/memory.py`** — load both models with `enable_cpu_mem_arena=False` + capped `threads` (env-overridable). RSS settles near model size; **output vectors are unchanged** (pure allocator config). Measured: settled ~1.4GB / peak ~2.35GB for the embedder, vs 5GB before.
- **compose** — `MALLOC_ARENA_MAX=2`; sidecar memory limit `5120M → 3072M`.

## Deploy notes
- Compose changes take effect on `docker stack deploy`.
- The `bootstrap.py` / `embeddings.py` changes need a new image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)