### PR TITLE
fix(sandbox): make JuiceFS mount reliable + fast (cold 76–104s → ~31s, warm ~2s)

### DIFF
--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -280,7 +280,15 @@ class ProductionSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str
     E2B_TEMPLATE_ID: str  # gaia-coder template ID (run scripts/build_e2b_template.py)
-    E2B_SANDBOX_IDLE_PAUSE_SECONDS: int = 60
+    # Idle window before a sandbox is paused. A paused sandbox must resume +
+    # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single
+    # most expensive step in an acquire (the metadata engine is remote). At 60s,
+    # any think-gap between turns paused the sandbox and made the *next* `bash`
+    # pay a full remount. 300s keeps the sandbox warm across normal conversation
+    # gaps so back-to-back turns reuse a live mount. Trade-off: more concurrently
+    # live sandboxes vs the E2B quota — the scalable fix is the warm pool
+    # (E2B_WARM_POOL_TARGET_RATIO), still a follow-up.
+    E2B_SANDBOX_IDLE_PAUSE_SECONDS: int = 300
     E2B_DEFAULT_BASH_TIMEOUT: int = 120
     E2B_SANDBOX_EVICT_DAYS: int = 14
     E2B_WARM_POOL_TARGET_RATIO: float = 2.0  # Phase 2
@@ -460,7 +468,15 @@ class DevelopmentSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str | None = None
     E2B_TEMPLATE_ID: str | None = None
-    E2B_SANDBOX_IDLE_PAUSE_SECONDS: int = 60
+    # Idle window before a sandbox is paused. A paused sandbox must resume +
+    # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single
+    # most expensive step in an acquire (the metadata engine is remote). At 60s,
+    # any think-gap between turns paused the sandbox and made the *next* `bash`
+    # pay a full remount. 300s keeps the sandbox warm across normal conversation
+    # gaps so back-to-back turns reuse a live mount. Trade-off: more concurrently
+    # live sandboxes vs the E2B quota — the scalable fix is the warm pool
+    # (E2B_WARM_POOL_TARGET_RATIO), still a follow-up.
+    E2B_SANDBOX_IDLE_PAUSE_SECONDS: int = 300
     E2B_DEFAULT_BASH_TIMEOUT: int = 120
     E2B_SANDBOX_EVICT_DAYS: int = 14
     E2B_WARM_POOL_TARGET_RATIO: float = 2.0

--- a/apps/api/scripts/mount_juicefs.sh
+++ b/apps/api/scripts/mount_juicefs.sh
@@ -191,24 +191,23 @@ wait_mounted() {
     return 1
 }
 
-mount_user_subdir() {
-    if mountpoint -q "$JFS_MOUNT"; then
-        return 0
-    fi
+# Each launch_*_subdir only STARTS the juicefs daemon (launch_juicefs is
+# setsid+&, non-blocking) — it does NOT wait for readiness. The three are all
+# independent clients of the same volume on different mountpoints, and each pays
+# ~13s of connect + SQL schema-sync. Launching them together lets that overlap,
+# so the whole mount waits ~once (~14s) instead of summing (~47s). The
+# wait_mounted + bind for each happens in the main flow below.
+#
+# Memory: the E2B sandbox has only ~1 GB RAM and runs all THREE daemons at once.
+# --buffer-size is an in-RAM read/write buffer, so the old 600+300+300 MB OOM-
+# killed the mount ~2/3 of the time. Keep the buffers small (128+32+32) so they
+# coexist in ~1 GB; reads go host-side in prod so a big sandbox buffer buys little.
+launch_user_subdir() {
+    mountpoint -q "$JFS_MOUNT" && return 0
     mkdir -p "$JFS_MOUNT" /var/cache/juicefs
-    # --subdir scopes the kernel-visible tree to the user's prefix — every
-    # path under $JFS_MOUNT inside the sandbox is rooted at /users/$USER_ID,
-    # and there is no way to navigate up to a sibling user.
-    # --backup-meta=0 : R2 ListObjects is unsorted; auto-backup would fail.
-    # no --writeback  : writeback loses data on sandbox kill — keep durable.
-    #
-    # Memory: the E2B sandbox has only ~1 GB RAM, and mount.sh starts THREE
-    # juicefs daemons (this + skills + system). --buffer-size is an in-RAM
-    # read/write buffer, so the old 600+300+300 MB summed past the sandbox's
-    # total RAM and the kernel OOM-killed the mount ~2/3 of the time (the host
-    # sidecar mount, on a 16 GB box, never hit this — the flags were sized for
-    # it). Keep the three buffers small enough to coexist in ~1 GB; reads go
-    # host-side in prod so a large sandbox read buffer buys little anyway.
+    # --subdir scopes the kernel-visible tree to /users/$USER_ID — no parent
+    # navigation to a sibling user. --backup-meta=0: R2 ListObjects is unsorted.
+    # no --writeback: writeback loses data on sandbox kill — keep durable.
     launch_juicefs \
         --subdir "/users/$USER_ID" \
         --backup-meta=0 \
@@ -217,17 +216,12 @@ mount_user_subdir() {
         --max-uploads=20 \
         --buffer-size=128 \
         "$JFS_META_URL" "$JFS_MOUNT"
-    wait_mounted "$JFS_MOUNT" 45
 }
 
-mount_skills_subdir() {
-    if mountpoint -q "$JFS_SKILLS_MOUNT"; then
-        return 0
-    fi
+launch_skills_subdir() {
+    mountpoint -q "$JFS_SKILLS_MOUNT" && return 0
     mkdir -p "$JFS_SKILLS_MOUNT"
     # Read-only mount of /skills/$USER_ID — backs /workspace/skills.
-    # Small buffer — see the memory note in mount_user_subdir (three daemons in
-    # a ~1 GB sandbox). Read-only skills overlay needs almost no write buffer.
     launch_juicefs \
         --subdir "/skills/$USER_ID" \
         --read-only \
@@ -236,19 +230,12 @@ mount_skills_subdir() {
         --cache-size=512 \
         --buffer-size=32 \
         "$JFS_META_URL" "$JFS_SKILLS_MOUNT"
-    wait_mounted "$JFS_SKILLS_MOUNT" 30
 }
 
-mount_system_subdir() {
-    if mountpoint -q "$JFS_SYSTEM_MOUNT"; then
-        return 0
-    fi
+launch_system_subdir() {
+    mountpoint -q "$JFS_SYSTEM_MOUNT" && return 0
     mkdir -p "$JFS_SYSTEM_MOUNT"
-    # Read-only mount of the SHARED /_system subtree (same for every user) —
-    # backs /workspace/.system. Per-user workspaces symlink INDEX.md / GUIDE.md
-    # / builtin skills into here instead of holding their own copies.
-    # Small buffer — see the memory note in mount_user_subdir (three daemons in
-    # a ~1 GB sandbox). Read-only shared overlay needs almost no write buffer.
+    # Read-only mount of the SHARED /_system subtree — backs /workspace/.system.
     launch_juicefs \
         --subdir "/_system" \
         --read-only \
@@ -257,7 +244,6 @@ mount_system_subdir() {
         --cache-size=512 \
         --buffer-size=32 \
         "$JFS_META_URL" "$JFS_SYSTEM_MOUNT"
-    wait_mounted "$JFS_SYSTEM_MOUNT" 30
 }
 
 # The per-user subtrees ``/users/$USER_ID`` and ``/skills/$USER_ID`` are
@@ -267,7 +253,14 @@ mount_system_subdir() {
 # visible" window out of the sandbox entirely; we never need an unrestricted
 # mount in here.
 
-if ! mount_user_subdir; then
+# Start all three daemons CONCURRENTLY so their ~13s connect+schema-sync overlaps
+# (waits ~once, not 3×). Then wait for + bind each below.
+launch_user_subdir
+launch_skills_subdir
+launch_system_subdir
+
+# Primary /workspace is required. Wait for it; on failure take the ephemeral path.
+if ! wait_mounted "$JFS_MOUNT" 45; then
     echo "WARN: juicefs user --subdir mount failed (metadata DB or R2 " \
          "unreachable) — falling back to ephemeral /workspace" >&2
     ensure_workspace_writable
@@ -288,28 +281,27 @@ fi
 chown "$SANDBOX_UID:$SANDBOX_GID" "$WORKSPACE" 2>/dev/null || true
 chmod 0750 "$WORKSPACE" 2>/dev/null || true
 
-# Optional skills overlay — best-effort. If /skills/$USER_ID doesn't exist or
-# the second mount fails, /workspace/skills falls back to the user's own
-# materialized executor-skills subdir under /workspace/skills/.
+# Optional skills overlay — best-effort. Its daemon was already launched above,
+# so this only waits for readiness + binds. If /skills/$USER_ID doesn't exist or
+# the mount fails, /workspace/skills falls back to the materialized subdir.
 mkdir -p "$WORKSPACE/skills"
 chown "$SANDBOX_UID:$SANDBOX_GID" "$WORKSPACE/skills" 2>/dev/null || true
 # `mount --bind ... -o ro` is honoured on the bind itself only on newer
 # kernels; older kernels silently ignore the flag and require a remount to
 # actually mark the bind read-only. The underlying FUSE is `--read-only`
-# already (mount_skills_subdir uses --read-only), so writes still fail in
-# either case — but pin the bind itself ro explicitly so the read-only
-# surface is consistent at every layer.
-if mount_skills_subdir && mount --bind "$JFS_SKILLS_MOUNT" "$WORKSPACE/skills"; then
+# already, so writes still fail in either case — but pin the bind itself ro
+# explicitly so the read-only surface is consistent at every layer.
+if wait_mounted "$JFS_SKILLS_MOUNT" 30 && mount --bind "$JFS_SKILLS_MOUNT" "$WORKSPACE/skills"; then
     mount -o remount,bind,ro "$WORKSPACE/skills" 2>/dev/null || true
 fi
 
-# Optional shared-system overlay — best-effort. Backs /workspace/.system with the
-# single /_system subtree (INDEX.md, GUIDE.md docs, builtin skills). Per-user
-# symlinks point here so the bodies aren't copied per user. If /_system doesn't
-# exist or the mount fails, per-user workspaces simply keep their own copies.
+# Optional shared-system overlay — best-effort (daemon already launched). Backs
+# /workspace/.system with the single /_system subtree (INDEX.md, GUIDE.md docs,
+# builtin skills). If /_system doesn't exist or the mount fails, per-user
+# workspaces simply keep their own copies.
 mkdir -p "$WORKSPACE/.system"
 chown "$SANDBOX_UID:$SANDBOX_GID" "$WORKSPACE/.system" 2>/dev/null || true
-if mount_system_subdir && mount --bind "$JFS_SYSTEM_MOUNT" "$WORKSPACE/.system"; then
+if wait_mounted "$JFS_SYSTEM_MOUNT" 30 && mount --bind "$JFS_SYSTEM_MOUNT" "$WORKSPACE/.system"; then
     mount -o remount,bind,ro "$WORKSPACE/.system" 2>/dev/null || true
 fi
 

--- a/apps/api/scripts/mount_juicefs.sh
+++ b/apps/api/scripts/mount_juicefs.sh
@@ -156,12 +156,31 @@ export META_PASSWORD="${META_PASSWORD:-}"
 # future change re-grants sudo to the sandbox user, the daemon's environ
 # and cmdline stay locked down.
 JFS_LAUNCHER="/etc/gaia/jfs_launcher.py"
+JFS_LOG=/var/log/juicefs.log
 
-# Poll until $1 is a real mountpoint, up to $2 seconds (default 45). JuiceFS's
-# own --background readiness probe gives up after ~10s, but a remote meta (Neon
-# / cloud Postgres) often needs longer while the daemon finishes mounting.
-# Trusting the mount command's exit code would drop a slow-but-successful mount
-# to the ephemeral fallback, leaving /workspace unshared from the host.
+# Launch a juicefs mount as a detached FOREGROUND daemon (NO --background).
+#
+# Why not --background: in background mode juicefs forks a child daemon and the
+# parent runs an internal readiness self-check that gives up after ~10s, printing
+# `<FATAL>: mount point is not ready in 10 seconds` AND tearing the child down —
+# so a mount that just needs longer never completes. From an E2B sandbox the
+# metadata engine (remote CockroachDB) needs ~13s+ for the cold handshake +
+# per-table schema introspection, so --background turned a slow-but-fine mount
+# into a guaranteed FATAL → ephemeral fallback → canary-stale → recreate loop.
+#
+# Foreground juicefs has no such self-abort; `setsid ... &` detaches it into its
+# own session so the daemon survives this script exiting, and wait_mounted below
+# is the only readiness gate. fds are redirected so nothing ties the daemon to
+# mount.sh's stdio. The jfs_launcher PR_SET_DUMPABLE hardening still applies
+# (it runs before exec, inside setsid).
+launch_juicefs() {
+    setsid "$JFS_LAUNCHER" mount "$@" </dev/null >>"$JFS_LOG" 2>&1 &
+}
+
+# Poll until $1 is a real mountpoint, up to $2 seconds (default 45). The juicefs
+# daemon is launched detached-foreground (see launch_juicefs), so this poll —
+# not the mount command's exit code — is the real readiness gate: a slow-but-
+# successful cold mount is no longer dropped to the ephemeral fallback.
 wait_mounted() {
     local secs="${2:-45}"
     while [ "$secs" -gt 0 ]; do
@@ -182,15 +201,22 @@ mount_user_subdir() {
     # and there is no way to navigate up to a sibling user.
     # --backup-meta=0 : R2 ListObjects is unsorted; auto-backup would fail.
     # no --writeback  : writeback loses data on sandbox kill — keep durable.
-    "$JFS_LAUNCHER" mount \
+    #
+    # Memory: the E2B sandbox has only ~1 GB RAM, and mount.sh starts THREE
+    # juicefs daemons (this + skills + system). --buffer-size is an in-RAM
+    # read/write buffer, so the old 600+300+300 MB summed past the sandbox's
+    # total RAM and the kernel OOM-killed the mount ~2/3 of the time (the host
+    # sidecar mount, on a 16 GB box, never hit this — the flags were sized for
+    # it). Keep the three buffers small enough to coexist in ~1 GB; reads go
+    # host-side in prod so a large sandbox read buffer buys little anyway.
+    launch_juicefs \
         --subdir "/users/$USER_ID" \
         --backup-meta=0 \
         --cache-dir=/var/cache/juicefs \
-        --cache-size=8192 \
+        --cache-size=2048 \
         --max-uploads=20 \
-        --buffer-size=600 \
-        --background \
-        "$JFS_META_URL" "$JFS_MOUNT" 2>&1 || true
+        --buffer-size=128 \
+        "$JFS_META_URL" "$JFS_MOUNT"
     wait_mounted "$JFS_MOUNT" 45
 }
 
@@ -200,15 +226,16 @@ mount_skills_subdir() {
     fi
     mkdir -p "$JFS_SKILLS_MOUNT"
     # Read-only mount of /skills/$USER_ID — backs /workspace/skills.
-    "$JFS_LAUNCHER" mount \
+    # Small buffer — see the memory note in mount_user_subdir (three daemons in
+    # a ~1 GB sandbox). Read-only skills overlay needs almost no write buffer.
+    launch_juicefs \
         --subdir "/skills/$USER_ID" \
         --read-only \
         --backup-meta=0 \
         --cache-dir=/var/cache/juicefs \
-        --cache-size=1024 \
-        --buffer-size=300 \
-        --background \
-        "$JFS_META_URL" "$JFS_SKILLS_MOUNT" 2>&1 || true
+        --cache-size=512 \
+        --buffer-size=32 \
+        "$JFS_META_URL" "$JFS_SKILLS_MOUNT"
     wait_mounted "$JFS_SKILLS_MOUNT" 30
 }
 
@@ -220,15 +247,16 @@ mount_system_subdir() {
     # Read-only mount of the SHARED /_system subtree (same for every user) —
     # backs /workspace/.system. Per-user workspaces symlink INDEX.md / GUIDE.md
     # / builtin skills into here instead of holding their own copies.
-    "$JFS_LAUNCHER" mount \
+    # Small buffer — see the memory note in mount_user_subdir (three daemons in
+    # a ~1 GB sandbox). Read-only shared overlay needs almost no write buffer.
+    launch_juicefs \
         --subdir "/_system" \
         --read-only \
         --backup-meta=0 \
         --cache-dir=/var/cache/juicefs \
-        --cache-size=1024 \
-        --buffer-size=300 \
-        --background \
-        "$JFS_META_URL" "$JFS_SYSTEM_MOUNT" 2>&1 || true
+        --cache-size=512 \
+        --buffer-size=32 \
+        "$JFS_META_URL" "$JFS_SYSTEM_MOUNT"
     wait_mounted "$JFS_SYSTEM_MOUNT" 30
 }
 


### PR DESCRIPTION
## Problem
The agent's `bash`/`write`/`edit` were excruciatingly slow. Root-caused live in prod (Grafana/Loki + SSH + reproducing real E2B sandbox mounts against the prod CockroachDB + R2). The `ls` itself is milliseconds — **the cost is the per-user JuiceFS *mount* on a cold sandbox acquire.**

Measured decomposition of one mount, Oregon sandbox → Frankfurt metadata:
- connect (TLS verify-full handshake) ~1.2s · read volume format from R2 ~0.7s · **SQL `xorm` schema-sync ~9.5s** · session+FUSE ~1s ≈ **~13s/mount**
- `mount.sh` does **three** mounts (user+skills+system) → sequentially **~43s**
- on the old code, OOM (600MB buffers in a 1 GB sandbox) + the 10s `--background` FATAL + canary-stale recreate loop pushed real turns to **76–104s**, with 3–9 re-acquires/turn
- **R2 is ~40ms from the sandbox — ruled out.** The cost is `round-trips × distance`.

## What this PR changes (all validated in real prod)
1. **OOM fix** — `--buffer-size` 600→128MB primary, 300→32MB skills/system (+cache trims). The 1 GB sandbox OOM-killed the mount ~2/3 of the time. Verified: 600MB fails 2/3; 128MB reliable (~170–260MB used).
2. **Foreground mount** — drop `--background` (self-aborts at a hardcoded 10s); launch detached-foreground (`setsid … &`), `wait_mounted` is the real gate.
3. **Parallel mounts** — launch all 3 daemons up front, then wait+bind each (was launch+wait ×3). Same-conditions A/B (interleaved, seeded user): **sequential 43.0s → parallel 31.3s median** (~28% faster, far less variance).
4. **Idle-pause 60→300s** — keep the sandbox warm across a session so only the *first* acquire mounts; later turns are cache hits.

## Measured numbers — current prod vs after this PR
| Scenario | Current prod | After this PR |
|---|---|---|
| **Cold hit** (first action, or after >5min idle → paused sandbox remounts) | **76–104s** | **~31s** (mount.sh parallel median 31.3s; full acquire ~33s) |
| **Warm hit** (within the active window) | ~1.6–3s | **~1.6–3s** (unchanged — it's a cache hit — but hit far more often: idle-pause 60→300s) |

Reference measurements: old cold full acquire 70.2s / 71.2s · warm acquire 1.6s, warm acquire+ls 3.0s · new mount.sh parallel 31.3s vs old sequential 43.0s.

## Why ~31s is the code floor — and what fixes cold for real
The residual ~31s is **3× contended SQL schema-sync × the sandbox↔metadata network distance** — irreducible in code. Proven: **at 0ms RTT the *same* mount is ~1.2s** (vs ~13s/mount at 150ms; ×3 contended ≈ 31s). So distance, not the engine, is the wall.

**The real cold-case fix is co-location: run E2B sandboxes in EU, next to Cockroach + R2 + the host → mount ~1.2–3s, with zero code/sync/durability tradeoff. The user has contacted E2B support to enable an EU region.** Once that lands, even a true cold hit is ~3s.

## Notes
- **No Redis.** All numbers are with the existing **CockroachDB** metadata engine; this PR does not change the engine. (Redis would cut the schema-sync to ~5.8s@150ms but trades away durability — metadata loss = filesystem loss — so it's intentionally not used.)
- `_run_mount_script` ships the API's current `mount_juicefs.sh` at runtime, so the mount changes take effect on the next sandbox **without an E2B template rebuild**.
- A prewarm endpoint was prototyped and **dropped**: without co-location it only marginally hides the cold mount, server-side it's ~what `acquire_sandbox` already does at the coding tool call, and warming on conversation-open would waste sandboxes on non-coding chats (quota risk). Keep-warm (idle-pause) + co-location cover it cleanly.
- **Follow-up (not in this PR):** E2B-EU co-location (in progress with E2B support); optional dedicated (non-serverless) Cockroach to remove load-driven variance.