### PR TITLE
feat(voice-agent): build in CI and run the worker in production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           api=false
           bots=false
 
-          if echo "$AFFECTED" | grep -qx "api"; then # || echo "$AFFECTED" | grep -qx "voice-agent"; then
+          if echo "$AFFECTED" | grep -qx "api" || echo "$AFFECTED" | grep -qx "voice-agent"; then
             api=true
           fi
 
@@ -108,8 +108,8 @@ jobs:
             }
 
             if [ "$api" = "false" ]; then
-              if image_missing "ghcr.io/theexperiencecompany/gaia:latest"; then # || image_missing "ghcr.io/theexperiencecompany/gaia-voice-agent:latest"; then
-                echo "⚠️ API image missing from GHCR — forcing build"
+              if image_missing "ghcr.io/theexperiencecompany/gaia:latest" || image_missing "ghcr.io/theexperiencecompany/gaia-voice-agent:latest"; then
+                echo "⚠️ API/voice-agent image missing from GHCR — forcing build"
                 api=true
               fi
             fi

--- a/.github/workflows/deploy-swarm-prod.yml
+++ b/.github/workflows/deploy-swarm-prod.yml
@@ -93,12 +93,13 @@ jobs:
       - name: Wait for convergence
         id: converge
         run: |
-          echo "Waiting for gaia-backend and arq_worker to converge (up to 5 minutes)..."
+          SERVICES="gaia-backend arq_worker voice-agent-worker"
+          echo "Waiting for ${SERVICES} to converge (up to 5 minutes)..."
           DEADLINE=$(( $(date +%s) + 300 ))
 
           while true; do
             # Detect if Swarm auto-rolled back any app service
-            for svc in gaia-backend arq_worker; do
+            for svc in $SERVICES; do
               state=$(docker --context prod service inspect "gaia-prod_${svc}" \
                 --format '{{.UpdateStatus.State}}' 2>/dev/null || echo "")
               if echo "$state" | grep -qE "rollback_completed|rollback_started|rollback_paused"; then
@@ -108,31 +109,32 @@ jobs:
               fi
             done
 
-            # Check running replicas for both app services
-            running_backend=$(docker --context prod service ps gaia-prod_gaia-backend \
-              --filter desired-state=running \
-              --format '{{.CurrentState}}' 2>/dev/null | grep -c "^Running" || true)
-            running_backend=${running_backend:-0}
+            # Check running replicas for every app service
+            pending=""
+            status=""
+            for svc in $SERVICES; do
+              running=$(docker --context prod service ps "gaia-prod_${svc}" \
+                --filter desired-state=running \
+                --format '{{.CurrentState}}' 2>/dev/null | grep -c "^Running" || true)
+              running=${running:-0}
+              status="${status}${svc}=${running} "
+              [ "$running" -lt 1 ] && pending="${pending}${svc} "
+            done
 
-            running_worker=$(docker --context prod service ps gaia-prod_arq_worker \
-              --filter desired-state=running \
-              --format '{{.CurrentState}}' 2>/dev/null | grep -c "^Running" || true)
-            running_worker=${running_worker:-0}
-
-            if [ "$running_backend" -ge 1 ] && [ "$running_worker" -ge 1 ]; then
-              echo "gaia-backend and arq_worker are running"
+            if [ -z "$pending" ]; then
+              echo "All app services are running (${status})"
               break
             fi
 
             now=$(date +%s)
             if [ "$now" -ge "$DEADLINE" ]; then
               echo "timed_out=true" >> "$GITHUB_OUTPUT"
-              echo "::error::services did not converge within 5 minutes (backend=${running_backend} worker=${running_worker})"
+              echo "::error::services did not converge within 5 minutes (${status})"
               exit 1
             fi
 
             remaining=$(( DEADLINE - now ))
-            echo "  ... waiting (backend=${running_backend} worker=${running_worker}, ${remaining}s remaining)"
+            echo "  ... waiting (${status}${remaining}s remaining)"
             sleep 15
           done
 
@@ -189,7 +191,7 @@ jobs:
           color: "#ff6b6b"
           message: |
             **Backend Deploy Failed — Convergence Timeout**
-            gaia-backend and arq_worker did not reach Running state within 5 minutes. Check `docker service ps gaia-prod_gaia-backend` and `docker service ps gaia-prod_arq_worker` on the VM.
+            gaia-backend, arq_worker, and voice-agent-worker did not all reach Running state within 5 minutes. Check `docker service ps gaia-prod_<service>` on the VM.
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
             **Actor:** ${{ github.actor }}
@@ -240,7 +242,7 @@ jobs:
         run: |
           if [ "$ROLLBACK_MODE" = "last" ]; then
             for svc in $(docker --context prod stack services gaia-prod --format '{{.Name}}' \
-              | grep -E 'gaia-backend|arq_worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
+              | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
               echo "Rolling back $svc..."
               docker --context prod service rollback "$svc"
             done
@@ -257,7 +259,7 @@ jobs:
         run: |
           if [ "$ROLLBACK_MODE" = "last" ]; then
             SERVICES=$(docker --context prod stack services gaia-prod --format '{{.Name}}' \
-              | grep -E 'gaia-backend|arq_worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot')
+              | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot')
           else
             SERVICES="gaia-prod_gaia-backend gaia-prod_arq_worker"
           fi

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -870,9 +870,7 @@ services:
       retries: 5
       start_period: 60s
     deploy:
-      # replicas: 0 — not started by default; scale up manually when needed:
-      #   docker --context gaia-prod service scale gaia-prod_voice-agent-worker=1
-      replicas: 0
+      replicas: 1
       update_config:
         parallelism: 1
         delay: 5s

--- a/nx.json
+++ b/nx.json
@@ -82,10 +82,10 @@
     },
     "groups": {
       "apps": {
-        "projects": ["api"],
+        "projects": ["api", "voice-agent"],
         "projectsRelationship": "independent",
         "docker": {
-          "groupPreVersionCommand": "npx nx run-many -t docker:build -p api --skipNxCache",
+          "groupPreVersionCommand": "npx nx run-many -t docker:build -p api,voice-agent --skipNxCache",
           "skipVersionActions": true,
           "registryUrl": "ghcr.io"
         },


### PR DESCRIPTION
## Why

Voice mode (the LiveKit-backed real-time voice feature) is fully wired in the product — the composer voice button, the `/api/v1/token` endpoint, voice settings, and paid-tier gating are all live in prod. But the **voice-agent worker** that actually joins the LiveKit room and runs STT → backend LLM → TTS was never deployed:

- `voice-agent` was **not in any Nx release group**, so CI never built/pushed `gaia-voice-agent:latest`.
- The affected-check and GHCR bootstrap checks for it in `build.yml` were **commented out**.
- In the prod Swarm stack it was declared with **`replicas: 0`** ("scale up manually").

Net effect: a paid user could start a voice session, get a token, connect to the room — and no agent would ever answer, unless someone manually scaled the worker. This PR makes voice-agent a first-class, CI-built, prod-deployed service like the `gaia` (api) image.

## Changes

- **`nx.json`** — add `voice-agent` to the `apps` release group (and its `groupPreVersionCommand`) so `nx release --group=apps` builds and pushes `ghcr.io/theexperiencecompany/gaia-voice-agent:latest` alongside `gaia`.
- **`.github/workflows/build.yml`** — uncomment the `voice-agent` affected check (a voice-agent change now triggers the apps release and flows through `api_affected` → `backend_deploy`) and the master-only GHCR image-missing bootstrap for `gaia-voice-agent`.
- **`infra/docker/docker-compose.prod.yml`** — `voice-agent-worker` `replicas: 0` → `replicas: 1`.
- **`.github/workflows/deploy-swarm-prod.yml`** — gate deploy **convergence** on `voice-agent-worker` (rewritten to a list-driven check over all three app services) and include it in **`last`-mode rollback**.

## Notes / risk

- The convergence wait is 5 min; voice-agent has a 60s model cold-load (`start_period: 60s`) with models baked into the image (`HF_HUB_OFFLINE=1`), so it should converge comfortably. If the worker image is ever broken it will now (intentionally) fail/roll back a backend deploy — same contract as `gaia-backend`/`arq_worker`.
- Digest-mode rollback is unchanged (it targets the shared `gaia` image; voice-agent uses a separate image).
- Lint/type-check/security for voice-agent were already covered in `code-quality.yml`; this PR only closes the build + deploy gap.

## Verification

- `nx.json` / all three YAML files validate (JSON + YAML parse).
- `nx show projects --projects=voice-agent` confirms it resolves in the `apps` group.
- Pre-commit hooks (check yaml/json, biome) pass.