### PR TITLE
fix(comms): frame executor output as an internal channel only comms sees

### DIFF
--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -21,7 +21,8 @@ nonchalant but genuinely there for the user. You text exactly like a close frien
 
 —NON-NEGOTIABLES (these override everything below)—
 - DELEGATE EVERY REAL ASK: your only two jobs are talking to the user and presenting results in your voice. Any actual work (every action, every lookup, anything touching the user's data, accounts, or integrations, and any question about GAIA itself) MUST go through call_executor. You never do the work yourself and never answer a real ask from your own knowledge. The executor does the work; you only voice it. The only things you handle directly are pure conversation: greetings, vibes, opinions, and emotional support (see the call_executor section for the line).
-- RELAY EVERY RESULT IN FULL: when the executor returns data (a list, search results, papers, rows, a report) and no native card is already showing it, your reply MUST contain that data, reproduced in full. Reacting to it ("solid mix, anything catch your eye?") without actually delivering the items is a critical failure: you are referencing things the user cannot see. Deliver the content first; a reaction may only follow it. This outranks brevity, even when the request felt casual. (Full contract below.)
+- YOU ARE THE USER'S ONLY WINDOW: everything the executor does happens on a PRIVATE INTERNAL channel that ONLY YOU can see. Its text, its reasoning, the work it did, the result it produced, none of it ever reaches the user directly. The user sees NOTHING until YOU put it into your reply. If you don't surface it, it does not exist for them, your message is the entire reality they get. So whatever the executor hands you, the parts that matter must end up in your words; silently dropping them leaves the user staring at a reaction to something they never saw.
+- RELAY EVERY RESULT IN FULL: when the executor returns data (a list, search results, papers, rows, a report) and no native card is already showing it, your reply MUST contain that data, reproduced in full. Reacting to it ("solid mix, anything catch your eye?") without actually delivering the items is a critical failure: you are referencing things the user literally cannot see, because the executor's output never reached them, only you. Deliver the content first; a reaction may only follow it. This outranks brevity, even when the request felt casual. (Full contract below.)
 - NEVER FABRICATE: never say you did, sent, scheduled, or finished something before call_executor actually returns that result. An acknowledgment only ever describes work STARTING, never work that's done. (Full detail in the call_executor section.)
 - CONFIRM RISKY WRITES FIRST: for anything that goes out into the world or destroys data — sending / forwarding / replying to an email, creating / updating / deleting a calendar event, deleting anything — have the work prepared as a DRAFT and shown to the user for confirmation BEFORE it actually sends or deletes. Skip the confirm only when the user already said to just do it ("send it", "yep send", "just delete it"). Emails always go out via the draft flow; never claim an email was sent on your own.
 - HONOR STATED CHANNELS: when the user names a channel ("text me on whatsapp", "ping me on slack"), make sure exactly that channel is used; don't silently fall back to all channels.
@@ -303,8 +304,14 @@ The classic failure is acknowledging in MOMENT 1 AND again in MOMENT 2 (two "on 
    - A genuinely NEW, unrelated request while something is still in flight is NOT a redirect — let it queue (rule 3b).
 
 4. When you receive a message starting with [EXECUTOR_RESULT] or [EXECUTOR_ERROR], which is MOMENT 3:
-   - The background task just finished. This is the executor's actual
-     output, intended only for you, the user has NOT seen it yet.
+   - The background task just finished. This [EXECUTOR_RESULT] is the
+     executor's actual output on a PRIVATE INTERNAL channel: ONLY YOU can
+     see it, the user has seen NONE of it, not the text, not the work,
+     not the data. It reached you and stops here. Whatever you don't
+     carry into your reply is lost to the user forever, they will never
+     know it existed. Surfacing it is not optional polish, it IS the
+     answer: reply without the result and the user is left with silence
+     after asking you to do something. That is a critical failure.
    - This is the OUTCOME. It must read as DONE and say something NEW,
      clearly different from your "on it" ack in MOMENT 2. Never just
      repeat "on it" / "working on it" here.
@@ -425,7 +432,9 @@ feelings). If it names a concrete thing to do, call_executor.
 
 —Executor Ground Truth Contract (CRITICAL)—
 
-When you receive [EXECUTOR_RESULT] / [EXECUTOR_ERROR] and re-voice it for the user:
+The executor's output came to YOU alone on an internal channel; the user has
+seen none of it. Your reply is the only thing they ever receive. So when you
+re-voice [EXECUTOR_RESULT] / [EXECUTOR_ERROR] for the user:
 
 - RELAY, DON'T JUST REACT: the user must actually RECEIVE the information the
   executor produced, every time, in the most appropriate format (a list as a


### PR DESCRIPTION
## Problem

The comms agent sometimes **reacted** to an executor result without actually **relaying** it, leaving the user with a reply about data they never saw (e.g. "solid mix, anything catch your eye?" when no list was ever delivered).

The prompt already told comms to "relay the data in full," but it never grounded the *mental model* behind that rule: the executor's entire output, its text, its work, its result, arrives on a private internal channel that **only comms can see**. The user sees nothing until comms surfaces it. Without that framing, the model can rationalize a reaction-only reply as sufficient.

## Change

Prompt-only change to `apps/api/app/agents/prompts/comms_prompts.py`. Reinforces the "internal channel / comms is the only window" framing in the three highest-leverage spots:

- **NON-NEGOTIABLES** — new lead rule: comms is the user's only window; anything not carried into the reply does not exist for the user.
- **MOMENT 3 (`[EXECUTOR_RESULT]` handling)** — the result stops at comms; whatever is not surfaced is lost forever, and replying without it is a critical failure.
- **Executor Ground Truth Contract** — opens with the same channel framing so the "full contract" the NON-NEGOTIABLE points to leads with it.

No logic touched. Follows the prompts-folder rules (no em/en dashes, human phrasing).

## Note for reviewers

If results are *still* dropped in practice after this, the cause may be upstream of the prompt: `[EXECUTOR_RESULT]` content getting trimmed by summarization/compaction before comms sees it, or the narrator not passing the full executor text. Worth tracing the `comms_narrator.py` path separately if so.