### PR TITLE
fix(storage): mypy call-arg in juicefs mount-probe timeout warning

### DIFF
--- a/apps/api/app/services/storage/bootstrap.py
+++ b/apps/api/app/services/storage/bootstrap.py
@@ -393,9 +393,8 @@ async def init_juicefs_mount() -> str:
         )
     except TimeoutError:
         log.warning(
-            "[juicefs] mount probe timed out after %ss — mount likely unresponsive; "
-            "(re)starting bootstrap",
-            _MOUNT_PROBE_TIMEOUT_SECONDS,
+            f"[juicefs] mount probe timed out after {_MOUNT_PROBE_TIMEOUT_SECONDS}s — "
+            "mount likely unresponsive; (re)starting bootstrap"
         )
         already_mounted = False
 


### PR DESCRIPTION
## Problem

CI `Python mypy (staged-strict)` fails on `develop`:

```
apps/api/app/services/storage/bootstrap.py:395:9: error: Too many arguments for "warning" of "WideEventLogger"  [call-arg]
```

`WideEventLogger.warning(message: str, **kwargs)` takes no positional format args, but the call used `%s`-style interpolation and passed `_MOUNT_PROBE_TIMEOUT_SECONDS` as a second positional argument.

## Fix

Interpolate via an f-string — the same style used by the other `log.warning` calls in this file. No behavioral change to the emitted message.

Verified with `uv run mypy app/services/storage/bootstrap.py` → no issues.