### PR TITLE
fix(whatsapp): template fallback on any free-form failure (not just code 131047)

### DIFF
--- a/apps/bots/whatsapp/src/adapter.ts
+++ b/apps/bots/whatsapp/src/adapter.ts
@@ -37,14 +37,13 @@ import {
   sanitizeErrorForLog,
   unsupportedMediaMessage,
 } from "@gaia/shared";
-import { GraphApiError, WhatsAppClient } from "@kapso/whatsapp-cloud-api";
+import { WhatsAppClient } from "@kapso/whatsapp-cloud-api";
 import {
   NOTIFICATION_TEMPLATE_LANGUAGE,
   NOTIFICATION_TEMPLATE_NAME,
   NOTIFICATION_TEMPLATE_PARAM_NAME,
   REPLAY_WINDOW_MS,
   TEMPLATE_BODY_MAX_LENGTH,
-  WHATSAPP_REENGAGEMENT_ERROR_CODE,
 } from "./constants";
 import {
   extractMedia,
@@ -79,25 +78,6 @@ function loadWhatsAppConfig(): WhatsAppConfig {
   if (!kapsoWebhookSecret) throw new Error("KAPSO_WEBHOOK_SECRET is required");
 
   return { kapsoApiKey, kapsoPhoneNumberId, kapsoWebhookSecret };
-}
-
-/**
- * True when Meta rejected a free-form message because it was sent outside the
- * 24-hour customer-service window (Graph API error 131047) — the signal to
- * retry delivery through an approved message template.
- *
- * Deliberately matches the exact error code rather than the broader
- * `reengagementWindow` error category: 131047 is the canonical "closed window"
- * rejection, and only it is reliably recoverable by resending as a template.
- * Sibling category codes (e.g. undeliverable / unsupported-type) are different
- * failures that templating would not fix, so they fall through to the
- * consumer's normal retry/dead-letter path instead.
- */
-function isReengagementWindowError(err: unknown): boolean {
-  return (
-    err instanceof GraphApiError &&
-    err.code === WHATSAPP_REENGAGEMENT_ERROR_CODE
-  );
 }
 
 /**
@@ -814,12 +794,13 @@ export class WhatsAppAdapter extends BaseBotAdapter {
     try {
       await this.sendWhatsAppText(destinationId, text);
     } catch (err) {
-      if (!isReengagementWindowError(err)) throw err;
-      // The 24-hour customer-service window is closed, so Meta rejected the
-      // free-form message. Fall back to the approved utility template, which can
-      // be delivered any time, so proactive notifications still reach the user.
-      this.adapterLogger.info("outbound_reengagement_template_fallback", {
+      // Free-form send failed — most often the 24-hour window is closed. Fall
+      // back to the approved template (sendable any time); if it also fails it
+      // rethrows so the consumer dead-letters it. The original error is logged
+      // so a non-window failure stays visible.
+      this.adapterLogger.info("outbound_template_fallback", {
         wa_hash: hashLogIdentifier(destinationId),
+        ...sanitizeErrorForLog(err),
       });
       await this.sendNotificationTemplate(destinationId, text);
     }

--- a/apps/bots/whatsapp/src/constants.ts
+++ b/apps/bots/whatsapp/src/constants.ts
@@ -6,15 +6,9 @@
 export const REPLAY_WINDOW_MS = 5 * 60 * 1000;
 
 /**
- * Meta Graph API error code returned when a free-form message is sent outside
- * the 24-hour customer-service window. This is the signal to fall back to an
- * approved message template, which can be delivered at any time.
- */
-export const WHATSAPP_REENGAGEMENT_ERROR_CODE = 131047;
-
-/**
- * Approved utility template used to deliver proactive notifications when the
- * 24-hour window is closed. Single body variable named `body`.
+ * Approved utility template used to deliver proactive notifications when a
+ * free-form send fails (e.g. the 24-hour window is closed). Single body
+ * variable named `body`.
  */
 export const NOTIFICATION_TEMPLATE_NAME = "gaia_notification";
 export const NOTIFICATION_TEMPLATE_LANGUAGE = "en_US";


### PR DESCRIPTION
## Problem

Proactive WhatsApp notifications silently never arrived when the recipient's 24-hour customer-service window was closed. The bot tried a free-form send, Meta rejected it (`GraphApiError: "Cannot send non-template messages outside the 24-hour window."`), and the template fallback existed — but it only fired when `err.code === 131047` exactly. In prod that guard never matched (no `outbound_reengagement_template_fallback` log ever appeared), so the message fell through to dead-letter and the user got nothing. We also never logged the error `code`/`category` (the shared serializer keeps only name+message), so the real code was invisible.

## Fix

`deliverOutbound` now falls back to the approved `gaia_notification` template on **any** free-form send failure, instead of pattern-matching Meta's error. The template is the designated notification fallback and is sendable any time, so attempting it can only add successful deliveries; if it *also* fails it rethrows and the consumer dead-letters exactly as before. The original free-form error is logged (`outbound_template_fallback` + `sanitizeErrorForLog`) so a genuinely different failure stays visible.

Removes the brittle `isReengagementWindowError` guard and the now-dead `WHATSAPP_REENGAGEMENT_ERROR_CODE` constant.

## Validation
- `nx type-check bot-whatsapp` ✓, `nx lint bot-whatsapp` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)