### PR TITLE
fix(chat): make links legible in user bubbles

### DIFF
--- a/apps/web/src/features/chat/components/code-block/CustomAnchor.tsx
+++ b/apps/web/src/features/chat/components/code-block/CustomAnchor.tsx
@@ -7,6 +7,15 @@ import {
   usePrefetchUrlMetadata,
   useUrlMetadata,
 } from "@/features/chat/hooks/useUrlMetadata";
+import { cn } from "@/lib/utils";
+
+// Link chip styling. The bot bubble is dark (bg-zinc-800), so the brand-blue
+// `text-primary` link reads fine there. The user bubble is `#00bbff` (the same
+// value as `--color-primary`), so blue-on-blue is invisible — there we switch
+// to the bubble's black-text treatment with a translucent-black chip.
+const DARK_BUBBLE_LINK =
+  "bg-primary/20 text-primary hover:text-white hover:underline";
+const LIGHT_BUBBLE_LINK = "bg-black/10 text-black underline hover:bg-black/20";
 
 // Global set to track failed image URLs across all instances
 const globalFailedUrls = new Set<string>();
@@ -281,10 +290,12 @@ const CustomAnchor = memo(
     href,
     children,
     isStreaming,
+    lightBackground,
   }: {
     href: string | undefined;
     children: ReactNode | string | null;
     isStreaming?: boolean;
+    lightBackground?: boolean;
   }) => {
     const elementRef = useRef<HTMLAnchorElement>(null);
     const [isInView, setIsInView] = useState(false);
@@ -365,7 +376,10 @@ const CustomAnchor = memo(
         <a
           ref={elementRef}
           href={href}
-          className="inline-flex cursor-pointer items-center gap-1 rounded-sm bg-primary/20 px-1 text-sm font-medium text-primary transition-all hover:text-white hover:underline"
+          className={cn(
+            "inline-flex cursor-pointer items-center gap-1 rounded-sm px-1 text-sm font-medium transition-all",
+            lightBackground ? LIGHT_BUBBLE_LINK : DARK_BUBBLE_LINK,
+          )}
           rel="noopener noreferrer"
           target="_blank"
           onMouseEnter={handleMouseEnter}
@@ -388,11 +402,12 @@ const CustomAnchor = memo(
     );
   },
   (prevProps, nextProps) => {
-    // Only re-render if href, children, or isStreaming actually change
+    // Only re-render if href, children, isStreaming, or lightBackground change
     return (
       prevProps.href === nextProps.href &&
       prevProps.children === nextProps.children &&
-      prevProps.isStreaming === nextProps.isStreaming
+      prevProps.isStreaming === nextProps.isStreaming &&
+      prevProps.lightBackground === nextProps.lightBackground
     );
   },
 );

--- a/apps/web/src/features/chat/components/interface/MarkdownRenderer.tsx
+++ b/apps/web/src/features/chat/components/interface/MarkdownRenderer.tsx
@@ -131,6 +131,7 @@ const MarkdownImageNode: React.FC<{ src?: string | Blob; alt?: string }> = ({
 function buildMarkdownComponents(
   hideCodeToolbar: boolean | undefined,
   isStreaming: boolean | undefined,
+  lightBackground: boolean | undefined,
   overrides: Components | undefined,
 ): Components {
   return {
@@ -151,7 +152,11 @@ function buildMarkdownComponents(
     ul: ({ ...props }) => <ul className="mb-4 list-disc pl-6" {...props} />,
     ol: ({ ...props }) => <ol className="mb-4 list-decimal pl-6" {...props} />,
     a: ({ href, children }) => (
-      <CustomAnchor href={href} isStreaming={isStreaming}>
+      <CustomAnchor
+        href={href}
+        isStreaming={isStreaming}
+        lightBackground={lightBackground}
+      >
         {children}
       </CustomAnchor>
     ),
@@ -245,8 +250,14 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   // components object each render defeats streamdown's per-block memoization,
   // forcing every block (math, code, tables) to re-render on every token.
   const mergedComponents = useMemo<Components>(
-    () => buildMarkdownComponents(hideCodeToolbar, isStreaming, components),
-    [hideCodeToolbar, isStreaming, components],
+    () =>
+      buildMarkdownComponents(
+        hideCodeToolbar,
+        isStreaming,
+        lightBackground,
+        components,
+      ),
+    [hideCodeToolbar, isStreaming, lightBackground, components],
   );
 
   return (


### PR DESCRIPTION
## Problem

Links in chat are rendered through `CustomAnchor`, whose `<a>` hardcoded `bg-primary/20 text-primary hover:text-white`. Since `--color-primary` is `#00bbff` — **the exact background color of the user bubble** (`imessage-from-me` / `.n`) — links inside user bubbles rendered blue-on-blue (effectively invisible), and the `hover:text-white` made them worse on the light surface. The bot bubble (`bg-zinc-800`) was unaffected, which is why only user bubbles looked broken.

## Fix

`MarkdownRenderer` already threads a `lightBackground` flag for the user bubble (its doc comment notes the bubble is `#00bbff` with black text by design), but that flag never reached the link renderer. This wires it through to the missing seam:

- **`MarkdownRenderer.tsx`** — `buildMarkdownComponents` now takes `lightBackground` and passes it to `CustomAnchor`; added to the `useMemo` deps.
- **`CustomAnchor.tsx`** — accepts `lightBackground` and selects between two link treatments:
  - dark bubble → `bg-primary/20 text-primary hover:text-white` (unchanged)
  - light bubble → `bg-black/10 text-black underline hover:bg-black/20` (black text matching the bubble's design, persistent underline so links stay distinguishable from black body text)
  - added the prop to the `memo` comparator so it re-renders on change.

Fixed at the root — one styling source for all chat links — rather than patching the color at the user-bubble call site.

## Verification

- `nx run web:type-check` — passes
- `nx lint web` — passes (remaining warnings are pre-existing, none in these files)