### PR TITLE
fix(api): unblock embedding sidecar event loop + cap concurrency

### DIFF
--- a/apps/api/app/constants/memory.py
+++ b/apps/api/app/constants/memory.py
@@ -36,6 +36,21 @@ except ValueError:
 EMBEDDING_SIDECAR_URL_ENV = "MEMORY_EMBEDDING_SIDECAR_URL"
 EMBEDDING_SIDECAR_TIMEOUT_SECONDS = 30.0
 
+# Max in-flight inferences the sidecar runs at once. Each inference uses
+# ONNX_INTRA_OP_THREADS cores, so more than (cores / threads) concurrent calls
+# oversubscribe the CPU and inflate every caller's latency past the client
+# timeout above. Default to that ratio (>= 1); env-overridable for hosts with a
+# different core/thread budget.
+_default_sidecar_concurrency = max(
+    1, (os.cpu_count() or ONNX_INTRA_OP_THREADS) // ONNX_INTRA_OP_THREADS
+)
+try:
+    EMBEDDING_SIDECAR_MAX_CONCURRENCY = max(
+        1, int(os.getenv("MEMORY_EMBEDDING_SIDECAR_CONCURRENCY", str(_default_sidecar_concurrency)))
+    )
+except ValueError:
+    EMBEDDING_SIDECAR_MAX_CONCURRENCY = _default_sidecar_concurrency
+
 # Persistent on-disk cache for the fastembed model weights. Set in prod (on the
 # embedding sidecar) to a mounted volume so the ~1.85GB download happens ONCE
 # rather than on every restart/redeploy (measured ~148s cold-load). Unset falls

--- a/apps/api/app/services/embedding_sidecar/server.py
+++ b/apps/api/app/services/embedding_sidecar/server.py
@@ -15,14 +15,24 @@ The API and worker then set ``MEMORY_EMBEDDING_SIDECAR_URL`` to its address and
 call it instead of loading their own copy.
 """
 
+import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from app.constants.memory import EMBEDDING_SIDECAR_MAX_CONCURRENCY
 from app.memory.embeddings import _embed_query_sync, _embed_sync, _rerank_sync
 from shared.py.wide_events import log
+
+# fastembed is sync and CPU-bound. Running it directly in these async handlers
+# would block the single uvicorn event loop, so one batch embed would freeze
+# every other request AND the /health check — which is what made Swarm kill the
+# container as unhealthy under load. Offload to a thread (like the in-process
+# path in app.memory.embeddings) and bound concurrency so the CPU isn't
+# oversubscribed. /health deliberately takes neither, so it always responds.
+_inference_slots = asyncio.Semaphore(EMBEDDING_SIDECAR_MAX_CONCURRENCY)
 
 
 class EmbedRequest(BaseModel):
@@ -58,14 +68,21 @@ async def health() -> dict[str, str]:
 
 @app.post("/embed")
 async def embed(request: EmbedRequest) -> dict[str, list[list[float]]]:
-    return {"vectors": _embed_sync(request.texts) if request.texts else []}
+    if not request.texts:
+        return {"vectors": []}
+    async with _inference_slots:
+        return {"vectors": await asyncio.to_thread(_embed_sync, request.texts)}
 
 
 @app.post("/embed_query")
 async def embed_query(request: EmbedQueryRequest) -> dict[str, list[float]]:
-    return {"vector": _embed_query_sync(request.text)}
+    async with _inference_slots:
+        return {"vector": await asyncio.to_thread(_embed_query_sync, request.text)}
 
 
 @app.post("/rerank")
 async def rerank(request: RerankRequest) -> dict[str, list[float]]:
-    return {"scores": _rerank_sync(request.query, request.documents) if request.documents else []}
+    if not request.documents:
+        return {"scores": []}
+    async with _inference_slots:
+        return {"scores": await asyncio.to_thread(_rerank_sync, request.query, request.documents)}

--- a/apps/api/app/services/embedding_sidecar/server.py
+++ b/apps/api/app/services/embedding_sidecar/server.py
@@ -36,14 +36,20 @@ _inference_slots = asyncio.Semaphore(EMBEDDING_SIDECAR_MAX_CONCURRENCY)
 
 
 class EmbedRequest(BaseModel):
+    """Passage texts to embed in one fastembed pass."""
+
     texts: list[str]
 
 
 class EmbedQueryRequest(BaseModel):
+    """A single query string to embed with the model's query instruction."""
+
     text: str
 
 
 class RerankRequest(BaseModel):
+    """A query and the documents to score against it."""
+
     query: str
     documents: list[str]
 
@@ -63,11 +69,13 @@ app = FastAPI(title="GAIA Embedding Sidecar", lifespan=_lifespan)
 
 @app.get("/health")
 async def health() -> dict[str, str]:
+    """Liveness probe — must never block, so it takes no inference slot."""
     return {"status": "ok"}
 
 
 @app.post("/embed")
 async def embed(request: EmbedRequest) -> dict[str, list[list[float]]]:
+    """Embed a batch of passage texts."""
     if not request.texts:
         return {"vectors": []}
     async with _inference_slots:
@@ -76,12 +84,14 @@ async def embed(request: EmbedRequest) -> dict[str, list[list[float]]]:
 
 @app.post("/embed_query")
 async def embed_query(request: EmbedQueryRequest) -> dict[str, list[float]]:
+    """Embed a single query with the model's query instruction."""
     async with _inference_slots:
         return {"vector": await asyncio.to_thread(_embed_query_sync, request.text)}
 
 
 @app.post("/rerank")
 async def rerank(request: RerankRequest) -> dict[str, list[float]]:
+    """Score documents against the query, aligned with input order."""
     if not request.documents:
         return {"scores": []}
     async with _inference_slots:

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -305,9 +305,14 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
             return f"Workflow {workflow_id} executed successfully"
 
         except Exception as e:
-            log.exception(
-                f"Error executing workflow {workflow_id}: {e}",
-            )
+            if isinstance(e, RateLimitExceededException):
+                # User hit their plan's workflow-execution quota — an expected,
+                # by-design outcome, not a worker failure. Log at WARNING so it
+                # doesn't trip the ARQ failed-task alert. The execution is still
+                # recorded as failed and the user is notified below.
+                log.warning(f"Workflow {workflow_id} skipped — rate limit exceeded: {e}")
+            else:
+                log.exception(f"Error executing workflow {workflow_id}: {e}")
 
             # Complete execution record with failure
             if execution_id:


### PR DESCRIPTION
## Why

A Grafana alert fired for **ARQ worker failed tasks** in prod. Tracing it through Loki + the prod swarm showed ~98% of the failures (over 6h: `memory_retain` 168, `backfill_user_memories` 34, `memory_vfs` 2) were the embedding sidecar timing out, plus the sidecar being repeatedly killed.

### Root cause
The sidecar's FastAPI handlers ran the CPU-bound fastembed models **directly on the single uvicorn event loop**:

```python
@app.post("/embed")
async def embed(request): return {"vectors": _embed_sync(request.texts) ...}  # blocks the loop
```

Under batch memory load one inference froze the whole worker, so concurrent `/embed`, `/embed_query`, `/rerank` **and** `/health` all serialized behind it. Evidence from prod:
- Worker logs: `memory_embedding_failed`, `backend: sidecar`, `error_type: ReadTimeout`, `latency_ms: ~30017` (the client's 30s `EMBEDDING_SIDECAR_TIMEOUT_SECONDS`).
- Sidecar logs: 30–36s gaps between `/embed` calls that line up exactly with those timeouts.
- Swarm task history: repeated `non-zero exit (137): unhealthy container` — the blocked `/health` failed the Docker healthcheck (timeout 5s × 5 retries), so Swarm SIGKILLed and rescheduled the task ~5× in 3h, dropping in-flight requests each time.

The in-process path in `app.memory.embeddings` already offloads via `asyncio.to_thread`; the sidecar dropped that. PR #789 (yesterday) capped the sidecar to 4 ONNX threads + 3G RAM, which made the saturation sharper.

## What changed

1. **Offload inference to a thread** (`asyncio.to_thread`) in all three handlers, mirroring the in-process path. `/health` takes no slot, so it always responds → ends the kill/restart cycle.
2. **Bound in-flight inferences** with a semaphore sized to `cores / ONNX_INTRA_OP_THREADS` (`EMBEDDING_SIDECAR_MAX_CONCURRENCY`, env-overridable via `MEMORY_EMBEDDING_SIDECAR_CONCURRENCY`). On the 8-core prod host this is **2**, so a batch burst can't oversubscribe the CPU or reinflate latency — and keeps RSS within the 3G limit #789 set.
3. **Downgrade workflow 429 logs ERROR → WARNING.** `execute_workflow_by_id` logged plan-quota `rate_limit_exceeded` at ERROR, counting a by-design user quota hit as a worker failure and polluting the alert. The execution is still recorded as failed and the user is still notified.

## Verification
- `ruff check` clean on all three files (+ pre-commit: ruff/bandit/pip-audit passed).
- `mypy` clean: `Success: no issues found in 3 source files`.
- Runtime smoke test: constant computes to 2 on an 8-core host (3 on 12-core dev), module-level `asyncio.Semaphore` constructs fine outside a running loop.

## Risk
Low — restores the threadpool offload the in-process path already uses; vectors/scores are byte-for-byte unchanged. No infra/compose changes; concurrency is env-tunable without a redeploy.