### PR TITLE
fix(web): keep desktop-only wake-word out of the Cloudflare Worker bu…

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -39,6 +39,14 @@ const useCloudflareImageLoader = process.env.IMAGE_LOADER === "cloudflare";
 
 const nextConfig = {
   productionBrowserSourceMaps: true,
+  // OpenNext file-traces every `public/*.wasm` into the Worker as a wasm chunk
+  // (it shows up even in unrelated routes' .nft.json), which collects the
+  // desktop-only ~12 MiB wake-word WASM into the Worker script and blows past
+  // Cloudflare's 10 MiB limit. Exclude it from tracing on the Cloudflare build;
+  // the Electron standalone build copies `public/` wholesale and is unaffected.
+  ...(useCloudflareImageLoader
+    ? { outputFileTracingExcludes: { "*": ["**/public/wake-word/**"] } }
+    : {}),
   compiler: {
     removeConsole:
       process.env.NODE_ENV === "production"
@@ -64,6 +72,19 @@ const nextConfig = {
     // and:  https://nextjs-forum.com/post/1471409705514569798
     resolveAlias: {
       "@icons": "@theexperiencecompany/gaia-icons/solid-rounded",
+      // The wake-word ONNX runtime (onnxruntime-web + its ~12 MiB WASM) is
+      // desktop-only: the `/wake-listener` route runs solely in the Electron
+      // shell. On Cloudflare, Turbopack still pulls onnxruntime's WASM loader
+      // into the route's server chunk, and the WASM gets collected into the
+      // Worker script — pushing it past Cloudflare's 10 MiB limit. Stub it out
+      // for the Cloudflare build only; the standalone build Electron bundles
+      // (IMAGE_LOADER unset) keeps the real runtime.
+      ...(useCloudflareImageLoader
+        ? {
+            "onnxruntime-web": "./scripts/empty-module.mjs",
+            "onnxruntime-web/wasm": "./scripts/empty-module.mjs",
+          }
+        : {}),
       // Stub out unused heavy deps (mirrors the webpack hook below). Webpack's
       // `alias: false` doesn't exist for Turbopack — we point to a tiny empty
       // module that exports a no-op proxy.
@@ -141,6 +162,13 @@ const nextConfig = {
     // Alias @icons to the active icon variant — change here to swap the entire set
     config.resolve.alias["@icons"] =
       "@theexperiencecompany/gaia-icons/solid-rounded";
+
+    // Desktop-only wake-word ONNX runtime — stub out of the Cloudflare build
+    // so its WASM never lands in the Worker script (see turbopack alias above).
+    if (useCloudflareImageLoader) {
+      config.resolve.alias["onnxruntime-web"] = false;
+      config.resolve.alias["onnxruntime-web/wasm"] = false;
+    }
 
     // Keep gaia-icons out of the eager/initial landing chunk.
     // By default, modules reachable from >= 2 chunks get hoisted into a shared

--- a/apps/web/scripts/prune-desktop-assets.mjs
+++ b/apps/web/scripts/prune-desktop-assets.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Remove desktop-only assets from the Cloudflare Workers Static Assets dir.
+ * Remove desktop-only assets from the Cloudflare build output.
  *
  * Why: `public/` is shared by every build target, but some assets are only
  * ever served to the Electron desktop shell — which loads them from its OWN
@@ -13,42 +13,75 @@
  *    exclusively by Electron;
  *  - the dev-only `/dev/wake-word` page is stripped from production builds.
  * That makes `public/wake-word/` (~17 MiB: a 12 MiB WASM binary + ONNX
- * models) unreachable on the web. Pruning it also keeps the deploy under
- * Cloudflare's 25 MiB per-asset limit with margin to spare.
+ * models) unreachable on the web.
  *
- * This only touches `.open-next/assets` (the Cloudflare output). The
- * standalone build Electron bundles keeps `public/wake-word/` intact.
+ * OpenNext copies `public/` into TWO places, and the wake-word tree must be
+ * removed from both:
+ *  - `.open-next/assets/` — the Workers Static Assets layer (25 MiB
+ *    per-file limit; the 25 MiB JSEP wasm tripped this).
+ *  - `.open-next/server-functions/<fn>/apps/web/public/` — bundled INTO the
+ *    Worker script (10 MiB total-script limit; the 12.7 MiB CPU wasm tripped
+ *    this). This is the copy the Node server would read at runtime, which on
+ *    Cloudflare never happens for these files.
+ *
+ * The standalone build Electron bundles is produced separately and keeps
+ * `public/wake-word/` intact.
  *
  * Run AFTER `opennextjs-cloudflare build`, alongside promote-static.
  */
-import { existsSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const ASSETS_DIR = join(root, ".open-next/assets");
+const OPEN_NEXT_DIR = join(root, ".open-next");
 
-// Asset subtrees served only by the Electron desktop shell's local server.
-const DESKTOP_ONLY_ASSETS = ["wake-word"];
+// Asset directory names that exist only for the Electron desktop shell.
+const DESKTOP_ONLY_DIRS = new Set(["wake-word"]);
 
-if (!existsSync(ASSETS_DIR)) {
+if (!existsSync(OPEN_NEXT_DIR)) {
   console.error(
-    `[prune-desktop-assets] assets dir missing: ${ASSETS_DIR} — run the build first.`,
+    `[prune-desktop-assets] .open-next missing: ${OPEN_NEXT_DIR} — run the build first.`,
   );
   process.exit(1);
 }
 
-const pruned = [];
-for (const entry of DESKTOP_ONLY_ASSETS) {
-  const target = join(ASSETS_DIR, entry);
-  if (existsSync(target)) {
-    rmSync(target, { recursive: true, force: true });
-    pruned.push(entry);
+/**
+ * Recursively collect every desktop-only directory under `dir`. Does not
+ * descend into a match (nothing useful lives below it).
+ */
+function collect(dir, found) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    // A directory may vanish between discovery and read; that's expected.
+    // Any other failure (permissions, I/O) must fail the build loudly rather
+    // than silently skip pruning and ship a too-large Worker.
+    if (error?.code === "ENOENT") return found;
+    throw error;
   }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = join(dir, entry.name);
+    if (DESKTOP_ONLY_DIRS.has(entry.name)) {
+      found.push(full);
+    } else {
+      collect(full, found);
+    }
+  }
+  return found;
+}
+
+const targets = collect(OPEN_NEXT_DIR, []);
+for (const target of targets) {
+  rmSync(target, { recursive: true, force: true });
 }
 
 console.log(
-  pruned.length
-    ? `[prune-desktop-assets] removed desktop-only asset(s) from worker bundle: ${pruned.join(", ")}`
+  targets.length
+    ? `[prune-desktop-assets] removed ${targets.length} desktop-only tree(s) from the Cloudflare build:\n${targets
+        .map((t) => `  - ${relative(root, t)}`)
+        .join("\n")}`
     : "[prune-desktop-assets] no desktop-only assets present — nothing to prune.",
 );

--- a/apps/web/src/app/[locale]/(desktop)/wake-listener/page.tsx
+++ b/apps/web/src/app/[locale]/(desktop)/wake-listener/page.tsx
@@ -1,32 +1,30 @@
 "use client";
 
-import { useEffect } from "react";
-import { useHeyGaia } from "@/features/wake-word";
-import { useElectron } from "@/hooks/useElectron";
+import dynamic from "next/dynamic";
+import ErrorBoundary from "@/components/shared/ErrorBoundary";
 
 /**
  * Headless wake-word listener.
  *
  * Loaded by a hidden Electron window that runs for the lifetime of the
  * desktop app. Listens for "Hey GAIA" on-device and notifies the main
- * process, which summons the assistant popup. Renders a minimal status
- * readout for debugging (the window is never shown).
+ * process, which summons the assistant popup.
+ *
+ * The listener body is loaded with `ssr: false` so the onnxruntime-web
+ * runtime stays out of the server/Worker bundle (see WakeListenerClient).
  */
+const WakeListenerClient = dynamic(
+  () =>
+    import("@/features/wake-word/components/WakeListenerClient").then(
+      (m) => m.WakeListenerClient,
+    ),
+  { ssr: false },
+);
+
 export default function WakeListenerPage() {
-  const { isElectron, notifyWakeWord } = useElectron();
-  const { state, lastDetection, error, lastScore } = useHeyGaia({
-    enabled: isElectron,
-  });
-
-  useEffect(() => {
-    if (lastDetection) notifyWakeWord();
-  }, [lastDetection, notifyWakeWord]);
-
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-1 bg-black font-mono text-xs text-zinc-500">
-      <p>wake-listener: {state}</p>
-      <p data-wake-score>{lastScore?.toFixed(4) ?? "0"}</p>
-      {error && <p className="px-4 text-red-400">{error.message}</p>}
-    </div>
+    <ErrorBoundary>
+      <WakeListenerClient />
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/features/wake-word/components/WakeListenerClient.tsx
+++ b/apps/web/src/features/wake-word/components/WakeListenerClient.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { useElectron } from "@/hooks/useElectron";
+import { useHeyGaia } from "../hooks/useHeyGaia";
+
+/**
+ * Client-only body of the headless wake-word listener.
+ *
+ * Pulled out of the route and loaded via `next/dynamic` with `ssr: false`
+ * so the onnxruntime-web runtime (a ~12 MiB WASM module) never enters the
+ * server bundle. The wake-word pipeline runs exclusively in the Electron
+ * desktop shell, so server-rendering it is pure dead weight — and bundling
+ * the WASM into the Cloudflare Worker pushes it past the 10 MiB script
+ * limit. Keeping it client-only confines onnxruntime-web to the browser
+ * chunk where it belongs.
+ */
+export function WakeListenerClient() {
+  const { isElectron, notifyWakeWord } = useElectron();
+  const { state, lastDetection, error, lastScore } = useHeyGaia({
+    enabled: isElectron,
+  });
+
+  useEffect(() => {
+    if (lastDetection) notifyWakeWord();
+  }, [lastDetection, notifyWakeWord]);
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-1 bg-black font-mono text-xs text-zinc-500">
+      <p>wake-listener: {state}</p>
+      <p data-wake-score>{lastScore?.toFixed(4) ?? "0"}</p>
+      {error && <p className="px-4 text-red-400">{error.message}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
…ndle (#796)

* fix(web): keep desktop-only wake-word out of the Cloudflare Worker bundle

Cloudflare rejected the deploy: the ~12 MiB onnxruntime-web WASM was bundled INTO the Worker script (handler.mjs), exceeding Cloudflare's 10 MiB limit. OpenNext file-traces every `public/*.wasm` into the Worker as a wasm chunk (it appears even in unrelated routes' .nft.json), and the desktop-only wake-word route pulls onnxruntime-web's WASM loader into the server graph.

The wake-word pipeline is desktop-only — `/wake-listener` runs solely in the Electron shell. Exclude it from the web/Cloudflare build:

- outputFileTracingExcludes drops public/wake-word from Worker file tracing, so the WASM is no longer collected into the Worker script
- alias onnxruntime-web -> empty stub in the Cloudflare build (turbopack + webpack), gated on IMAGE_LOADER=cloudflare, so the runtime never enters the web bundle; the Electron standalone build keeps the real runtime
- load the wake-listener body via next/dynamic({ ssr: false }) so the client-only audio pipeline is not server-rendered
- prune-desktop-assets walks .open-next and removes the wake-word tree from the asset layer and any server-function public copy

Verified locally: `wrangler deploy --dry-run` reports 7081 KiB gzip (was failing >10 MiB); the Electron standalone build retains the real onnxruntime runtime and public/wake-word.

* fix(web): address CodeRabbit review on wake-word Cloudflare fix

- prune-desktop-assets: only swallow ENOENT during recursive discovery; rethrow other filesystem errors so a read failure fails the build loudly instead of silently shipping a too-large Worker
- wake-listener page: wrap the independently-rendered route in the shared ErrorBoundary per apps/web/CLAUDE.md