### PR TITLE
fix(chat): show integration name instead of id in planning task header

### DIFF
--- a/apps/api/app/agents/core/subagents/base_subagent.py
+++ b/apps/api/app/agents/core/subagents/base_subagent.py
@@ -105,6 +105,7 @@ class SubAgentFactory:
         auto_bind_tools: list[str] | None = None,
         include_finish_task: bool = True,
         mcp_tools: list[BaseTool] | None = None,
+        source_label: str | None = None,
     ) -> CompiledStateGraph:
         """
         Creates a specialized sub-agent graph for a specific provider with tool registry.
@@ -125,6 +126,9 @@ class SubAgentFactory:
                 captures as the final answer. Use False for answer-only
                 subagents (e.g. documentation fetchers) where finish_task adds
                 latency without value.
+            source_label: Human-readable name for the provider, streamed with
+                todo_progress events so the frontend shows the integration's
+                name instead of its raw id (provider).
 
         Returns:
             Compiled LangGraph agent with tool registry, retrieval, and checkpointer
@@ -163,7 +167,7 @@ class SubAgentFactory:
         )
 
         # Create todo tools and register them in the scoped tool registry
-        todo_tools: list[BaseTool] = create_todo_tools(source=provider)
+        todo_tools: list[BaseTool] = create_todo_tools(source=provider, source_label=source_label)
         todo_hook = create_todo_pre_model_hook(source=provider)
         todo_tool_names: list[str] = []
         for todo_tool in todo_tools:

--- a/apps/api/app/agents/core/subagents/provider_subagents.py
+++ b/apps/api/app/agents/core/subagents/provider_subagents.py
@@ -109,6 +109,7 @@ async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
         disable_retrieve_tools=config.disable_retrieve_tools,
         auto_bind_tools=config.auto_bind_tools,
         include_finish_task=config.include_finish_task,
+        source_label=subagent.name,
     )
 
     log.info(f"Subagent {config.agent_name} created successfully")
@@ -192,6 +193,7 @@ async def _build_user_subagent(integration_id: str, user_id: str) -> CompiledSta
         auto_bind_tools=config.auto_bind_tools,
         include_finish_task=config.include_finish_task,
         mcp_tools=tools,
+        source_label=subagent.name,
     )
 
     log.info(f"User-specific subagent {config.agent_name} created successfully")
@@ -253,6 +255,7 @@ async def _create_custom_mcp_subagent(
         use_direct_tools=use_direct,
         disable_retrieve_tools=use_direct,
         mcp_tools=tools,
+        source_label=custom_doc.get("name"),
     )
 
     log.info(f"Custom MCP subagent {agent_name} created successfully")

--- a/apps/api/app/agents/tools/todo_tools.py
+++ b/apps/api/app/agents/tools/todo_tools.py
@@ -69,16 +69,20 @@ class TaskUpdate(TypedDict, total=False):
     status: Literal["in_progress", "completed", "cancelled"] | None  # required when updating
 
 
-def _emit_todo_progress(todos: list[Todo], source: str) -> None:
-    """Emit a todo_progress event via LangGraph stream_writer."""
-    payload = {
-        "todo_progress": {
-            "todos": [
-                {"id": t["id"], "content": t["content"], "status": t["status"]} for t in todos
-            ],
-            "source": source,
-        }
+def _emit_todo_progress(todos: list[Todo], source: str, source_label: str | None = None) -> None:
+    """Emit a todo_progress event via LangGraph stream_writer.
+
+    `source` is the stable grouping key (e.g. a custom MCP integration id);
+    `source_label` is its human-readable name, included so the frontend can
+    show the integration's name instead of reverse-mapping the id.
+    """
+    snapshot: dict[str, Any] = {
+        "todos": [{"id": t["id"], "content": t["content"], "status": t["status"]} for t in todos],
+        "source": source,
     }
+    if source_label:
+        snapshot["integration_name"] = source_label
+    payload = {"todo_progress": snapshot}
     try:
         writer = get_stream_writer()
         writer(payload)
@@ -104,7 +108,7 @@ def _format_todos(todos: list[Todo]) -> str:
     return "\n".join(lines)
 
 
-def create_todo_tools(source: str = "executor") -> list[BaseTool]:
+def create_todo_tools(source: str = "executor", source_label: str | None = None) -> list[BaseTool]:
     """Create plan_tasks and update_tasks tools with `source` baked in.
 
     Each tool reads current todos via InjectedState("todos"), mutates,
@@ -112,6 +116,9 @@ def create_todo_tools(source: str = "executor") -> list[BaseTool]:
 
     Args:
         source: Identifier for todo_progress events (e.g. "executor", "gmail")
+        source_label: Human-readable name for the source (e.g. a custom MCP
+            integration's display name). Streamed so the frontend shows the
+            name instead of the raw id.
 
     Returns:
         List of two BaseTool instances
@@ -141,7 +148,7 @@ def create_todo_tools(source: str = "executor") -> list[BaseTool]:
                 )
             )
 
-        _emit_todo_progress(new_todos, source)
+        _emit_todo_progress(new_todos, source, source_label)
 
         first_task = new_todos[0]["content"] if new_todos else "none"
         return Command(
@@ -198,7 +205,7 @@ def create_todo_tools(source: str = "executor") -> list[BaseTool]:
             summary_parts.append(f"added: {', '.join(added)}")
 
         summary = "; ".join(summary_parts) if summary_parts else "no changes"
-        _emit_todo_progress(updated_todos, source)
+        _emit_todo_progress(updated_todos, source, source_label)
 
         return Command(
             update={

--- a/apps/web/src/features/chat/components/bubbles/bot/TodoProgressSection.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/TodoProgressSection.tsx
@@ -12,10 +12,14 @@ import {
 import { useMemo, useRef } from "react";
 import { ChevronDown } from "@/components/shared/icons";
 import { toTitleCase } from "@/features/chat/utils/chatUtils";
+import { useIntegrationLookup } from "@/features/integrations/hooks/useIntegrationLookup";
 import type {
   TodoProgressData,
   TodoProgressItem,
 } from "@/types/features/todoProgressTypes";
+
+/** Resolver mapping a todo_progress source to its display label. */
+type SourceLabel = (source: string) => string;
 
 interface TodoProgressSectionProps {
   todo_progress: TodoProgressData;
@@ -99,7 +103,17 @@ export default function TodoProgressSection({
   todo_progress,
   isStreaming,
 }: TodoProgressSectionProps) {
+  const { getIntegrationName } = useIntegrationLookup();
   const sources = Object.keys(todo_progress);
+
+  // Custom MCP integrations stream their raw integration id as the source.
+  // Prefer the backend-provided display name, fall back to the client-side
+  // integration lookup (for older messages without it), then prettify the id.
+  const getSourceLabel: SourceLabel = (source) =>
+    todo_progress[source]?.integration_name ??
+    getIntegrationName(source) ??
+    toTitleCase(source);
+
   if (sources.length === 0) return null;
 
   const activeSources = sources.filter(
@@ -113,6 +127,7 @@ export default function TodoProgressSection({
         source={activeSources[0]}
         todos={todo_progress[activeSources[0]].todos}
         isStreaming={isStreaming}
+        getSourceLabel={getSourceLabel}
       />
     );
   }
@@ -122,6 +137,7 @@ export default function TodoProgressSection({
       activeSources={activeSources}
       todo_progress={todo_progress}
       isStreaming={isStreaming}
+      getSourceLabel={getSourceLabel}
     />
   );
 }
@@ -130,10 +146,12 @@ function SingleSourceCard({
   source,
   todos,
   isStreaming,
+  getSourceLabel,
 }: {
   source: string;
   todos: TodoProgressItem[];
   isStreaming?: boolean;
+  getSourceLabel: SourceLabel;
 }) {
   const completedCount = todos.filter((t) => t.status === "completed").length;
   const pct = todos.length > 0 ? (completedCount / todos.length) * 100 : 0;
@@ -143,7 +161,7 @@ function SingleSourceCard({
     <div className="mt-2 mb-2 animate-scale-in rounded-3xl bg-zinc-800/70 backdrop-blur-xl p-4 w-full max-w-96">
       <div className="flex items-center justify-between mb-2">
         <span className="text-xs font-medium text-zinc-400">
-          {toTitleCase(source)}
+          {getSourceLabel(source)}
         </span>
         <Chip
           size="sm"
@@ -166,10 +184,12 @@ function MultiSourceAccordion({
   activeSources,
   todo_progress,
   isStreaming,
+  getSourceLabel,
 }: {
   activeSources: string[];
   todo_progress: TodoProgressData;
   isStreaming?: boolean;
+  getSourceLabel: SourceLabel;
 }) {
   const prevDataRef = useRef<TodoProgressData>({});
 
@@ -217,7 +237,7 @@ function MultiSourceAccordion({
               title={
                 <div className="flex items-center gap-2 w-full pr-1">
                   <span className="text-xs font-medium text-zinc-400 min-w-0 flex-1 truncate">
-                    {toTitleCase(source)}
+                    {getSourceLabel(source)}
                   </span>
                   <Progress
                     size="sm"

--- a/apps/web/src/features/chat/components/bubbles/bot/TodoProgressSection.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/TodoProgressSection.tsx
@@ -108,11 +108,14 @@ export default function TodoProgressSection({
 
   // Custom MCP integrations stream their raw integration id as the source.
   // Prefer the backend-provided display name, fall back to the client-side
-  // integration lookup (for older messages without it), then prettify the id.
+  // integration lookup (for older messages without it), then the raw id.
+  // Title-case whichever we land on so lowercase names/ids read cleanly.
   const getSourceLabel: SourceLabel = (source) =>
-    todo_progress[source]?.integration_name ??
-    getIntegrationName(source) ??
-    toTitleCase(source);
+    toTitleCase(
+      todo_progress[source]?.integration_name ??
+        getIntegrationName(source) ??
+        source,
+    );
 
   if (sources.length === 0) return null;
 

--- a/apps/web/src/features/chat/components/bubbles/bot/UnifiedToolThread.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/UnifiedToolThread.tsx
@@ -9,7 +9,7 @@ import type {
   ToolCallEntry,
 } from "@/config/registries/toolRegistry";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
-import { useIntegrations } from "@/features/integrations/hooks/useIntegrations";
+import { useIntegrationLookup } from "@/features/integrations/hooks/useIntegrationLookup";
 import { StepRow, SubagentRow } from "./SubagentRow";
 
 /**
@@ -45,30 +45,23 @@ export default function UnifiedToolThread({
   isStreaming,
 }: Readonly<UnifiedToolThreadProps>) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { integrations } = useIntegrations();
-
-  const integrationLookup = useMemo(() => {
-    const lookup = new Map<string, { iconUrl?: string; name?: string }>();
-    for (const int of integrations) {
-      if (int.id) lookup.set(int.id, { iconUrl: int.iconUrl, name: int.name });
-    }
-    return lookup;
-  }, [integrations]);
+  const { getIntegrationName: lookupName, getIntegrationIconUrl } =
+    useIntegrationLookup();
 
   const getIconUrl = useCallback(
     (call: ToolCallEntry): string | undefined => {
       if (call.icon_url) return call.icon_url;
-      return integrationLookup.get(call.tool_category)?.iconUrl;
+      return getIntegrationIconUrl(call.tool_category);
     },
-    [integrationLookup],
+    [getIntegrationIconUrl],
   );
 
   const getIntegrationName = useCallback(
     (call: ToolCallEntry): string | undefined => {
       if (call.integration_name) return call.integration_name;
-      return integrationLookup.get(call.tool_category)?.name;
+      return lookupName(call.tool_category);
     },
-    [integrationLookup],
+    [lookupName],
   );
 
   // Total tool count (root-level + all nested subagent tool calls)

--- a/apps/web/src/features/integrations/hooks/useIntegrationLookup.ts
+++ b/apps/web/src/features/integrations/hooks/useIntegrationLookup.ts
@@ -1,0 +1,46 @@
+import { useCallback, useMemo } from "react";
+import { useIntegrations } from "./useIntegrations";
+
+interface IntegrationLookupEntry {
+  iconUrl?: string;
+  name?: string;
+}
+
+export interface UseIntegrationLookupReturn {
+  /** Resolve an integration id (e.g. a custom MCP id) to its display name. */
+  getIntegrationName: (integrationId: string) => string | undefined;
+  /** Resolve an integration id to its icon URL. */
+  getIntegrationIconUrl: (integrationId: string) => string | undefined;
+}
+
+/**
+ * Resolves an integration id to its human-readable name / icon.
+ *
+ * Custom MCP integrations are surfaced by id in several backend streams
+ * (tool categories, todo_progress sources), so any UI that displays one needs
+ * the same id-to-name lookup. Centralised here so there is a single source of
+ * truth instead of each consumer rebuilding the map from `useIntegrations`.
+ */
+export const useIntegrationLookup = (): UseIntegrationLookupReturn => {
+  const { integrations } = useIntegrations();
+
+  const lookup = useMemo(() => {
+    const map = new Map<string, IntegrationLookupEntry>();
+    for (const int of integrations) {
+      if (int.id) map.set(int.id, { iconUrl: int.iconUrl, name: int.name });
+    }
+    return map;
+  }, [integrations]);
+
+  const getIntegrationName = useCallback(
+    (integrationId: string) => lookup.get(integrationId)?.name,
+    [lookup],
+  );
+
+  const getIntegrationIconUrl = useCallback(
+    (integrationId: string) => lookup.get(integrationId)?.iconUrl,
+    [lookup],
+  );
+
+  return { getIntegrationName, getIntegrationIconUrl };
+};

--- a/apps/web/src/types/features/todoProgressTypes.ts
+++ b/apps/web/src/types/features/todoProgressTypes.ts
@@ -21,6 +21,12 @@ export interface TodoProgressItem {
 export interface TodoProgressSnapshot {
   todos: TodoProgressItem[];
   source: string;
+  /**
+   * Human-readable name for the source (e.g. a custom MCP integration's
+   * display name). Sent by the backend so the UI shows the integration name
+   * instead of its raw id. Absent on older persisted messages.
+   */
+  integration_name?: string;
 }
 
 /**


### PR DESCRIPTION
Custom MCP integrations stream their raw integration id as the `todo_progress` source, so the planning-task card header rendered the id instead of the integration's name. The backend now emits the display name as `integration_name` in the snapshot (threaded through `create_todo_tools` → `SubAgentFactory.create_provider_subagent`, mirroring the existing `ToolCallEntry.integration_name` pattern), sourced from `custom_doc["name"]` for custom MCPs and `subagent.name` for registry/builtin agents. On the frontend, the duplicated `integrationLookup`/`getIntegrationName` logic from `UnifiedToolThread` was extracted into a shared `useIntegrationLookup` hook, and `TodoProgressSection` resolves the header as `integration_name ?? lookup(source) ?? toTitleCase(source)` — backend name first, client lookup as a fallback for already-persisted messages. Verified clean via backend `mypy`/`ruff` and the project Biome on the changed frontend files.