### PR TITLE
fix(chat): block send until composer attachments finish uploading

### DIFF
--- a/apps/web/src/features/chat/components/composer/Composer.tsx
+++ b/apps/web/src/features/chat/components/composer/Composer.tsx
@@ -21,6 +21,7 @@ import { useSendMessage } from "@/hooks/useSendMessage";
 import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import {
   useComposerFiles,
+  useComposerIsUploading,
   useComposerModeSelection,
   useComposerTextActions,
   useComposerUI,
@@ -94,6 +95,7 @@ const Composer: React.FC<MainSearchbarProps> = ({
     removeUploadedFile,
     clearAllFiles,
   } = useComposerFiles();
+  const isUploadingFiles = useComposerIsUploading();
   const { isSlashCommandDropdownOpen, setIsSlashCommandDropdownOpen } =
     useComposerUI();
   const { selectedWorkflow, clearSelectedWorkflow } = useWorkflowSelection();
@@ -167,6 +169,10 @@ const Composer: React.FC<MainSearchbarProps> = ({
 
     // Prevent double execution when workflow is auto-sending
     if (autoSend) return;
+
+    // Hold the send until every attachment has finished uploading, otherwise the
+    // message goes out before its file data is ready and the attachment is lost.
+    if (isUploadingFiles) return;
 
     // Only prevent submission if there's no text AND no files AND no selected tool AND no selected workflow AND no selected calendar event
     if (

--- a/apps/web/src/features/chat/components/composer/ComposerRight.tsx
+++ b/apps/web/src/features/chat/components/composer/ComposerRight.tsx
@@ -6,7 +6,10 @@ import SendStopButton from "@/features/chat/components/composer/SendStopButton";
 import { useCalendarEventSelection } from "@/features/chat/hooks/useCalendarEventSelection";
 import { useComposerSendMode } from "@/features/chat/hooks/useComposerSendMode";
 import { useWorkflowSelection } from "@/features/chat/hooks/useWorkflowSelection";
-import { useComposerFiles } from "@/stores/composerStore";
+import {
+  useComposerFiles,
+  useComposerIsUploading,
+} from "@/stores/composerStore";
 
 interface RightSideProps {
   handleFormSubmit: (e?: React.FormEvent<HTMLFormElement>) => void;
@@ -27,6 +30,7 @@ export default function RightSide({
   const { selectedWorkflow } = useWorkflowSelection();
   const { selectedCalendarEvent } = useCalendarEventSelection();
   const { uploadedFiles } = useComposerFiles();
+  const isUploading = useComposerIsUploading();
   const hasText = (searchbarText || "").trim().length > 0;
   const hasSelectedTool = selectedTool != null;
   const hasSelectedWorkflow = selectedWorkflow != null;
@@ -46,6 +50,10 @@ export default function RightSide({
 
   const getTooltipContent = () => {
     if (showStop) return "Stop generation";
+
+    if (isUploading) {
+      return `Uploading file${uploadedFiles.length > 1 ? "s" : ""}...`;
+    }
 
     if (showQueue) {
       return (
@@ -118,7 +126,11 @@ export default function RightSide({
         color={showStop ? "danger" : "primary"}
         showArrow
       >
-        <SendStopButton hasContent={hasContent} onSend={handleFormSubmit} />
+        <SendStopButton
+          hasContent={hasContent}
+          isUploading={isUploading}
+          onSend={handleFormSubmit}
+        />
       </Tooltip>
     </div>
   );

--- a/apps/web/src/features/chat/components/composer/SendStopButton.tsx
+++ b/apps/web/src/features/chat/components/composer/SendStopButton.tsx
@@ -84,8 +84,7 @@ export default function SendStopButton({
   className = "h-9 min-h-9 w-9 max-w-9 min-w-9",
 }: Readonly<SendStopButtonProps>) {
   const { stopStream } = useLoading();
-  const { isStreaming, showQueue, showStop, mode } =
-    useComposerSendMode(hasContent);
+  const { showQueue, showStop, mode } = useComposerSendMode(hasContent);
 
   const handlePress = () => {
     if (showStop) {
@@ -113,9 +112,10 @@ export default function SendStopButton({
       aria-label={MODE_ARIA_LABEL[mode]}
       className={`transition-all duration-300 ${contentColor} ${shapeClass}`}
       color={bg}
-      // While streaming the button is Stop and stays active; otherwise it must
-      // be empty of content AND have no in-flight upload before it can send.
-      disabled={!isStreaming && (!hasContent || isUploading)}
+      // Stop (abort the stream) is always pressable; send/queue is gated on
+      // readiness — there must be content AND no in-flight upload, otherwise the
+      // submit is dropped by the composer's uploading guard.
+      disabled={!showStop && (!hasContent || isUploading)}
       radius="full"
       // In stop mode the button aborts the stream rather than submitting, so it
       // must not trigger the composer form. Only send/queue submit.

--- a/apps/web/src/features/chat/components/composer/SendStopButton.tsx
+++ b/apps/web/src/features/chat/components/composer/SendStopButton.tsx
@@ -62,6 +62,8 @@ interface SendStopButtonProps {
   hasContent: boolean;
   /** Submit handler invoked when sending or queueing. */
   onSend: () => void;
+  /** While true an attachment is still uploading, so send is held. */
+  isUploading?: boolean;
   className?: string;
 }
 
@@ -74,6 +76,7 @@ interface SendStopButtonProps {
 export default function SendStopButton({
   hasContent,
   onSend,
+  isUploading = false,
   className = "h-9 min-h-9 w-9 max-w-9 min-w-9",
 }: Readonly<SendStopButtonProps>) {
   const { stopStream } = useLoading();
@@ -102,7 +105,9 @@ export default function SendStopButton({
       aria-label={MODE_ARIA_LABEL[mode]}
       className={`transition-all duration-300 ${contentColor} ${shapeClass}`}
       color={bg}
-      disabled={!isStreaming && !hasContent}
+      // While streaming the button is Stop and stays active; otherwise it must
+      // be empty of content AND have no in-flight upload before it can send.
+      disabled={!isStreaming && (!hasContent || isUploading)}
       radius="full"
       // In stop mode the button aborts the stream rather than submitting, so it
       // must not trigger the composer form. Only send/queue submit.

--- a/apps/web/src/features/chat/components/composer/SendStopButton.tsx
+++ b/apps/web/src/features/chat/components/composer/SendStopButton.tsx
@@ -18,9 +18,13 @@ import { useLoading } from "@/features/chat/hooks/useLoading";
 function getButtonStyle(
   showStop: boolean,
   hasContent: boolean,
+  isUploading: boolean,
 ): { bg: "default" | "primary"; contentColor: string } {
   if (showStop) return { bg: "default", contentColor: "text-zinc-300" };
-  if (hasContent) return { bg: "primary", contentColor: "text-black" };
+  // An in-flight upload holds the send, so it must read as muted/not-ready
+  // rather than the live primary fill even though there is content.
+  if (hasContent && !isUploading)
+    return { bg: "primary", contentColor: "text-black" };
   return { bg: "default", contentColor: "text-zinc-500" };
 }
 
@@ -91,7 +95,11 @@ export default function SendStopButton({
     }
   };
 
-  const { bg, contentColor } = getButtonStyle(showStop, hasContent);
+  const { bg, contentColor } = getButtonStyle(
+    showStop,
+    hasContent,
+    isUploading,
+  );
 
   // Queue widens into a labelled pill; stop/send stay icon-only square buttons.
   const stopCursor = showStop ? "cursor-pointer" : "";

--- a/apps/web/src/stores/composerStore.ts
+++ b/apps/web/src/stores/composerStore.ts
@@ -285,6 +285,13 @@ export const useComposerFiles = () =>
     })),
   );
 
+// True while any composer file is still uploading. Send is blocked until this
+// clears so a message never goes out before its attachment finishes uploading.
+export const useComposerIsUploading = () =>
+  useComposerStore((state) =>
+    state.uploadedFiles.some((file) => file.isUploading),
+  );
+
 export const useComposerUI = () =>
   useComposerStore(
     useShallow((state) => ({


### PR DESCRIPTION
## Problem

Uploading an image in the composer dropped temporary previews into state and ran the upload in the background, but the send path only checked that *some* file existed — not that it had finished uploading. Hitting send (or Enter) mid-upload fired the message before the real file data (`fileId`s) was ready, so the attachment was silently lost.

## Fix

Added a `useComposerIsUploading` selector as the single source of truth and gated send on it: `handleFormSubmit` now returns early while any attachment is uploading (covering the Enter-key path), the send button is disabled, and the tooltip shows an "Uploading file(s)..." state. The instant uploads complete the button re-enables, so a message can never go out without its attachment.