### PR TITLE
feat(logging): greppable subsystem prefixes + structured wide events

### DIFF
--- a/apps/api/app/agents/core/agent.py
+++ b/apps/api/app/agents/core/agent.py
@@ -25,6 +25,7 @@ from app.agents.core.messages import construct_langchain_messages
 from app.agents.llm.plan_model import apply_plan_model
 from app.config.langfuse import trace_id_for_message
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.helpers.agent_helpers import (
     build_agent_config,
     build_initial_state,
@@ -201,7 +202,7 @@ async def call_agent(
         return execute_graph_streaming(graph, initial_state, config)
 
     except Exception as exc:
-        log.error(f"Error when calling agent: {exc}")
+        log.error(f"{LogTag.AGENT} Error when calling agent: {exc}")
         error_message = f"Error when calling agent: {exc!s}"
 
         async def error_generator():
@@ -281,7 +282,7 @@ async def call_agent_silent(
         return complete_message, tool_data
 
     except Exception as exc:
-        log.error(f"Error when calling silent agent: {exc}")
+        log.error(f"{LogTag.AGENT} Error when calling silent agent: {exc}")
         return f"Error when calling silent agent: {exc!s}", {}
     finally:
         teardown_executor_capture(stream_id)

--- a/apps/api/app/agents/core/background/comms_narrator.py
+++ b/apps/api/app/agents/core/background/comms_narrator.py
@@ -11,6 +11,7 @@ from langchain_core.messages import HumanMessage
 from app.agents.core.graph_manager import GraphManager
 from app.agents.prompts.comms_prompts import PLATFORM_DELIVERY_NOTE
 from app.constants.agents import EXECUTOR_ERROR_MARKER, EXECUTOR_RESULT_MARKER
+from app.constants.log_tags import LogTag
 from app.helpers.agent_helpers import build_agent_config, execute_graph_silent
 from app.utils.agent_utils import strip_internal_agent_markers
 from shared.py.wide_events import log
@@ -50,7 +51,7 @@ async def narrate_executor_result(
     try:
         comms_graph = await GraphManager.get_graph("comms_agent")
         if not comms_graph:
-            log.warning("narrate_executor_result: comms_agent graph unavailable")
+            log.warning(f"{LogTag.AGENT} narrate_executor_result: comms_agent graph unavailable")
             return ""
         config = build_agent_config(
             conversation_id=conversation_id,
@@ -79,5 +80,5 @@ async def narrate_executor_result(
         notification_text, _ = await execute_graph_silent(comms_graph, initial_state, config)
         return strip_internal_agent_markers(notification_text)
     except Exception as e:
-        log.error("narrate_executor_result: failed", error=str(e))
+        log.error(f"{LogTag.AGENT} narrate_executor_result: failed", error=str(e))
         return ""

--- a/apps/api/app/agents/core/background/executor_capture.py
+++ b/apps/api/app/agents/core/background/executor_capture.py
@@ -22,6 +22,7 @@ from app.agents.core.background.session import (
 )
 from app.constants.agents import RETURNED_TO_FRONTEND_MARKER
 from app.constants.cache import EXECUTOR_WAIT_TIMEOUT
+from app.constants.log_tags import LogTag
 from app.models.chat_models import tool_fields
 from app.utils.stream_utils import (
     absorb_collector_event,
@@ -61,12 +62,14 @@ async def await_executor_done(
     session = get_session(stream_id)
     if session is None:
         return
-    log.info("Waiting for executor completion", stream_id=stream_id)
+    log.info(f"{LogTag.AGENT} Waiting for executor completion", stream_id=stream_id)
     try:
         async with asyncio.timeout(timeout):
             await session.done_event.wait()
     except TimeoutError:
-        log.warning("Timed out waiting for executor — draining anyway", stream_id=stream_id)
+        log.warning(
+            f"{LogTag.AGENT} Timed out waiting for executor — draining anyway", stream_id=stream_id
+        )
 
 
 def drain_executor_tool_data(stream_id: str) -> list[dict[str, Any]]:

--- a/apps/api/app/agents/core/background/executor_queue.py
+++ b/apps/api/app/agents/core/background/executor_queue.py
@@ -26,6 +26,7 @@ from app.constants.cache import (
     EXECUTOR_QUEUE_PREFIX,
     EXECUTOR_QUEUE_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import StreamManager
 from app.core.websocket_manager import websocket_manager
 from app.db.redis import redis_cache
@@ -252,7 +253,7 @@ async def pop_next_queued_run(conversation_id: str) -> PreparedQueuedTask | None
         item: dict = json.loads(raw)
     except (json.JSONDecodeError, ValueError) as e:
         log.error(
-            "Failed to parse queued executor task",
+            f"{LogTag.AGENT} Failed to parse queued executor task",
             conversation_id=conversation_id,
             error=str(e),
         )

--- a/apps/api/app/agents/core/background/executor_runner.py
+++ b/apps/api/app/agents/core/background/executor_runner.py
@@ -41,6 +41,7 @@ from app.agents.core.subagents.subagent_runner import (
     prepare_executor_execution,
 )
 from app.constants.executor import MESSAGE_ID_KEY, VOICE_TTS_KEY
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import StreamManager
 from app.utils.agent_utils import format_sse_data
 from shared.py.wide_events import log
@@ -72,7 +73,11 @@ async def run_executor_background(
 
     try:
         result_text, result_type = await _execute_executor(task, configurable, run.stream_id)
-        log.info("Background executor completed", task_id=run.task_id, stream_id=run.stream_id)
+        log.info(
+            f"{LogTag.AGENT} Background executor completed",
+            task_id=run.task_id,
+            stream_id=run.stream_id,
+        )
     finally:
         await _finalize_executor_run(run, result_text, result_type)
 
@@ -98,13 +103,13 @@ async def _execute_executor(
             stream_id=stream_id,
         )
         if error or ctx is None:
-            log.error("Executor prep failed", error=error)
+            log.error(f"{LogTag.AGENT} Executor prep failed", error=error)
             return (error or "Executor agent not available"), "error"
         writer = make_redis_stream_writer(stream_id)
         result_text = await execute_subagent_stream(ctx=ctx, stream_writer=writer)
         return result_text, "final"
     except Exception as e:
-        log.error("Executor run failed", stream_id=stream_id, error=str(e))
+        log.error(f"{LogTag.AGENT} Executor run failed", stream_id=stream_id, error=str(e))
         return str(e), "error"
 
 
@@ -133,7 +138,7 @@ async def _finalize_executor_run(
         await _close_queued_stream(run, was_cancelled)
     except Exception as e:  # noqa: BLE001 — never let delivery failure strand the queue
         log.error(
-            "Executor finalize delivery/close failed",
+            f"{LogTag.AGENT} Executor finalize delivery/close failed",
             stream_id=run.stream_id,
             task_id=run.task_id,
             error=str(e),
@@ -163,7 +168,7 @@ async def _deliver_terminal_outcome(
             await persist_cancelled_run(run)
         else:
             log.info(
-                "Live executor cancelled; comms stream owns tool_data persistence",
+                f"{LogTag.AGENT} Live executor cancelled; comms stream owns tool_data persistence",
                 task_id=run.task_id,
                 stream_id=run.stream_id,
             )
@@ -261,7 +266,7 @@ def _spawn_queued_run(run: ExecutorRun, prepared: PreparedQueuedTask) -> None:
     bg_task.add_done_callback(_queued_executor_tasks.discard)
 
     log.info(
-        "Queued executor task spawned",
+        f"{LogTag.AGENT} Queued executor task spawned",
         task_id=prepared.run.task_id,
         conversation_id=run.conversation_id,
         stream_id=prepared.run.stream_id,

--- a/apps/api/app/agents/core/background/redis_writer.py
+++ b/apps/api/app/agents/core/background/redis_writer.py
@@ -15,6 +15,7 @@ import json
 from typing import Any
 
 from app.agents.core.background.session import get_session
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from shared.py.wide_events import log
 
@@ -42,7 +43,7 @@ def make_redis_stream_writer(stream_id: str) -> Callable[[dict[str, Any]], None]
             _publish_tasks.add(task)
             task.add_done_callback(_publish_tasks.discard)
         except RuntimeError:
-            log.error("redis_writer: no event loop for stream", stream_id=stream_id)
+            log.error(f"{LogTag.AGENT} redis_writer: no event loop for stream", stream_id=stream_id)
 
         session = get_session(stream_id)
         if session is not None:

--- a/apps/api/app/agents/core/background/result_delivery.py
+++ b/apps/api/app/agents/core/background/result_delivery.py
@@ -24,6 +24,7 @@ from app.agents.core.background.comms_narrator import narrate_executor_result
 from app.agents.core.background.executor_capture import drain_executor_tool_data
 from app.agents.core.background.session import ExecutorRun
 from app.agents.core.nodes.follow_up_actions_node import generate_follow_up_actions
+from app.constants.log_tags import LogTag
 from app.core.websocket_manager import websocket_manager
 from app.db.mongodb.collections import conversations_collection
 from app.models.chat_models import ConversationSource, MessageModel, UpdateMessagesRequest
@@ -72,7 +73,7 @@ async def deliver_result(
             run, result_text, result_type, attach_tool_data, returned_note
         )
     except Exception as e:  # noqa: BLE001 — delivery is best-effort, never propagates
-        log.error("Background notification delivery failed", error=str(e))
+        log.error(f"{LogTag.AGENT} Background notification delivery failed", error=str(e))
         return None, None
 
 
@@ -91,7 +92,7 @@ async def persist_cancelled_run(run: ExecutorRun) -> None:
     tool_data = drain_executor_tool_data(run.stream_id)
     if not tool_data:
         log.info(
-            "Cancelled executor produced no cards to persist",
+            f"{LogTag.AGENT} Cancelled executor produced no cards to persist",
             task_id=run.task_id,
             stream_id=run.stream_id,
         )
@@ -114,11 +115,11 @@ async def persist_cancelled_run(run: ExecutorRun) -> None:
             user=run.user,
         )
     except Exception as e:  # noqa: BLE001 — best-effort save of a stopped run
-        log.error("Failed to save cancelled executor cards", error=str(e))
+        log.error(f"{LogTag.AGENT} Failed to save cancelled executor cards", error=str(e))
         return
 
     log.info(
-        "Persisted cancelled executor cards",
+        f"{LogTag.AGENT} Persisted cancelled executor cards",
         message_id=bot_message.message_id,
         task_id=run.task_id,
         stream_id=run.stream_id,
@@ -210,7 +211,7 @@ async def _narrate_and_deliver(
             user=run.user,
         )
     except Exception as e:
-        log.error("deliver_result: failed to save message", error=str(e))
+        log.error(f"{LogTag.AGENT} deliver_result: failed to save message", error=str(e))
         return None, None
 
     # Workflow run: the result was produced with no human watching, so deliver it
@@ -269,7 +270,7 @@ async def _narrate_and_deliver(
         transport = "websocket"
 
     log.info(
-        "deliver_result: delivered message",
+        f"{LogTag.AGENT} deliver_result: delivered message",
         message_id=bot_message.message_id,
         task_id=run.task_id,
         conversation_id=run.conversation_id,
@@ -305,7 +306,7 @@ async def _safe_inline_follow_ups(
         )
     except Exception as e:  # noqa: BLE001 — follow-ups are best-effort
         log.error(
-            "deliver_result: failed to generate follow-up actions",
+            f"{LogTag.AGENT} deliver_result: failed to generate follow-up actions",
             error=str(e),
             conversation_id=conversation_id,
             message_id=message_id,
@@ -414,7 +415,7 @@ async def _generate_and_push_follow_ups(
     except Exception as e:
         # Non-critical enhancement — the answer is already delivered. Log loudly
         # but never let a follow-up failure crash the background task.
-        log.error("deliver_result: deferred follow-up actions failed", error=str(e))
+        log.error(f"{LogTag.AGENT} deliver_result: deferred follow-up actions failed", error=str(e))
 
 
 async def _dispatch_workflow_notification(
@@ -450,7 +451,7 @@ async def _dispatch_workflow_notification(
         )
     elif not notify_on_completion:
         log.info(
-            "deliver_result: completion notification skipped (workflow is silent)",
+            f"{LogTag.AGENT} deliver_result: completion notification skipped (workflow is silent)",
             workflow_id=workflow_id,
             message_id=message_id,
         )
@@ -464,7 +465,7 @@ async def _dispatch_workflow_notification(
             result_text=notification_text,
         )
     log.info(
-        "deliver_result: workflow notification dispatched",
+        f"{LogTag.AGENT} deliver_result: workflow notification dispatched",
         workflow_id=workflow_id,
         message_id=message_id,
     )
@@ -525,7 +526,7 @@ async def _broadcast_message(user_id: str, ws_event: dict[str, Any]) -> None:
             return
         except Exception as ws_err:
             log.warning(
-                "_broadcast_message: broadcast attempt failed",
+                f"{LogTag.AGENT} _broadcast_message: broadcast attempt failed",
                 attempt=attempt + 1,
                 user_id=user_id,
                 error=str(ws_err),
@@ -550,7 +551,7 @@ async def _lookup_user_message_content(
         if conv_doc and conv_doc.get("messages"):
             return conv_doc["messages"][0].get("response", "")[:150]
     except Exception as e:
-        log.warning("_lookup_user_message_content: failed", error=str(e))
+        log.warning(f"{LogTag.AGENT} _lookup_user_message_content: failed", error=str(e))
     return ""
 
 
@@ -568,6 +569,6 @@ async def _get_conversation_source(conversation_id: str, user_id: str) -> Conver
             {"source": 1},
         )
     except Exception as e:
-        log.warning("_get_conversation_source: lookup failed", error=str(e))
+        log.warning(f"{LogTag.AGENT} _get_conversation_source: lookup failed", error=str(e))
         return None
     return ConversationSource.coerce(doc.get("source")) if doc else None

--- a/apps/api/app/agents/core/background/session.py
+++ b/apps/api/app/agents/core/background/session.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -152,7 +153,10 @@ def get_or_create_session(stream_id: str, kind: RunKind = RunKind.LIVE) -> Strea
     """
     session = _sessions.get(stream_id)
     if session is None:
-        log.warning("Implicit session creation — registration ordering gap", stream_id=stream_id)
+        log.warning(
+            f"{LogTag.AGENT} Implicit session creation — registration ordering gap",
+            stream_id=stream_id,
+        )
         session = create_session(stream_id, kind)
     return session
 

--- a/apps/api/app/agents/core/background/subagent_runner.py
+++ b/apps/api/app/agents/core/background/subagent_runner.py
@@ -19,6 +19,7 @@ from app.agents.core.subagents.subagent_runner import (
     SubagentExecutionContext,
     execute_subagent_stream,
 )
+from app.constants.log_tags import LogTag
 from app.utils.agent_utils import (
     IntegrationMetadata,
     format_subagent_end_event,
@@ -81,14 +82,14 @@ async def run_subagent_background(
                 }
             )
         log.info(
-            "Background subagent completed",
+            f"{LogTag.AGENT} Background subagent completed",
             agent_name=ctx.agent_name,
             stream_id=stream_id,
         )
         append_bg_subagent_result(stream_id, ctx.agent_name, result)
     except Exception as e:
         log.error(
-            "Background subagent failed",
+            f"{LogTag.AGENT} Background subagent failed",
             agent_name=ctx.agent_name,
             stream_id=stream_id,
             error=str(e),

--- a/apps/api/app/agents/core/graph_builder/build_graph.py
+++ b/apps/api/app/agents/core/graph_builder/build_graph.py
@@ -30,6 +30,7 @@ from app.agents.tools.core.tool_runtime_config import (
 from app.agents.tools.executor_tool import call_executor, cancel_executor
 from app.agents.tools.todo_tools import create_todo_pre_model_hook, create_todo_tools
 from app.agents.tools.wait_for_subagents_tool import wait_for_subagents as wait_for_subagents_tool
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider
 from app.override.langgraph_bigtool.create_agent import create_agent
 from app.override.langgraph_bigtool.hooks import HookType
@@ -74,7 +75,7 @@ async def build_executor_graph(
     )
     if subagent_mw is None:
         log.warning(
-            "SubagentMiddleware not found in middleware stack; spawn_subagent will be unavailable"
+            f"{LogTag.AGENT} SubagentMiddleware not found in middleware stack; spawn_subagent will be unavailable"
         )
     else:
         subagent_mw.set_llm(chat_llm)
@@ -149,10 +150,10 @@ async def build_executor_graph(
 )
 async def build_executor_agent():
     """Build and return the executor agent with full tool access."""
-    log.debug("Building executor agent with lazy providers")
+    log.debug(f"{LogTag.AGENT} Building executor agent with lazy providers")
 
     async with build_executor_graph() as graph:
-        log.info("Executor agent built successfully")
+        log.info(f"{LogTag.AGENT} Executor agent built successfully")
     return graph
 
 
@@ -208,13 +209,13 @@ async def build_comms_graph(
     if in_memory_checkpointer or not checkpointer_manager:
         in_memory_checkpointer_instance = InMemorySaver()
         graph = builder.compile(checkpointer=in_memory_checkpointer_instance, store=store)
-        log.debug("Comms graph compiled with in-memory checkpointer")
+        log.debug(f"{LogTag.AGENT} Comms graph compiled with in-memory checkpointer")
         log.set(agent={"model": model_name})
         yield graph
     else:
         postgres_checkpointer = checkpointer_manager.get_checkpointer()
         graph = builder.compile(checkpointer=postgres_checkpointer, store=store)
-        log.debug("Comms graph compiled with PostgreSQL checkpointer")
+        log.debug(f"{LogTag.AGENT} Comms graph compiled with PostgreSQL checkpointer")
         log.set(agent={"model": model_name})
         yield graph
 
@@ -227,19 +228,19 @@ async def build_comms_graph(
 )
 async def build_comms_agent():
     """Build and return the comms agent using lazy providers."""
-    log.debug("Building comms agent with lazy providers")
+    log.debug(f"{LogTag.AGENT} Building comms agent with lazy providers")
 
     async with build_comms_graph() as graph:
-        log.info("Comms agent built successfully")
+        log.info(f"{LogTag.AGENT} Comms agent built successfully")
     return graph
 
 
 def build_graphs():
     """Build comms and executor agents and register subagent providers."""
-    log.info("Building core agent graphs...")
+    log.info(f"{LogTag.AGENT} Building core agent graphs...")
 
     register_subagent_providers()
     build_executor_agent()
     build_comms_agent()
 
-    log.info("Core agent graphs built and registered successfully")
+    log.info(f"{LogTag.AGENT} Core agent graphs built and registered successfully")

--- a/apps/api/app/agents/core/graph_manager.py
+++ b/apps/api/app/agents/core/graph_manager.py
@@ -6,6 +6,7 @@ This module helps avoid circular imports between app.api.v1 and app.agents.agent
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from shared.py.wide_events import log
 
@@ -14,19 +15,23 @@ class GraphManager:
     @classmethod
     async def get_graph(cls, graph_name: str = "default_graph") -> Any:
         """Get the graph instance by name."""
-        log.info(f"Attempting to get graph '{graph_name}'")
+        log.info(f"{LogTag.AGENT} Attempting to get graph '{graph_name}'")
         try:
             graph = await providers.aget(graph_name)
             if graph is not None:
-                log.info(f"Successfully retrieved graph '{graph_name}' from lazy provider")
+                log.info(
+                    f"{LogTag.AGENT} Successfully retrieved graph '{graph_name}' from lazy provider"
+                )
                 return graph
             log.error(
-                f"Graph '{graph_name}' returned None from lazy provider - this means the provider function failed or returned None"
+                f"{LogTag.AGENT} Graph '{graph_name}' returned None from lazy provider - this means the provider function failed or returned None"
             )
             return None
         except KeyError as e:
-            log.error(f"Graph provider '{graph_name}' not registered in lazy providers: {e}")
+            log.error(
+                f"{LogTag.AGENT} Graph provider '{graph_name}' not registered in lazy providers: {e}"
+            )
             return None
         except Exception as e:
-            log.error(f"Error retrieving graph '{graph_name}': {e}", exc_info=True)
+            log.error(f"{LogTag.AGENT} Error retrieving graph '{graph_name}': {e}", exc_info=True)
             return None

--- a/apps/api/app/agents/core/nodes/filter_messages.py
+++ b/apps/api/app/agents/core/nodes/filter_messages.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph import MessagesState
 from langgraph.store.base import BaseStore
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 T = TypeVar("T", bound=MessagesState)
@@ -66,5 +67,5 @@ def filter_messages_node(state: T, config: RunnableConfig, store: BaseStore) -> 
         return {**state, "messages": filtered_messages}  # type: ignore[return-value]
 
     except Exception as e:
-        log.error(f"Error in filter messages node: {e}")
+        log.error(f"{LogTag.AGENT} Error in filter messages node: {e}")
         return state

--- a/apps/api/app/agents/core/nodes/follow_up_actions_node.py
+++ b/apps/api/app/agents/core/nodes/follow_up_actions_node.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 from app.agents.llm.client import get_free_llm_chain, invoke_with_fallback
 from app.agents.tools.core.registry import get_tool_registry
 from app.constants.general import CALL_EXECUTOR_NAME
+from app.constants.log_tags import LogTag
 from app.override.langgraph_bigtool.utils import State
 from app.services.integrations.user_integrations import (
     get_user_integration_capabilities,
@@ -95,7 +96,7 @@ async def generate_follow_up_actions(
         actions = parser.parse(result if isinstance(result, str) else result.text)
         return actions.actions if actions.actions else []
     except Exception as e:
-        log.debug(f"Follow-up action generation failed: {e}")
+        log.debug(f"{LogTag.AGENT} Follow-up action generation failed: {e}")
         return []
 
 
@@ -110,7 +111,9 @@ async def follow_up_actions_node(state: State, config: RunnableConfig, store: Ba
         writer({"main_response_complete": True})
     except Exception as write_error:
         # Stream is closed (user disconnected), no need to continue
-        log.debug(f"Stream already closed when sending completion marker: {write_error}")
+        log.debug(
+            f"{LogTag.AGENT} Stream already closed when sending completion marker: {write_error}"
+        )
         return state
 
     messages = state.get("messages", [])
@@ -121,7 +124,7 @@ async def follow_up_actions_node(state: State, config: RunnableConfig, store: Ba
     # intermediate comms acknowledgement, where they flash then vanish once the
     # executor's result message supersedes it.
     if _delegated_to_executor(messages):
-        log.debug("Skipping comms follow-ups: turn delegated to executor")
+        log.debug(f"{LogTag.AGENT} Skipping comms follow-ups: turn delegated to executor")
         return state
 
     # Skip if insufficient conversation history for meaningful suggestions
@@ -151,7 +154,7 @@ def _safe_write_actions(writer: StreamWriter, actions: list[str]) -> None:
     try:
         writer({"follow_up_actions": actions})
     except Exception as e:
-        log.debug(f"Stream closed when sending follow-up actions: {e}")
+        log.debug(f"{LogTag.AGENT} Stream closed when sending follow-up actions: {e}")
 
 
 def _delegated_to_executor(messages: list[AnyMessage]) -> bool:

--- a/apps/api/app/agents/core/nodes/manage_system_prompts.py
+++ b/apps/api/app/agents/core/nodes/manage_system_prompts.py
@@ -22,6 +22,7 @@ from langchain_core.messages import AnyMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
+from app.constants.log_tags import LogTag
 from app.override.langgraph_bigtool.utils import State
 from shared.py.wide_events import log
 
@@ -209,5 +210,5 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         return cast(State, {**state, "messages": filtered})
 
     except Exception as e:
-        log.error(f"Error in manage system prompts node: {e}")
+        log.error(f"{LogTag.AGENT} Error in manage system prompts node: {e}")
         return state

--- a/apps/api/app/agents/core/nodes/memory_node.py
+++ b/apps/api/app/agents/core/nodes/memory_node.py
@@ -14,6 +14,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
 from app.config.oauth_config import get_memory_extraction_prompt
+from app.constants.log_tags import LogTag
 from app.constants.memory import (
     MIN_USER_CONTENT_CHARS,
     MemorySourceType,
@@ -197,7 +198,7 @@ async def memory_node(
     # Quick validation - skip trivial conversations
     should_learn, reason = _check_worth_learning(messages)
     if not should_learn:
-        log.debug(f"Memory learning skipped: {reason}")
+        log.debug(f"{LogTag.AGENT} Memory learning skipped: {reason}")
         return state
 
     if user_id:
@@ -215,6 +216,8 @@ async def memory_node(
 
         _background_tasks.add(task)
         task.add_done_callback(_task_done_callback)
-        log.debug(f"[{subagent_id or 'agent'}] Memory learning spawned: {task.get_name()}")
+        log.debug(
+            f"{LogTag.AGENT} Memory learning spawned ({subagent_id or 'agent'}): {task.get_name()}"
+        )
 
     return state

--- a/apps/api/app/agents/core/subagents/base_subagent.py
+++ b/apps/api/app/agents/core/subagents/base_subagent.py
@@ -36,6 +36,7 @@ from app.agents.tools.research_tool import deep_research
 from app.agents.tools.todo_tools import create_todo_pre_model_hook, create_todo_tools
 from app.agents.tools.webpage_tool import fetch_webpages, web_search_tool
 from app.constants.general import FINISH_TASK_NAME
+from app.constants.log_tags import LogTag
 from app.override.langgraph_bigtool.create_agent import create_agent
 from app.override.langgraph_bigtool.hooks import HookType
 from shared.py.wide_events import log
@@ -135,7 +136,7 @@ class SubAgentFactory:
         """
         log.set(subagent={"name": name, "provider": provider})
         log.info(
-            f"Creating {provider} sub-agent graph using tool space '{tool_space}' with "
+            f"{LogTag.AGENT} Creating {provider} sub-agent graph using tool space '{tool_space}' with "
             + ("direct tools binding" if use_direct_tools else "retrieve tools")
         )
 
@@ -197,7 +198,9 @@ class SubAgentFactory:
             else None
         )
         if valid_auto_bind:
-            log.info(f"Auto-binding {len(valid_auto_bind)} tools for {provider}: {valid_auto_bind}")
+            log.info(
+                f"{LogTag.AGENT} Auto-binding {len(valid_auto_bind)} tools for {provider}: {valid_auto_bind}"
+            )
 
         parent_tool_runtime = build_provider_parent_tool_runtime_config(
             provider_tool_names=initial_tool_ids,
@@ -237,14 +240,16 @@ class SubAgentFactory:
         try:
             checkpointer_manager = await get_checkpointer_manager()
             checkpointer = checkpointer_manager.get_checkpointer()
-            log.debug(f"Using PostgreSQL checkpointer for {provider} sub-agent")
+            log.debug(f"{LogTag.AGENT} Using PostgreSQL checkpointer for {provider} sub-agent")
         except Exception as e:
             log.warning(
-                f"PostgreSQL checkpointer unavailable for {provider} sub-agent: {e}. Using InMemorySaver."
+                f"{LogTag.AGENT} PostgreSQL checkpointer unavailable for {provider} sub-agent: {e}. Using InMemorySaver."
             )
             checkpointer = InMemorySaver()
 
         subagent_graph = builder.compile(store=store, name=name, checkpointer=checkpointer)
 
-        log.info(f"Successfully created {provider} sub-agent graph with checkpointer")
+        log.info(
+            f"{LogTag.AGENT} Successfully created {provider} sub-agent graph with checkpointer"
+        )
         return subagent_graph

--- a/apps/api/app/agents/core/subagents/handoff_tools.py
+++ b/apps/api/app/agents/core/subagents/handoff_tools.py
@@ -34,6 +34,7 @@ from app.agents.core.subagents.subagent_runner import (
     execute_subagent_stream,
 )
 from app.constants.cache import SUBAGENT_CACHE_PREFIX, SUBAGENT_CACHE_TTL
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.mongodb.collections import integrations_collection
 from app.db.redis import get_cache, set_cache
@@ -123,7 +124,7 @@ async def check_integration_connection(
         return build_integration_connection_message(subagent.name, connect_url)
 
     except Exception as e:
-        log.error(f"Error checking integration status for {integration_id}: {e}")
+        log.error(f"{LogTag.AGENT} Error checking integration status for {integration_id}: {e}")
         return None
 
 
@@ -260,7 +261,7 @@ async def index_custom_mcp_as_subagent(
 
     await store.abatch([put_op])
     log.info(
-        f"Indexed custom MCP {name} ({integration_id}) as subagent with {len(tools or [])} tools"
+        f"{LogTag.AGENT} Indexed custom MCP {name} ({integration_id}) as subagent with {len(tools or [])} tools"
     )
 
 
@@ -623,7 +624,7 @@ async def handoff(
         if background:
             if not stream_id:
                 log.warning(
-                    "handoff background=True but stream_id is missing — "
+                    f"{LogTag.AGENT} handoff background=True but stream_id is missing — "
                     "falling back to blocking execution"
                 )
                 blocking_result = await _run_blocking_handoff(
@@ -653,7 +654,9 @@ async def handoff(
             )
             _background_subagent_tasks.add(bg_task)
             bg_task.add_done_callback(_background_subagent_tasks.discard)
-            log.info(f"Subagent {agent_name} dispatched to background for stream {sid}")
+            log.info(
+                f"{LogTag.AGENT} Subagent {agent_name} dispatched to background for stream {sid}"
+            )
             return (
                 f"Subagent {agent_name} started in background. "
                 "Call wait_for_subagents() when ready to collect results."
@@ -664,7 +667,7 @@ async def handoff(
 
     except Exception as e:
         log.error(
-            "handoff_failed",
+            f"{LogTag.AGENT} handoff_failed",
             subagent_id=subagent_id,
             user_id=user_id,
             error_type=type(e).__name__,

--- a/apps/api/app/agents/core/subagents/provider_subagents.py
+++ b/apps/api/app/agents/core/subagents/provider_subagents.py
@@ -17,6 +17,7 @@ from app.agents.core.subagents.registry import all_subagents, get_subagent_by_id
 from app.agents.llm.client import init_llm
 from app.agents.tools.core.registry import get_tool_registry
 from app.config.oauth_config import get_integration_by_id
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.mongodb.collections import integrations_collection
 from app.helpers.namespace_utils import derive_integration_namespace
@@ -47,7 +48,7 @@ async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
     if subagent.managed_by == "internal":
         # Internal integrations use core tools that are registered at startup
         # No additional setup needed - tools are already in the registry
-        log.info(f"Internal integration {subagent.id}: using pre-registered tools")
+        log.info(f"{LogTag.AGENT} Internal integration {subagent.id}: using pre-registered tools")
 
     # Handle MCP-managed integrations (like DeepWiki)
     elif subagent.managed_by == "mcp" and subagent.mcp_config:
@@ -71,7 +72,7 @@ async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
                     integration_name=subagent.id,
                 )
                 await tool_registry._index_category_tools(category_name)
-                log.info(f"Registered {len(tools)} MCP tools for {subagent.id}")
+                log.info(f"{LogTag.AGENT} Registered {len(tools)} MCP tools for {subagent.id}")
 
     # Handle Composio-managed integrations
     # `Subagent` does not carry composio_config; look up the OAuth integration
@@ -98,7 +99,9 @@ async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
     llm = init_llm()
 
     log.set(subagent={"name": config.agent_name, "provider": subagent.provider})
-    log.info(f"Creating {config.agent_name} on-demand using tool space: {config.tool_space}")
+    log.info(
+        f"{LogTag.AGENT} Creating {config.agent_name} on-demand using tool space: {config.tool_space}"
+    )
 
     graph = await SubAgentFactory.create_provider_subagent(
         provider=subagent.provider,
@@ -112,7 +115,7 @@ async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
         source_label=subagent.name,
     )
 
-    log.info(f"Subagent {config.agent_name} created successfully")
+    log.info(f"{LogTag.AGENT} Subagent {config.agent_name} created successfully")
     return graph
 
 
@@ -143,7 +146,7 @@ async def _build_user_subagent(integration_id: str, user_id: str) -> CompiledSta
 
     mcp_config = subagent.mcp_config
     if not (subagent.managed_by == "mcp" and mcp_config):
-        log.error(f"{integration_id} is not an MCP integration")
+        log.error(f"{LogTag.AGENT} {integration_id} is not an MCP integration")
         return None
 
     config = subagent.config
@@ -152,26 +155,26 @@ async def _build_user_subagent(integration_id: str, user_id: str) -> CompiledSta
     if subagent.id in mcp_client._tools:
         tools = mcp_client._tools[subagent.id]
         log.info(
-            f"_build_user_subagent: integration={integration_id} user={user_id} "
+            f"{LogTag.AGENT} _build_user_subagent: integration={integration_id} user={user_id} "
             f"using warm MCPClient tools ({len(tools)})"
         )
     else:
         try:
             tools = await mcp_client.connect(subagent.id)
             log.info(
-                f"_build_user_subagent: integration={integration_id} user={user_id} "
+                f"{LogTag.AGENT} _build_user_subagent: integration={integration_id} user={user_id} "
                 f"cold connect, got {len(tools)} tools"
             )
         except Exception as e:
             log.error(
-                f"_build_user_subagent: integration={integration_id} user={user_id} "
+                f"{LogTag.AGENT} _build_user_subagent: integration={integration_id} user={user_id} "
                 f"connect FAILED: {type(e).__name__}: {e}"
             )
             return None
 
     if not tools:
         log.error(
-            f"_build_user_subagent: integration={integration_id} user={user_id} "
+            f"{LogTag.AGENT} _build_user_subagent: integration={integration_id} user={user_id} "
             f"got 0 tools — cannot create subagent"
         )
         return None
@@ -180,7 +183,7 @@ async def _build_user_subagent(integration_id: str, user_id: str) -> CompiledSta
 
     log.set(subagent={"name": config.agent_name, "provider": subagent.provider})
     log.info(
-        f"Creating {config.agent_name} for user {user_id} using tool space: {config.tool_space}"
+        f"{LogTag.AGENT} Creating {config.agent_name} for user {user_id} using tool space: {config.tool_space}"
     )
 
     graph = await SubAgentFactory.create_provider_subagent(
@@ -196,7 +199,7 @@ async def _build_user_subagent(integration_id: str, user_id: str) -> CompiledSta
         source_label=subagent.name,
     )
 
-    log.info(f"User-specific subagent {config.agent_name} created successfully")
+    log.info(f"{LogTag.AGENT} User-specific subagent {config.agent_name} created successfully")
     return graph
 
 
@@ -210,7 +213,7 @@ async def _create_custom_mcp_subagent(
     """
     custom_doc = await integrations_collection.find_one({"integration_id": integration_id})
     if not custom_doc:
-        log.error(f"Custom integration {integration_id} not found in MongoDB")
+        log.error(f"{LogTag.AGENT} Custom integration {integration_id} not found in MongoDB")
         return None
 
     mcp_config = custom_doc.get("mcp_config", {})
@@ -225,11 +228,11 @@ async def _create_custom_mcp_subagent(
         try:
             tools = await mcp_client.connect(integration_id)
         except Exception as e:
-            log.error(f"Failed to get MCP tools for {integration_id}: {e}")
+            log.error(f"{LogTag.AGENT} Failed to get MCP tools for {integration_id}: {e}")
             return None
 
     if not tools:
-        log.error(f"No tools available for {integration_id}")
+        log.error(f"{LogTag.AGENT} No tools available for {integration_id}")
         return None
 
     llm = init_llm()
@@ -243,7 +246,7 @@ async def _create_custom_mcp_subagent(
     use_direct = 0 < tool_count <= 10
 
     log.info(
-        f"Custom MCP {integration_id} has {tool_count} tools — "
+        f"{LogTag.AGENT} Custom MCP {integration_id} has {tool_count} tools — "
         f"using {'direct binding' if use_direct else 'retrieve_tools'}"
     )
 
@@ -258,7 +261,7 @@ async def _create_custom_mcp_subagent(
         source_label=custom_doc.get("name"),
     )
 
-    log.info(f"Custom MCP subagent {agent_name} created successfully")
+    log.info(f"{LogTag.AGENT} Custom MCP subagent {agent_name} created successfully")
     return graph
 
 
@@ -303,7 +306,7 @@ def register_subagent_providers(integration_ids: list[str] | None = None) -> int
             and subagent.mcp_config.requires_auth
         ):
             log.info(
-                f"Auth-required MCP subagent {subagent.config.agent_name} "
+                f"{LogTag.AGENT} Auth-required MCP subagent {subagent.config.agent_name} "
                 f"will be created on-demand via handoff"
             )
             continue
@@ -320,5 +323,5 @@ def register_subagent_providers(integration_ids: list[str] | None = None) -> int
         )
         registered_count += 1
 
-    log.info(f"Registered {registered_count} subagent lazy providers")
+    log.info(f"{LogTag.AGENT} Registered {registered_count} subagent lazy providers")
     return registered_count

--- a/apps/api/app/agents/core/subagents/subagent_helpers.py
+++ b/apps/api/app/agents/core/subagents/subagent_helpers.py
@@ -18,6 +18,7 @@ from app.agents.prompts.custom_mcp_prompts import CUSTOM_MCP_SUBAGENT_PROMPT
 from app.agents.skills.discovery import get_available_skills_text
 from app.agents.workspace.skill_loader import target_to_subagent
 from app.config.oauth_config import get_integration_by_id
+from app.constants.log_tags import LogTag
 from app.constants.skills import EXECUTOR_SUBAGENT_ID
 from app.helpers.message_helpers import (
     BACKGROUND_EXECUTION_BANNER,
@@ -55,7 +56,7 @@ async def build_subagent_system_prompt(
         # Custom or public MCP fallback — universal prompt; no per-user injection.
         if integration_id:
             return base_system_prompt or CUSTOM_MCP_SUBAGENT_PROMPT
-        log.warning(f"Integration {integration_id} not found")
+        log.warning(f"{LogTag.AGENT} Integration {integration_id} not found")
         return base_system_prompt or ""
 
     return base_system_prompt or subagent.config.system_prompt or ""
@@ -96,7 +97,9 @@ async def _fetch_provider_metadata_block(integration_id: str | None, user_id: st
     try:
         metadata = await get_provider_metadata(user_id, integration.provider)
     except Exception as e:
-        log.warning(f"Failed to fetch provider metadata for {integration.provider}: {e}")
+        log.warning(
+            f"{LogTag.AGENT} Failed to fetch provider metadata for {integration.provider}: {e}"
+        )
         return ""
     if not metadata:
         return ""
@@ -117,7 +120,7 @@ async def _fetch_instructions_block(integration_id: str | None, user_id: str | N
     try:
         content = await get_instructions(user_id, integration_id)
     except Exception as e:
-        log.warning(f"Failed to fetch custom instructions for {integration_id}: {e}")
+        log.warning(f"{LogTag.AGENT} Failed to fetch custom instructions for {integration_id}: {e}")
         return ""
     if not content:
         return ""
@@ -211,12 +214,14 @@ async def create_agent_context_message(
         try:
             results = await memory_engine.recall(user_id, query, limit=5)
             if results.memories:
-                log.info(f"Added {len(results.memories)} memories to subagent context")
+                log.info(
+                    f"{LogTag.AGENT} Added {len(results.memories)} memories to subagent context"
+                )
                 return "\n\nBased on our previous conversations:\n" + "\n".join(
                     f"- {mem.content}" for mem in results.memories
                 )
         except Exception as e:
-            log.warning(f"Error retrieving memories for subagent: {e}")
+            log.warning(f"{LogTag.AGENT} Error retrieving memories for subagent: {e}")
         return ""
 
     async def _fetch_skills() -> str:
@@ -230,10 +235,10 @@ async def create_agent_context_message(
                 agent_for_skills = subagent_id or EXECUTOR_SUBAGENT_ID
                 text = await get_available_skills_text(user_id=user_id, agent_name=agent_for_skills)
                 if text:
-                    log.info(f"Injected installable skills for {agent_for_skills}")
+                    log.info(f"{LogTag.AGENT} Injected installable skills for {agent_for_skills}")
                     block = text
             except Exception as e:
-                log.warning(f"Error injecting installable skills: {e}")
+                log.warning(f"{LogTag.AGENT} Error injecting installable skills: {e}")
 
         if subagent_id:
             # `subagent_id` carries the agent_name ("docgen_agent"), but

--- a/apps/api/app/agents/core/subagents/subagent_runner.py
+++ b/apps/api/app/agents/core/subagents/subagent_runner.py
@@ -22,6 +22,7 @@ from app.agents.prompts.workflow_prompts import (
     WORKFLOW_SILENT_NOTIFY_SECTION,
 )
 from app.constants.general import FINISH_TASK_NAME
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from app.helpers.agent_helpers import build_agent_config
 from app.helpers.message_helpers import (
@@ -256,7 +257,7 @@ async def execute_subagent_stream(
     ):
         # Check for cancellation
         if ctx.stream_id and await stream_manager.is_cancelled(ctx.stream_id):
-            log.info(f"Subagent stream {ctx.stream_id} cancelled by user")
+            log.info(f"{LogTag.AGENT} Subagent stream {ctx.stream_id} cancelled by user")
             break
 
         # Handle 2-tuple format only (no subgraphs)

--- a/apps/api/app/agents/llm/chatbot.py
+++ b/apps/api/app/agents/llm/chatbot.py
@@ -2,6 +2,7 @@ from langchain_core.messages import AIMessage
 
 from app.agents.core.state import State
 from app.agents.llm.client import get_free_llm_chain, init_llm, invoke_with_fallback
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -28,7 +29,7 @@ async def chatbot(
 
         return {"messages": [response]}
     except Exception as e:
-        log.error(f"Error in LLM API call: {e!s}")
+        log.error(f"{LogTag.AGENT} Error in LLM API call: {e!s}")
 
         return {
             "messages": [

--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -25,6 +25,7 @@ from app.constants.llm import (
     OPENROUTER_MAX_OUTPUT_TOKENS,
     OPENROUTER_REASONING,
 )
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from shared.py.wide_events import log
 
@@ -316,8 +317,10 @@ async def invoke_with_fallback(
             provider_name = type(llm).__name__
             last_error = e
             if i < len(llm_chain) - 1:
-                log.warning(f"LLM {provider_name} failed, falling back to next provider: {e}")
+                log.warning(
+                    f"{LogTag.AGENT} LLM {provider_name} failed, falling back to next provider: {e}"
+                )
             else:
-                log.error(f"All LLM providers failed. Last error: {e}")
+                log.error(f"{LogTag.AGENT} All LLM providers failed. Last error: {e}")
 
     raise RuntimeError(f"All LLM providers failed. Last error: {last_error}")

--- a/apps/api/app/agents/llm/plan_model.py
+++ b/apps/api/app/agents/llm/plan_model.py
@@ -10,6 +10,7 @@ from app.constants.llm import (
     PAID_MODEL_NAME,
     PAID_MODEL_PROVIDER,
 )
+from app.constants.log_tags import LogTag
 from app.models.payment_models import PlanType
 from app.services.payments.payment_service import payment_service
 from shared.py.wide_events import log
@@ -31,7 +32,7 @@ async def apply_plan_model(configurable: dict, user_id: str | None) -> None:
         plan = await payment_service.get_cached_plan_type(user_id)
     except Exception as e:
         # A transient lookup failure must not fail the turn — keep the default model.
-        log.warning("plan_model lookup failed; keeping default model", error=str(e))
+        log.warning(f"{LogTag.AGENT} plan_model lookup failed; keeping default model", error=str(e))
         return
 
     # Free runs the default model; every other (paid) tier gets the better model,

--- a/apps/api/app/agents/memory/email_processor.py
+++ b/apps/api/app/agents/memory/email_processor.py
@@ -47,6 +47,7 @@ from app.constants.email import (
     MAX_RESULTS,
     ONBOARDING_EMAIL_SCAN_LIMIT,
 )
+from app.constants.log_tags import LogTag
 from app.constants.memory import MemorySourceType
 from app.db.mongodb.collections import users_collection
 from app.helpers.email_helpers import (
@@ -126,7 +127,7 @@ async def _search_platform_emails_parallel(user_id: str) -> dict[str, list[dict]
     platform_emails: dict[str, list[dict]] = {}
     for (platform, _), result in zip(search_tasks, results):
         if isinstance(result, Exception):
-            log.error(f"Search failed for {platform}: {result}")
+            log.error(f"{LogTag.MEMORY} Search failed for {platform}: {result}")
             platform_emails[platform] = []
         elif isinstance(result, list):
             platform_emails[platform] = result
@@ -136,7 +137,7 @@ async def _search_platform_emails_parallel(user_id: str) -> dict[str, list[dict]
     elapsed = time.time() - search_start
     total_found = sum(len(emails) for emails in platform_emails.values())
     log.info(
-        f"Parallel Gmail searches completed in {elapsed:.2f}s: "
+        f"{LogTag.MEMORY} Parallel Gmail searches completed in {elapsed:.2f}s: "
         f"found {total_found} platform emails across {len(platform_emails)} platforms"
     )
 
@@ -169,7 +170,7 @@ async def _search_platform_emails(
         return emails
 
     except Exception as e:
-        log.error(f"Error searching {platform} emails: {e}")
+        log.error(f"{LogTag.MEMORY} Error searching {platform} emails: {e}")
         return []
 
 
@@ -230,12 +231,12 @@ async def fetch_emails_for_onboarding(
                 break
     except Exception as e:
         log.error(
-            f"[fetch_emails_for_onboarding] Failed for {user_id} after {len(all_emails)} emails: {e}",
+            f"{LogTag.MEMORY} fetch_emails_for_onboarding failed for {user_id} after {len(all_emails)} emails: {e}",
             exc_info=True,
         )
 
     log.info(
-        f"[fetch_emails_for_onboarding] Fetched {len(all_emails)} emails for {user_id} (fmt={fmt})"
+        f"{LogTag.MEMORY} fetch_emails_for_onboarding fetched {len(all_emails)} emails for {user_id} (fmt={fmt})"
     )
     return all_emails
 
@@ -256,7 +257,7 @@ async def process_gmail_to_memory(user_id: str) -> dict:
     timer = _StepTimer()
     user = await users_collection.find_one({"_id": ObjectId(user_id)})
     if user and user.get("email_memory_processed", False):
-        log.info(f"User {user_id} emails already processed, skipping")
+        log.info(f"{LogTag.MEMORY} User {user_id} emails already processed, skipping")
         return {
             "total": 0,
             "successful": 0,
@@ -315,7 +316,7 @@ async def process_gmail_to_memory(user_id: str) -> dict:
             )
             fetch_elapsed = time.monotonic() - t0_search
             log.info(
-                f"[timing] Gmail fetch batch {batch_count}: {fetch_elapsed:.1f}s "
+                f"{LogTag.MEMORY} Gmail fetch batch {batch_count}: {fetch_elapsed:.1f}s "
                 f"(fetched so far: {total_fetched + len(result.get('messages', []))})"
             )
             timer.record(f"Gmail API fetch — batch {batch_count}", fetch_elapsed)
@@ -338,7 +339,7 @@ async def process_gmail_to_memory(user_id: str) -> dict:
             total_parsed += len(processed_batch)
             total_failed += failed
             log.info(
-                f"[timing] Email content parsing batch {batch_count}: {parse_elapsed:.3f}s "
+                f"{LogTag.MEMORY} Email content parsing batch {batch_count}: {parse_elapsed:.3f}s "
                 f"({len(processed_batch)} parsed, {failed} failed/skipped)"
             )
             timer.record(
@@ -362,13 +363,13 @@ async def process_gmail_to_memory(user_id: str) -> dict:
                 break
 
     except Exception as e:
-        log.error(f"Error in email processing pipeline: {e}")
+        log.error(f"{LogTag.MEMORY} Error in email processing pipeline: {e}")
 
     timer.record("Gmail fetch + parse phase (total)", time.monotonic() - t0_fetch_phase)
 
     # Await all email storage tasks in parallel with error handling
     log.info(
-        f"[timing] Awaiting {len(email_storage_tasks)} memory storage tasks ({total_parsed} emails total)..."
+        f"{LogTag.MEMORY} Awaiting {len(email_storage_tasks)} memory storage tasks ({total_parsed} emails total)..."
     )
     storage_results: list[Any] = []
     storage_errors = 0
@@ -381,20 +382,22 @@ async def process_gmail_to_memory(user_id: str) -> dict:
                 f"Memory email storage await ({len(email_storage_tasks)} batches queued)",
                 storage_elapsed,
             )
-            log.info(f"[timing] Memory email storage tasks dispatched in {storage_elapsed:.1f}s")
+            log.info(
+                f"{LogTag.MEMORY} Memory email storage tasks dispatched in {storage_elapsed:.1f}s"
+            )
 
             for idx, result in enumerate(storage_results):
                 if isinstance(result, Exception):
                     storage_errors += 1
-                    log.warning(f"Email storage task {idx + 1} failed: {result}")
+                    log.warning(f"{LogTag.MEMORY} Email storage task {idx + 1} failed: {result}")
 
             successful_batches = len(storage_results) - storage_errors
             log.info(
-                f"Email storage complete: {successful_batches}/{len(storage_results)} batches succeeded, "
+                f"{LogTag.MEMORY} Email storage complete: {successful_batches}/{len(storage_results)} batches succeeded, "
                 f"{storage_errors} failed (continuing anyway)"
             )
         except Exception as e:
-            log.error(f"Critical error in email storage tasks: {e}")
+            log.error(f"{LogTag.MEMORY} Critical error in email storage tasks: {e}")
             storage_errors = len(email_storage_tasks)
 
     # Wait for profile extraction task (also with error handling)
@@ -405,16 +408,16 @@ async def process_gmail_to_memory(user_id: str) -> dict:
         profile_result: dict = await profile_extraction_task
         profile_elapsed = time.monotonic() - t0_profile
         timer.record("Profile extraction track (wait for completion)", profile_elapsed)
-        log.info(f"[timing] Profile extraction track finished: {profile_elapsed:.1f}s")
+        log.info(f"{LogTag.MEMORY} Profile extraction track finished: {profile_elapsed:.1f}s")
         profiles_stored = profile_result.get("profiles_stored", 0)
         extracted_profiles = profile_result.get("extracted_profiles", [])
     except Exception as e:
-        log.error(f"Profile extraction task failed: {e}")
+        log.error(f"{LogTag.MEMORY} Profile extraction task failed: {e}")
         # Continue anyway - don't let profile failures block completion
 
     total_elapsed = time.time() - fetch_start_time
     log.info(
-        f"Processing complete in {total_elapsed:.2f}s: "
+        f"{LogTag.MEMORY} Processing complete in {total_elapsed:.2f}s: "
         f"{total_parsed} emails processed, {profiles_stored} profiles stored, "
         f"{storage_errors} storage errors"
     )
@@ -430,10 +433,10 @@ async def process_gmail_to_memory(user_id: str) -> dict:
             await mark_email_processing_complete(user_id, total_parsed + profiles_stored)
             mark_elapsed = time.monotonic() - t0_mark
             timer.record("DB mark-complete write", mark_elapsed)
-            log.info(f"[timing] mark_email_processing_complete: {mark_elapsed:.1f}s")
-            log.info(f"✓ Marked email processing as complete for user {user_id}")
+            log.info(f"{LogTag.MEMORY} mark_email_processing_complete: {mark_elapsed:.1f}s")
+            log.info(f"{LogTag.MEMORY} Marked email processing as complete for user {user_id}")
     except Exception as e:
-        log.error(f"Failed to mark email processing complete: {e}")
+        log.error(f"{LogTag.MEMORY} Failed to mark email processing complete: {e}")
         # Continue anyway - we still want to trigger post-onboarding
 
     # Update the scan timestamp after processing (regardless of success/failure)
@@ -445,9 +448,9 @@ async def process_gmail_to_memory(user_id: str) -> dict:
             {"$set": {"integration_scan_states.gmail.last_scan_timestamp": current_time}},
         )
     except Exception as e:
-        log.error(f"Failed to update Gmail scan timestamp: {e}")
+        log.error(f"{LogTag.MEMORY} Failed to update Gmail scan timestamp: {e}")
 
-    log.info(timer.summary())
+    log.info(f"{LogTag.MEMORY} {timer.summary()}")
 
     return {
         "total": total_fetched,
@@ -486,7 +489,7 @@ async def _extract_profiles_from_parallel_searches(user_id: str) -> dict:
         t0_platform_search = time.monotonic()
         platform_emails = await _search_platform_emails_parallel(user_id)
         log.info(
-            f"[email_processor:timing] _search_platform_emails_parallel: {time.monotonic() - t0_platform_search:.1f}s"
+            f"{LogTag.MEMORY} _search_platform_emails_parallel: {time.monotonic() - t0_platform_search:.1f}s"
         )
 
         # Filter out platforms with no emails
@@ -522,7 +525,7 @@ async def _extract_profiles_from_parallel_searches(user_id: str) -> dict:
             *[task for _, task in platform_tasks], return_exceptions=True
         )
         log.info(
-            f"[email_processor:timing] asyncio.gather platform_tasks: {time.monotonic() - t0_platform_gather:.1f}s"
+            f"{LogTag.MEMORY} asyncio.gather platform_tasks: {time.monotonic() - t0_platform_gather:.1f}s"
         )
 
         # Step 3: Count successful profiles, collect pairs and discovery tasks
@@ -530,7 +533,7 @@ async def _extract_profiles_from_parallel_searches(user_id: str) -> dict:
         extracted_profiles: list[dict] = []
         for (platform, _), result in zip(platform_tasks, results):
             if isinstance(result, Exception):
-                log.error(f"Platform {platform} extraction failed: {result}")
+                log.error(f"{LogTag.MEMORY} Platform {platform} extraction failed: {result}")
             elif isinstance(result, dict) and result.get("success"):
                 if "discovery_task" in result:
                     discovered_profile_tasks.append(result["discovery_task"])
@@ -545,17 +548,17 @@ async def _extract_profiles_from_parallel_searches(user_id: str) -> dict:
                 *discovered_profile_tasks, return_exceptions=True
             )
             log.info(
-                f"[email_processor:timing] asyncio.gather discovered_profile_tasks: {time.monotonic() - t0_discovery:.1f}s"
+                f"{LogTag.MEMORY} asyncio.gather discovered_profile_tasks: {time.monotonic() - t0_discovery:.1f}s"
             )
             for result in discovery_results:
                 if isinstance(result, int):  # Discovery task returns count of profiles stored
                     discovered_count += result
                 elif isinstance(result, Exception):
-                    log.error(f"Discovery task failed: {result}")
+                    log.error(f"{LogTag.MEMORY} Discovery task failed: {result}")
 
         elapsed = time.time() - extraction_start
         log.info(
-            f"Profile extraction completed in {elapsed:.2f}s: "
+            f"{LogTag.MEMORY} Profile extraction completed in {elapsed:.2f}s: "
             f"{profiles_stored}/{len(platforms_with_emails)} profiles stored (including {discovered_count} discovered)"
         )
 
@@ -565,7 +568,7 @@ async def _extract_profiles_from_parallel_searches(user_id: str) -> dict:
         }
 
     except Exception as e:
-        log.error(f"Error in profile extraction from parallel searches: {e}")
+        log.error(f"{LogTag.MEMORY} Error in profile extraction from parallel searches: {e}")
         return {"profiles_stored": 0, "extracted_profiles": []}
 
 
@@ -591,18 +594,22 @@ async def _process_single_platform(
         t0_llm = time.monotonic()
         username = await extract_username_with_llm(platform, emails, user_name)
         llm_elapsed = time.monotonic() - t0_llm
-        log.info(f"[timing:{platform}] LLM username extraction: {llm_elapsed:.1f}s → '{username}'")
+        log.info(
+            f"{LogTag.MEMORY} [{platform}] LLM username extraction: {llm_elapsed:.1f}s → '{username}'"
+        )
 
         if not validate_username(username, platform):
             log.warning(
-                f"Username validation failed for {platform}: '{username}' "
+                f"{LogTag.MEMORY} Username validation failed for {platform}: '{username}' "
                 f"(expected pattern: {PLATFORM_CONFIG[platform]['regex_pattern']})"
             )
             return {"error": f"Invalid username '{username}' for {platform}"}
 
         profile_url = build_profile_url(username, platform)
         if not profile_url:
-            log.warning(f"Could not build profile URL for {platform} with username: {username}")
+            log.warning(
+                f"{LogTag.MEMORY} Could not build profile URL for {platform} with username: {username}"
+            )
             return {"error": f"Could not build URL for {platform}"}
 
         # Check if already crawled (deduplication)
@@ -618,12 +625,14 @@ async def _process_single_platform(
         crawl_result = await crawl_profile_url(profile_url, platform, semaphore)
         crawl_elapsed = time.monotonic() - t0_crawl
         log.info(
-            f"[timing:{platform}] Profile crawl: {crawl_elapsed:.1f}s "
+            f"{LogTag.MEMORY} [{platform}] Profile crawl: {crawl_elapsed:.1f}s "
             f"({'OK' if crawl_result['content'] else 'FAILED'})"
         )
 
         if not crawl_result["content"] or crawl_result["error"]:
-            log.warning(f"Failed to crawl {platform} profile: {crawl_result.get('error')}")
+            log.warning(
+                f"{LogTag.MEMORY} Failed to crawl {platform} profile: {crawl_result.get('error')}"
+            )
             return {"error": crawl_result.get("error", "Crawl failed")}
 
         # 3. Store profile
@@ -636,9 +645,9 @@ async def _process_single_platform(
             user_name,
         )
         store_elapsed = time.monotonic() - t0_store
-        log.info(f"[timing:{platform}] Memory profile store: {store_elapsed:.1f}s")
+        log.info(f"{LogTag.MEMORY} [{platform}] Memory profile store: {store_elapsed:.1f}s")
         log.info(
-            f"[timing:{platform}] TOTAL {time.monotonic() - t0_platform:.1f}s "
+            f"{LogTag.MEMORY} [{platform}] TOTAL {time.monotonic() - t0_platform:.1f}s "
             f"(llm={llm_elapsed:.1f}s, crawl={crawl_elapsed:.1f}s, store={store_elapsed:.1f}s)"
         )
 
@@ -658,7 +667,7 @@ async def _process_single_platform(
         }
 
     except Exception as e:
-        log.error(f"Error processing {platform} profile: {e}")
+        log.error(f"{LogTag.MEMORY} Error processing {platform} profile: {e}")
         return {"error": str(e)}
 
 
@@ -774,14 +783,16 @@ async def _discover_and_store_linked_profiles(
             )
             if retain_result.facts_extracted > 0:
                 log.info(
-                    f"Stored {len(profile_messages)} discovered profiles from {source_platform}"
+                    f"{LogTag.MEMORY} Stored {len(profile_messages)} discovered profiles from {source_platform}"
                 )
                 return len(profile_messages)
-            log.warning(f"No facts extracted from discovered profiles from {source_platform}")
+            log.warning(
+                f"{LogTag.MEMORY} No facts extracted from discovered profiles from {source_platform}"
+            )
             return 0
 
         return 0
 
     except Exception as e:
-        log.error(f"Error discovering linked profiles from {source_platform}: {e}")
+        log.error(f"{LogTag.MEMORY} Error discovering linked profiles from {source_platform}: {e}")
         return 0

--- a/apps/api/app/agents/memory/profile_crawler.py
+++ b/apps/api/app/agents/memory/profile_crawler.py
@@ -13,6 +13,7 @@ import asyncio
 import time
 import traceback
 
+from app.constants.log_tags import LogTag
 from app.utils.crawl4ai_utils import get_browser_semaphore, managed_crawler
 from shared.py.wide_events import log
 
@@ -32,7 +33,7 @@ async def crawl_profile_url(url: str, platform: str, semaphore: asyncio.Semaphor
     async with semaphore:
         start_time = time.time()
         try:
-            log.info(f"Crawling {platform} profile: {url}")
+            log.info(f"{LogTag.MEMORY} Crawling {platform} profile: {url}")
 
             # Process-wide cap on live Chromium instances (shared with
             # crawl4ai_utils) so concurrent profile crawls can't fan out into
@@ -57,7 +58,9 @@ async def crawl_profile_url(url: str, platform: str, semaphore: asyncio.Semaphor
 
                 elapsed = time.time() - start_time
                 content_size = len(result.markdown)
-                log.info(f"Successfully crawled {url} in {elapsed:.2f}s ({content_size:,} chars)")
+                log.info(
+                    f"{LogTag.MEMORY} Successfully crawled {url} in {elapsed:.2f}s ({content_size:,} chars)"
+                )
                 return {
                     "url": url,
                     "platform": platform,
@@ -72,8 +75,10 @@ async def crawl_profile_url(url: str, platform: str, semaphore: asyncio.Semaphor
             if not error_msg or error_msg == "No error message":
                 error_msg = f"{error_type}: {e!r}"
 
-            log.error(f"Failed to crawl {url} after {elapsed:.2f}s: {error_type}: {error_msg}")
-            log.debug(f"Full traceback for {url}:\n{traceback.format_exc()}")
+            log.error(
+                f"{LogTag.MEMORY} Failed to crawl {url} after {elapsed:.2f}s: {error_type}: {error_msg}"
+            )
+            log.debug(f"{LogTag.MEMORY} Full traceback for {url}:\n{traceback.format_exc()}")
 
             return {
                 "url": url,

--- a/apps/api/app/agents/memory/profile_extractor.py
+++ b/apps/api/app/agents/memory/profile_extractor.py
@@ -27,6 +27,7 @@ from app.constants.general import (
     PROFILE_EXTRACTION_LLM_MODEL,
     PROFILE_EXTRACTION_LLM_PROVIDER,
 )
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 PLATFORM_CONFIG = {
@@ -358,7 +359,7 @@ async def extract_username_with_llm(
     # Deduplicate similar emails to avoid sending redundant context
     unique_emails = _deduplicate_emails(emails)
     log.info(
-        f"Deduplicated {len(emails)} emails down to {len(unique_emails)} unique emails for {platform}"
+        f"{LogTag.MEMORY} Deduplicated {len(emails)} emails down to {len(unique_emails)} unique emails for {platform}"
     )
 
     # Debug: Log deduplication results
@@ -471,7 +472,7 @@ async def extract_username_with_llm(
 
         elapsed = time.time() - start_time
         log.info(
-            f"LLM extracted username for {platform}: '{username}' "
+            f"{LogTag.MEMORY} LLM extracted username for {platform}: '{username}' "
             f"(confidence: {confidence}) in {elapsed:.2f}s"
         )
 
@@ -496,5 +497,5 @@ async def extract_username_with_llm(
 
     except Exception as e:
         elapsed = time.time() - start_time
-        log.error(f"LLM extraction failed for {platform} after {elapsed:.2f}s: {e}")
+        log.error(f"{LogTag.MEMORY} LLM extraction failed for {platform} after {elapsed:.2f}s: {e}")
         return "NOT_FOUND"

--- a/apps/api/app/agents/middleware/accounting.py
+++ b/apps/api/app/agents/middleware/accounting.py
@@ -24,6 +24,7 @@ from langgraph.runtime import Runtime, get_config
 
 from app.config.model_pricing import calculate_token_cost
 from app.constants.llm import AGENT_RECURSION_LIMIT, RECURSION_HWM_FRACTION
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import ModelContext, log
 
 
@@ -193,7 +194,7 @@ class LLMAccountingMiddleware(AgentMiddleware[AgentState[Any], Any]):
             )
             total_cost = float(cost.get("total_cost", 0.0))
         except Exception as e:
-            log.warning(f"Token cost calc failed for {model_name}: {e}")
+            log.warning(f"{LogTag.AGENT} Token cost calc failed for {model_name}: {e}")
             total_cost = 0.0
 
         step_index = self._next_step(thread_id)

--- a/apps/api/app/agents/middleware/compaction.py
+++ b/apps/api/app/agents/middleware/compaction.py
@@ -23,6 +23,7 @@ from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
+from app.constants.log_tags import LogTag
 from app.constants.summarization import MIN_COMPACTION_SIZE
 from app.services.storage import JuiceFSUnavailable, write_session_file
 from shared.py.wide_events import log
@@ -72,10 +73,10 @@ class WorkspaceCompactionMiddleware(AgentMiddleware):
         try:
             return await self._persist(result, request, reason)
         except JuiceFSUnavailable as e:
-            log.warning(f"Compaction skipped (workspace unavailable): {e}")
+            log.warning(f"{LogTag.AGENT} Compaction skipped (workspace unavailable): {e}")
             return result
         except Exception as e:
-            log.error(f"Compaction failed for {tool_name}: {e}")
+            log.error(f"{LogTag.AGENT} Compaction failed for {tool_name}: {e}")
             return result
 
     def _get_context_usage(self, request: ToolCallRequest) -> float:
@@ -161,7 +162,7 @@ class WorkspaceCompactionMiddleware(AgentMiddleware):
         )
 
         log.info(
-            f"Compacted {tool_name} output ({len(content_str)} chars) to {sandbox_path} ({reason})"
+            f"{LogTag.AGENT} Compacted {tool_name} output ({len(content_str)} chars) to {sandbox_path} ({reason})"
         )
         return ToolMessage(
             content=body,

--- a/apps/api/app/agents/middleware/executor.py
+++ b/apps/api/app/agents/middleware/executor.py
@@ -35,6 +35,7 @@ from app.agents.middleware.runtime_adapter import (
     create_tool_call_request,
     to_agent_state,
 )
+from app.constants.log_tags import LogTag
 from app.override.langgraph_bigtool.utils import State
 from shared.py.wide_events import log
 
@@ -163,7 +164,9 @@ class MiddlewareExecutor:
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                log.warning(f"Middleware {mw.__class__.__name__}.before_model failed: {e}")
+                log.warning(
+                    f"{LogTag.AGENT} Middleware {mw.__class__.__name__}.before_model failed: {e}"
+                )
 
         return State(**current_state)
 
@@ -210,7 +213,9 @@ class MiddlewareExecutor:
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                log.warning(f"Middleware {mw.__class__.__name__}.after_model failed: {e}")
+                log.warning(
+                    f"{LogTag.AGENT} Middleware {mw.__class__.__name__}.after_model failed: {e}"
+                )
 
         return State(**current_state)
 
@@ -294,7 +299,7 @@ class MiddlewareExecutor:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            log.error(f"Middleware wrap_model_call chain failed: {e}")
+            log.error(f"{LogTag.AGENT} Middleware wrap_model_call chain failed: {e}")
             # Fallback to direct invocation
             return await invoke_fn(state.get("messages", []))
 
@@ -364,7 +369,7 @@ class MiddlewareExecutor:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            log.error(f"Middleware wrap_tool_call chain failed for {tool_name}: {e}")
+            log.error(f"{LogTag.AGENT} Middleware wrap_tool_call chain failed for {tool_name}: {e}")
             # Fallback to direct invocation
             return await invoke_fn(tool_call)
 

--- a/apps/api/app/agents/middleware/factory.py
+++ b/apps/api/app/agents/middleware/factory.py
@@ -17,6 +17,7 @@ from app.agents.middleware.summarization import (
 )
 from app.agents.tools.core.tool_runtime_config import ToolRuntimeConfig
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.constants.summarization import (
     COMPACTION_THRESHOLD,
     MAX_OUTPUT_CHARS,
@@ -44,7 +45,9 @@ def get_summarization_llm() -> BaseChatModel | None:
         return _summarization_llm
 
     if not settings.GOOGLE_API_KEY:
-        log.warning("Google API key not configured. Summarization middleware disabled.")
+        log.warning(
+            f"{LogTag.AGENT} Google API key not configured. Summarization middleware disabled."
+        )
         return None
 
     _summarization_llm = ChatGoogleGenerativeAI(
@@ -115,7 +118,7 @@ def create_middleware_stack(
     # so we can compare state.messages before vs. after other middleware.
     if enable_accounting:
         middleware.append(LLMAccountingMiddleware(agent_name=agent_name))
-        log.debug(f"LLMAccountingMiddleware enabled for {agent_name}")
+        log.debug(f"{LogTag.AGENT} LLMAccountingMiddleware enabled for {agent_name}")
         log.set(
             middleware_stack={
                 "agent_name": agent_name,
@@ -134,7 +137,7 @@ def create_middleware_stack(
             tool_runtime_config=subagent_tool_runtime_config,
         )
         middleware.append(subagent)
-        log.debug("SubagentMiddleware enabled with spawn_subagent tool")
+        log.debug(f"{LogTag.AGENT} SubagentMiddleware enabled with spawn_subagent tool")
 
     # Summarization middleware (requires Gemini API key)
     if enable_summarization:
@@ -149,7 +152,7 @@ def create_middleware_stack(
             )
             middleware.append(summarization)
             log.debug(
-                f"Summarization middleware enabled: trigger={summarization_trigger}, keep={summarization_keep}"
+                f"{LogTag.AGENT} Summarization middleware enabled: trigger={summarization_trigger}, keep={summarization_keep}"
             )
 
     # Compaction middleware (always available, but respects enable flag)
@@ -160,7 +163,7 @@ def create_middleware_stack(
             excluded_tools=compaction_excluded_tools,
         )
         middleware.append(compaction)
-        log.debug(f"Compaction middleware enabled: threshold={compaction_threshold}")
+        log.debug(f"{LogTag.AGENT} Compaction middleware enabled: threshold={compaction_threshold}")
 
     return middleware
 

--- a/apps/api/app/agents/middleware/subagent.py
+++ b/apps/api/app/agents/middleware/subagent.py
@@ -36,6 +36,7 @@ from app.agents.tools.core.retrieval import get_retrieve_tools_function
 from app.agents.tools.core.tool_runtime_config import ToolRuntimeConfig
 from app.constants.general import FINISH_TASK_NAME
 from app.constants.llm import SUBAGENT_RECURSION_LIMIT
+from app.constants.log_tags import LogTag
 from app.utils.agent_utils import (
     StreamWriterCallable,
     emit_subagent_tool_calls,
@@ -176,7 +177,7 @@ class SubagentMiddleware(AgentMiddleware[SubagentState, Any]):
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                log.error(f"Subagent execution failed: {e}")
+                log.error(f"{LogTag.AGENT} Subagent execution failed: {e}")
                 return Command(
                     update={
                         "messages": [
@@ -323,12 +324,14 @@ class SubagentMiddleware(AgentMiddleware[SubagentState, Any]):
                             bound_tool_names,
                         )
                         if newly_bound:
-                            log.info(f"Subagent bound {len(newly_bound)} tools: {newly_bound}")
+                            log.info(
+                                f"{LogTag.AGENT} Subagent bound {len(newly_bound)} tools: {newly_bound}"
+                            )
                         content = "\n".join(result.get("response", [])) or "No tools found."
                     except asyncio.CancelledError:
                         raise
                     except Exception as e:
-                        log.error(f"Subagent retrieve_tools error: {e}")
+                        log.error(f"{LogTag.AGENT} Subagent retrieve_tools error: {e}")
                         content = f"retrieve_tools error: {e}"
 
                     messages.append(ToolMessage(content=content, tool_call_id=tc_id, name=name))
@@ -380,7 +383,7 @@ class SubagentMiddleware(AgentMiddleware[SubagentState, Any]):
                     raise
                 except Exception:
                     log.exception(
-                        f"Subagent tool invocation failed for tool '{name}' (tool_call_id={tc_id})",
+                        f"{LogTag.AGENT} Subagent tool invocation failed for tool '{name}' (tool_call_id={tc_id})",
                     )
                     return ToolMessage(
                         content="Tool error: internal failure while executing tool.",

--- a/apps/api/app/agents/middleware/summarization.py
+++ b/apps/api/app/agents/middleware/summarization.py
@@ -18,6 +18,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AnyMessage, HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
 
+from app.constants.log_tags import LogTag
 from app.services.storage import JuiceFSUnavailable, write_session_file
 from shared.py.wide_events import log
 
@@ -52,9 +53,9 @@ class WorkspaceArchivingSummarizationMiddleware(SummarizationMiddleware):
             try:
                 archive_path = await self._archive(state, runtime)
             except JuiceFSUnavailable as e:
-                log.warning(f"Archive skipped (workspace unavailable): {e}")
+                log.warning(f"{LogTag.AGENT} Archive skipped (workspace unavailable): {e}")
             except Exception as e:
-                log.error(f"Archive failed: {e}")
+                log.error(f"{LogTag.AGENT} Archive failed: {e}")
 
         result = await super().abefore_model(state, runtime)
         if result is not None and archive_path:
@@ -109,7 +110,9 @@ class WorkspaceArchivingSummarizationMiddleware(SummarizationMiddleware):
             relative_path=relative_path,
             content=json.dumps(history, indent=2, default=str),
         )
-        log.info(f"Archived {len(messages)} messages to {sandbox_path} before summarization")
+        log.info(
+            f"{LogTag.AGENT} Archived {len(messages)} messages to {sandbox_path} before summarization"
+        )
         return sandbox_path
 
     def _serialize_messages(self, messages: list[AnyMessage]) -> list[dict[str, Any]]:

--- a/apps/api/app/agents/prompts/comms_prompts.py
+++ b/apps/api/app/agents/prompts/comms_prompts.py
@@ -6,6 +6,8 @@ Executor agent handles task execution with full tool access.
 
 from app.constants.agents import PLATFORM_DELIVERY_MARKER
 from app.constants.general import NEW_MESSAGE_BREAKER
+from app.constants.log_tags import LogTag
+from shared.py.wide_events import log
 
 COMMS_AGENT_PROMPT = f"""
 You are GAIA (General-purpose AI Assistant), but you don't act like an assistant.
@@ -600,12 +602,10 @@ def _strip_openui_section(prompt: str) -> str:
     would be far worse than logging a noisy startup warning that someone
     edited the prompt and forgot to keep the markers in sync.
     """
-    from shared.py.wide_events import log
-
     start = prompt.find(_OPENUI_SECTION_START_MARKER)
     if start == -1:
         log.warning(
-            "comms_prompts: OpenUI section start marker not found in "
+            f"{LogTag.AGENT} comms_prompts: OpenUI section start marker not found in "
             "COMMS_AGENT_PROMPT — plain (whatsapp/telegram/discord/slack) "
             "variant will still contain OpenUI instructions. Update "
             "_OPENUI_SECTION_START_MARKER to match the prompt."
@@ -614,7 +614,7 @@ def _strip_openui_section(prompt: str) -> str:
     end_marker_idx = prompt.find(_OPENUI_SECTION_END_MARKER, start)
     if end_marker_idx == -1:
         log.warning(
-            "comms_prompts: OpenUI section end marker not found after the "
+            f"{LogTag.AGENT} comms_prompts: OpenUI section end marker not found after the "
             "start marker — plain variant strip aborted. Update "
             "_OPENUI_SECTION_END_MARKER to match the prompt."
         )

--- a/apps/api/app/agents/skills/discovery.py
+++ b/apps/api/app/agents/skills/discovery.py
@@ -32,9 +32,10 @@ from app.constants.cache import (
     SKILLS_TEXT_CACHE_KEY,
     SKILLS_TEXT_CACHE_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.constants.skills import EXECUTOR_SUBAGENT_ID
 from app.decorators.caching import Cacheable
-from shared.py.wide_events import log
+from shared.py.wide_events import SkillContext, log
 
 
 def _builtin_entries(agent_name: str) -> list[tuple[str, str, str]]:
@@ -76,7 +77,7 @@ async def get_available_skills_text(
     Returns:
         Plain text string for system prompt injection, or empty string if no skills
     """
-    log.set(user_id=user_id, agent_name=agent_name, skill_op="get_available_skills_text")
+    log.set(user_id=user_id, agent_name=agent_name, skill=SkillContext(operation="get"))
 
     # Builtins come from process memory and are always available. Only the
     # executor needs them merged here: integration subagents already get their
@@ -86,13 +87,13 @@ async def get_available_skills_text(
     try:
         user_skills = await get_skills_for_agent(user_id, agent_name)
     except Exception as e:
-        log.warning(f"[skills] Failed to load user skills for {agent_name}: {e}")
+        log.warning(f"{LogTag.SKILLS} Failed to load user skills for {agent_name}: {e}")
         user_skills = []
 
     if not builtins and not user_skills:
         return ""
 
-    log.set(skill_count=len(builtins) + len(user_skills))
+    log.set_ns("skill", result_count=len(builtins) + len(user_skills))
     return _format_skills(builtins, user_skills)
 
 

--- a/apps/api/app/agents/skills/github_discovery.py
+++ b/apps/api/app/agents/skills/github_discovery.py
@@ -26,7 +26,8 @@ from app.agents.skills.utils import (
     get_github_headers,
     parse_github_url,
 )
-from shared.py.wide_events import log
+from app.constants.log_tags import LogTag
+from shared.py.wide_events import SkillContext, log
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,7 +79,7 @@ async def _fetch_git_tree(
             return await _fetch_git_tree(owner, repo, "master")
 
         if resp.status_code == 403:
-            log.warning("[skills] GitHub rate limited. Set GITHUB_TOKEN for higher limits")
+            log.warning(f"{LogTag.SKILLS} GitHub rate limited. Set GITHUB_TOKEN for higher limits")
             return [], branch
 
         resp.raise_for_status()
@@ -114,14 +115,14 @@ async def _fetch_single_file_content(
             resp = await client.get(url, headers=get_github_headers())
 
             if resp.status_code == 404:
-                log.debug(f"[skills] File not found: {path}")
+                log.debug(f"{LogTag.SKILLS} File not found: {path}")
                 return None
 
             resp.raise_for_status()
             return path, resp.text
 
     except Exception as e:
-        log.debug(f"[skills] Failed to fetch {path}: {e}")
+        log.debug(f"{LogTag.SKILLS} Failed to fetch {path}: {e}")
         return None
 
 
@@ -149,7 +150,7 @@ async def _fetch_file_contents_batch(
     contents: list[tuple[str, str]] = []
     for result in results:
         if isinstance(result, BaseException):
-            log.debug(f"[skills] Exception fetching file: {result}")
+            log.debug(f"{LogTag.SKILLS} Exception fetching file: {result}")
             continue
         if result is not None:
             contents.append(result)
@@ -173,7 +174,7 @@ async def _parse_skill_from_content(
             subagent_id=metadata.target,
         )
     except Exception as e:
-        log.debug(f"[skills] Failed to parse SKILL.md in {folder_path}: {e}")
+        log.debug(f"{LogTag.SKILLS} Failed to parse SKILL.md in {folder_path}: {e}")
         return None
 
 
@@ -195,23 +196,18 @@ async def discover_skills_from_repo(
     """
     owner, repo = parse_github_url(repo_url)
     full_repo_url = f"https://github.com/{owner}/{repo}"
-    log.set(
-        github_owner=owner,
-        github_repo=repo,
-        github_branch=branch,
-        skill_op="discover_skills_from_repo",
-    )
-    log.info(f"[skills] Discovering skills in {owner}/{repo}")
+    log.set(skill=SkillContext(operation="list"))
+    log.info(f"{LogTag.SKILLS} Discovering skills in {owner}/{repo}")
 
     # Step 1: Fetch entire repo tree in one API call
     tree_entries, resolved_branch = await _fetch_git_tree(owner, repo, branch)
 
     if not tree_entries:
-        log.warning(f"[skills] No tree entries found in {owner}/{repo}")
+        log.warning(f"{LogTag.SKILLS} No tree entries found in {owner}/{repo}")
         return []
 
     log.info(
-        f"[skills] Fetched tree with {len(tree_entries)} entries from "
+        f"{LogTag.SKILLS} Fetched tree with {len(tree_entries)} entries from "
         f"{owner}/{repo} ({resolved_branch})"
     )
 
@@ -219,10 +215,10 @@ async def discover_skills_from_repo(
     skill_files = find_skill_files(tree_entries)
 
     if not skill_files:
-        log.info(f"[skills] No SKILL.md files found in {owner}/{repo}")
+        log.info(f"{LogTag.SKILLS} No SKILL.md files found in {owner}/{repo}")
         return []
 
-    log.info(f"[skills] Found {len(skill_files)} potential skill files")
+    log.info(f"{LogTag.SKILLS} Found {len(skill_files)} potential skill files")
 
     # Step 3: Sort by priority (standard folders first)
     skill_files.sort(key=get_folder_priority)
@@ -239,13 +235,14 @@ async def discover_skills_from_repo(
         skill = await _parse_skill_from_content(content, folder_path, full_repo_url)
         if skill:
             all_skills.append(skill)
-            log.debug(f"[skills] Parsed skill: {skill.name} from {folder_path}")
+            log.debug(f"{LogTag.SKILLS} Parsed skill: {skill.name} from {folder_path}")
 
         if len(all_skills) >= MAX_SKILLS_PER_REPO:
-            log.warning(f"[skills] Reached max skills limit ({MAX_SKILLS_PER_REPO})")
+            log.warning(f"{LogTag.SKILLS} Reached max skills limit ({MAX_SKILLS_PER_REPO})")
             break
 
-    log.info(f"[skills] Found {len(all_skills)} valid skills in {owner}/{repo}")
+    log.info(f"{LogTag.SKILLS} Found {len(all_skills)} valid skills in {owner}/{repo}")
+    log.set_ns("skill", result_count=len(all_skills))
     return all_skills
 
 
@@ -268,14 +265,8 @@ async def get_skill_from_repo(
     """
     owner, repo = parse_github_url(repo_url)
     full_repo_url = f"https://github.com/{owner}/{repo}"
-    log.set(
-        github_owner=owner,
-        github_repo=repo,
-        github_branch=branch,
-        skill_name=skill_name,
-        skill_op="get_skill_from_repo",
-    )
-    log.info(f"[skills] Looking for skill '{skill_name}' in {owner}/{repo}")
+    log.set(skill=SkillContext(operation="get", skill_name=skill_name))
+    log.info(f"{LogTag.SKILLS} Looking for skill '{skill_name}' in {owner}/{repo}")
 
     # Fetch tree and find skill files
     tree_entries, resolved_branch = await _fetch_git_tree(owner, repo, branch)
@@ -293,8 +284,10 @@ async def get_skill_from_repo(
 
         skill = await _parse_skill_from_content(content, folder_path, full_repo_url)
         if skill and skill.name == skill_name:
-            log.info(f"[skills] Found skill '{skill_name}' at {folder_path}")
+            log.info(f"{LogTag.SKILLS} Found skill '{skill_name}' at {folder_path}")
+            log.set_ns("skill", success=True)
             return skill
 
-    log.info(f"[skills] Skill '{skill_name}' not found in {owner}/{repo}")
+    log.info(f"{LogTag.SKILLS} Skill '{skill_name}' not found in {owner}/{repo}")
+    log.set_ns("skill", success=False)
     return None

--- a/apps/api/app/agents/skills/installer.py
+++ b/apps/api/app/agents/skills/installer.py
@@ -27,13 +27,14 @@ from app.agents.skills.registry import (
     update_skill,
 )
 from app.agents.skills.utils import GITHUB_API_BASE, get_github_headers
+from app.constants.log_tags import LogTag
 from app.services.storage import (
     JuiceFSUnavailable,
     delete_user_skill,
     ensure_user_skills_dir,
     write_skill_file,
 )
-from shared.py.wide_events import log
+from shared.py.wide_events import SkillContext, log
 
 
 def _skill_storage_path(user_id: str, name: str) -> str:
@@ -101,7 +102,7 @@ async def _fetch_github_contents(
         raise ValueError(f"Path not found: {owner}/{repo}/{path}")
 
     if resp.status_code == 403:
-        log.warning("GitHub API rate limit exceeded. Try again later.")
+        log.warning(f"{LogTag.SKILLS} GitHub API rate limit exceeded. Try again later.")
         raise ValueError(
             "GitHub API rate limit exceeded. Please try again later, or set GITHUB_TOKEN for higher limits (5000/hr vs 60/hr)."
         )
@@ -165,15 +166,8 @@ async def install_from_github(
 
     source_url = f"https://github.com/{owner}/{repo}/tree/main/{base_path}"
 
-    log.set(
-        user_id=user_id,
-        github_owner=owner,
-        github_repo=repo,
-        github_skill_path=base_path,
-        skill_op="install_from_github",
-        skill_target=target_override,
-    )
-    log.info(f"[skills] Fetching from GitHub: {owner}/{repo}/{base_path}")
+    log.set(user_id=user_id, skill=SkillContext(operation="install"))
+    log.info(f"{LogTag.SKILLS} Fetching from GitHub: {owner}/{repo}/{base_path}")
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         # Fetch the directory contents
@@ -202,6 +196,7 @@ async def install_from_github(
 
         # Parse frontmatter → metadata + body
         metadata, body = parse_skill_md(skill_md_content)
+        log.set_ns("skill", skill_name=metadata.name)
 
         # Apply target override, then validate the effective target so a repo's
         # frontmatter can't scope a skill to an unconnected/invalid agent.
@@ -252,7 +247,7 @@ async def install_from_github(
     )
 
     log.info(
-        f"[skills] Installed '{metadata.name}' from GitHub "
+        f"{LogTag.SKILLS} Installed '{metadata.name}' from GitHub "
         f"({len(file_list)} files, target={target})"
     )
     return installed
@@ -322,9 +317,7 @@ async def install_from_inline(
     """
     log.set(
         user_id=user_id,
-        skill_name=name,
-        skill_target=target,
-        skill_op="install_from_inline",
+        skill=SkillContext(operation="install", skill_name=name),
     )
     # Generate SKILL.md content (with frontmatter for validation)
     skill_md_content = generate_skill_md(
@@ -364,7 +357,7 @@ async def install_from_inline(
         allowed_tools=metadata.allowed_tools,
     )
 
-    log.info(f"[skills] Created inline skill '{name}' (target={target})")
+    log.info(f"{LogTag.SKILLS} Created inline skill '{name}' (target={target})")
     return installed
 
 
@@ -436,7 +429,7 @@ async def update_skill_inline(
         },
     )
 
-    log.info(f"[skills] Updated inline skill '{skill.name}' (target={metadata.target})")
+    log.info(f"{LogTag.SKILLS} Updated inline skill '{skill.name}' (target={metadata.target})")
     return updated
 
 
@@ -456,19 +449,16 @@ async def uninstall_skill_full(user_id: str, skill_id: str) -> bool:
 
     log.set(
         user_id=user_id,
-        skill_id=skill_id,
-        skill_name=skill.name,
-        skill_storage_path=skill.vfs_path,
-        skill_op="uninstall_skill_full",
+        skill=SkillContext(operation="delete", skill_id=skill_id, skill_name=skill.name),
     )
 
     # Delete the skill directory from JuiceFS
     try:
         await delete_user_skill(user_id, skill.name)
     except JuiceFSUnavailable as e:
-        log.warning(f"[skills] storage cleanup skipped (mount unavailable): {e}")
+        log.warning(f"{LogTag.SKILLS} storage cleanup skipped (mount unavailable): {e}")
     except Exception as e:
-        log.warning(f"[skills] storage cleanup failed for {skill_id}: {e}")
+        log.warning(f"{LogTag.SKILLS} storage cleanup failed for {skill_id}: {e}")
 
     # Remove from registry
     return await uninstall_skill(user_id, skill_id)

--- a/apps/api/app/agents/skills/registry.py
+++ b/apps/api/app/agents/skills/registry.py
@@ -24,8 +24,9 @@ from app.constants.cache import (
     USER_SKILLS_CACHE_KEY,
     USER_SKILLS_CACHE_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.decorators.caching import Cacheable, CacheInvalidator
-from shared.py.wide_events import log
+from shared.py.wide_events import SkillContext, log
 
 COLLECTION_NAME = "skills"
 
@@ -104,10 +105,7 @@ async def install_skill(
     """
     log.set(
         user_id=user_id,
-        skill_name=name,
-        skill_target=target,
-        skill_source=source.value,
-        skill_op="install_skill",
+        skill=SkillContext(operation="install", skill_name=name),
     )
     collection = _get_collection()
 
@@ -148,7 +146,7 @@ async def install_skill(
     await collection.insert_one(doc)
 
     log.info(
-        f"[skills] Installed '{name}' for user {user_id} (target={target}, source={source.value})"
+        f"{LogTag.SKILLS} Installed '{name}' for user {user_id} (target={target}, source={source.value})"
     )
     return skill
 
@@ -166,11 +164,13 @@ async def uninstall_skill(user_id: str, skill_id: str) -> bool:
     Returns:
         True if deleted, False if not found
     """
-    log.set(user_id=user_id, skill_id=skill_id, skill_op="uninstall_skill")
+    log.set(user_id=user_id, skill=SkillContext(operation="delete", skill_id=skill_id))
     collection = _get_collection()
     result = await collection.delete_one({"_id": skill_id, "user_id": user_id})
-    if result.deleted_count > 0:
-        log.info(f"[skills] Uninstalled skill {skill_id} for user {user_id}")
+    deleted = result.deleted_count > 0
+    log.set_ns("skill", success=deleted)
+    if deleted:
+        log.info(f"{LogTag.SKILLS} Uninstalled skill {skill_id} for user {user_id}")
         return True
     return False
 
@@ -240,7 +240,7 @@ async def get_skills_for_agent(user_id: str, agent_name: str) -> list[Skill]:
     Returns:
         List of enabled skills available to this agent
     """
-    log.set(user_id=user_id, agent_name=agent_name, skill_op="get_skills_for_agent")
+    log.set(user_id=user_id, agent_name=agent_name, skill=SkillContext(operation="get"))
     collection = _get_collection()
 
     query = {
@@ -254,7 +254,9 @@ async def get_skills_for_agent(user_id: str, agent_name: str) -> list[Skill]:
 
     cursor = collection.find(query).sort("installed_at", -1)
     docs = await cursor.to_list(length=500)
-    return [_doc_to_skill(doc) for doc in docs]
+    skills = [_doc_to_skill(doc) for doc in docs]
+    log.set_ns("skill", result_count=len(skills))
+    return skills
 
 
 @CacheInvalidator(key_patterns=_SKILLS_INVALIDATION_PATTERNS)
@@ -296,7 +298,7 @@ async def update_skill(user_id: str, skill_id: str, fields: dict[str, Any]) -> S
     Always stamps ``updated_at``. Scoped to ``{_id, user_id}`` so a user can only
     edit their own skills. Returns None if no matching skill exists.
     """
-    log.set(user_id=user_id, skill_id=skill_id, skill_op="update_skill")
+    log.set(user_id=user_id, skill=SkillContext(skill_id=skill_id))
     collection = _get_collection()
     updates = {**fields, "updated_at": datetime.now(UTC).isoformat()}
     doc = await collection.find_one_and_update(
@@ -304,7 +306,8 @@ async def update_skill(user_id: str, skill_id: str, fields: dict[str, Any]) -> S
         {"$set": updates},
         return_document=ReturnDocument.AFTER,
     )
+    log.set_ns("skill", success=doc is not None)
     if not doc:
         return None
-    log.info(f"[skills] Updated skill {skill_id} for user {user_id}")
+    log.info(f"{LogTag.SKILLS} Updated skill {skill_id} for user {user_id}")
     return _doc_to_skill(doc)

--- a/apps/api/app/agents/skills/utils.py
+++ b/apps/api/app/agents/skills/utils.py
@@ -11,6 +11,7 @@ This module provides utility functions for:
 import os
 from urllib.parse import urlparse
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 GITHUB_API_BASE = "https://api.github.com"
@@ -153,6 +154,6 @@ def check_tree_truncated(tree_data: dict, owner: str, repo: str) -> None:
     """
     if tree_data.get("truncated"):
         log.warning(
-            f"[skills] Repository {owner}/{repo} tree is truncated. "
+            f"{LogTag.SKILLS} Repository {owner}/{repo} tree is truncated. "
             "Some skills may not be discovered."
         )

--- a/apps/api/app/agents/tools/coding/bash_tool.py
+++ b/apps/api/app/agents/tools/coding/bash_tool.py
@@ -32,6 +32,7 @@ from app.agents.workspace.paths import (
     session_artifacts,
     session_dir,
 )
+from app.constants.log_tags import LogTag
 from app.constants.sandbox import (
     BASH_DEFAULT_TIMEOUT_SECONDS,
     BASH_MAX_COMMAND_LENGTH,
@@ -231,7 +232,7 @@ async def bash(
     except Exception as e:
         # acquire_sandbox already evicted the sandbox if this failure means it
         # died (it health-checks on any error) — here we just surface it.
-        log.error(f"bash tool failed: {e}", exc_info=True)
+        log.error(f"{LogTag.SANDBOX} bash tool failed: {e}", exc_info=True)
         return _emit_bash_error(run_id, str(e), f"Error executing command: {e}", session_id)
 
 

--- a/apps/api/app/agents/tools/coding/read_tool.py
+++ b/apps/api/app/agents/tools/coding/read_tool.py
@@ -23,6 +23,7 @@ from app.agents.tools.coding._context import (
 )
 from app.agents.workspace.paths import WORKSPACE_ROOT
 from app.agents.workspace.system_files import system_file_body
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc, with_rate_limiting
 from app.services.sandbox import SandboxAcquisitionError, acquire_sandbox
 from app.services.storage import FsOps, JuiceFSUnavailable, fs_timer, read_user_file
@@ -91,7 +92,7 @@ async def read(
     except SandboxAcquisitionError as e:
         return f"Error: sandbox unavailable — {e}"
     except Exception as e:
-        log.error(f"read tool failed: {e}", exc_info=True)
+        log.error(f"{LogTag.SANDBOX} read tool failed: {e}", exc_info=True)
         return f"Error reading file: {e}"
 
 

--- a/apps/api/app/agents/tools/coding/write_tool.py
+++ b/apps/api/app/agents/tools/coding/write_tool.py
@@ -16,6 +16,7 @@ from app.agents.tools.coding._context import (
     safe_emit,
 )
 from app.agents.workspace.paths import MountRole
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc, with_rate_limiting
 from app.services.sandbox import SandboxAcquisitionError, acquire_sandbox
 from app.services.storage import FsOps, add_fs_bytes, fs_timer
@@ -61,7 +62,7 @@ async def write(
     except SandboxAcquisitionError as e:
         return f"Error: sandbox unavailable — {e}"
     except Exception as e:
-        log.error(f"write tool failed: {e}", exc_info=True)
+        log.error(f"{LogTag.SANDBOX} write tool failed: {e}", exc_info=True)
         return f"Error writing file: {e}"
 
     safe_emit(

--- a/apps/api/app/agents/tools/context_tool.py
+++ b/apps/api/app/agents/tools/context_tool.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.services.composio.custom_tools.context_tool import (
     PROVIDER_TOOLS,
@@ -62,7 +63,9 @@ async def gather_context(
     )
 
     total_time = time.time() - start_time
-    log.info(f"Context fetched from {len(resolved_providers)} providers in {total_time:.2f}s")
+    log.info(
+        f"{LogTag.TOOL} Context fetched from {len(resolved_providers)} providers in {total_time:.2f}s"
+    )
 
     return {
         "date": date_str,

--- a/apps/api/app/agents/tools/core/registry.py
+++ b/apps/api/app/agents/tools/core/registry.py
@@ -4,6 +4,7 @@ from collections.abc import ItemsView, Iterator, KeysView, Mapping
 from langchain_core.tools import BaseTool
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from app.models.oauth_models import OAuthIntegration
 from app.services.composio.composio_service import get_composio_service
@@ -211,7 +212,7 @@ class ToolRegistry:
             }
         )
         log.info(
-            f"_add_category: '{name}' space='{space}' tools_in="
+            f"{LogTag.TOOL} _add_category: '{name}' space='{space}' tools_in="
             f"{len(tools) if tools else 0} core_in="
             f"{len(core_tools) if core_tools else 0} final="
             f"{len(category.tools)} replacing={replacing} (was {prior_tools_count})"
@@ -337,7 +338,9 @@ class ToolRegistry:
         if toolkit_name in self._categories:
             return self._categories[toolkit_name]
 
-        log.info(f"Registering provider tools for {toolkit_name} (space: {space_name})")
+        log.info(
+            f"{LogTag.TOOL} Registering provider tools for {toolkit_name} (space: {space_name})"
+        )
 
         composio_service = get_composio_service()
 
@@ -357,7 +360,7 @@ class ToolRegistry:
 
         await self._index_category_tools(toolkit_name)
 
-        log.info(f"Registered {len(tools)} tools for {toolkit_name}")
+        log.info(f"{LogTag.TOOL} Registered {len(tools)} tools for {toolkit_name}")
         return self._categories[toolkit_name]
 
     async def populate_provider_catalog(self) -> int:
@@ -409,7 +412,7 @@ class ToolRegistry:
                     tool_kit=toolkit, specific_tools=specific
                 )
             except Exception as e:
-                log.error(f"Failed to load catalog metadata for {toolkit}: {e}")
+                log.error(f"{LogTag.TOOL} Failed to load catalog metadata for {toolkit}: {e}")
                 return
 
             metas = [
@@ -425,7 +428,7 @@ class ToolRegistry:
             try:
                 await index_tools_to_store([(m, space) for m in metas])
             except Exception as e:
-                log.error(f"Failed to index catalog metadata for {toolkit}: {e}")
+                log.error(f"{LogTag.TOOL} Failed to index catalog metadata for {toolkit}: {e}")
                 return
 
             mongo_batch.append(
@@ -444,7 +447,7 @@ class ToolRegistry:
         for integration, result in zip(integrations, results):
             if isinstance(result, Exception):
                 log.error(
-                    "Catalog metadata population failed for "
+                    f"{LogTag.TOOL} Catalog metadata population failed for "
                     f"{integration.composio_config.toolkit}: {result}"
                 )
 
@@ -452,10 +455,12 @@ class ToolRegistry:
             try:
                 await mcp_store.store_tools_batch(mongo_batch)
             except Exception as e:
-                log.warning(f"Failed to store provider catalog metadata to Mongo: {e}")
+                log.warning(
+                    f"{LogTag.TOOL} Failed to store provider catalog metadata to Mongo: {e}"
+                )
 
         log.info(
-            f"Provider catalog metadata indexed: {total} tools "
+            f"{LogTag.TOOL} Provider catalog metadata indexed: {total} tools "
             f"across {len(integrations)} toolkits (no StructuredTools materialized)"
         )
         return total
@@ -476,7 +481,7 @@ class ToolRegistry:
         category = self._categories.get(category_name)
         if not category:
             log.warning(
-                f"_index_category_tools: category '{category_name}' not in registry, "
+                f"{LogTag.TOOL} _index_category_tools: category '{category_name}' not in registry, "
                 f"known={sorted(self._categories.keys())[:20]}..."
             )
             return
@@ -490,14 +495,14 @@ class ToolRegistry:
             }
         )
         log.info(
-            f"_index_category_tools: '{category_name}' space='{category.space}' "
+            f"{LogTag.TOOL} _index_category_tools: '{category_name}' space='{category.space}' "
             f"category.tools count={category_tools_count}"
         )
 
         tools_with_space = [(tool.tool, category.space) for tool in category.tools]
         if not tools_with_space:
             log.warning(
-                f"_index_category_tools: category '{category_name}' has 0 tools "
+                f"{LogTag.TOOL} _index_category_tools: category '{category_name}' has 0 tools "
                 f"(space='{category.space}'), nothing to index — caller likely passed "
                 f"empty tools to _add_category"
             )

--- a/apps/api/app/agents/tools/core/retrieval.py
+++ b/apps/api/app/agents/tools/core/retrieval.py
@@ -31,6 +31,7 @@ from app.agents.tools.core.registry import (
 from app.agents.tools.research_tool import deep_research
 from app.agents.tools.webpage_tool import fetch_webpages, web_search_tool
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.db.chroma.public_integrations_store import search_public_integrations
 from app.models.chat_models import ConversationSource
 from app.services.integrations.integration_service import (
@@ -64,7 +65,9 @@ async def _user_mcp_tool_names(user_id: str | None) -> set[str]:
             names.update(t.name for t in integration_tools)
         return names
     except Exception as e:
-        log.warning(f"_user_mcp_tool_names: failed for user {user_id}: {type(e).__name__}: {e}")
+        log.warning(
+            f"{LogTag.TOOL} _user_mcp_tool_names: failed for user {user_id}: {type(e).__name__}: {e}"
+        )
         return set()
 
 
@@ -268,11 +271,13 @@ async def _get_user_context(
 
         if include_subagents:
             connected_integrations = await _resolve_connected_subagents(user_id)
-            log.info(f"User {user_id} connected subagents: {set(connected_integrations)}")
+            log.info(
+                f"{LogTag.TOOL} User {user_id} connected subagents: {set(connected_integrations)}"
+            )
 
-        log.info(f"User {user_id} namespaces: {user_namespaces}")
+        log.info(f"{LogTag.TOOL} User {user_id} namespaces: {user_namespaces}")
     except Exception as e:
-        log.warning(f"Failed to get user namespaces: {e}")
+        log.warning(f"{LogTag.TOOL} Failed to get user namespaces: {e}")
 
     return user_namespaces, connected_integrations, internal_subagents
 
@@ -299,14 +304,14 @@ def _build_search_tasks(
 
     # Search in tool_space
     if tool_space in user_namespaces or tool_space == "general":
-        log.info(f"Adding search for tool_space: {tool_space}")
+        log.info(f"{LogTag.TOOL} Adding search for tool_space: {tool_space}")
         search_tasks.append(store.asearch((tool_space,), query=query, limit=limit))
     else:
         # Caller is in a subagent whose namespace they don't own. This is
         # unusual — usually it means a stale cache or a misrouted handoff.
         # We refuse the search rather than leak another user's tool index.
         log.warning(
-            "retrieve_tools refused search: tool_space not in user_namespaces",
+            f"{LogTag.TOOL} retrieve_tools refused search: tool_space not in user_namespaces",
             tool_space=tool_space,
             user_namespaces=sorted(user_namespaces),
         )
@@ -314,18 +319,18 @@ def _build_search_tasks(
     # For subagents, also search 'general' namespace with a small limit
     # so core tools (e.g. webpage tools) are still discoverable.
     if tool_space != "general":
-        log.info("Adding search for general namespace (limited to 5 for core tools)")
+        log.info(f"{LogTag.TOOL} Adding search for general namespace (limited to 5 for core tools)")
         search_tasks.append(store.asearch(("general",), query=query, limit=5))
 
     # Desktop-executed tools are only discoverable for desktop-app sessions
     # (include_desktop is derived from conversation_source upstream).
     if include_desktop:
-        log.info("Adding search for desktop namespace")
+        log.info(f"{LogTag.TOOL} Adding search for desktop namespace")
         search_tasks.append(store.asearch((DESKTOP_TOOL_SPACE,), query=query, limit=10))
 
     # Search subagents namespace
     if include_subagents:
-        log.info("Adding search for subagents namespace")
+        log.info(f"{LogTag.TOOL} Adding search for subagents namespace")
         search_tasks.append(store.asearch(("subagents",), query=query, limit=15))
         search_tasks.append(search_public_integrations(query=query, limit=15))
 
@@ -432,7 +437,7 @@ async def _process_search_results(
 
     for idx, result in enumerate(results):
         if isinstance(result, BaseException):
-            log.warning(f"Task {idx}: Search error - {result}")
+            log.warning(f"{LogTag.TOOL} Task {idx}: Search error - {result}")
             continue
 
         if not result:
@@ -454,11 +459,11 @@ async def _process_search_results(
                     for item in result[:20]
                 ]
                 log.debug(
-                    f"Chroma search raw hits (task={idx}, tool_space={tool_space}): "
+                    f"{LogTag.TOOL} Chroma search raw hits (task={idx}, tool_space={tool_space}): "
                     f"{len(result)} items, preview={preview}"
                 )
             except Exception as e:
-                log.debug(f"Chroma search raw hits log failed (task={idx}): {e}")
+                log.debug(f"{LogTag.TOOL} Chroma search raw hits log failed (task={idx}): {e}")
             processed = _process_chroma_search_result(
                 result,
                 available_tool_names,
@@ -586,7 +591,7 @@ def get_retrieve_tools_function(
         exact_tool_names: list[str] = Field(default_factory=list),
     ) -> RetrieveToolsResult:
         log.info(
-            "retrieve_tools called",
+            f"{LogTag.TOOL} retrieve_tools called",
             query=query,
             exact_tool_names=exact_tool_names,
             tool_space=tool_space,
@@ -613,7 +618,7 @@ def get_retrieve_tools_function(
 
         tool_registry = await get_tool_registry()
         available_tool_names = tool_registry.get_tool_names()
-        log.info(f"Registry has {len(available_tool_names)} available tools")
+        log.info(f"{LogTag.TOOL} Registry has {len(available_tool_names)} available tools")
 
         # Desktop tools only surface for desktop-app conversations, and only
         # in the main agent context (subagents keep their own tool space).
@@ -634,7 +639,9 @@ def get_retrieve_tools_function(
                 config["configurable"]["user_id"] = user_id
 
         if not user_id:
-            log.warning("retrieve_tools called with NO user_id (not in configurable or metadata)")
+            log.warning(
+                f"{LogTag.TOOL} retrieve_tools called with NO user_id (not in configurable or metadata)"
+            )
 
         # BINDING MODE: Validate and bind exact tool names
         if exact_tool_names:
@@ -677,7 +684,7 @@ def get_retrieve_tools_function(
                 # Surfacing this is important: silently dropping requested tools
                 # makes registry-population bugs invisible to operators.
                 log.warning(
-                    "retrieve_tools binding dropped unknown tools",
+                    f"{LogTag.TOOL} retrieve_tools binding dropped unknown tools",
                     tool_space=tool_space,
                     unknown=unknown_tool_names,
                     available_count=len(available_tool_names_set),
@@ -808,7 +815,7 @@ def get_retrieve_tools_function(
         )
         if chroma_hits == 0 and tool_space != "general":
             log.warning(
-                f"retrieve_tools: 0 ChromaDB hits for tool_space='{tool_space}' "
+                f"{LogTag.TOOL} retrieve_tools: 0 ChromaDB hits for tool_space='{tool_space}' "
                 f"user={user_id} query={query!r}. Check that index_tools_to_store "
                 f"actually wrote docs for this namespace."
             )

--- a/apps/api/app/agents/tools/desktop_tools.py
+++ b/apps/api/app/agents/tools/desktop_tools.py
@@ -13,6 +13,7 @@ from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
 from app.agents.llm.client import init_llm
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.models.chat_models import ConversationSource
 from app.services.desktop.bridge import DesktopToolOutcome, request_desktop_action
@@ -53,13 +54,13 @@ async def _run_desktop_action(
     configurable = config.get("configurable", {})
     source = ConversationSource.coerce(configurable.get("conversation_source"))
     if source is not ConversationSource.DESKTOP:
-        log.warning(f"Desktop tool '{tool_name}' refused for source '{source}'")
+        log.warning(f"{LogTag.TOOL} Desktop tool '{tool_name}' refused for source '{source}'")
         return _NOT_DESKTOP_ERROR
 
     stream_id = configurable.get("stream_id")
     user_id = configurable.get("user_id")
     if not stream_id or not user_id:
-        log.warning(f"Desktop tool '{tool_name}' missing stream_id/user_id in config")
+        log.warning(f"{LogTag.TOOL} Desktop tool '{tool_name}' missing stream_id/user_id in config")
         return _MISSING_CONTEXT_ERROR
 
     return await request_desktop_action(
@@ -114,7 +115,7 @@ async def _describe_screenshot(image_b64: str, query: str) -> str | None:
             ],
         )
     except Exception as exc:  # noqa: BLE001 - any provider failure degrades gracefully
-        log.warning(f"Screenshot vision call failed: {exc}")
+        log.warning(f"{LogTag.TOOL} Screenshot vision call failed: {exc}")
         return None
     content = getattr(response, "content", response)
     return content if isinstance(content, str) else str(content)

--- a/apps/api/app/agents/tools/executor_tool.py
+++ b/apps/api/app/agents/tools/executor_tool.py
@@ -34,6 +34,7 @@ from app.constants.cache import (
     EXECUTOR_QUEUE_TTL,
 )
 from app.constants.general import CALL_EXECUTOR_NAME
+from app.constants.log_tags import LogTag
 from app.constants.streaming import WS_EVENT_EXECUTOR_CANCELLED
 from app.core.stream_manager import StreamManager
 from app.core.websocket_manager import websocket_manager
@@ -129,7 +130,7 @@ async def call_executor(
     conversation_id = configurable.get("thread_id", "")
 
     if not conversation_id:
-        log.error("call_executor: missing thread_id in configurable")
+        log.error(f"{LogTag.TOOL} call_executor: missing thread_id in configurable")
         return "Internal error: conversation context unavailable. Please try again."
 
     task_id = str(uuid4())
@@ -144,7 +145,7 @@ async def call_executor(
     except (LangChainRateLimitException, RateLimitExceededException) as e:
         return _rate_limit_message(e)
     except Exception as e:  # noqa: BLE001
-        log.error("Error dispatching executor", error=str(e))
+        log.error(f"{LogTag.TOOL} Error dispatching executor", error=str(e))
         await redis_cache.delete(
             f"{EXECUTOR_BUSY_PREFIX}{conversation_id}",
         )
@@ -158,7 +159,7 @@ def _rate_limit_message(e: LangChainRateLimitException | RateLimitExceededExcept
     else:
         detail: dict[str, str] = e.detail if isinstance(e.detail, dict) else {}
         feature = detail.get("feature", "")
-    log.warning("Rate limit exceeded for executor task", feature=feature)
+    log.warning(f"{LogTag.TOOL} Rate limit exceeded for executor task", feature=feature)
     return (
         f"Rate limit exceeded for {feature or 'this feature'}. "
         "The user has already been notified of this limit; "
@@ -199,7 +200,7 @@ async def _dispatch_executor(
         held_stream_id = parse_lock_value(decode_raw_item(held_value))[0] if held_value else ""
         if stream_id and held_stream_id == stream_id:
             log.warning(
-                "Duplicate call_executor in same turn — ignored, not queued",
+                f"{LogTag.TOOL} Duplicate call_executor in same turn — ignored, not queued",
                 task_id=task_id,
                 stream_id=stream_id,
                 conversation_id=conversation_id,
@@ -216,7 +217,7 @@ async def _dispatch_executor(
         # one. Only waits when a cancel is actually in flight (see helper).
         if await _acquire_lock_through_redirect(lock_key, lock_value, held_stream_id):
             log.info(
-                "Acquired executor lock after redirect cancel — running live",
+                f"{LogTag.TOOL} Acquired executor lock after redirect cancel — running live",
                 task_id=task_id,
                 conversation_id=conversation_id,
             )
@@ -232,7 +233,7 @@ async def _dispatch_executor(
                 user_message_id=user_message_id,
             )
             log.info(
-                "Executor busy — task queued",
+                f"{LogTag.TOOL} Executor busy — task queued",
                 task_id=task_id,
                 conversation_id=conversation_id,
             )
@@ -268,7 +269,7 @@ async def _dispatch_executor(
     bg_task.add_done_callback(_executor_tasks.discard)
 
     log.info(
-        "Executor dispatched to background",
+        f"{LogTag.TOOL} Executor dispatched to background",
         task_id=task_id,
         stream_id=stream_id,
     )
@@ -356,7 +357,7 @@ async def cancel_executor(
         return result
 
     except Exception as e:  # noqa: BLE001
-        log.error("cancel_executor failed", error=str(e))
+        log.error(f"{LogTag.TOOL} cancel_executor failed", error=str(e))
         await redis_cache.delete(lock_key)
         return f"Cancellation attempted but hit an error: {e}"
 
@@ -380,7 +381,7 @@ async def _broadcast_executor_cancelled(
             },
         )
     except Exception as e:  # noqa: BLE001 — best-effort UI signal
-        log.warning("Failed to broadcast executor.cancelled", error=str(e))
+        log.warning(f"{LogTag.TOOL} Failed to broadcast executor.cancelled", error=str(e))
 
 
 async def _cancel_running_task(
@@ -406,7 +407,7 @@ async def _cancel_running_task(
     await redis_cache.delete(lock_key)
 
     log.info(
-        "cancel_executor: stopped running task",
+        f"{LogTag.TOOL} cancel_executor: stopped running task",
         task_id=active_task_id,
         stream_id=active_stream_id,
         conversation_id=conversation_id,
@@ -431,7 +432,7 @@ async def _cancel_queued_tasks(
     if cancel_all:
         await redis_cache.client.delete(queue_key)
         log.info(
-            "cancel_executor: cleared entire queue",
+            f"{LogTag.TOOL} cancel_executor: cleared entire queue",
             queue_len=queue_len,
             conversation_id=conversation_id,
         )
@@ -477,7 +478,7 @@ async def _remove_queued_by_ids(
                 EXECUTOR_QUEUE_TTL,
             )
         log.info(
-            "cancel_executor: removed queued tasks",
+            f"{LogTag.TOOL} cancel_executor: removed queued tasks",
             removed=len(cancelled),
             remaining=len(keep),
             conversation_id=conversation_id,

--- a/apps/api/app/agents/tools/file_tools.py
+++ b/apps/api/app/agents/tools/file_tools.py
@@ -4,6 +4,7 @@ from langchain_core.documents import Document
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chromadb import ChromaClient
 from app.db.mongodb.collections import files_collection
 from app.decorators import with_doc, with_rate_limiting
@@ -30,7 +31,7 @@ async def query_file(
         configurable = config.get("configurable")
 
         if not configurable:
-            log.error("Configurable is not set in the config.")
+            log.error(f"{LogTag.TOOL} Configurable is not set in the config.")
             raise ValueError("Configurable is not set in the config.")
 
         conversation_id = configurable["thread_id"]
@@ -42,13 +43,13 @@ async def query_file(
             user_id=configurable["user_id"],
         )
 
-        log.info(f"Similar documents found: {similar_documents}")
+        log.info(f"{LogTag.TOOL} Similar documents found: {similar_documents}")
 
         document_ids = list(
             set([document.metadata.get("file_id") for document, score in similar_documents])
         )
 
-        log.info(f"Document IDs: {document_ids}")
+        log.info(f"{LogTag.TOOL} Document IDs: {document_ids}")
 
         documents = await files_collection.find(
             filter={
@@ -57,7 +58,7 @@ async def query_file(
             },
         ).to_list(length=None)
 
-        log.info(f"Documents found: {documents}")
+        log.info(f"{LogTag.TOOL} Documents found: {documents}")
 
         return _construct_content(
             documents=documents,
@@ -65,7 +66,7 @@ async def query_file(
         )
 
     except Exception as e:
-        log.error(f"Error in querying document: {e!s}")
+        log.error(f"{LogTag.TOOL} Error in querying document: {e!s}")
         raise e
 
 
@@ -96,7 +97,7 @@ async def _get_similar_documents(
     )
 
     if not chroma_documents_collection:
-        log.error("ChromaDB client is not available.")
+        log.error(f"{LogTag.TOOL} ChromaDB client is not available.")
         return []
 
     filters = {
@@ -142,7 +143,7 @@ def _construct_content(documents: list, similar_documents: list[tuple[Document, 
         )
 
         if not document:
-            log.error(f"Document with ID {document_id} not found.")
+            log.error(f"{LogTag.TOOL} Document with ID {document_id} not found.")
             continue
 
         document_content = document["page_wise_summary"]
@@ -166,10 +167,12 @@ def _construct_content(documents: list, similar_documents: list[tuple[Document, 
             content += f"Document ID: {document_id}\n"
             content += f"Description: {document_content.get('data', {}).get('content', 'Description not available!')}\n\n"
         else:
-            log.error(f"Unexpected document description type: {type(document['description'])}")
+            log.error(
+                f"{LogTag.TOOL} Unexpected document description type: {type(document['description'])}"
+            )
             content += f"Document ID: {document_id}\n"
             content += "Description: Invalid format\n\n"
 
-    log.info(f"Constructed content: {content}")
+    log.info(f"{LogTag.TOOL} Constructed content: {content}")
 
     return content

--- a/apps/api/app/agents/tools/goal_tool.py
+++ b/apps/api/app/agents/tools/goal_tool.py
@@ -7,6 +7,7 @@ from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
 from app.constants.cache import DEFAULT_CACHE_TTL
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import goals_collection
 from app.db.redis import delete_cache, get_cache, set_cache
 from app.decorators import with_doc, with_rate_limiting
@@ -62,12 +63,12 @@ async def invalidate_goal_caches(user_id: str, goal_id: str | None = None) -> No
             await delete_cache(cache_key_goal)
 
         log.info(
-            f"Goal caches invalidated for user {user_id}"
+            f"{LogTag.TOOL} Goal caches invalidated for user {user_id}"
             + (f" and goal {goal_id}" if goal_id else "")
         )
 
     except Exception as e:
-        log.error(f"Error invalidating goal caches: {e!s}")
+        log.error(f"{LogTag.TOOL} Error invalidating goal caches: {e!s}")
         # Don't raise exception as cache invalidation failure shouldn't break the operation
 
 
@@ -81,7 +82,7 @@ async def create_goal(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "create_goal", "action": "create"})
-        log.info(f"Goal Tool: Creating goal with title '{title}'")
+        log.info(f"{LogTag.TOOL} Goal Tool: Creating goal with title '{title}'")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "goal": None}
@@ -127,7 +128,7 @@ async def create_goal(
 
     except Exception as e:
         error_msg = f"Error creating goal: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "goal": None}
 
 
@@ -136,7 +137,7 @@ async def create_goal(
 async def list_goals(config: RunnableConfig) -> dict[str, Any]:
     try:
         log.set(tool={"name": "list_goals", "action": "list"})
-        log.info("Goal Tool: Listing all goals")
+        log.info(f"{LogTag.TOOL} Goal Tool: Listing all goals")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "goals": []}
@@ -170,7 +171,7 @@ async def list_goals(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error listing goals: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "goals": []}
 
 
@@ -182,7 +183,7 @@ async def get_goal(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_goal", "action": "get"})
-        log.info(f"Goal Tool: Getting goal {goal_id}")
+        log.info(f"{LogTag.TOOL} Goal Tool: Getting goal {goal_id}")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "goal": None}
@@ -229,7 +230,7 @@ async def get_goal(
 
     except Exception as e:
         error_msg = f"Error getting goal: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "goal": None}
 
 
@@ -241,7 +242,7 @@ async def delete_goal(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "delete_goal", "action": "delete"})
-        log.info(f"Goal Tool: Deleting goal {goal_id}")
+        log.info(f"{LogTag.TOOL} Goal Tool: Deleting goal {goal_id}")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "success": False}
@@ -279,7 +280,7 @@ async def delete_goal(
 
     except Exception as e:
         error_msg = f"Error deleting goal: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "success": False}
 
 
@@ -292,7 +293,7 @@ async def generate_roadmap(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "generate_roadmap", "action": "generate"})
-        log.info(f"Goal Tool: Generating roadmap for goal {goal_id}")
+        log.info(f"{LogTag.TOOL} Goal Tool: Generating roadmap for goal {goal_id}")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "roadmap": None}
@@ -391,7 +392,7 @@ async def generate_roadmap(
 
     except Exception as e:
         error_msg = f"Error generating roadmap: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "roadmap": None}
 
 
@@ -405,7 +406,9 @@ async def update_goal_node(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "update_goal_node", "action": "update"})
-        log.info(f"Goal Tool: Updating node {node_id} in goal {goal_id} to complete={is_complete}")
+        log.info(
+            f"{LogTag.TOOL} Goal Tool: Updating node {node_id} in goal {goal_id} to complete={is_complete}"
+        )
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "goal": None}
@@ -446,7 +449,7 @@ async def update_goal_node(
 
     except Exception as e:
         error_msg = f"Error updating goal node: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "goal": None}
 
 
@@ -459,7 +462,7 @@ async def search_goals(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "search_goals", "action": "search"})
-        log.info(f"Goal Tool: Searching goals with query '{query}'")
+        log.info(f"{LogTag.TOOL} Goal Tool: Searching goals with query '{query}'")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "goals": []}
@@ -514,7 +517,7 @@ async def search_goals(
 
     except Exception as e:
         error_msg = f"Error searching goals: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "goals": []}
 
 
@@ -523,7 +526,7 @@ async def search_goals(
 async def get_goal_statistics(config: RunnableConfig) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_goal_statistics", "action": "stats"})
-        log.info("Goal Tool: Getting goal statistics")
+        log.info(f"{LogTag.TOOL} Goal Tool: Getting goal statistics")
         user_id = get_user_id_from_config(config)
         if not user_id:
             return {"error": "User authentication required", "stats": None}
@@ -546,7 +549,7 @@ async def get_goal_statistics(config: RunnableConfig) -> dict[str, Any]:
         cache_key_stats = f"goal_stats_cache:{user_id}"
         cached_stats = await get_cache(cache_key_stats)
         if cached_stats:
-            log.info(f"Goal statistics fetched from cache for user {user_id}")
+            log.info(f"{LogTag.TOOL} Goal statistics fetched from cache for user {user_id}")
             if isinstance(cached_stats, str):
                 stats = json.loads(cached_stats)
             else:
@@ -626,7 +629,7 @@ async def get_goal_statistics(config: RunnableConfig) -> dict[str, Any]:
 
         # Cache the computed statistics (1 hour to balance freshness with performance)
         await set_cache(cache_key_stats, json.dumps(stats), DEFAULT_CACHE_TTL)
-        log.info(f"Goal statistics computed and cached for user {user_id}")
+        log.info(f"{LogTag.TOOL} Goal statistics computed and cached for user {user_id}")
 
         # Stream the stats to frontend
         writer(
@@ -643,7 +646,7 @@ async def get_goal_statistics(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error getting goal statistics: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "stats": None}
 
 

--- a/apps/api/app/agents/tools/image_tool.py
+++ b/apps/api/app/agents/tools/image_tool.py
@@ -4,6 +4,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc, with_rate_limiting
 from app.services.image_service import api_generate_image
 from app.templates.docstrings.image_tool_docs import GENERATE_IMAGE
@@ -38,6 +39,6 @@ async def generate_image(
 
     except Exception as e:
         writer = get_stream_writer()
-        log.error(f"Error generating image: {e!s}")
+        log.error(f"{LogTag.TOOL} Error generating image: {e!s}")
         writer({"error": f"Error generating image: {e!s}"})
         return {"status": "error", "message": f"Error generating image: {e!s}"}

--- a/apps/api/app/agents/tools/integration_tool.py
+++ b/apps/api/app/agents/tools/integration_tool.py
@@ -17,6 +17,7 @@ from app.constants.integrations import (
     MAX_CONNECTED_FOR_LLM,
     MAX_SUGGESTED_FOR_LLM,
 )
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     integrations_collection,
     user_integrations_collection,
@@ -159,7 +160,7 @@ async def list_integrations(
         if search_public_query and search_public_query.strip():
             try:
                 query = search_public_query.strip()
-                log.info(f"Searching public integrations with query: {query}")
+                log.info(f"{LogTag.TOOL} Searching public integrations with query: {query}")
 
                 # Get IDs to exclude (user already has these)
                 existing_ids = {i["id"] for i in connected_list + available_list}
@@ -204,7 +205,7 @@ async def list_integrations(
                 async for doc in docs_cursor:
                     iid = doc.get("integration_id")
                     mcp_config = doc.get("mcp_config", {})
-                    log.info(f"Found public integration: {iid} - {doc.get('name')}")
+                    log.info(f"{LogTag.TOOL} Found public integration: {iid} - {doc.get('name')}")
 
                     suggested_list.append(
                         {
@@ -223,10 +224,10 @@ async def list_integrations(
                         }
                     )
 
-                log.info(f"Found {len(suggested_list)} public integrations")
+                log.info(f"{LogTag.TOOL} Found {len(suggested_list)} public integrations")
 
             except Exception as e:
-                log.warning(f"Failed to search public integrations: {e}")
+                log.warning(f"{LogTag.TOOL} Failed to search public integrations: {e}")
 
         # Stream suggested integrations to frontend (camelCase)
         suggested_for_stream = [
@@ -260,7 +261,7 @@ async def list_integrations(
         }
 
     except Exception as e:
-        log.error(f"Error listing integrations: {e}")
+        log.error(f"{LogTag.TOOL} Error listing integrations: {e}")
         return f"Error listing integrations: {e!s}"
 
 
@@ -353,7 +354,7 @@ async def connect_integration(
         return "\n".join(results) if results else "No integrations to connect."
 
     except Exception as e:
-        log.error(f"Error connecting integrations {integration_ids}: {e}")
+        log.error(f"{LogTag.TOOL} Error connecting integrations {integration_ids}: {e}")
         return f"Error connecting integrations: {e!s}"
 
 
@@ -400,7 +401,7 @@ async def check_integrations_status(
         return "\n".join(results)
 
     except Exception as e:
-        log.error(f"Error checking integration status: {e}")
+        log.error(f"{LogTag.TOOL} Error checking integration status: {e}")
         return f"Error checking status: {e!s}"
 
 

--- a/apps/api/app/agents/tools/integrations/airtable_tool.py
+++ b/apps/api/app/agents/tools/integrations/airtable_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 from shared.py.wide_events import log
@@ -32,7 +33,7 @@ def register_airtable_custom_tools(composio: Composio) -> list[str]:
             data = execute_tool("AIRTABLE_LIST_BASES", {}, user_id)
             bases_raw = data.get("bases", [])
         except Exception as e:
-            log.debug(f"Airtable bases fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Airtable bases fetch failed: {e}")
 
         bases: list[dict[str, Any]] = []
         for base in bases_raw[:3]:
@@ -49,7 +50,7 @@ def register_airtable_custom_tools(composio: Composio) -> list[str]:
                     for t in schema_data.get("tables", [])
                 ]
             except Exception as e:
-                log.debug(f"Airtable tables fetch for {base_id} failed: {e}")
+                log.debug(f"{LogTag.TOOL} Airtable tables fetch for {base_id} failed: {e}")
             bases.append({"id": base_id, "name": base.get("name", ""), "tables": tables})
 
         return {"bases": bases, "base_count": len(bases_raw)}

--- a/apps/api/app/agents/tools/integrations/calendar_tool.py
+++ b/apps/api/app/agents/tools/integrations/calendar_tool.py
@@ -17,6 +17,7 @@ from composio import Composio
 from langgraph.config import get_config, get_stream_writer
 
 from app.constants.calendar import DEFAULT_CALENDAR_COLOR
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.models.calendar_models import (
     AddRecurrenceInput,
@@ -113,7 +114,7 @@ def _get_user_timezone() -> tzinfo | None:
         if (config.get("configurable") or {}).get("user_timezone"):
             return home_timezone_from_config(config).tzinfo
     except Exception:
-        log.error("Error getting user timezone")
+        log.error(f"{LogTag.TOOL} Error getting user timezone")
     return None
 
 
@@ -359,7 +360,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
                     }
                 )
             except AppError as e:
-                log.error(f"Error getting event {event_ref.event_id}: {e}")
+                log.error(f"{LogTag.TOOL} Error getting event {event_ref.event_id}: {e}")
                 errors.append(
                     {
                         "event_id": event_ref.event_id,
@@ -404,7 +405,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
                     }
                 )
             except AppError as e:
-                log.error(f"Error deleting event {event_ref.event_id}: {e}")
+                log.error(f"{LogTag.TOOL} Error deleting event {event_ref.event_id}: {e}")
                 errors.append(
                     {
                         "event_id": event_ref.event_id,

--- a/apps/api/app/agents/tools/integrations/github_tool.py
+++ b/apps/api/app/agents/tools/integrations/github_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 from shared.py.wide_events import log
@@ -45,7 +46,7 @@ def register_github_custom_tools(composio: Composio) -> list[str]:
             )
             review_requests = reviews_data.get("items", [])
         except Exception as e:
-            log.debug(f"GitHub review requests fetch skipped: {e}")
+            log.debug(f"{LogTag.TOOL} GitHub review requests fetch skipped: {e}")
 
         notifications: list[dict[str, Any]] = []
         try:
@@ -57,7 +58,7 @@ def register_github_custom_tools(composio: Composio) -> list[str]:
             raw = notif_data.get("notifications", notif_data)
             notifications = raw if isinstance(raw, list) else []
         except Exception as e:
-            log.debug(f"GitHub notifications fetch skipped: {e}")
+            log.debug(f"{LogTag.TOOL} GitHub notifications fetch skipped: {e}")
 
         return {
             "assigned_issues": actual_issues,

--- a/apps/api/app/agents/tools/integrations/google_docs_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_docs_tool.py
@@ -12,6 +12,7 @@ from typing import Any
 from composio import Composio
 from composio.core.models.tools import ToolExecutionResponse
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.google_docs_models import CreateTOCInput, DeleteDocInput, ShareDocInput
@@ -79,7 +80,7 @@ def register_google_docs_custom_tools(composio: Composio) -> list[str]:
                     }
                 )
             except AppError as e:
-                log.error(f"Error sharing with {recipient.email}: {e}")
+                log.error(f"{LogTag.TOOL} Error sharing with {recipient.email}: {e}")
                 errors.append(
                     {
                         "email": recipient.email,
@@ -116,7 +117,7 @@ def register_google_docs_custom_tools(composio: Composio) -> list[str]:
                 user_id=auth_credentials.get("user_id"),
             )
         except TypeError as e:
-            log.debug(f"TypeError in execute: {e}")
+            log.debug(f"{LogTag.TOOL} TypeError in execute: {e}")
             raise
 
         # Unwrap response (ToolExecutionResponse format)
@@ -129,7 +130,7 @@ def register_google_docs_custom_tools(composio: Composio) -> list[str]:
             try:
                 doc_data = json.loads(doc_data)
             except json.JSONDecodeError as e:
-                log.debug(f"JSON parsing skipped for doc_data: {e}")
+                log.debug(f"{LogTag.TOOL} JSON parsing skipped for doc_data: {e}")
 
         if not doc_data or "body" not in doc_data:
             raise ValueError("Failed to get document or document has no body content")
@@ -194,7 +195,7 @@ def register_google_docs_custom_tools(composio: Composio) -> list[str]:
                 method="DELETE",
             )
         except AppError as e:
-            log.error(f"Error deleting doc {request.document_id}: {e}")
+            log.error(f"{LogTag.TOOL} Error deleting doc {request.document_id}: {e}")
             raise RuntimeError(f"Failed to delete document: {e.status_code} - {e.message}")
 
         return {
@@ -240,7 +241,7 @@ def register_google_docs_custom_tools(composio: Composio) -> list[str]:
                 for f in (data or {}).get("files", [])
             ]
         except Exception as e:
-            log.debug(f"Google Docs fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Google Docs fetch failed: {e}")
 
         return {"recent_docs": files, "doc_count": len(files)}
 

--- a/apps/api/app/agents/tools/integrations/google_maps_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_maps_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from app.utils.errors import AppError
@@ -46,7 +47,7 @@ def register_google_maps_custom_tools(composio: Composio) -> list[str]:
             status = data.get("status", "UNKNOWN")
             connected = status == "OK"
         except Exception as e:
-            log.debug(f"Google Maps integration failed: {e}")
+            log.debug(f"{LogTag.TOOL} Google Maps integration failed: {e}")
             status = "ERROR"
             connected = False
 

--- a/apps/api/app/agents/tools/integrations/google_meet_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_meet_tool.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
@@ -39,7 +40,7 @@ def register_google_meet_custom_tools(composio: Composio) -> list[str]:
                 or {}
             )
         except Exception as e:
-            log.debug(f"Google Meet userinfo fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Google Meet userinfo fetch failed: {e}")
 
         # The calendar fetch may fail if the GOOGLEMEET connection lacks
         # calendar scope. The legacy tool gated on status_code == 200 and
@@ -65,7 +66,7 @@ def register_google_meet_custom_tools(composio: Composio) -> list[str]:
                 or {}
             )
         except Exception as e:
-            log.debug(f"Google Meet calendar fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Google Meet calendar fetch failed: {e}")
 
         upcoming_meets: list[dict[str, Any]] = []
         for event in events_data.get("items", []):

--- a/apps/api/app/agents/tools/integrations/google_sheets_tool.py
+++ b/apps/api/app/agents/tools/integrations/google_sheets_tool.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.google_sheets_models import (
@@ -107,7 +108,7 @@ def register_google_sheets_custom_tools(composio: Composio) -> list[str]:
                     }
                 )
             except AppError as e:
-                log.error(f"Error sharing with {recipient.email}: {e}")
+                log.error(f"{LogTag.TOOL} Error sharing with {recipient.email}: {e}")
                 errors.append(
                     {
                         "email": recipient.email,
@@ -116,7 +117,7 @@ def register_google_sheets_custom_tools(composio: Composio) -> list[str]:
                     }
                 )
             except Exception as e:
-                log.error(f"Error sharing with {recipient.email}: {e}")
+                log.error(f"{LogTag.TOOL} Error sharing with {recipient.email}: {e}")
                 errors.append(
                     {
                         "email": recipient.email,
@@ -376,7 +377,7 @@ def register_google_sheets_custom_tools(composio: Composio) -> list[str]:
                 body=batch_request,
             )
         except AppError as e:
-            log.error(f"Error setting data validation: {e.message}")
+            log.error(f"{LogTag.TOOL} Error setting data validation: {e.message}")
             raise RuntimeError(f"Failed to set data validation: {e.message}") from e
 
         url = f"https://docs.google.com/spreadsheets/d/{request.spreadsheet_id}/edit"
@@ -661,7 +662,7 @@ def register_google_sheets_custom_tools(composio: Composio) -> list[str]:
                 body=batch_request,
             )
         except AppError as e:
-            log.error(f"Error creating chart: {e.message}")
+            log.error(f"{LogTag.TOOL} Error creating chart: {e.message}")
             raise RuntimeError(f"Failed to create chart: {e.message}") from e
 
         chart_id = None
@@ -716,7 +717,7 @@ def register_google_sheets_custom_tools(composio: Composio) -> list[str]:
                 for f in (data or {}).get("files", [])
             ]
         except Exception as e:
-            log.debug(f"Google Sheets fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Google Sheets fetch failed: {e}")
 
         return {"recent_spreadsheets": files, "spreadsheet_count": len(files)}
 

--- a/apps/api/app/agents/tools/integrations/hubspot_tool.py
+++ b/apps/api/app/agents/tools/integrations/hubspot_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
@@ -47,7 +48,7 @@ def register_hubspot_custom_tools(composio: Composio) -> list[str]:
             )
             contacts = data.get("results", [])
         except Exception as e:
-            log.debug(f"HubSpot contacts fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} HubSpot contacts fetch failed: {e}")
 
         deals: list[dict[str, Any]] = []
         try:
@@ -67,7 +68,7 @@ def register_hubspot_custom_tools(composio: Composio) -> list[str]:
             )
             deals = data.get("results", [])
         except Exception as e:
-            log.debug(f"HubSpot deals fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} HubSpot deals fetch failed: {e}")
 
         recent_contacts = [
             {

--- a/apps/api/app/agents/tools/integrations/instagram_tool.py
+++ b/apps/api/app/agents/tools/integrations/instagram_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
@@ -73,7 +74,7 @@ def register_instagram_custom_tools(composio: Composio) -> list[str]:
                 for m in media_data.get("data", [])
             ]
         except Exception as e:
-            log.warning(f"Instagram media fetch failed for user {user_id}: {e}")
+            log.warning(f"{LogTag.TOOL} Instagram media fetch failed for user {user_id}: {e}")
 
         return {
             "user": {

--- a/apps/api/app/agents/tools/integrations/microsoft_teams_tool.py
+++ b/apps/api/app/agents/tools/integrations/microsoft_teams_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
@@ -48,7 +49,7 @@ def register_microsoft_teams_custom_tools(composio: Composio) -> list[str]:
                 "email": me.get("mail") or me.get("userPrincipalName"),
             }
         except Exception as e:
-            log.debug(f"Teams /me fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Teams /me fetch failed: {e}")
 
         teams: list[dict[str, Any]] = []
         try:
@@ -71,7 +72,7 @@ def register_microsoft_teams_custom_tools(composio: Composio) -> list[str]:
                 for t in data.get("value", [])
             ]
         except Exception as e:
-            log.debug(f"Teams joinedTeams fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Teams joinedTeams fetch failed: {e}")
 
         chats: list[dict[str, Any]] = []
         unread_count = 0
@@ -111,7 +112,7 @@ def register_microsoft_teams_custom_tools(composio: Composio) -> list[str]:
                 for c in raw_chats
             ]
         except Exception as e:
-            log.debug(f"Teams chats fetch failed: {e}")
+            log.debug(f"{LogTag.TOOL} Teams chats fetch failed: {e}")
 
         return {
             "user": user_info,

--- a/apps/api/app/agents/tools/integrations/notion_tool.py
+++ b/apps/api/app/agents/tools/integrations/notion_tool.py
@@ -14,6 +14,7 @@ from typing import Any
 from composio import Composio
 from composio.core.models.tools import ToolExecutionResponse
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.models.common_models import GatherContextInput
 from app.models.notion_models import (
@@ -99,7 +100,7 @@ def register_notion_custom_tools(composio: Composio) -> list[str]:
             )
             # Composio tools return ToolExecutionResponse format
             if not title_response["successful"]:
-                log.warning(f"Failed to fetch title: {title_response.get('error')}")
+                log.warning(f"{LogTag.TOOL} Failed to fetch title: {title_response.get('error')}")
             else:
                 title_data = title_response["data"]
                 # Extract title from results array
@@ -113,7 +114,7 @@ def register_notion_custom_tools(composio: Composio) -> list[str]:
                             title = item["title"].get("plain_text", "")
                             break
         except Exception as e:
-            log.warning(f"Could not fetch title: {e}")
+            log.warning(f"{LogTag.TOOL} Could not fetch title: {e}")
 
         # Call NOTION_FETCH_ALL_BLOCK_CONTENTS via composio
         blocks_response: ToolExecutionResponse = composio.tools.execute(
@@ -291,10 +292,10 @@ def register_notion_custom_tools(composio: Composio) -> list[str]:
             }
 
         except AppError as e:
-            log.error(f"Notion API error: {e.message}")
+            log.error(f"{LogTag.TOOL} Notion API error: {e.message}")
             raise RuntimeError(f"Failed to fetch {request.fetch_type}: {e.message}")
         except Exception as e:
-            log.error(f"Error fetching Notion {request.fetch_type}: {e}")
+            log.error(f"{LogTag.TOOL} Error fetching Notion {request.fetch_type}: {e}")
             raise RuntimeError(f"Failed to fetch {request.fetch_type}: {e!s}")
 
     @composio.tools.custom_tool(toolkit="NOTION")

--- a/apps/api/app/agents/tools/integrations/reddit_tool.py
+++ b/apps/api/app/agents/tools/integrations/reddit_tool.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from app.utils.errors import AppError
@@ -49,7 +50,7 @@ def register_reddit_custom_tools(composio: Composio) -> list[str]:
             log.set(
                 user_id=user_id, endpoint=f"{REDDIT_API_BASE}/api/v1/me", toolkit=REDDIT_TOOLKIT
             )
-            log.error("Reddit /me fetch failed", exc=e)
+            log.error(f"{LogTag.TOOL} Reddit /me fetch failed", exc=e)
 
         subreddits: list[dict[str, Any]] = []
         try:
@@ -79,7 +80,7 @@ def register_reddit_custom_tools(composio: Composio) -> list[str]:
                 endpoint=f"{REDDIT_API_BASE}/subreddits/mine/subscriber",
                 toolkit=REDDIT_TOOLKIT,
             )
-            log.error("Reddit subreddits fetch failed", exc=e)
+            log.error(f"{LogTag.TOOL} Reddit subreddits fetch failed", exc=e)
 
         unread_messages: list[dict[str, Any]] = []
         try:
@@ -110,7 +111,7 @@ def register_reddit_custom_tools(composio: Composio) -> list[str]:
                 endpoint=f"{REDDIT_API_BASE}/message/unread",
                 toolkit=REDDIT_TOOLKIT,
             )
-            log.error("Reddit unread messages fetch failed", exc=e)
+            log.error(f"{LogTag.TOOL} Reddit unread messages fetch failed", exc=e)
 
         return {
             "user": {

--- a/apps/api/app/agents/tools/integrations/slack_tool.py
+++ b/apps/api/app/agents/tools/integrations/slack_tool.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from composio import Composio
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.utils.context_utils import execute_tool
 from shared.py.wide_events import log
@@ -47,7 +48,7 @@ def register_slack_custom_tools(composio: Composio) -> list[str]:
             )
             mentions = mention_data.get("messages", {}).get("matches", [])
         except Exception as e:
-            log.debug(f"Slack mentions fetch skipped: {e}")
+            log.debug(f"{LogTag.TOOL} Slack mentions fetch skipped: {e}")
 
         mention_ts = {m.get("ts") for m in mentions}
         other_messages = [m for m in messages if m.get("ts") not in mention_ts]

--- a/apps/api/app/agents/tools/notification_tool.py
+++ b/apps/api/app/agents/tools/notification_tool.py
@@ -4,6 +4,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from app.constants.notifications import ALL_AUTO_INJECTED_CHANNELS, CHANNEL_TYPE_INAPP
 from app.decorators import with_doc, with_rate_limiting
 from app.models.notification.notification_models import (
@@ -66,7 +67,7 @@ async def get_notifications(
         return {"notifications": notifications}
 
     except Exception as e:
-        log.error(f"Error getting notifications: {e!s}")
+        log.error(f"{LogTag.TOOL} Error getting notifications: {e!s}")
         return {"error": str(e), "notifications": []}
 
 
@@ -119,7 +120,7 @@ async def search_notifications(
         return {"notifications": matching_notifications}
 
     except Exception as e:
-        log.error(f"Error searching notifications: {e!s}")
+        log.error(f"{LogTag.TOOL} Error searching notifications: {e!s}")
         return {"error": str(e), "notifications": []}
 
 
@@ -144,7 +145,7 @@ async def get_notification_count(
         return {"count": total_count}
 
     except Exception as e:
-        log.error(f"Error getting notification count: {e!s}")
+        log.error(f"{LogTag.TOOL} Error getting notification count: {e!s}")
         return {"error": str(e), "count": 0}
 
 
@@ -181,7 +182,7 @@ async def mark_notifications_read(
         return {"success": success}
 
     except Exception as e:
-        log.error(f"Error marking notifications as read: {e!s}")
+        log.error(f"{LogTag.TOOL} Error marking notifications as read: {e!s}")
         return {"error": str(e), "success": False}
 
 
@@ -296,7 +297,7 @@ async def send_notification(
         return result
 
     except Exception as e:
-        log.error(f"Error sending notification: {e!s}")
+        log.error(f"{LogTag.TOOL} Error sending notification: {e!s}")
         return {"error": str(e), "success": False}
 
 
@@ -326,7 +327,7 @@ async def get_notification_preferences(
         }
 
     except Exception as e:
-        log.error(f"Error fetching notification preferences: {e!s}")
+        log.error(f"{LogTag.TOOL} Error fetching notification preferences: {e!s}")
         return {"error": str(e), "preferences": {}}
 
 

--- a/apps/api/app/agents/tools/reminder_tool.py
+++ b/apps/api/app/agents/tools/reminder_tool.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import tool
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc, with_rate_limiting
 from app.models.reminder_models import (
     AgentType,
@@ -103,10 +104,10 @@ async def create_reminder_tool(
         return "Reminder created successfully"
 
     except ValueError as e:
-        log.error(f"Validation error: {e}")
+        log.error(f"{LogTag.TOOL} Validation error: {e}")
         return {"error": str(e)}
     except Exception as e:
-        log.exception("Exception occurred while creating reminder")
+        log.exception(f"{LogTag.TOOL} Exception occurred while creating reminder")
         return {"error": str(e)}
 
 
@@ -132,7 +133,7 @@ async def list_user_reminders_tool(
         )
         return [r.model_dump() for r in reminders]
     except Exception as e:
-        log.exception("Exception occurred while listing reminders")
+        log.exception(f"{LogTag.TOOL} Exception occurred while listing reminders")
         return {"error": str(e)}
 
 
@@ -156,7 +157,7 @@ async def get_reminder_tool(
             return reminder.model_dump()
         return {"error": "Reminder not found"}
     except Exception as e:
-        log.exception("Exception occurred while getting reminder")
+        log.exception(f"{LogTag.TOOL} Exception occurred while getting reminder")
         return {"error": str(e)}
 
 
@@ -173,7 +174,7 @@ async def delete_reminder_tool(
         log.set(tool={"name": "delete_reminder_tool", "action": "delete"})
         user_id = config.get("configurable", {}).get("user_id")
         if not user_id:
-            log.error("Missing user_id in config")
+            log.error(f"{LogTag.TOOL} Missing user_id in config")
             return {"error": "User ID is required to delete reminder"}
 
         success = await reminder_scheduler.cancel_task(reminder_id, user_id)
@@ -181,7 +182,7 @@ async def delete_reminder_tool(
             return {"status": "cancelled"}
         return {"error": "Failed to cancel reminder"}
     except Exception as e:
-        log.exception("Exception occurred while deleting reminder")
+        log.exception(f"{LogTag.TOOL} Exception occurred while deleting reminder")
         return {"error": str(e)}
 
 
@@ -235,7 +236,7 @@ async def update_reminder_tool(
 
                 update_data["stop_after"] = processed_stop_after
             except ValueError as e:
-                log.error(f"Invalid stop_after format: {stop_after}, error: {e}")
+                log.error(f"{LogTag.TOOL} Invalid stop_after format: {stop_after}, error: {e}")
                 return {
                     "error": f"Invalid stop_after format: {stop_after}. Use YYYY-MM-DD HH:MM:SS format."
                 }
@@ -245,10 +246,10 @@ async def update_reminder_tool(
         success = await reminder_scheduler.update_reminder(reminder_id, update_data, user_id)
         if success:
             return {"status": "updated"}
-        log.error("Failed to update reminder")
+        log.error(f"{LogTag.TOOL} Failed to update reminder")
         return {"error": "Failed to update reminder"}
     except Exception as e:
-        log.exception("Exception occurred while updating reminder")
+        log.exception(f"{LogTag.TOOL} Exception occurred while updating reminder")
         return {"error": str(e)}
 
 
@@ -265,7 +266,7 @@ async def search_reminders_tool(
         log.set(tool={"name": "search_reminders_tool", "action": "search"})
         user_id = config.get("configurable", {}).get("user_id")
         if not user_id:
-            log.error("Missing user_id in config")
+            log.error(f"{LogTag.TOOL} Missing user_id in config")
             return {"error": "User ID is required to search reminders"}
 
         reminders = await reminder_scheduler.list_user_reminders(user_id=user_id, limit=100, skip=0)
@@ -278,7 +279,7 @@ async def search_reminders_tool(
 
         return results
     except Exception as e:
-        log.exception("Exception occurred while searching reminders")
+        log.exception(f"{LogTag.TOOL} Exception occurred while searching reminders")
         return {"error": str(e)}
 
 

--- a/apps/api/app/agents/tools/research_tool.py
+++ b/apps/api/app/agents/tools/research_tool.py
@@ -7,6 +7,7 @@ from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
 from app.constants.cache import ONE_HOUR_TTL
+from app.constants.log_tags import LogTag
 from app.constants.search import (
     CRAWL4AI_PAGE_TIMEOUT_MS,
     DEEP_RESEARCH_CRAWL4AI_BATCH_TIMEOUT_SECONDS,
@@ -187,7 +188,9 @@ async def deep_research(
                 fetch_counter += 1
                 snippet = url_info.get("snippet", "").strip()
                 if snippet:
-                    log.warning(f"All fetchers failed for {url[:60]}, using search snippet")
+                    log.warning(
+                        f"{LogTag.TOOL} All fetchers failed for {url[:60]}, using search snippet"
+                    )
                     return {
                         **url_info,
                         "content": f"[Snippet only — full page unavailable]\n\n{snippet}",
@@ -245,5 +248,5 @@ async def deep_research(
         }
 
     except Exception as e:
-        log.error(f"Deep research error: {e}", exc_info=True)
+        log.error(f"{LogTag.TOOL} Deep research error: {e}", exc_info=True)
         return {"error": str(e), "query": query, "data": None}

--- a/apps/api/app/agents/tools/skill_tools.py
+++ b/apps/api/app/agents/tools/skill_tools.py
@@ -22,6 +22,7 @@ from app.agents.skills.registry import (
     get_skill_by_name,
     list_skills,
 )
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -87,7 +88,7 @@ async def install_skill_from_github(
     except ValueError as e:
         return f"Failed to install skill: {e}"
     except Exception as e:
-        log.error(f"[skills] GitHub install error: {e}")
+        log.error(f"{LogTag.TOOL} GitHub install error: {e}")
         return f"Error installing skill from GitHub: {e}"
 
 
@@ -150,7 +151,7 @@ async def create_skill(
     except ValueError as e:
         return f"Failed to create skill: {e}"
     except Exception as e:
-        log.error(f"[skills] Inline create error: {e}")
+        log.error(f"{LogTag.TOOL} Inline create error: {e}")
         return f"Error creating skill: {e}"
 
 
@@ -195,7 +196,7 @@ async def list_installed_skills(
 
         return "\n".join(lines)
     except Exception as e:
-        log.error(f"[skills] List error: {e}")
+        log.error(f"{LogTag.TOOL} List error: {e}")
         return f"Error listing skills: {e}"
 
 
@@ -243,7 +244,7 @@ async def manage_skill(
         return f"Unknown action '{action}'. Use 'enable', 'disable', or 'uninstall'."
 
     except Exception as e:
-        log.error(f"[skills] Manage error: {e}")
+        log.error(f"{LogTag.TOOL} Manage error: {e}")
         return f"Error managing skill: {e}"
 
 

--- a/apps/api/app/agents/tools/support_tool.py
+++ b/apps/api/app/agents/tools/support_tool.py
@@ -6,6 +6,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc
 from app.models.support_models import (
     SupportRequestType,
@@ -48,7 +49,7 @@ async def create_support_ticket(
     """
     try:
         log.set(tool={"name": "create_support_ticket", "action": "create"})
-        log.info(f"Support Tool: Preparing support ticket draft with title '{title}'")
+        log.info(f"{LogTag.TOOL} Support Tool: Preparing support ticket draft with title '{title}'")
 
         metadata = config.get("metadata", {})
         user_id = metadata.get("user_id")
@@ -83,7 +84,7 @@ async def create_support_ticket(
         writer({"progress": "Creating support ticket..."})
         writer({"support_ticket_data": [support_ticket_data]})
 
-        log.info(f"Support ticket draft prepared for user {user_id}")
+        log.info(f"{LogTag.TOOL} Support ticket draft prepared for user {user_id}")
 
         # Return confirmation message
         ticket_type_display = (
@@ -92,7 +93,7 @@ async def create_support_ticket(
         return f"I've prepared a {ticket_type_display} draft for you to review. Please check the details and click 'Submit Ticket' when you're ready to send it to our support team."
 
     except Exception as e:
-        log.error(f"Error preparing support ticket: {e!s}")
+        log.error(f"{LogTag.TOOL} Error preparing support ticket: {e!s}")
         return f"Sorry, I encountered an error while preparing your support ticket: {e!s}"
 
 

--- a/apps/api/app/agents/tools/todo_tool.py
+++ b/apps/api/app/agents/tools/todo_tool.py
@@ -7,6 +7,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc, with_rate_limiting
 from app.models.todo_models import (
     Priority,
@@ -83,7 +84,7 @@ async def create_todo(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "create_todo", "action": "create"})
-        log.info(f"Todo Tool: Creating todo with title '{title}'")
+        log.info(f"{LogTag.TOOL} Todo Tool: Creating todo with title '{title}'")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -125,7 +126,7 @@ async def create_todo(
 
     except Exception as e:
         error_msg = f"Error creating todo: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todo": None}
 
 
@@ -143,7 +144,7 @@ async def list_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "list_todos", "action": "list"})
-        log.info("Todo Tool: Listing todos with filters")
+        log.info(f"{LogTag.TOOL} Todo Tool: Listing todos with filters")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -184,7 +185,7 @@ async def list_todos(
 
     except Exception as e:
         error_msg = f"Error listing todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -204,7 +205,7 @@ async def update_todo(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "update_todo", "action": "update"})
-        log.info(f"Todo Tool: Updating todo {todo_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Updating todo {todo_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -240,7 +241,7 @@ async def update_todo(
 
     except Exception as e:
         error_msg = f"Error updating todo: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todo": None}
 
 
@@ -252,7 +253,7 @@ async def delete_todo(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "delete_todo", "action": "delete"})
-        log.info(f"Todo Tool: Deleting todo {todo_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Deleting todo {todo_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -279,7 +280,7 @@ async def delete_todo(
 
     except Exception as e:
         error_msg = f"Error deleting todo: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "success": False}
 
 
@@ -291,7 +292,7 @@ async def search_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "search_todos", "action": "search"})
-        log.info(f"Todo Tool: Searching todos with query '{query}'")
+        log.info(f"{LogTag.TOOL} Todo Tool: Searching todos with query '{query}'")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -316,7 +317,7 @@ async def search_todos(
 
     except Exception as e:
         error_msg = f"Error searching todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -332,7 +333,7 @@ async def semantic_search_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "semantic_search_todos", "action": "search"})
-        log.info(f"Todo Tool: Semantic search for '{query}'")
+        log.info(f"{LogTag.TOOL} Todo Tool: Semantic search for '{query}'")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -373,7 +374,7 @@ async def semantic_search_todos(
 
     except Exception as e:
         error_msg = f"Error in semantic search: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -382,7 +383,7 @@ async def semantic_search_todos(
 async def get_todo_statistics(config: RunnableConfig) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_todo_statistics", "action": "stats"})
-        log.info("Todo Tool: Getting todo statistics")
+        log.info(f"{LogTag.TOOL} Todo Tool: Getting todo statistics")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -406,7 +407,7 @@ async def get_todo_statistics(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error getting todo statistics: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "stats": None}
 
 
@@ -415,7 +416,7 @@ async def get_todo_statistics(config: RunnableConfig) -> dict[str, Any]:
 async def get_today_todos(config: RunnableConfig) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_today_todos", "action": "get"})
-        log.info("Todo Tool: Getting today's todos")
+        log.info(f"{LogTag.TOOL} Todo Tool: Getting today's todos")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -447,7 +448,7 @@ async def get_today_todos(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error getting today's todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -459,7 +460,7 @@ async def get_upcoming_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_upcoming_todos", "action": "get"})
-        log.info(f"Todo Tool: Getting upcoming todos for next {days} days")
+        log.info(f"{LogTag.TOOL} Todo Tool: Getting upcoming todos for next {days} days")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -491,7 +492,7 @@ async def get_upcoming_todos(
 
     except Exception as e:
         error_msg = f"Error getting upcoming todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -505,7 +506,7 @@ async def create_project(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "create_project", "action": "create"})
-        log.info(f"Todo Tool: Creating project '{name}'")
+        log.info(f"{LogTag.TOOL} Todo Tool: Creating project '{name}'")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -536,7 +537,7 @@ async def create_project(
 
     except Exception as e:
         error_msg = f"Error creating project: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "project": None}
 
 
@@ -545,7 +546,7 @@ async def create_project(
 async def list_projects(config: RunnableConfig) -> dict[str, Any]:
     try:
         log.set(tool={"name": "list_projects", "action": "list"})
-        log.info("Todo Tool: Listing all projects")
+        log.info(f"{LogTag.TOOL} Todo Tool: Listing all projects")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -570,7 +571,7 @@ async def list_projects(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error listing projects: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "projects": []}
 
 
@@ -585,7 +586,7 @@ async def update_project(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "update_project", "action": "update"})
-        log.info(f"Todo Tool: Updating project {project_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Updating project {project_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -620,7 +621,7 @@ async def update_project(
 
     except Exception as e:
         error_msg = f"Error updating project: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "project": None}
 
 
@@ -632,7 +633,7 @@ async def delete_project(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "delete_project", "action": "delete"})
-        log.info(f"Todo Tool: Deleting project {project_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Deleting project {project_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -660,7 +661,7 @@ async def delete_project(
 
     except Exception as e:
         error_msg = f"Error deleting project: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "success": False}
 
 
@@ -672,7 +673,7 @@ async def get_todos_by_label(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_todos_by_label", "action": "get"})
-        log.info(f"Todo Tool: Getting todos with label '{label}'")
+        log.info(f"{LogTag.TOOL} Todo Tool: Getting todos with label '{label}'")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -701,7 +702,7 @@ async def get_todos_by_label(
 
     except Exception as e:
         error_msg = f"Error getting todos by label: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -710,7 +711,7 @@ async def get_todos_by_label(
 async def get_all_labels(config: RunnableConfig) -> dict[str, Any]:
     try:
         log.set(tool={"name": "get_all_labels", "action": "get"})
-        log.info("Todo Tool: Getting all labels")
+        log.info(f"{LogTag.TOOL} Todo Tool: Getting all labels")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -721,7 +722,7 @@ async def get_all_labels(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error getting labels: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "labels": []}
 
 
@@ -733,7 +734,7 @@ async def bulk_complete_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "bulk_complete_todos", "action": "bulk_complete"})
-        log.info(f"Todo Tool: Bulk completing {len(todo_ids)} todos")
+        log.info(f"{LogTag.TOOL} Todo Tool: Bulk completing {len(todo_ids)} todos")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -762,7 +763,7 @@ async def bulk_complete_todos(
 
     except Exception as e:
         error_msg = f"Error bulk completing todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -775,7 +776,7 @@ async def bulk_move_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "bulk_move_todos", "action": "bulk_move"})
-        log.info(f"Todo Tool: Moving {len(todo_ids)} todos to project {project_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Moving {len(todo_ids)} todos to project {project_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -804,7 +805,7 @@ async def bulk_move_todos(
 
     except Exception as e:
         error_msg = f"Error bulk moving todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todos": []}
 
 
@@ -816,7 +817,7 @@ async def bulk_delete_todos(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "bulk_delete_todos", "action": "bulk_delete"})
-        log.info(f"Todo Tool: Bulk deleting {len(todo_ids)} todos")
+        log.info(f"{LogTag.TOOL} Todo Tool: Bulk deleting {len(todo_ids)} todos")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -839,7 +840,7 @@ async def bulk_delete_todos(
 
     except Exception as e:
         error_msg = f"Error bulk deleting todos: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "success": False}
 
 
@@ -852,7 +853,7 @@ async def add_subtask(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "add_subtask", "action": "create"})
-        log.info(f"Todo Tool: Adding subtask to todo {todo_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Adding subtask to todo {todo_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -886,7 +887,7 @@ async def add_subtask(
 
     except Exception as e:
         error_msg = f"Error adding subtask: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todo": None}
 
 
@@ -901,7 +902,7 @@ async def update_subtask(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "update_subtask", "action": "update"})
-        log.info(f"Todo Tool: Updating subtask {subtask_id} in todo {todo_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Updating subtask {subtask_id} in todo {todo_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -946,7 +947,7 @@ async def update_subtask(
 
     except Exception as e:
         error_msg = f"Error updating subtask: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todo": None}
 
 
@@ -959,7 +960,7 @@ async def delete_subtask(
 ) -> dict[str, Any]:
     try:
         log.set(tool={"name": "delete_subtask", "action": "delete"})
-        log.info(f"Todo Tool: Deleting subtask {subtask_id} from todo {todo_id}")
+        log.info(f"{LogTag.TOOL} Todo Tool: Deleting subtask {subtask_id} from todo {todo_id}")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -995,7 +996,7 @@ async def delete_subtask(
 
     except Exception as e:
         error_msg = f"Error deleting subtask: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "todo": None}
 
 
@@ -1006,7 +1007,7 @@ async def get_todos_summary(config: RunnableConfig) -> dict[str, Any]:
 
     try:
         log.set(tool={"name": "get_todos_summary", "action": "summary"})
-        log.info("Todo Tool: Getting comprehensive todos summary")
+        log.info(f"{LogTag.TOOL} Todo Tool: Getting comprehensive todos summary")
         user_id = get_user_id_from_config(config)
 
         if not user_id:
@@ -1124,7 +1125,7 @@ async def get_todos_summary(config: RunnableConfig) -> dict[str, Any]:
 
     except Exception as e:
         error_msg = f"Error getting todos summary: {e!s}"
-        log.error(error_msg)
+        log.error(f"{LogTag.TOOL} {error_msg}")
         return {"error": error_msg, "summary": None}
 
 

--- a/apps/api/app/agents/tools/todo_tools.py
+++ b/apps/api/app/agents/tools/todo_tools.py
@@ -36,6 +36,7 @@ from app.agents.prompts.todo_prompts import (
     TODO_SYSTEM_PROMPT,
     UPDATE_TASKS_DESCRIPTION,
 )
+from app.constants.log_tags import LogTag
 from app.override.langgraph_bigtool.utils import State
 from shared.py.wide_events import log
 
@@ -87,7 +88,7 @@ def _emit_todo_progress(todos: list[Todo], source: str, source_label: str | None
         writer = get_stream_writer()
         writer(payload)
     except Exception as e:
-        log.warning(f"Stream writer not available for todo_progress: {e}")
+        log.warning(f"{LogTag.TOOL} Stream writer not available for todo_progress: {e}")
 
 
 def _format_todos(todos: list[Todo]) -> str:

--- a/apps/api/app/agents/tools/wait_for_subagents_tool.py
+++ b/apps/api/app/agents/tools/wait_for_subagents_tool.py
@@ -18,6 +18,7 @@ from app.agents.core.background.session import (
     drain_bg_subagent_results,
     get_pending_subagents,
 )
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -48,7 +49,7 @@ async def wait_for_subagents(
 
     deadline = asyncio.get_running_loop().time() + timeout
     log.info(
-        f"wait_for_subagents: waiting for {get_pending_subagents(stream_id)} "
+        f"{LogTag.TOOL} wait_for_subagents: waiting for {get_pending_subagents(stream_id)} "
         f"subagent(s) on stream {stream_id}"
     )
 
@@ -57,7 +58,7 @@ async def wait_for_subagents(
     # guarantees all results are visible.
     while get_pending_subagents(stream_id) > 0:
         if asyncio.get_running_loop().time() >= deadline:
-            log.warning(f"wait_for_subagents: timed out after {timeout}s")
+            log.warning(f"{LogTag.TOOL} wait_for_subagents: timed out after {timeout}s")
             break
         await asyncio.sleep(0.1)
 
@@ -66,7 +67,9 @@ async def wait_for_subagents(
     if not results:
         return "No background subagent results to collect."
 
-    log.info(f"wait_for_subagents: collected {len(results)} result(s) for stream {stream_id}")
+    log.info(
+        f"{LogTag.TOOL} wait_for_subagents: collected {len(results)} result(s) for stream {stream_id}"
+    )
     return "\n\n---\n\n".join(f"[{item['agent']} result]\n{item['message']}" for item in results)
 
 

--- a/apps/api/app/agents/tools/webpage_tool.py
+++ b/apps/api/app/agents/tools/webpage_tool.py
@@ -9,6 +9,7 @@ from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
 from app.agents.templates.fetch_template import FETCH_TEMPLATE
+from app.constants.log_tags import LogTag
 from app.decorators import with_doc, with_rate_limiting
 from app.templates.docstrings.search_tool_docs import (
     WEB_SEARCH_TOOL,
@@ -105,7 +106,7 @@ async def web_search_tool(
         elapsed_time = time.time() - start_time
         formatted_text = f"Web search completed in {elapsed_time:.2f} seconds. Found {len(web_results)} web results, {len(image_results)} images, and {len(video_results)} videos."
 
-        log.info(formatted_text)
+        log.info(f"{LogTag.TOOL} {formatted_text}")
         writer({"progress": formatted_text})
 
         # Send search data to frontend via writer
@@ -152,7 +153,7 @@ async def web_search_tool(
         }
 
     except (TimeoutError, ConnectionError) as e:
-        log.error(f"Network error in web search: {e}", exc_info=True)
+        log.error(f"{LogTag.TOOL} Network error in web search: {e}", exc_info=True)
         return {
             "formatted_text": "\n\nConnection timed out during web search. Please try again later.",
             "error": str(e),
@@ -160,7 +161,7 @@ async def web_search_tool(
             "integrity_note": _NO_URLS_RETRIEVED_MSG,
         }
     except ValueError as e:
-        log.error(f"Value error in web search: {e}", exc_info=True)
+        log.error(f"{LogTag.TOOL} Value error in web search: {e}", exc_info=True)
         return {
             "formatted_text": "\n\nInvalid search parameters. Please try a different query.",
             "error": str(e),
@@ -168,7 +169,7 @@ async def web_search_tool(
             "integrity_note": _NO_URLS_RETRIEVED_MSG,
         }
     except Exception as e:
-        log.error(f"Unexpected error in web search: {e}", exc_info=True)
+        log.error(f"{LogTag.TOOL} Unexpected error in web search: {e}", exc_info=True)
         return {
             "formatted_text": "\n\nError performing web search. Please try again later.",
             "error": str(e),

--- a/apps/api/app/agents/tools/workflow_shared_tools.py
+++ b/apps/api/app/agents/tools/workflow_shared_tools.py
@@ -6,6 +6,7 @@ from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from app.decorators import with_rate_limiting
 from app.services.workflow import WorkflowService
 from app.services.workflow.trigger_search import TriggerSearchService
@@ -51,7 +52,7 @@ async def search_triggers(
         )
 
     except Exception as e:
-        log.error(f"Error searching triggers: {e}")
+        log.error(f"{LogTag.TOOL} Error searching triggers: {e}")
         return error_response("search_failed", str(e))
 
 
@@ -93,7 +94,7 @@ async def list_workflows(config: RunnableConfig) -> dict:
         return success_response({"workflows": workflow_summaries, "total": len(workflows)})
 
     except Exception as e:
-        log.error(f"Error listing workflows: {e}")
+        log.error(f"{LogTag.TOOL} Error listing workflows: {e}")
         return error_response("fetch_failed", str(e))
 
 

--- a/apps/api/app/agents/tools/workflow_tool.py
+++ b/apps/api/app/agents/tools/workflow_tool.py
@@ -25,6 +25,7 @@ from app.agents.tools.workflow_shared_tools import (
     list_workflows,
     search_triggers,
 )
+from app.constants.log_tags import LogTag
 from app.decorators import with_rate_limiting
 from app.models.workflow_models import WorkflowExecutionRequest
 from app.services.workflow import WorkflowService
@@ -138,7 +139,7 @@ async def create_workflow(
                 f"Unknown mode: {mode}. Use 'new' or 'from_conversation'.",
             )
 
-        log.info(f"[create_workflow] Executing with mode={mode}")
+        log.info(f"{LogTag.TOOL} create_workflow: Executing with mode={mode}")
 
         # Execute workflow subagent
         subagent_response = await WorkflowSubagentRunner.execute(
@@ -152,14 +153,16 @@ async def create_workflow(
 
         # Parse the response
         result = parse_subagent_response(subagent_response)
-        log.info(f"[create_workflow] Parsed mode={result.mode}")
+        log.info(f"{LogTag.TOOL} create_workflow: Parsed mode={result.mode}")
 
         if result.mode == "finalized" and result.draft:
             draft = result.draft
 
             # Check if we can create directly (simple, unambiguous workflows)
             if can_create_directly(draft):
-                log.info(f"[create_workflow] Attempting direct creation for: {draft.title}")
+                log.info(
+                    f"{LogTag.TOOL} create_workflow: Attempting direct creation for: {draft.title}"
+                )
 
                 # Try to create the workflow directly
                 direct_result = await create_workflow_directly(
@@ -174,11 +177,13 @@ async def create_workflow(
                     return direct_result
 
                 # Fall through to draft card if direct creation failed
-                log.info("[create_workflow] Direct creation failed, falling back to draft")
+                log.info(
+                    f"{LogTag.TOOL} create_workflow: Direct creation failed, falling back to draft"
+                )
 
             # Stream workflow draft to frontend for user confirmation
             writer(result.draft.to_stream_payload())
-            log.info(f"[create_workflow] Streamed draft: {result.draft.title}")
+            log.info(f"{LogTag.TOOL} create_workflow: Streamed draft: {result.draft.title}")
 
             return success_response(
                 {"status": "draft_sent", "mode": mode},
@@ -202,7 +207,7 @@ async def create_workflow(
         if result.mode == "parse_error":
             # Subagent returned something we couldn't parse.
             # Let the executor know so it can inform the user or retry.
-            log.warning(f"[create_workflow] Parse error: {result.parse_error}")
+            log.warning(f"{LogTag.TOOL} create_workflow: Parse error: {result.parse_error}")
             return error_response(
                 "parse_error",
                 f"Failed to process the workflow assistant's response: {result.parse_error}. "
@@ -215,7 +220,7 @@ async def create_workflow(
         )
 
     except Exception as e:
-        log.error(f"[create_workflow] Exception: {e}", exc_info=True)
+        log.error(f"{LogTag.TOOL} create_workflow: Exception: {e}", exc_info=True)
         return error_response("subagent_failed", str(e))
 
 
@@ -239,7 +244,7 @@ async def get_workflow(
         return success_response(workflow.model_dump())
 
     except Exception as e:
-        log.error(f"Error getting workflow {workflow_id}: {e}")
+        log.error(f"{LogTag.TOOL} Error getting workflow {workflow_id}: {e}")
         return error_response("fetch_failed", str(e))
 
 
@@ -269,7 +274,7 @@ async def execute_workflow(
         return success_response(data)
 
     except Exception as e:
-        log.error(f"Error executing workflow {workflow_id}: {e}")
+        log.error(f"{LogTag.TOOL} Error executing workflow {workflow_id}: {e}")
         return error_response("execution_failed", str(e))
 
 

--- a/apps/api/app/agents/workspace/skill_loader.py
+++ b/apps/api/app/agents/workspace/skill_loader.py
@@ -26,6 +26,7 @@ import hashlib
 from pathlib import Path
 
 from app.agents.core.subagents.registry import resolve_subagent_id
+from app.constants.log_tags import LogTag
 from app.constants.skills import (
     BUILTIN_SKILLS_DIRNAME,
     EXECUTOR_SUBAGENT_ID,
@@ -63,7 +64,7 @@ def target_to_subagent(agent_name: str) -> str:
     resolved = resolve_subagent_id(agent_name)
     if resolved is None:
         log.set(skill_target=agent_name, component="skill_loader")
-        log.warning("skill target matches no subagent agent_name")
+        log.warning(f"{LogTag.AGENT} skill target matches no subagent agent_name")
         return agent_name
     return resolved
 
@@ -124,7 +125,7 @@ def _load_resources(skill_dir: Path) -> tuple[tuple[str, str], ...]:
             # A repo-owned template/script that can't be read signals broken
             # packaging or image contents — surface it so the gap is detectable
             # at load time instead of as an opaque downstream docgen failure.
-            log.warning(f"skill_loader: skipping unreadable resource {path}: {exc}")
+            log.warning(f"{LogTag.AGENT} skill_loader: skipping unreadable resource {path}: {exc}")
             continue
         resources.append((path.relative_to(skill_dir).as_posix(), content))
     return tuple(resources)

--- a/apps/api/app/api/v1/dependencies/google_scope_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/google_scope_dependencies.py
@@ -23,6 +23,7 @@ import httpx
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.config.oauth_config import get_integration_by_id, get_short_name_mapping
 from app.constants.error_codes import INTEGRATION_NOT_CONNECTED
+from app.constants.log_tags import LogTag
 from app.services.oauth.oauth_service import check_integration_status
 from shared.py.wide_events import log
 
@@ -89,7 +90,7 @@ def require_integration(integration_short_name: str):
         except HTTPException:
             raise
         except Exception as e:
-            log.error(f"Error checking integration {integration_short_name}: {e}")
+            log.error(f"{LogTag.API} Error checking integration {integration_short_name}: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to verify integration permissions",

--- a/apps/api/app/api/v1/dependencies/oauth_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/oauth_dependencies.py
@@ -6,6 +6,7 @@ from bson import ObjectId
 from fastapi import Depends, Header, HTTPException, Request, WebSocket, status
 
 from app.constants.error_codes import NOT_AUTHENTICATED
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.utils.timezone import Timezone, TimezoneSource, resolve_home_timezone
 from shared.py.wide_events import log
@@ -21,12 +22,12 @@ async def _backfill_user_timezone(user_id: str, tz: str) -> None:
             {"$set": {"timezone": tz, "updated_at": datetime.now(UTC)}},
         )
         log.info(
-            "Backfilled user.timezone from x-timezone header",
+            f"{LogTag.OAUTH} Backfilled user.timezone from x-timezone header",
             user_id=user_id,
             timezone=tz,
         )
     except Exception as e:
-        log.warning(f"Failed to backfill user.timezone for {user_id}: {e}")
+        log.warning(f"{LogTag.OAUTH} Failed to backfill user.timezone for {user_id}: {e}")
 
 
 async def get_current_user(request: Request):
@@ -44,7 +45,7 @@ async def get_current_user(request: Request):
         HTTPException: On authentication failure
     """
     if not hasattr(request.state, "authenticated") or not request.state.authenticated:
-        log.info("No authenticated user found in request state")
+        log.info(f"{LogTag.OAUTH} No authenticated user found in request state")
         raise HTTPException(
             status_code=401,
             detail={
@@ -53,7 +54,7 @@ async def get_current_user(request: Request):
             },
         )
     if not request.state.user:
-        log.error("User marked as authenticated but no user data found")
+        log.error(f"{LogTag.OAUTH} User marked as authenticated but no user data found")
         raise HTTPException(
             status_code=401,
             detail={
@@ -116,7 +117,7 @@ async def get_current_user_ws(websocket: WebSocket):
             wos_session = protocol_header[8:]  # Extract token after "Bearer, "
 
     if not wos_session:
-        log.info("No session cookie or protocol token in WebSocket request")
+        log.info(f"{LogTag.OAUTH} No session cookie or protocol token in WebSocket request")
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return {}
 
@@ -124,7 +125,7 @@ async def get_current_user_ws(websocket: WebSocket):
     user_info, _ = await authenticate_workos_session(session_token=wos_session)
 
     if not user_info:
-        log.warning("WebSocket authentication failed")
+        log.warning(f"{LogTag.OAUTH} WebSocket authentication failed")
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return {}
 
@@ -146,7 +147,7 @@ def get_user_timezone(
     """
     tz = Timezone.parse(x_timezone)
     now = tz.now()
-    log.debug(f"User timezone: {tz.value}, Current time: {now}")
+    log.debug(f"{LogTag.OAUTH} User timezone: {tz.value}, Current time: {now}")
     return tz.value, now
 
 
@@ -179,7 +180,7 @@ async def get_user_timezone_from_preferences(
 
         if resolved.source is TimezoneSource.X_TIMEZONE_HEADER:
             log.warning(
-                "Healing user.timezone from x-timezone header",
+                f"{LogTag.OAUTH} Healing user.timezone from x-timezone header",
                 user_id=user_id,
                 stored_timezone=(user.get("timezone") or "").strip() or None,
                 header_timezone=resolved.timezone.value,
@@ -189,7 +190,7 @@ async def get_user_timezone_from_preferences(
             and not (user.get("timezone") or "").strip()
         ):
             log.warning(
-                "user.timezone missing and no valid x-timezone header; falling back to UTC",
+                f"{LogTag.OAUTH} user.timezone missing and no valid x-timezone header; falling back to UTC",
                 user_id=user_id,
                 header_value=(x_timezone or "").strip() or None,
             )
@@ -202,6 +203,6 @@ async def get_user_timezone_from_preferences(
         return resolved.timezone.value
 
     except Exception as e:
-        log.warning(f"Error resolving user timezone: {e}", user_id=user_id)
+        log.warning(f"{LogTag.OAUTH} Error resolving user timezone: {e}", user_id=user_id)
         log.set(timezone_source=TimezoneSource.FALLBACK_UTC.value, user_timezone="UTC")
         return "UTC"

--- a/apps/api/app/api/v1/endpoints/bot.py
+++ b/apps/api/app/api/v1/endpoints/bot.py
@@ -10,6 +10,7 @@ from fastapi.responses import StreamingResponse
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.config.settings import settings
 from app.constants.cache import PLATFORM_LINK_TOKEN_PREFIX, PLATFORM_LINK_TOKEN_TTL
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from app.db.redis import redis_cache
 from app.decorators import tiered_rate_limit
@@ -235,7 +236,7 @@ async def bot_chat_stream(request: Request, body: BotChatRequest) -> StreamingRe
         """Drop the finished background task from the registry and log failures."""
         _background_tasks.discard(t)
         if t.exception():
-            log.error(f"Background stream task failed: {t.exception()}")
+            log.error(f"{LogTag.API} Background stream task failed: {t.exception()}")
 
     task.add_done_callback(task_done_callback)
     _background_tasks.add(task)
@@ -306,7 +307,7 @@ async def bot_chat_stream(request: Request, body: BotChatRequest) -> StreamingRe
                 except json.JSONDecodeError:
                     continue
         except Exception as e:
-            log.error(f"Bot stream subscription error: {e}")
+            log.error(f"{LogTag.API} Bot stream subscription error: {e}")
             yield f"data: {json.dumps({'error': 'Stream error occurred'})}\n\n"
 
     return StreamingResponse(stream_from_redis(), media_type="text/event-stream")
@@ -417,7 +418,7 @@ async def get_settings(
                         )
                     )
     except Exception as e:
-        log.error(f"Error fetching integrations for settings: {e}")
+        log.error(f"{LogTag.API} Error fetching integrations for settings: {e}")
 
     user_name = user.get("name") or user.get("username")
     profile_image_url = user.get("profile_image_url") or user.get("avatar_url")
@@ -523,7 +524,7 @@ async def transcribe_bot_audio(
             content_type=normalized,
         )
     except Exception as e:
-        log.error(f"Transcription failed: {e}", exc_info=True)
+        log.error(f"{LogTag.API} Transcription failed: {e}", exc_info=True)
         raise HTTPException(status_code=502, detail="Transcription failed")
 
     return {"text": text}

--- a/apps/api/app/api/v1/endpoints/chat.py
+++ b/apps/api/app/api/v1/endpoints/chat.py
@@ -17,6 +17,7 @@ from app.api.v1.dependencies.oauth_dependencies import (
     get_current_user,
     get_user_timezone_from_preferences,
 )
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from app.db.redis import redis_cache
 from app.decorators import tiered_rate_limit
@@ -70,7 +71,7 @@ async def _stream_from_redis(
     stream_id: str, request: Request, start_event: asyncio.Event | None = None
 ) -> AsyncGenerator[str, None]:
     if not redis_cache.redis:
-        log.error(f"Redis unavailable for stream {stream_id}")
+        log.error(f"{LogTag.CHAT} Redis unavailable for stream {stream_id}")
         if start_event and not start_event.is_set():
             start_event.set()
         yield "data: [STREAM_ERROR]\n\n"
@@ -79,13 +80,15 @@ async def _stream_from_redis(
     try:
         async for chunk in stream_manager.subscribe_stream(stream_id, start_event=start_event):
             if await request.is_disconnected():
-                log.info(f"Client disconnected, stream {stream_id} continues in background")
+                log.info(
+                    f"{LogTag.CHAT} Client disconnected, stream {stream_id} continues in background"
+                )
                 break
             yield chunk
     except asyncio.CancelledError:
-        log.info(f"Stream {stream_id}: client connection cancelled")
+        log.info(f"{LogTag.CHAT} Stream {stream_id}: client connection cancelled")
     except Exception as e:
-        log.error(f"Error streaming to client: {e}")
+        log.error(f"{LogTag.CHAT} Error streaming to client: {e}")
     finally:
         if start_event and not start_event.is_set():
             start_event.set()
@@ -183,7 +186,7 @@ async def cancel_stream_endpoint(
         )
 
     success = await stream_manager.cancel_stream(stream_id)
-    log.info(f"Cancel stream request: stream_id={stream_id}, success={success}")
+    log.info(f"{LogTag.CHAT} Cancel stream request: stream_id={stream_id}, success={success}")
 
     return {
         "success": success,
@@ -229,7 +232,7 @@ async def subscribe_executor_stream(
     # Race condition: executor finished before frontend subscribed.
     # Return [DONE] immediately so the client closes cleanly.
     if progress.get("is_complete"):
-        log.info(f"Executor stream {stream_id} already complete, returning [DONE]")
+        log.info(f"{LogTag.CHAT} Executor stream {stream_id} already complete, returning [DONE]")
 
         async def _already_done() -> AsyncGenerator[str, None]:
             yield "data: [DONE]\n\n"
@@ -245,7 +248,7 @@ async def subscribe_executor_stream(
             },
         )
 
-    log.info(f"Client subscribed to executor stream {stream_id}")
+    log.info(f"{LogTag.CHAT} Client subscribed to executor stream {stream_id}")
 
     return StreamingResponse(
         _stream_from_redis(stream_id, request),

--- a/apps/api/app/api/v1/endpoints/goals.py
+++ b/apps/api/app/api/v1/endpoints/goals.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from fastapi.websockets import WebSocketState
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import goals_collection
 from app.decorators import tiered_rate_limit
 from app.models.goals_models import (
@@ -130,7 +131,7 @@ async def websocket_generate_roadmap(websocket: WebSocket):
         goal_title = data.get("goal_title")
 
         if not goal_id or not goal_title:
-            log.warning("Invalid data received in websocket for roadmap generation.")
+            log.warning(f"{LogTag.API} Invalid data received in websocket for roadmap generation.")
             await websocket.send_json({"error": "Invalid data received"})
             return
 
@@ -138,11 +139,13 @@ async def websocket_generate_roadmap(websocket: WebSocket):
         # Verify goal exists before proceeding
         goal = await goals_collection.find_one({"_id": ObjectId(goal_id)})
         if not goal:
-            log.error(f"Goal {goal_id} not found")
+            log.error(f"{LogTag.API} Goal {goal_id} not found")
             await websocket.send_json({"error": "Goal not found"})
             return
 
-        log.info(f"Starting roadmap generation for goal {goal_id} titled '{goal_title}'.")
+        log.info(
+            f"{LogTag.API} Starting roadmap generation for goal {goal_id} titled '{goal_title}'."
+        )
         await websocket.send_json({"status": "Generating roadmap..."})
 
         try:
@@ -185,21 +188,21 @@ async def websocket_generate_roadmap(websocket: WebSocket):
                 await websocket.send_json({"error": "No roadmap was generated"})
 
         except Exception as e:
-            log.error(f"Error generating roadmap for goal {goal_id}: {e!s}")
+            log.error(f"{LogTag.API} Error generating roadmap for goal {goal_id}: {e!s}")
             await websocket.send_json({"error": f"Roadmap generation failed: {e!s}"})
 
     except WebSocketDisconnect:
-        log.info("WebSocket disconnected.")
+        log.info(f"{LogTag.API} WebSocket disconnected.")
     except Exception as e:
-        log.error(f"WebSocket error: {e!s}")
+        log.error(f"{LogTag.API} WebSocket error: {e!s}")
         try:
             await websocket.send_json({"error": f"WebSocket error: {e!s}"})
         except Exception as send_error:
-            log.error(f"Failed to send error message via WebSocket: {send_error!s}")
+            log.error(f"{LogTag.API} Failed to send error message via WebSocket: {send_error!s}")
     finally:
         # Ensure WebSocket is closed
         try:
             if websocket.client_state == WebSocketState.CONNECTED:
                 await websocket.close()
         except Exception as close_error:
-            log.error(f"Failed to close WebSocket: {close_error!s}")
+            log.error(f"{LogTag.API} Failed to close WebSocket: {close_error!s}")

--- a/apps/api/app/api/v1/endpoints/integrations/community.py
+++ b/apps/api/app/api/v1/endpoints/integrations/community.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, HTTPException
 
+from app.constants.log_tags import LogTag
 from app.schemas.integrations.responses import CommunityListResponse
 from app.services.integrations.community_service import (
     list_community_integrations as list_community,
@@ -26,5 +27,5 @@ async def list_community_integrations(
         log.set(outcome="success")
         return result
     except Exception as e:
-        log.error(f"Error fetching community integrations: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error fetching community integrations: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch community integrations")

--- a/apps/api/app/api/v1/endpoints/integrations/config.py
+++ b/apps/api/app/api/v1/endpoints/integrations/config.py
@@ -8,6 +8,7 @@ from fastapi.responses import RedirectResponse
 from app.api.v1.dependencies.oauth_dependencies import get_current_user, get_user_id
 from app.config.oauth_config import OAUTH_INTEGRATIONS
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.schemas.integrations.requests import ConnectIntegrationRequest
 from app.schemas.integrations.responses import (
@@ -57,7 +58,7 @@ async def get_integrations_status(
             ]
         )
     except Exception as e:
-        log.error(f"Error checking integration status: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error checking integration status: {e}")
         return IntegrationsStatusResponse(
             integrations=[
                 IntegrationStatusItem(integration_id=i.id, connected=False)
@@ -90,7 +91,7 @@ async def disconnect_integration_endpoint(
         # For "no active connected account" or other cases, return 400
         raise HTTPException(status_code=400, detail=error_message)
     except Exception as e:
-        log.error(f"Error disconnecting {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error disconnecting {integration_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to disconnect integration")
 
 
@@ -194,7 +195,7 @@ async def connect_integration_endpoint(
             error=f"Unsupported integration type: {resolved.managed_by}",
         )
     except Exception as e:
-        log.error(f"Failed to connect {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Failed to connect {integration_id}: {e}")
         log.set(integration={"id": integration_id, "status": "error"})
         return ConnectIntegrationResponse(
             status="error",

--- a/apps/api/app/api/v1/endpoints/integrations/custom.py
+++ b/apps/api/app/api/v1/endpoints/integrations/custom.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.api.v1.dependencies.oauth_dependencies import get_user_id
+from app.constants.log_tags import LogTag
 from app.models.integration_models import (
     CreateCustomIntegrationRequest as RequestModel,
     UpdateCustomIntegrationRequest as UpdateCustomIntegrationRequestModel,
@@ -77,7 +78,7 @@ async def create_custom_mcp_integration(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        log.error(f"Error creating custom integration: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error creating custom integration: {e}")
         raise HTTPException(status_code=500, detail="Failed to create integration")
 
 
@@ -119,7 +120,7 @@ async def update_custom_mcp_integration(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error updating integration {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error updating integration {integration_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to update integration")
 
 
@@ -148,7 +149,7 @@ async def delete_custom_mcp_integration(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error deleting integration {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error deleting integration {integration_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to delete integration")
 
 
@@ -174,7 +175,7 @@ async def publish_integration(
     except PublishError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
     except Exception as e:
-        log.error(f"Error publishing integration {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error publishing integration {integration_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to publish integration")
 
 
@@ -199,5 +200,5 @@ async def unpublish_integration(
     except PublishError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
     except Exception as e:
-        log.error(f"Error unpublishing integration {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error unpublishing integration {integration_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to unpublish integration")

--- a/apps/api/app/api/v1/endpoints/integrations/marketplace.py
+++ b/apps/api/app/api/v1/endpoints/integrations/marketplace.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, HTTPException
 
+from app.constants.log_tags import LogTag
 from app.schemas.integrations.responses import IntegrationResponse, MarketplaceResponse
 from app.services.integrations.marketplace import (
     get_all_integrations,
@@ -21,7 +22,7 @@ async def list_marketplace_integrations(category: str | None = None):
         log.set(outcome="success")
         return result
     except Exception as e:
-        log.error(f"Error fetching marketplace: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error fetching marketplace: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch integrations")
 
 

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app.api.v1.dependencies.oauth_dependencies import get_user_id
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.db.chroma.public_integrations_store import search_public_integrations
 from app.db.mongodb.collections import (
     integrations_collection,
@@ -112,7 +113,7 @@ async def get_public_integration(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error fetching public integration {identifier}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error fetching public integration {identifier}: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch integration")
 
 
@@ -149,7 +150,9 @@ async def add_public_integration(
                     status="connected",
                     message="Integration already connected",
                 )
-            log.info(f"User {user_id} re-attempting connection to {integration_id}")
+            log.info(
+                f"{LogTag.INTEGRATION} User {user_id} re-attempting connection to {integration_id}"
+            )
         else:
             try:
                 await add_user_integration(
@@ -165,7 +168,7 @@ async def add_public_integration(
                 {"$inc": {"clone_count": 1}},
             )
 
-            log.info(f"User {user_id} added integration {integration_id}")
+            log.info(f"{LogTag.INTEGRATION} User {user_id} added integration {integration_id}")
 
         mcp_config = original_doc.get("mcp_config", {})
         server_url = mcp_config.get("server_url")
@@ -208,7 +211,7 @@ async def add_public_integration(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error adding integration {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error adding integration {integration_id}: {e}")
         raise HTTPException(status_code=500, detail="Failed to add integration")
 
 
@@ -268,7 +271,7 @@ async def search_integrations(q: str) -> SearchIntegrationsResponse:
         return SearchIntegrationsResponse(integrations=formatted, query=q)
 
     except Exception as e:
-        log.error(f"Error searching integrations: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error searching integrations: {e}")
         raise HTTPException(status_code=500, detail="Failed to search integrations")
 
 
@@ -380,5 +383,5 @@ async def get_related_workflows(
         return PublicWorkflowsResponse(workflows=formatted_workflows, total=total)
 
     except Exception as e:
-        log.error(f"Error fetching related workflows for {identifier}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error fetching related workflows for {identifier}: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch related workflows")

--- a/apps/api/app/api/v1/endpoints/integrations/user.py
+++ b/apps/api/app/api/v1/endpoints/integrations/user.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.api.v1.dependencies.oauth_dependencies import get_user_id
+from app.constants.log_tags import LogTag
 from app.models.integration_instructions_models import InstructionsEditor
 from app.models.integration_models import (
     UserIntegrationsListResponse as UserIntegrationsListResponseModel,
@@ -47,7 +48,7 @@ async def list_user_integrations(
         log.set(outcome="success")
         return result
     except Exception as e:
-        log.error(f"Error fetching user integrations: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error fetching user integrations: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch user integrations")
 
 
@@ -73,7 +74,7 @@ async def add_integration_to_workspace(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        log.error(f"Error adding integration: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error adding integration: {e}")
         raise HTTPException(status_code=500, detail="Failed to add integration")
 
 
@@ -101,7 +102,7 @@ async def remove_integration_from_workspace(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error removing integration: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error removing integration: {e}")
         raise HTTPException(status_code=500, detail="Failed to remove integration")
 
 
@@ -140,7 +141,7 @@ async def get_integration_instructions(
             updated_at=record.updated_at,
         )
     except Exception as e:
-        log.error(f"Error fetching integration instructions: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error fetching integration instructions: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch integration instructions")
 
 
@@ -185,5 +186,5 @@ async def update_integration_instructions(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        log.error(f"Error updating integration instructions: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error updating integration instructions: {e}")
         raise HTTPException(status_code=500, detail="Failed to update integration instructions")

--- a/apps/api/app/api/v1/endpoints/mcp.py
+++ b/apps/api/app/api/v1/endpoints/mcp.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.constants.log_tags import LogTag
 from app.db.redis import delete_cache
 from app.helpers.mcp_helpers import (
     get_api_base_url,
@@ -19,7 +20,7 @@ from app.helpers.mcp_helpers import (
 )
 from app.services.integrations.integration_resolver import IntegrationResolver
 from app.services.mcp.mcp_client import get_mcp_client
-from shared.py.wide_events import log
+from shared.py.wide_events import McpContext, log
 
 router = APIRouter()
 
@@ -40,8 +41,8 @@ async def test_mcp_connection(
         raise HTTPException(status_code=400, detail="User ID not found")
     log.set(
         user={"id": user_id},
-        integration_id=integration_id,
         operation="test_mcp_connection",
+        mcp=McpContext(operation="health", server_id=integration_id),
     )
 
     client = await get_mcp_client(user_id=str(user_id))
@@ -64,6 +65,7 @@ async def test_mcp_connection(
 
     if probe_result.get("error"):
         log.set(outcome="failed")
+        log.set_ns("mcp", success=False)
         return JSONResponse(
             content={
                 "status": "failed",
@@ -77,7 +79,13 @@ async def test_mcp_connection(
             tools = await client.connect(integration_id)
             # Note: status update now handled in connect()
             await invalidate_mcp_status_cache(str(user_id))
-            log.set(outcome="connected", tools_count=len(tools) if tools else 0)
+            log.set(outcome="connected")
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                success=True,
+                tool_count=len(tools) if tools else 0,
+            )
             return JSONResponse(
                 content={
                     "status": "connected",
@@ -86,6 +94,12 @@ async def test_mcp_connection(
             )
         except Exception as e:
             log.set(outcome="failed")
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                success=False,
+                error_type=type(e).__name__,
+            )
             return JSONResponse(
                 content={
                     "status": "failed",
@@ -113,7 +127,7 @@ async def test_mcp_connection(
             }
         )
     except Exception as e:
-        log.error(f"OAuth URL build failed for {integration_id}: {e}")
+        log.error(f"{LogTag.MCP} OAuth URL build failed for {integration_id}: {e}")
         return JSONResponse(
             content={
                 "status": "failed",
@@ -149,9 +163,9 @@ async def mcp_oauth_callback(
         state_token = parts[0]
         integration_id = parts[1]
         redirect_path = parts[2] if len(parts) > 2 else "/integrations"
-        log.set(integration_id=integration_id)
+        log.set(mcp=McpContext(operation="connect", server_id=integration_id))
     except Exception as e:
-        log.error("Failed to parse OAuth state", error=str(e))
+        log.error(f"{LogTag.MCP} Failed to parse OAuth state", error=str(e))
         return RedirectResponse(
             url=f"{frontend_url}/integrations?status=failed&error=invalid_state"
         )
@@ -162,7 +176,7 @@ async def mcp_oauth_callback(
     # Handle OAuth error response from authorization server
     if error:
         log.warning(
-            f"OAuth error for {integration_id}: {error} - {error_description or 'no description'}"
+            f"{LogTag.MCP} OAuth error for {integration_id}: {error} - {error_description or 'no description'}"
         )
 
         # Some servers advertise scopes in their metadata that a dynamically
@@ -178,11 +192,15 @@ async def mcp_oauth_callback(
                 if retry_url:
                     return RedirectResponse(url=retry_url)
             except Exception as retry_err:
-                log.warning(f"Scope retry URL build failed for {integration_id}: {retry_err}")
+                log.warning(
+                    f"{LogTag.MCP} Scope retry URL build failed for {integration_id}: {retry_err}"
+                )
         try:
             await client.token_store.clear_excluded_scopes(integration_id)
         except Exception as clear_err:
-            log.warning(f"Failed to clear excluded scopes for {integration_id}: {clear_err}")
+            log.warning(
+                f"{LogTag.MCP} Failed to clear excluded scopes for {integration_id}: {clear_err}"
+            )
 
         # Map common OAuth errors to user-friendly codes
         error_code = error
@@ -205,7 +223,7 @@ async def mcp_oauth_callback(
 
     # Validate code is present (required for success case)
     if not code:
-        log.error(f"OAuth callback missing code for {integration_id}")
+        log.error(f"{LogTag.MCP} OAuth callback missing code for {integration_id}")
         return RedirectResponse(
             url=f"{frontend_url}{redirect_path}?id={integration_id}&status=failed&error=missing_code"
         )
@@ -214,16 +232,9 @@ async def mcp_oauth_callback(
     resolved = await IntegrationResolver.resolve(integration_id)
     integration_name = resolved.name if resolved else integration_id
 
-    log.set(
-        mcp_oauth_callback={
-            "integration_id": integration_id,
-            "integration_name": integration_name,
-            "user_id": user_id,
-            "redirect_path": redirect_path,
-        }
-    )
+    log.set_ns("mcp", server_name=integration_name)
     log.info(
-        f"mcp_oauth_callback: starting handle_oauth_callback for "
+        f"{LogTag.MCP} mcp_oauth_callback: starting handle_oauth_callback for "
         f"integration={integration_id} user={user_id}"
     )
     try:
@@ -245,7 +256,7 @@ async def mcp_oauth_callback(
             await client.token_store.clear_excluded_scopes(integration_id)
         except Exception as clear_err:
             log.warning(
-                f"Failed to clear excluded scopes after OAuth success for "
+                f"{LogTag.MCP} Failed to clear excluded scopes after OAuth success for "
                 f"{integration_id}: {clear_err}"
             )
 
@@ -253,15 +264,16 @@ async def mcp_oauth_callback(
             await delete_cache("api:get_available_tools:*")
         except Exception as cache_err:
             log.warning(
-                f"Failed to invalidate tools cache: {type(cache_err).__name__}: {cache_err}"
+                f"{LogTag.MCP} Failed to invalidate tools cache: {type(cache_err).__name__}: {cache_err}"
             )
 
         await invalidate_mcp_status_cache(str(user_id))
 
         frontend_url = get_frontend_url()
         log.set(outcome="connected")
+        log.set_ns("mcp", success=True)
         log.info(
-            f"mcp_oauth_callback: OAuth complete for {integration_id} user={user_id}; "
+            f"{LogTag.MCP} mcp_oauth_callback: OAuth complete for {integration_id} user={user_id}; "
             f"connect dispatched to background, redirecting now"
         )
         return RedirectResponse(
@@ -269,17 +281,10 @@ async def mcp_oauth_callback(
         )
 
     except Exception as e:
-        log.set(
-            outcome="failed",
-            mcp_oauth_callback_error={
-                "integration_id": integration_id,
-                "user_id": user_id,
-                "error_type": type(e).__name__,
-                "error_message": str(e)[:500],
-            },
-        )
+        log.set(outcome="failed")
+        log.set_ns("mcp", success=False, error_type=type(e).__name__)
         log.error(
-            f"mcp_oauth_callback FAILED for integration={integration_id} user={user_id}: "
+            f"{LogTag.MCP} mcp_oauth_callback FAILED for integration={integration_id} user={user_id}: "
             f"{type(e).__name__}: {e}"
         )
         frontend_url = get_frontend_url()

--- a/apps/api/app/api/v1/endpoints/mcp_proxy.py
+++ b/apps/api/app/api/v1/endpoints/mcp_proxy.py
@@ -101,9 +101,7 @@ async def proxy_mcp_resources_list(
             cursor=request.cursor,
         )
         log.set(outcome="success")
-        log.set(
-            mcp=McpContext(success=True, result_count=len(result.get("resources", [])))
-        )
+        log.set(mcp=McpContext(success=True, result_count=len(result.get("resources", []))))
         return MCPProxyResourcesListResponse(
             resources=result.get("resources", []),
             next_cursor=result.get("next_cursor") or result.get("nextCursor"),
@@ -149,9 +147,7 @@ async def proxy_mcp_resource_templates_list(
             mcp=McpContext(
                 success=True,
                 result_count=len(
-                    result.get("resource_templates")
-                    or result.get("resourceTemplates")
-                    or []
+                    result.get("resource_templates") or result.get("resourceTemplates") or []
                 ),
             )
         )
@@ -202,9 +198,7 @@ async def proxy_mcp_resource_read(
             uri=request.uri,
         )
         log.set(outcome="success")
-        log.set(
-            mcp=McpContext(success=True, result_count=len(result.get("contents", [])))
-        )
+        log.set(mcp=McpContext(success=True, result_count=len(result.get("contents", []))))
         return MCPProxyResourceReadResponse(
             contents=result.get("contents", []),
         )
@@ -245,9 +239,7 @@ async def proxy_mcp_prompts_list(
             cursor=request.cursor,
         )
         log.set(outcome="success")
-        log.set(
-            mcp=McpContext(success=True, result_count=len(result.get("prompts", [])))
-        )
+        log.set(mcp=McpContext(success=True, result_count=len(result.get("prompts", []))))
         return MCPProxyPromptsListResponse(
             prompts=result.get("prompts", []),
             next_cursor=result.get("next_cursor") or result.get("nextCursor"),

--- a/apps/api/app/api/v1/endpoints/mcp_proxy.py
+++ b/apps/api/app/api/v1/endpoints/mcp_proxy.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.constants.log_tags import LogTag
 from app.schemas.mcp import (
     MCPProxyPromptsListRequest,
     MCPProxyPromptsListResponse,
@@ -20,7 +21,7 @@ from app.schemas.mcp import (
     MCPProxyToolCallResponse,
 )
 from app.services.mcp.mcp_client import get_mcp_client
-from shared.py.wide_events import log
+from shared.py.wide_events import McpContext, log
 
 router = APIRouter()
 
@@ -46,7 +47,7 @@ async def proxy_mcp_tool_call(
     log.set(
         user={"id": user_id},
         operation="mcp_proxy_tool_call",
-        tool_name=request.tool_name,
+        mcp=McpContext(operation="call_tool", tool_name=request.tool_name),
     )
 
     try:
@@ -57,7 +58,8 @@ async def proxy_mcp_tool_call(
             arguments=request.arguments,
         )
         is_error = result.get("is_error") or result.get("isError") or False
-        log.set(outcome="success", is_error=is_error)
+        log.set(outcome="success")
+        log.set_ns("mcp", success=not is_error)
         return MCPProxyToolCallResponse(
             content=result.get("content", []),
             is_error=is_error,
@@ -65,7 +67,7 @@ async def proxy_mcp_tool_call(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"MCP proxy tool call failed: {e}")
+        log.error(f"{LogTag.MCP} MCP proxy tool call failed: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Tool call failed: {e!s}",
@@ -98,7 +100,10 @@ async def proxy_mcp_resources_list(
             server_url=request.server_url,
             cursor=request.cursor,
         )
-        log.set(outcome="success", result_count=len(result.get("resources", [])))
+        log.set(outcome="success")
+        log.set(
+            mcp=McpContext(success=True, result_count=len(result.get("resources", [])))
+        )
         return MCPProxyResourcesListResponse(
             resources=result.get("resources", []),
             next_cursor=result.get("next_cursor") or result.get("nextCursor"),
@@ -106,7 +111,7 @@ async def proxy_mcp_resources_list(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"MCP proxy resources/list failed: {e}")
+        log.error(f"{LogTag.MCP} MCP proxy resources/list failed: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"resources/list failed: {e!s}",
@@ -139,11 +144,16 @@ async def proxy_mcp_resource_templates_list(
             server_url=request.server_url,
             cursor=request.cursor,
         )
+        log.set(outcome="success")
         log.set(
-            outcome="success",
-            result_count=len(
-                result.get("resource_templates") or result.get("resourceTemplates") or []
-            ),
+            mcp=McpContext(
+                success=True,
+                result_count=len(
+                    result.get("resource_templates")
+                    or result.get("resourceTemplates")
+                    or []
+                ),
+            )
         )
         return MCPProxyResourceTemplatesListResponse(
             resource_templates=result.get("resource_templates")
@@ -154,7 +164,7 @@ async def proxy_mcp_resource_templates_list(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"MCP proxy resources/templates/list failed: {e}")
+        log.error(f"{LogTag.MCP} MCP proxy resources/templates/list failed: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"resources/templates/list failed: {e!s}",
@@ -191,14 +201,17 @@ async def proxy_mcp_resource_read(
             server_url=request.server_url,
             uri=request.uri,
         )
-        log.set(outcome="success", result_count=len(result.get("contents", [])))
+        log.set(outcome="success")
+        log.set(
+            mcp=McpContext(success=True, result_count=len(result.get("contents", [])))
+        )
         return MCPProxyResourceReadResponse(
             contents=result.get("contents", []),
         )
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"MCP proxy resources/read failed: {e}")
+        log.error(f"{LogTag.MCP} MCP proxy resources/read failed: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"resources/read failed: {e!s}",
@@ -231,7 +244,10 @@ async def proxy_mcp_prompts_list(
             server_url=request.server_url,
             cursor=request.cursor,
         )
-        log.set(outcome="success", result_count=len(result.get("prompts", [])))
+        log.set(outcome="success")
+        log.set(
+            mcp=McpContext(success=True, result_count=len(result.get("prompts", [])))
+        )
         return MCPProxyPromptsListResponse(
             prompts=result.get("prompts", []),
             next_cursor=result.get("next_cursor") or result.get("nextCursor"),
@@ -239,7 +255,7 @@ async def proxy_mcp_prompts_list(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"MCP proxy prompts/list failed: {e}")
+        log.error(f"{LogTag.MCP} MCP proxy prompts/list failed: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"prompts/list failed: {e!s}",

--- a/apps/api/app/api/v1/endpoints/notes.py
+++ b/apps/api/app/api/v1/endpoints/notes.py
@@ -7,6 +7,7 @@ This module contains endpoints for creating, retrieving, updating, and deleting 
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.constants.log_tags import LogTag
 from app.decorators import tiered_rate_limit
 from app.models.notes_models import NoteModel, NoteResponse
 from app.services.notes_service import (
@@ -43,7 +44,7 @@ async def create_note_endpoint(
         log.set(outcome="success")
         return result
     except Exception as e:
-        log.error(f"Error creating note: {e!s}")
+        log.error(f"{LogTag.API} Error creating note: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create note",
@@ -69,7 +70,7 @@ async def get_note_endpoint(note_id: str, user: dict = Depends(get_current_user)
         log.set(outcome="success")
         return result
     except Exception as e:
-        log.error(f"Error getting note {note_id}: {e!s}")
+        log.error(f"{LogTag.API} Error getting note {note_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve note",
@@ -94,7 +95,7 @@ async def get_all_notes_endpoint(user: dict = Depends(get_current_user)):
         log.set(outcome="success")
         return notes
     except Exception as e:
-        log.error(f"Error listing notes: {e!s}")
+        log.error(f"{LogTag.API} Error listing notes: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve notes",
@@ -126,7 +127,7 @@ async def update_note_endpoint(
         log.set(outcome="success")
         return result
     except Exception as e:
-        log.error(f"Error updating note {note_id}: {e!s}")
+        log.error(f"{LogTag.API} Error updating note {note_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update note",
@@ -152,7 +153,7 @@ async def delete_note_endpoint(
         log.set(note_id=note_id)
         log.set(outcome="success")
     except Exception as e:
-        log.error(f"Error deleting note {note_id}: {e!s}")
+        log.error(f"{LogTag.API} Error deleting note {note_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete note",

--- a/apps/api/app/api/v1/endpoints/notification.py
+++ b/apps/api/app/api/v1/endpoints/notification.py
@@ -12,6 +12,7 @@ from fastapi import (
 )
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.constants.log_tags import LogTag
 from app.constants.notifications import EXPO_TOKEN_PATTERN, MAX_DEVICES_PER_USER
 from app.db.mongodb.collections import users_collection
 from app.models.device_token_models import (
@@ -31,7 +32,7 @@ from app.models.notification.request_models import (
 from app.services.device_token_service import get_device_token_service
 from app.services.notification_service import notification_service
 from app.utils.notification.channel_preferences import fetch_channel_preferences
-from shared.py.wide_events import log
+from shared.py.wide_events import NotificationContext, log
 
 router = APIRouter()
 
@@ -52,12 +53,10 @@ async def get_notifications(
 
     log.set(
         user={"id": user_id},
-        notification={
-            "status": str(status),
-            "channel_type": channel_type,
-            "limit": limit,
-            "offset": offset,
-        },
+        operation="list",
+        notification=NotificationContext(operation="list", channel=channel_type)
+        if channel_type
+        else NotificationContext(operation="list"),
     )
 
     try:
@@ -68,11 +67,8 @@ async def get_notifications(
             notification_service.get_user_notifications_count(user_id, status, channel_type),
         )
 
-        log.set(
-            operation="list",
-            result_count=len(notifications),
-            outcome="success",
-        )
+        log.set(outcome="success")
+        log.set_ns("notification", result_count=len(notifications), success=True)
         return PaginatedNotificationsResponse(
             notifications=notifications,
             total=notification_count,
@@ -81,7 +77,7 @@ async def get_notifications(
         )
 
     except Exception as e:
-        log.error(f"Failed to get notifications: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to get notifications: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -106,7 +102,7 @@ async def get_channel_preferences(
             slack=prefs["slack"],
         )
     except Exception as e:
-        log.error(f"Failed to get channel preferences: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to get channel preferences: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -148,7 +144,7 @@ async def update_channel_preferences(
             slack=prefs["slack"],
         )
     except Exception as e:
-        log.error(f"Failed to update channel preferences: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to update channel preferences: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -166,7 +162,10 @@ async def execute_action(
 
     log.set(
         user={"id": user_id},
-        notification={"id": notification_id, "action_id": action_id},
+        operation="execute_action",
+        notification=NotificationContext(
+            operation="dispatch", notification_id=notification_id
+        ),
     )
 
     try:
@@ -177,7 +176,8 @@ async def execute_action(
         if not result.success:
             raise HTTPException(status_code=400, detail=result.message)
 
-        log.set(operation="execute_action", outcome="success")
+        log.set(outcome="success")
+        log.set_ns("notification", success=True)
         return NotificationResponse(
             success=True,
             message=result.message or "Action executed successfully",
@@ -187,7 +187,7 @@ async def execute_action(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Failed to execute action: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to execute action: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -201,14 +201,19 @@ async def mark_as_read(
     if not user_id:
         raise HTTPException(status_code=401, detail="User not authenticated or user_id not found")
 
-    log.set(user={"id": user_id}, notification={"id": notification_id})
+    log.set(
+        user={"id": user_id},
+        operation="mark_read",
+        notification=NotificationContext(operation="read", notification_id=notification_id),
+    )
 
     try:
         updated_notification = await notification_service.mark_as_read(notification_id, user_id)
         if not updated_notification:
             raise HTTPException(status_code=404, detail="Notification not found")
 
-        log.set(operation="mark_read", notification_id=notification_id, outcome="success")
+        log.set(outcome="success")
+        log.set_ns("notification", success=True)
         return NotificationResponse(
             success=True,
             message="Notification marked as read",
@@ -218,7 +223,7 @@ async def mark_as_read(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Failed to mark notification as read: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to mark notification as read: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -234,12 +239,11 @@ async def bulk_actions(
 
     notification_ids = request.notification_ids or []
     log.set(
-        notification={
-            "bulk_action": request.action.value if request.action else None,
-            "action_type": str(request.action) if request.action else None,
-            "count": len(notification_ids),
-        },
-        user_id=user_id,
+        user={"id": user_id},
+        operation="bulk_actions",
+        notification=NotificationContext(
+            operation="mark_all_read", result_count=len(notification_ids)
+        ),
     )
 
     try:
@@ -249,18 +253,12 @@ async def bulk_actions(
         results = await notification_service.bulk_actions(notification_ids, user_id, request.action)
 
         successful = sum(1 for success in results.values() if success)
-        failed = len(results) - successful
         total = len(results)
 
-        log.set(
-            notification={
-                "bulk_action": request.action.value if request.action else None,
-                "action_type": str(request.action) if request.action else None,
-                "count": total,
-                "successful": successful,
-                "failed": failed,
-            },
-            user_id=user_id,
+        log.set_ns(
+            "notification",
+            result_count=successful,
+            success=successful == total,
         )
 
         return NotificationResponse(
@@ -270,7 +268,7 @@ async def bulk_actions(
         )
 
     except Exception as e:
-        log.error(f"Failed to perform bulk actions: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to perform bulk actions: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -327,7 +325,7 @@ async def register_device_token(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Failed to register device token: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to register device token: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -360,7 +358,7 @@ async def unregister_device_token(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Failed to unregister device token: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to unregister device token: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -374,14 +372,19 @@ async def get_notification(
     if not user_id:
         raise HTTPException(status_code=401, detail="User not authenticated or user_id not found")
 
-    log.set(user={"id": user_id}, notification={"id": notification_id})
+    log.set(
+        user={"id": user_id},
+        operation="get",
+        notification=NotificationContext(operation="read", notification_id=notification_id),
+    )
 
     try:
         notification = await notification_service.get_notification(notification_id, user_id)
         if not notification:
             raise HTTPException(status_code=404, detail="Notification not found")
 
-        log.set(operation="get", notification_id=notification_id, outcome="success")
+        log.set(outcome="success")
+        log.set_ns("notification", success=True)
         return NotificationResponse(
             success=True,
             message="Notification retrieved successfully",
@@ -391,5 +394,5 @@ async def get_notification(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Failed to get notification: {e}")
+        log.error(f"{LogTag.NOTIFICATION} Failed to get notification: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/app/api/v1/endpoints/notification.py
+++ b/apps/api/app/api/v1/endpoints/notification.py
@@ -163,9 +163,7 @@ async def execute_action(
     log.set(
         user={"id": user_id},
         operation="execute_action",
-        notification=NotificationContext(
-            operation="dispatch", notification_id=notification_id
-        ),
+        notification=NotificationContext(operation="dispatch", notification_id=notification_id),
     )
 
     try:

--- a/apps/api/app/api/v1/endpoints/oauth.py
+++ b/apps/api/app/api/v1/endpoints/oauth.py
@@ -17,6 +17,7 @@ from app.constants.auth import (
     WOS_SESSION_COOKIE,
 )
 from app.constants.cache import MOBILE_REDIRECT_TTL
+from app.constants.log_tags import LogTag
 from app.db.redis import redis_cache
 from app.helpers.mcp_helpers import get_api_base_url
 from app.services.composio.composio_service import get_composio_service
@@ -25,7 +26,7 @@ from app.services.oauth.oauth_state_service import (
     is_safe_redirect_path,
     validate_and_consume_oauth_state,
 )
-from shared.py.wide_events import log
+from shared.py.wide_events import OAuthContext, log
 
 router = APIRouter()
 http_async_client = httpx.AsyncClient()
@@ -120,8 +121,13 @@ async def login_workos_mobile(redirect_uri: str | None = None):
     mobile_callback = redirect_uri or MOBILE_DEEP_LINK
     await _store_mobile_redirect(state, mobile_callback)
 
-    log.set(oauth_flow_type=OAUTH_FLOW_MOBILE)
-    log.info(f"Mobile OAuth started with redirect_uri: {mobile_callback}, state: {state[:8]}...")
+    log.set(
+        oauth_flow_type=OAUTH_FLOW_MOBILE,
+        oauth=OAuthContext(operation="authorize", provider="authkit"),
+    )
+    log.info(
+        f"{LogTag.OAUTH} Mobile OAuth started with redirect_uri: {mobile_callback}, state: {state[:8]}..."
+    )
 
     authorization_url = workos.user_management.get_authorization_url(
         provider="authkit",
@@ -144,9 +150,12 @@ async def login_google_mobile(redirect_uri: str | None = None):
     mobile_callback = redirect_uri or MOBILE_DEEP_LINK
     await _store_mobile_redirect(state, mobile_callback)
 
-    log.set(oauth_flow_type=OAUTH_FLOW_MOBILE)
+    log.set(
+        oauth_flow_type=OAUTH_FLOW_MOBILE,
+        oauth=OAuthContext(operation="authorize", provider="GoogleOAuth"),
+    )
     log.info(
-        f"Mobile Google OAuth started with redirect_uri: {mobile_callback}, state: {state[:8]}..."
+        f"{LogTag.OAUTH} Mobile Google OAuth started with redirect_uri: {mobile_callback}, state: {state[:8]}..."
     )
 
     authorization_url = workos.user_management.get_authorization_url(
@@ -173,14 +182,19 @@ async def workos_mobile_callback(
 
     if not mobile_redirect:
         mobile_redirect = MOBILE_DEEP_LINK
-        log.warning(f"No stored redirect URI for state, using default: {mobile_redirect}")
+        log.warning(
+            f"{LogTag.OAUTH} No stored redirect URI for state, using default: {mobile_redirect}"
+        )
 
-    log.set(oauth_flow_type=OAUTH_FLOW_MOBILE)
-    log.info(f"Mobile OAuth callback, redirecting to: {mobile_redirect}")
+    log.set(
+        oauth_flow_type=OAUTH_FLOW_MOBILE,
+        oauth=OAuthContext(operation="callback", provider="authkit"),
+    )
+    log.info(f"{LogTag.OAUTH} Mobile OAuth callback, redirecting to: {mobile_redirect}")
 
     try:
         if not code:
-            log.error("No authorization code received from WorkOS (mobile)")
+            log.error(f"{LogTag.OAUTH} No authorization code received from WorkOS (mobile)")
             return RedirectResponse(url=f"{mobile_redirect}?error=missing_code")
 
         auth_response = workos.user_management.authenticate_with_code(
@@ -217,11 +231,11 @@ async def workos_mobile_callback(
         return RedirectResponse(url=f"{mobile_redirect}?token={quote(token, safe='')}")
 
     except HTTPException as e:
-        log.error(f"HTTP error during WorkOS mobile auth: {e.detail}")
+        log.error(f"{LogTag.OAUTH} HTTP error during WorkOS mobile auth: {e.detail}")
         return RedirectResponse(url=f"{mobile_redirect}?error={e.detail}")
 
     except Exception as e:
-        log.error(f"Unexpected error during WorkOS mobile callback: {e!s}")
+        log.error(f"{LogTag.OAUTH} Unexpected error during WorkOS mobile callback: {e!s}")
         return RedirectResponse(url=f"{settings.WORKOS_MOBILE_REDIRECT_URI}?error=server_error")
 
 
@@ -256,11 +270,14 @@ async def workos_desktop_callback(
     Returns:
         RedirectResponse to gaia:// deep link with token
     """
-    log.set(oauth_flow_type=OAUTH_FLOW_DESKTOP)
+    log.set(
+        oauth_flow_type=OAUTH_FLOW_DESKTOP,
+        oauth=OAuthContext(operation="callback", provider="authkit"),
+    )
     try:
         # Validate code parameter
         if not code:
-            log.error("No authorization code received from WorkOS (desktop)")
+            log.error(f"{LogTag.OAUTH} No authorization code received from WorkOS (desktop)")
             return RedirectResponse(url=f"{DESKTOP_DEEP_LINK}?error=missing_code")
 
         auth_response = workos.user_management.authenticate_with_code(
@@ -298,11 +315,11 @@ async def workos_desktop_callback(
         return RedirectResponse(url=f"{DESKTOP_DEEP_LINK}?token={quote(token, safe='')}")
 
     except HTTPException as e:
-        log.error(f"HTTP error during WorkOS desktop auth: {e.detail}")
+        log.error(f"{LogTag.OAUTH} HTTP error during WorkOS desktop auth: {e.detail}")
         return RedirectResponse(url=f"{DESKTOP_DEEP_LINK}?error={e.detail}")
 
     except Exception as e:
-        log.error(f"Unexpected error during WorkOS desktop callback: {e!s}")
+        log.error(f"{LogTag.OAUTH} Unexpected error during WorkOS desktop callback: {e!s}")
         return RedirectResponse(url=f"{DESKTOP_DEEP_LINK}?error=server_error")
 
 
@@ -329,11 +346,14 @@ async def workos_callback(
         if return_url:
             await redis_cache.client.delete(key)
 
-    log.set(oauth_flow_type=OAUTH_FLOW_WEB)
+    log.set(
+        oauth_flow_type=OAUTH_FLOW_WEB,
+        oauth=OAuthContext(operation="callback", provider="authkit"),
+    )
     try:
         # Validate code parameter
         if not code:
-            log.error("No authorization code received from WorkOS")
+            log.error(f"{LogTag.OAUTH} No authorization code received from WorkOS")
             return RedirectResponse(url=f"{settings.FRONTEND_URL}/login?error=missing_code")
 
         auth_response = workos.user_management.authenticate_with_code(
@@ -386,11 +406,11 @@ async def workos_callback(
         return response
 
     except HTTPException as e:
-        log.error(f"HTTP error during WorkOS : {e.detail}")
+        log.error(f"{LogTag.OAUTH} HTTP error during WorkOS: {e.detail}")
         return RedirectResponse(url=f"{settings.FRONTEND_URL}/login?error={e.detail}")
 
     except Exception as e:
-        log.error(f"Unexpected error during WorkOS callback: {e!s}")
+        log.error(f"{LogTag.OAUTH} Unexpected error during WorkOS callback: {e!s}")
         return RedirectResponse(url=f"{settings.FRONTEND_URL}/login?error=server_error")
 
 
@@ -418,7 +438,7 @@ async def composio_callback(
     # Validate and consume state token
     state_data = await validate_and_consume_oauth_state(state)
     if not state_data:
-        log.error(f"Invalid OAuth state token: {state}")
+        log.error(f"{LogTag.OAUTH} Invalid OAuth state token: {state}")
         return RedirectResponse(url=f"{settings.FRONTEND_URL}/redirect?oauth_error=invalid_state")
 
     redirect_path = state_data["redirect_path"]
@@ -428,7 +448,7 @@ async def composio_callback(
     if status != "success":
         error_type = "cancelled" if error == "access_denied" else "failed"
         log.warning(
-            f"Composio connection failed: status={status}, error={error}, accountId={connectedAccountId}"
+            f"{LogTag.OAUTH} Composio connection failed: status={status}, error={error}, accountId={connectedAccountId}"
         )
         return RedirectResponse(
             url=f"{settings.FRONTEND_URL}{redirect_path}?oauth_error={error_type}"
@@ -436,7 +456,7 @@ async def composio_callback(
 
     # Ensure we have connectedAccountId for success status
     if not connectedAccountId:
-        log.error("Connected account ID missing for successful connection")
+        log.error(f"{LogTag.OAUTH} Connected account ID missing for successful connection")
         return RedirectResponse(url=f"{settings.FRONTEND_URL}{redirect_path}?oauth_error=failed")
 
     composio_service = get_composio_service()
@@ -445,7 +465,7 @@ async def composio_callback(
         connected_account = composio_service.get_connected_account_by_id(connectedAccountId)
 
         if not connected_account:
-            log.error(f"Connected account not found: {connectedAccountId}")
+            log.error(f"{LogTag.OAUTH} Connected account not found: {connectedAccountId}")
             return RedirectResponse(url=f"{settings.FRONTEND_URL}/redirect?oauth_error=failed")
 
         # Extract essential information
@@ -453,25 +473,31 @@ async def composio_callback(
         user_id = connected_account.user_id  # type: ignore
 
         if not user_id:
-            log.error(f"User ID missing for account: {connectedAccountId}")
+            log.error(f"{LogTag.OAUTH} User ID missing for account: {connectedAccountId}")
             return RedirectResponse(url=f"{settings.FRONTEND_URL}/redirect?oauth_error=failed")
 
         # Find integration configuration by auth config ID
         integration_config = get_integration_by_config(config_id)
         if not integration_config:
-            log.error(f"Integration config not found for auth_config_id: {config_id}")
+            log.error(
+                f"{LogTag.OAUTH} Integration config not found for auth_config_id: {config_id}"
+            )
             return RedirectResponse(
                 url=f"{settings.FRONTEND_URL}{redirect_path}?oauth_error=failed"
             )
 
-        log.set(
-            user={"id": str(user_id)},
-            integration_id=integration_config.id if integration_config else None,
+        log.set(user={"id": str(user_id)})
+        log.set_ns(
+            "oauth",
+            provider=integration_config.provider,
+            integration_id=integration_config.id,
         )
 
         # Verify user_id matches the state token (security check)
         if str(user_id) != expected_user_id:
-            log.error(f"User ID mismatch: state={expected_user_id}, account={user_id}")
+            log.error(
+                f"{LogTag.OAUTH} User ID mismatch: state={expected_user_id}, account={user_id}"
+            )
             return RedirectResponse(
                 url=f"{settings.FRONTEND_URL}{redirect_path}?oauth_error=user_mismatch"
             )
@@ -485,7 +511,7 @@ async def composio_callback(
 
         # Successful connection - redirect to frontend with success indicator
         log.info(
-            f"Composio connection successful: user={user_id}, "
+            f"{LogTag.OAUTH} Composio connection successful: user={user_id}, "
             f"integration={integration_config.id}, account={connectedAccountId}"
         )
         # Add success parameter and integration name to URL
@@ -495,7 +521,7 @@ async def composio_callback(
 
     except Exception as e:
         log.error(
-            f"Unexpected error in Composio callback: {e!s}, accountId={connectedAccountId}",
+            f"{LogTag.OAUTH} Unexpected error in Composio callback: {e!s}, accountId={connectedAccountId}",
             exc_info=True,
         )
         return RedirectResponse(url=f"{settings.FRONTEND_URL}/redirect?oauth_error=failed")

--- a/apps/api/app/api/v1/endpoints/onboarding.py
+++ b/apps/api/app/api/v1/endpoints/onboarding.py
@@ -9,6 +9,7 @@ from app.api.v1.dependencies.oauth_dependencies import (
     get_current_user,
     get_user_timezone,
 )
+from app.constants.log_tags import LogTag
 from app.constants.todos import ONBOARDING_TODO_LIMIT
 from app.core.websocket_manager import websocket_manager
 from app.db.mongodb.collections import (
@@ -90,7 +91,7 @@ async def complete_user_onboarding(
     except HTTPException as e:
         raise e
     except Exception as e:
-        log.error(f"Error completing onboarding: {e!s}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error completing onboarding: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to complete onboarding")
 
 
@@ -134,7 +135,7 @@ async def reset_user_onboarding(user: dict = Depends(get_current_user)):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error resetting onboarding: {e!s}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error resetting onboarding: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to reset onboarding")
 
 
@@ -153,7 +154,7 @@ async def get_onboarding_status(user: dict = Depends(get_current_user)):
         log.set(onboarding={"operation": "get_status", "is_complete": is_complete})
         return status
     except Exception as e:
-        log.error(f"Error getting onboarding status: {e!s}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error getting onboarding status: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to get onboarding status")
 
 
@@ -175,10 +176,10 @@ async def update_onboarding_phase(
         )
 
         if not user_id or not isinstance(user_id, str):
-            log.error("[update_onboarding_phase] user_id is missing or not a string")
+            log.error(f"{LogTag.ONBOARDING} user_id is missing or not a string")
             raise HTTPException(status_code=400, detail="Invalid user_id")
 
-        log.info(f"[update_onboarding_phase] Updating phase to {phase} for user {user_id}")
+        log.info(f"{LogTag.ONBOARDING} Updating phase to {phase} for user {user_id}")
 
         result = await users_collection.update_one(
             {"_id": ObjectId(user_id)},
@@ -191,11 +192,11 @@ async def update_onboarding_phase(
         )
 
         if result.matched_count == 0:
-            log.warning(f"[update_onboarding_phase] No document found for user {user_id}")
+            log.warning(f"{LogTag.ONBOARDING} No document found for user {user_id}")
             raise HTTPException(status_code=404, detail="User not found")
 
         log.info(
-            f"[update_onboarding_phase] Successfully updated phase to {phase} for user {user_id}, modified_count={result.modified_count}"
+            f"{LogTag.ONBOARDING} Successfully updated phase to {phase} for user {user_id}, modified_count={result.modified_count}"
         )
 
         try:
@@ -206,11 +207,9 @@ async def update_onboarding_phase(
                     "data": {"phase": phase},
                 },
             )
-            log.info(
-                f"[update_onboarding_phase] Sent WebSocket notification for phase update to {phase}"
-            )
+            log.info(f"{LogTag.ONBOARDING} Sent WebSocket notification for phase update to {phase}")
         except Exception as ws_error:
-            log.warning(f"[update_onboarding_phase] Failed to send WebSocket update: {ws_error}")
+            log.warning(f"{LogTag.ONBOARDING} Failed to send WebSocket update: {ws_error}")
 
         return {
             "success": True,
@@ -221,7 +220,7 @@ async def update_onboarding_phase(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error updating onboarding phase: {e!s}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error updating onboarding phase: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update onboarding phase")
 
 
@@ -249,7 +248,7 @@ async def update_user_preferences(
     except HTTPException as e:
         raise e
     except Exception as e:
-        log.error(f"Error updating preferences: {e!s}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error updating preferences: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update preferences")
 
 
@@ -266,7 +265,7 @@ async def get_onboarding_personalization(user: dict = Depends(get_current_user))
             user={"id": user_id},
             onboarding={"operation": "get_personalization"},
         )
-        log.info(f"[get_onboarding_personalization] Fetching personalization for user {user_id}")
+        log.info(f"{LogTag.ONBOARDING} Fetching personalization for user {user_id}")
         user_doc = await users_collection.find_one({"_id": ObjectId(user_id)})
 
         if not user_doc:
@@ -276,7 +275,7 @@ async def get_onboarding_personalization(user: dict = Depends(get_current_user))
         user_bio = onboarding.get("user_bio", "")
         phase = onboarding.get("phase", "initial")
         log.info(
-            f"[get_onboarding_personalization] User {user_id} has phase: {phase}, bio_status: {onboarding.get('bio_status')}"
+            f"{LogTag.ONBOARDING} User {user_id} has phase: {phase}, bio_status: {onboarding.get('bio_status')}"
         )
         has_personalization = phase in [
             "personalization_complete",
@@ -322,7 +321,7 @@ async def get_onboarding_personalization(user: dict = Depends(get_current_user))
                             }
                         )
             except Exception as e:
-                log.error(f"Error fetching workflows: {e!s}", exc_info=True)
+                log.error(f"{LogTag.ONBOARDING} Error fetching workflows: {e!s}", exc_info=True)
 
         bio_status = onboarding.get("bio_status", "pending")
         display_bio = user_bio
@@ -378,7 +377,7 @@ async def get_onboarding_personalization(user: dict = Depends(get_current_user))
                 async for t in todo_cursor
             ]
         except Exception as e:
-            log.warning(f"Failed to fetch onboarding todos: {e}")
+            log.warning(f"{LogTag.ONBOARDING} Failed to fetch onboarding todos: {e}")
 
         return {
             "phase": phase,
@@ -409,7 +408,7 @@ async def get_onboarding_personalization(user: dict = Depends(get_current_user))
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error fetching personalization: {e!s}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error fetching personalization: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch personalization data")
 
 
@@ -438,7 +437,7 @@ async def save_writing_style(
         await save_user_edited_summary(user_id, request.edited_summary.strip())
         return {"success": True}
     except Exception as e:
-        log.error(f"[onboarding] Failed to save writing style: {e}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Failed to save writing style: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to save writing style")
 
 
@@ -465,7 +464,7 @@ async def regenerate_writing_style_example(
         return {"example": None}
     except Exception as e:
         log.error(
-            f"[onboarding] Failed to regenerate writing style example: {e}",
+            f"{LogTag.ONBOARDING} Failed to regenerate writing style example: {e}",
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="Failed to regenerate writing style example")
@@ -497,5 +496,5 @@ async def confirm_social_profiles(
         await save_confirmed_profiles(user_id, profiles)
         return {"success": True, "saved": len(profiles)}
     except Exception as e:
-        log.error(f"[onboarding] Failed to save social profiles: {e}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Failed to save social profiles: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to save social profiles")

--- a/apps/api/app/api/v1/endpoints/payments.py
+++ b/apps/api/app/api/v1/endpoints/payments.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.api.v1.middleware.rate_limiter import limiter
+from app.constants.log_tags import LogTag
 from app.models.payment_models import (
     CreateSubscriptionRequest,
     PaymentVerificationResponse,
@@ -30,7 +31,7 @@ async def get_plans_endpoint(request: Request, active_only: bool = True):
     try:
         return await payment_service.get_plans(active_only=active_only)
     except Exception as e:
-        log.error(f"Error getting plans: {e!s}")
+        log.error(f"{LogTag.PAYMENT} Error getting plans: {e!s}")
         raise HTTPException(status_code=500, detail="Failed to get plans")
 
 
@@ -60,7 +61,7 @@ async def create_subscription_endpoint(
             user_id, subscription_data.product_id, subscription_data.quantity
         )
     except Exception as e:
-        log.error(f"Error creating subscription: {e!s}")
+        log.error(f"{LogTag.PAYMENT} Error creating subscription: {e!s}")
         raise HTTPException(status_code=500, detail="Failed to create subscription")
 
 
@@ -83,7 +84,7 @@ async def verify_payment_endpoint(
         result = await payment_service.verify_payment_completion(user_id)
         return PaymentVerificationResponse(**result)
     except Exception as e:
-        log.error(f"Error verifying payment: {e!s}")
+        log.error(f"{LogTag.PAYMENT} Error verifying payment: {e!s}")
         raise HTTPException(status_code=500, detail="Failed to verify payment")
 
 
@@ -105,7 +106,7 @@ async def get_subscription_status_endpoint(
     try:
         return await payment_service.get_user_subscription_status(user_id)
     except Exception as e:
-        log.error(f"Error getting subscription status: {e!s}")
+        log.error(f"{LogTag.PAYMENT} Error getting subscription status: {e!s}")
         raise HTTPException(status_code=500, detail="Failed to get subscription status")
 
 
@@ -131,7 +132,7 @@ async def handle_dodo_webhook(
 
         # Verify webhook signature using Standard Webhooks library
         if not payment_webhook_service.verify_webhook_signature(payload, headers):
-            log.warning("Invalid webhook signature")
+            log.warning(f"{LogTag.PAYMENT} Invalid webhook signature")
             raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
         # Parse webhook data
@@ -148,7 +149,7 @@ async def handle_dodo_webhook(
         # Process the webhook with idempotency check using webhook_id
         result = await payment_webhook_service.process_webhook(webhook_data, webhook_id)
 
-        log.info(f"Webhook processed: {result.event_type} - {result.status}")
+        log.info(f"{LogTag.PAYMENT} Webhook processed: {result.event_type} - {result.status}")
         return {
             "status": "success",
             "event_type": result.event_type,
@@ -159,8 +160,8 @@ async def handle_dodo_webhook(
     except HTTPException:
         raise
     except json.JSONDecodeError:
-        log.error("Invalid JSON in webhook payload")
+        log.error(f"{LogTag.PAYMENT} Invalid JSON in webhook payload")
         raise HTTPException(status_code=400, detail="Invalid JSON payload")
     except Exception as e:
-        log.error(f"Error processing webhook: {e}")
+        log.error(f"{LogTag.PAYMENT} Error processing webhook: {e}")
         raise HTTPException(status_code=500, detail="Webhook processing failed")

--- a/apps/api/app/api/v1/endpoints/platform_auth.py
+++ b/apps/api/app/api/v1/endpoints/platform_auth.py
@@ -6,6 +6,7 @@ from fastapi.responses import RedirectResponse
 import httpx
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.services.platform_link_service import PlatformLinkService
 from shared.py.wide_events import log
 
@@ -141,7 +142,9 @@ async def _handle_platform_oauth_callback(
             )
 
             if token_response.status_code != 200:
-                log.error(f"{config.platform} token exchange failed: {token_response.text}")
+                log.error(
+                    f"{LogTag.API} {config.platform} token exchange failed: {token_response.text}"
+                )
                 return RedirectResponse(
                     url=_redirect_url(
                         settings.FRONTEND_URL, redirect_path, oauth_error="token_failed"
@@ -152,7 +155,7 @@ async def _handle_platform_oauth_callback(
 
             # Slack-specific error handling
             if config.platform == "slack" and not token_data.get("ok"):
-                log.error(f"Slack OAuth failed: {token_data.get('error')}")
+                log.error(f"{LogTag.API} Slack OAuth failed: {token_data.get('error')}")
                 return RedirectResponse(
                     url=_redirect_url(
                         settings.FRONTEND_URL, redirect_path, oauth_error="token_failed"
@@ -170,7 +173,9 @@ async def _handle_platform_oauth_callback(
                 )
 
                 if user_response.status_code != 200:
-                    log.error(f"{config.platform} user fetch failed: {user_response.text}")
+                    log.error(
+                        f"{LogTag.API} {config.platform} user fetch failed: {user_response.text}"
+                    )
                     return RedirectResponse(
                         url=_redirect_url(
                             settings.FRONTEND_URL,
@@ -198,7 +203,7 @@ async def _handle_platform_oauth_callback(
                 user_id, config.platform, platform_user_id, profile=profile or None
             )
             log.info(
-                f"{config.platform} account {platform_user_id} linked to user {user_id} via OAuth"
+                f"{LogTag.API} {config.platform} account {platform_user_id} linked to user {user_id} via OAuth"
             )
         except ValueError as e:
             error_msg = str(e)
@@ -211,7 +216,7 @@ async def _handle_platform_oauth_callback(
                         oauth_error="already_linked",
                     )
                 )
-            log.error(f"Failed to link account: {error_msg}")
+            log.error(f"{LogTag.API} Failed to link account: {error_msg}")
             return RedirectResponse(
                 url=_redirect_url(settings.FRONTEND_URL, redirect_path, oauth_error="failed")
             )
@@ -229,7 +234,7 @@ async def _handle_platform_oauth_callback(
 
     except Exception as e:
         log.set(outcome="failed")
-        log.error(f"{config.platform} OAuth callback error: {e!s}", exc_info=True)
+        log.error(f"{LogTag.API} {config.platform} OAuth callback error: {e!s}", exc_info=True)
         return RedirectResponse(
             url=_redirect_url(settings.FRONTEND_URL, redirect_path, oauth_error="failed")
         )

--- a/apps/api/app/api/v1/endpoints/reminders.py
+++ b/apps/api/app/api/v1/endpoints/reminders.py
@@ -10,6 +10,7 @@ from app.api.v1.dependencies.oauth_dependencies import (
     get_current_user,
     get_user_timezone_from_preferences,
 )
+from app.constants.log_tags import LogTag
 from app.decorators import tiered_rate_limit
 from app.models.reminder_models import (
     CreateReminderRequest,
@@ -89,7 +90,7 @@ async def create_reminder_endpoint(
         return ReminderResponse(**reminder.model_dump())
 
     except Exception as e:
-        log.error(f"Error creating reminder: {e}")
+        log.error(f"{LogTag.API} Error creating reminder: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create reminder",
@@ -143,7 +144,7 @@ async def get_reminder_endpoint(reminder_id: str, user: dict = Depends(get_curre
         return ReminderResponse(**reminder.model_dump())
 
     except Exception as e:
-        log.error(f"Error getting reminder {reminder_id}: {e}")
+        log.error(f"{LogTag.API} Error getting reminder {reminder_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve reminder",
@@ -218,7 +219,7 @@ async def update_reminder_endpoint(
         return ReminderResponse(**updated_reminder.model_dump())
 
     except Exception as e:
-        log.error(f"Error updating reminder {reminder_id}: {e}")
+        log.error(f"{LogTag.API} Error updating reminder {reminder_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update reminder",
@@ -260,7 +261,7 @@ async def cancel_reminder_endpoint(reminder_id: str, user: dict = Depends(get_cu
         log.set(outcome="success")
 
     except Exception as e:
-        log.error(f"Error cancelling reminder {reminder_id}: {e}")
+        log.error(f"{LogTag.API} Error cancelling reminder {reminder_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to cancel reminder",
@@ -317,7 +318,7 @@ async def list_reminders_endpoint(
         return [ReminderResponse(**reminder.model_dump()) for reminder in reminders]
 
     except Exception as e:
-        log.error(f"Error listing reminders for user {user_id}: {e}")
+        log.error(f"{LogTag.API} Error listing reminders for user {user_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reminders",
@@ -370,7 +371,7 @@ async def pause_reminder_endpoint(reminder_id: str, user: dict = Depends(get_cur
         return ReminderResponse(**updated_reminder.model_dump())
 
     except Exception as e:
-        log.error(f"Error pausing reminder {reminder_id}: {e}")
+        log.error(f"{LogTag.API} Error pausing reminder {reminder_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to pause reminder",
@@ -446,7 +447,7 @@ async def resume_reminder_endpoint(reminder_id: str, user: dict = Depends(get_cu
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error resuming reminder {reminder_id}: {e}")
+        log.error(f"{LogTag.API} Error resuming reminder {reminder_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to resume reminder",
@@ -481,5 +482,5 @@ async def validate_cron_endpoint(
         return result
 
     except Exception as e:
-        log.error(f"Error validating cron expression {expression}: {e}")
+        log.error(f"{LogTag.API} Error validating cron expression {expression}: {e}")
         return {"expression": expression, "valid": False, "error": str(e)}

--- a/apps/api/app/api/v1/endpoints/skills.py
+++ b/apps/api/app/api/v1/endpoints/skills.py
@@ -39,6 +39,7 @@ from app.agents.skills.targets import get_skill_targets
 from app.agents.workspace.skill_loader import load_builtin_skills
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.config.oauth_config import get_integration_by_id
+from app.constants.log_tags import LogTag
 from app.constants.skills import EXECUTOR_SUBAGENT_ID, EXECUTOR_TARGET_LABEL
 from app.decorators import tiered_rate_limit
 from app.services.integrations.user_integrations import get_connected_integration_ids
@@ -156,7 +157,7 @@ async def discover_skills_from_github(
             detail=str(e),
         )
     except Exception as e:
-        log.error(f"Error discovering skills from {repo}: {e}")
+        log.error(f"{LogTag.SKILLS} Error discovering skills from {repo}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to discover skills from repository",
@@ -233,7 +234,7 @@ async def install_skill_with_auto_discover(
             detail=str(e),
         ) from e
     except Exception as e:
-        log.error(f"Error installing skill from GitHub: {e}")
+        log.error(f"{LogTag.SKILLS} Error installing skill from GitHub: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to install skill from GitHub",
@@ -272,7 +273,7 @@ async def create_inline_skill_endpoint(
             detail=str(e),
         ) from e
     except Exception as e:
-        log.error(f"Error creating inline skill: {e}")
+        log.error(f"{LogTag.SKILLS} Error creating inline skill: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create skill",
@@ -318,7 +319,7 @@ async def update_skill_endpoint(
             detail=str(e),
         ) from e
     except Exception as e:
-        log.error(f"Error updating skill {skill_id}: {e}")
+        log.error(f"{LogTag.SKILLS} Error updating skill {skill_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update skill",
@@ -345,7 +346,7 @@ async def list_skills_endpoint(
         log.set(outcome="success")
         return SkillListResponse(skills=skills, total=len(skills))
     except Exception as e:
-        log.error(f"Error listing skills: {e}")
+        log.error(f"{LogTag.SKILLS} Error listing skills: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list skills",
@@ -372,7 +373,7 @@ async def get_skill_endpoint(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error getting skill {skill_id}: {e}")
+        log.error(f"{LogTag.SKILLS} Error getting skill {skill_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve skill",
@@ -391,7 +392,7 @@ async def enable_skill_endpoint(
         log.set(outcome="success")
         return {"success": success, "skill_id": skill_id, "enabled": True}
     except Exception as e:
-        log.error(f"Error enabling skill {skill_id}: {e}")
+        log.error(f"{LogTag.SKILLS} Error enabling skill {skill_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to enable skill",
@@ -410,7 +411,7 @@ async def disable_skill_endpoint(
         log.set(outcome="success")
         return {"success": success, "skill_id": skill_id, "enabled": False}
     except Exception as e:
-        log.error(f"Error disabling skill {skill_id}: {e}")
+        log.error(f"{LogTag.SKILLS} Error disabling skill {skill_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to disable skill",
@@ -435,7 +436,7 @@ async def uninstall_skill_endpoint(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error uninstalling skill {skill_id}: {e}")
+        log.error(f"{LogTag.SKILLS} Error uninstalling skill {skill_id}: {e}")
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to uninstall skill",

--- a/apps/api/app/api/v1/endpoints/todos.py
+++ b/apps/api/app/api/v1/endpoints/todos.py
@@ -12,6 +12,7 @@ from app.api.v1.dependencies.oauth_dependencies import (
     get_current_user,
     get_user_timezone_from_preferences,
 )
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import projects_collection, todos_collection
 from app.db.redis import delete_cache, get_cache, set_cache
 from app.db.utils import serialize_document
@@ -360,7 +361,7 @@ async def update_todo(
             try:
                 await tracked_todo_service.reschedule_execution(todo_id, updates.scheduled_at)
             except Exception as e:
-                log.warning(f"Failed to reschedule todo {todo_id} after update: {e}")
+                log.warning(f"{LogTag.TODO} Failed to reschedule todo {todo_id} after update: {e}")
 
         return updated_todo
     except ValueError as e:
@@ -830,7 +831,7 @@ async def update_subtask(
                     todo_id, subtask_id, updates.completed, user["user_id"]
                 )
             except Exception as e:
-                log.warning(f"Failed to sync subtask to goal: {e!s}")
+                log.warning(f"{LogTag.TODO} Failed to sync subtask to goal: {e!s}")
 
         return TodoResponse(**serialize_document(updated_todo))
     except ValueError as e:
@@ -948,7 +949,7 @@ async def toggle_subtask_completion(
                 todo_id, subtask_id, new_completed, user["user_id"]
             )
         except Exception as e:
-            log.warning(f"Failed to sync subtask to goal: {e!s}")
+            log.warning(f"{LogTag.TODO} Failed to sync subtask to goal: {e!s}")
 
         return TodoResponse(**serialize_document(updated_todo))
     except ValueError as e:

--- a/apps/api/app/api/v1/endpoints/user.py
+++ b/apps/api/app/api/v1/endpoints/user.py
@@ -17,6 +17,7 @@ from workos import WorkOSClient
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.config.settings import settings
 from app.constants.auth import WOS_SESSION_COOKIE
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.models.user_models import UserUpdateResponse
 from app.services.analytics_service import track_logout
@@ -130,7 +131,7 @@ async def update_user_name(
     except HTTPException as e:
         raise e
     except Exception as e:
-        log.error(f"Error updating user name: {e!s}", exc_info=True)
+        log.error(f"{LogTag.API} Error updating user name: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update name")
 
 
@@ -181,7 +182,7 @@ async def update_user_timezone(
     except HTTPException as e:
         raise e
     except Exception as e:
-        log.error(f"Error updating timezone: {e!s}", exc_info=True)
+        log.error(f"{LogTag.API} Error updating timezone: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update timezone")
 
 
@@ -242,7 +243,7 @@ async def get_public_holo_card(card_id: str):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error fetching holo card: {e!s}", exc_info=True)
+        log.error(f"{LogTag.API} Error fetching holo card: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch holo card data")
 
 
@@ -296,7 +297,7 @@ async def update_holo_card_colors(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error updating holo card colors: {e!s}", exc_info=True)
+        log.error(f"{LogTag.API} Error updating holo card colors: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update holo card colors")
 
 
@@ -331,7 +332,9 @@ async def logout(
             try:
                 track_logout(user_id=user_id or user_email, email=user_email)
             except Exception as analytics_error:
-                log.warning(f"Failed to track logout analytics for {user_email}: {analytics_error}")
+                log.warning(
+                    f"{LogTag.API} Failed to track logout analytics for {user_email}: {analytics_error}"
+                )
 
         logout_url = session.get_logout_url()
 
@@ -351,5 +354,5 @@ async def logout(
         return response
 
     except Exception as e:
-        log.error(f"Logout error: {e}")
+        log.error(f"{LogTag.API} Logout error: {e}")
         raise HTTPException(status_code=500, detail="Logout failed")

--- a/apps/api/app/api/v1/endpoints/webhook_composio.py
+++ b/apps/api/app/api/v1/endpoints/webhook_composio.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
+from app.constants.log_tags import LogTag
 from app.db.redis import redis_cache
 from app.models.webhook_models import ComposioWebhookEvent
 from app.services.triggers import get_handler_by_event
@@ -43,11 +44,13 @@ async def _process_webhook_event(handler: Any, event_data: ComposioWebhookEvent)
         )
     except TimeoutError:
         log.error(
-            f"Webhook background processing timed out after {_WEBHOOK_TASK_TIMEOUT}s "
+            f"{LogTag.COMPOSIO} Webhook background processing timed out after {_WEBHOOK_TASK_TIMEOUT}s "
             f"for {event_data.type}"
         )
     except Exception as e:
-        log.error(f"Webhook background processing failed for {event_data.type}: {e}")
+        log.error(
+            f"{LogTag.COMPOSIO} Webhook background processing failed for {event_data.type}: {e}"
+        )
 
 
 @router.post("/webhook/composio")
@@ -66,7 +69,7 @@ async def webhook_composio(request: Request) -> dict[str, str]:
             f"webhook:composio:{webhook_id}", "1", nx=True, ex=3600
         )
         if already_processed:
-            log.info(f"Duplicate webhook ignored: {webhook_id}")
+            log.info(f"{LogTag.COMPOSIO} Duplicate webhook ignored: {webhook_id}")
             return {"status": "success", "message": "Duplicate webhook ignored"}
 
     body = await request.json()
@@ -90,7 +93,7 @@ async def webhook_composio(request: Request) -> dict[str, str]:
     # Find handler for this event type
     handler = get_handler_by_event(event_data.type)
     if not handler:
-        log.debug(f"Unhandled webhook type: {event_data.type}")
+        log.debug(f"{LogTag.COMPOSIO} Unhandled webhook type: {event_data.type}")
         return {"status": "success", "message": "Webhook received"}
 
     # Fire-and-forget: return 200 immediately, process in background

--- a/apps/api/app/api/v1/endpoints/workflows.py
+++ b/apps/api/app/api/v1/endpoints/workflows.py
@@ -13,6 +13,7 @@ from app.api.v1.dependencies.oauth_dependencies import (
     get_user_timezone_from_preferences,
 )
 from app.api.v1.middleware.rate_limiter import limiter
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.decorators import tiered_rate_limit
 from app.models.workflow_execution_models import WorkflowExecutionsResponse
@@ -99,7 +100,7 @@ async def create_workflow(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
-        log.error(f"Error creating workflow: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error creating workflow: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create workflow",
@@ -125,7 +126,7 @@ async def list_workflows(request: Request, user: dict = Depends(get_current_user
         return WorkflowListResponse(workflows=workflows)
 
     except Exception as e:
-        log.error(f"Error listing workflows for user {user['user_id']}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error listing workflows for user {user['user_id']}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list workflows",
@@ -160,7 +161,7 @@ async def execute_workflow(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
-        log.error(f"Error executing workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error executing workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to execute workflow",
@@ -201,7 +202,7 @@ async def get_workflow_executions(
         )
         return result
     except Exception as e:
-        log.error(f"Error getting executions for workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error getting executions for workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get workflow executions",
@@ -231,7 +232,7 @@ async def get_workflow_status(workflow_id: str, user: dict = Depends(get_current
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:
-        log.error(f"Error getting workflow status {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error getting workflow status {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get workflow status",
@@ -272,7 +273,7 @@ async def activate_workflow(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error activating workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error activating workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to activate workflow",
@@ -307,7 +308,7 @@ async def deactivate_workflow(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error deactivating workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error deactivating workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to deactivate workflow",
@@ -346,7 +347,7 @@ async def regenerate_workflow_steps(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
-        log.error(f"Error regenerating workflow steps: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error regenerating workflow steps: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to regenerate workflow steps",
@@ -405,7 +406,7 @@ async def create_workflow_from_todo(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error creating workflow from todo: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error creating workflow from todo: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create workflow from todo",
@@ -469,7 +470,7 @@ async def publish_workflow(
             )
 
         log.set(outcome="success")
-        log.info(f"Published workflow {workflow_id} by user {user['user_id']}")
+        log.info(f"{LogTag.WORKFLOW} Published workflow {workflow_id} by user {user['user_id']}")
 
         return PublishWorkflowResponse(
             message="Workflow published successfully",
@@ -480,7 +481,7 @@ async def publish_workflow(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error publishing workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error publishing workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to publish workflow",
@@ -519,14 +520,14 @@ async def unpublish_workflow(
         )
 
         log.set(outcome="success")
-        log.info(f"Unpublished workflow {workflow_id} by user {user['user_id']}")
+        log.info(f"{LogTag.WORKFLOW} Unpublished workflow {workflow_id} by user {user['user_id']}")
 
         return {"message": "Workflow unpublished successfully"}
 
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error unpublishing workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error unpublishing workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to unpublish workflow",
@@ -545,7 +546,7 @@ async def get_explore_workflows(
     try:
         return await WorkflowService.get_explore_workflows(limit=limit, offset=offset)
     except Exception as e:
-        log.error(f"Error fetching explore workflows: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error fetching explore workflows: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to fetch explore workflows",
@@ -566,7 +567,7 @@ async def get_public_workflows(
             limit=limit, offset=offset, user_id=None
         )
     except Exception as e:
-        log.error(f"Error fetching public workflows: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error fetching public workflows: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to fetch public workflows",
@@ -598,7 +599,9 @@ async def get_public_workflow(request: Request, workflow_ref: str):
             break
 
         if not workflow_doc:
-            log.info(f"get_public_workflow: no public workflow for ref={workflow_ref}")
+            log.info(
+                f"{LogTag.WORKFLOW} get_public_workflow: no public workflow for ref={workflow_ref}"
+            )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Public workflow not found",
@@ -626,7 +629,7 @@ async def get_public_workflow(request: Request, workflow_ref: str):
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error getting public workflow {workflow_ref}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error getting public workflow {workflow_ref}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get workflow",
@@ -654,7 +657,7 @@ async def generate_workflow_prompt_endpoint(
         log.set(outcome="success")
         return GenerateWorkflowPromptResponse(**result)
     except Exception as e:
-        log.error(f"Error generating workflow prompt: {e}")
+        log.error(f"{LogTag.WORKFLOW} Error generating workflow prompt: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to generate workflow prompt",
@@ -693,7 +696,7 @@ async def get_workflow(request: Request, workflow_id: str, user: dict = Depends(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error getting workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error getting workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get workflow",
@@ -735,7 +738,7 @@ async def update_workflow(
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error updating workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error updating workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update workflow",
@@ -773,7 +776,7 @@ async def reset_workflow_to_default(workflow_id: str, user: dict = Depends(get_c
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error resetting workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error resetting workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to reset workflow",
@@ -802,7 +805,7 @@ async def delete_workflow(workflow_id: str, user: dict = Depends(get_current_use
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error deleting workflow {workflow_id}: {e!s}")
+        log.error(f"{LogTag.WORKFLOW} Error deleting workflow {workflow_id}: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete workflow",

--- a/apps/api/app/api/v1/middleware/auth.py
+++ b/apps/api/app/api/v1/middleware/auth.py
@@ -12,6 +12,7 @@ from workos import AsyncWorkOSClient
 
 from app.api.v1.middleware.agent_auth import verify_agent_token
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.utils.auth_utils import authenticate_workos_session, build_user_context
 from shared.py.wide_events import log
@@ -103,7 +104,7 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
 
             except Exception as e:
                 log.error(
-                    "auth_middleware_error",
+                    f"{LogTag.API} auth_middleware_error",
                     auth_failure=type(e).__name__,
                     path=request.url.path,
                     method=request.method,
@@ -127,7 +128,7 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
                     try:
                         user_id = ObjectId(user_id)
                     except Exception as e:
-                        log.error(f"Invalid user_id format: {user_id} - {e}")
+                        log.error(f"{LogTag.API} Invalid user_id format: {user_id} - {e}")
                         user_data = None
                     else:
                         user_data = await users_collection.find_one({"_id": user_id})
@@ -179,5 +180,5 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
             )
             return user_info, new_session
         except Exception as e:
-            log.error(f"Error in middleware additional processing: {e}")
+            log.error(f"{LogTag.API} Error in middleware additional processing: {e}")
             return None, new_session

--- a/apps/api/app/api/v1/middleware/profiling.py
+++ b/apps/api/app/api/v1/middleware/profiling.py
@@ -13,6 +13,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # Import pyinstrument with fallback
@@ -23,9 +24,9 @@ try:
 
     Profiler = _Profiler
     PYINSTRUMENT_AVAILABLE = True
-    log.info("PyInstrument profiling available")
+    log.info(f"{LogTag.API} PyInstrument profiling available")
 except ImportError:
-    log.info("PyInstrument not available. Profiling will be disabled.")
+    log.info(f"{LogTag.API} PyInstrument not available. Profiling will be disabled.")
 
 
 class ProfilingMiddleware(BaseHTTPMiddleware):
@@ -54,15 +55,17 @@ class ProfilingMiddleware(BaseHTTPMiddleware):
     def _log_startup_info(self):
         """Log profiling configuration at startup."""
         if not PYINSTRUMENT_AVAILABLE:
-            log.warning("PyInstrument profiling is not available (package not installed)")
+            log.warning(
+                f"{LogTag.API} PyInstrument profiling is not available (package not installed)"
+            )
             return
 
         if settings.ENABLE_PROFILING:
             log.info(
-                f"PyInstrument profiling enabled: sample_rate={settings.PROFILING_SAMPLE_RATE}"
+                f"{LogTag.API} PyInstrument profiling enabled: sample_rate={settings.PROFILING_SAMPLE_RATE}"
             )
         else:
-            log.info("PyInstrument profiling disabled (ENABLE_PROFILING=false)")
+            log.info(f"{LogTag.API} PyInstrument profiling disabled (ENABLE_PROFILING=false)")
 
     async def dispatch(self, request: Request, call_next) -> Response:
         # Check if profiling is available and enabled
@@ -101,17 +104,21 @@ class ProfilingMiddleware(BaseHTTPMiddleware):
                 # Get text output for logging
                 text_output = profiler.output_text()
                 log.info(
-                    f"Profiling Results for {request.method} {request.url.path}:\n{text_output}"
+                    f"{LogTag.API} Profiling Results for {request.method} {request.url.path}:\n{text_output}"
                 )
             except Exception as profile_error:
                 log.warning(
-                    f"Could not generate profiling output for {request.method} {request.url.path}: {profile_error}"
+                    f"{LogTag.API} Could not generate profiling output for {request.method} {request.url.path}: {profile_error}"
                 )
-                log.info(f"Profiled {request.method} {request.url.path} (output generation failed)")
+                log.info(
+                    f"{LogTag.API} Profiled {request.method} {request.url.path} (output generation failed)"
+                )
             return response
 
         except Exception as e:
             profiler.stop()
-            log.exception(f"Profiling error during {request.method} {request.url.path}: {e!s}")
+            log.exception(
+                f"{LogTag.API} Profiling error during {request.method} {request.url.path}: {e!s}"
+            )
             # Always return the original response on error
             return await call_next(request)

--- a/apps/api/app/api/v1/middleware/tiered_rate_limiter.py
+++ b/apps/api/app/api/v1/middleware/tiered_rate_limiter.py
@@ -28,6 +28,7 @@ from app.config.rate_limits import (
     get_reset_time,
     get_time_window_key,
 )
+from app.constants.log_tags import LogTag
 from app.db.redis import redis_cache
 from app.models.payment_models import PlanType
 from app.models.usage_models import (
@@ -225,7 +226,7 @@ class TieredRateLimiter:
         except Exception as e:
             # Log error but don't raise - this shouldn't break the main request
             log.error(
-                f"Real-time usage sync failed for user {user_id}, feature {feature_key}: {e!s}"
+                f"{LogTag.API} Real-time usage sync failed for user {user_id}, feature {feature_key}: {e!s}"
             )
 
     async def _collect_feature_usage(self, user_id: str, user_plan: PlanType) -> list[FeatureUsage]:

--- a/apps/api/app/api/v1/middleware/timeout.py
+++ b/apps/api/app/api/v1/middleware/timeout.py
@@ -14,6 +14,7 @@ import anyio
 from fastapi.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 TIMEOUT_EXCLUDE_PREFIXES: tuple[str, ...] = (
@@ -78,6 +79,6 @@ class RequestTimeoutMiddleware:
                 await response(scope, receive, send)
             else:
                 log.warning(
-                    f"Request to {path} timed out after {self.timeout}s "
+                    f"{LogTag.API} Request to {path} timed out after {self.timeout}s "
                     "but response already started — connection may be broken"
                 )

--- a/apps/api/app/config/model_pricing.py
+++ b/apps/api/app/config/model_pricing.py
@@ -5,6 +5,7 @@ Uses model_service to fetch models with caching support.
 
 from typing import NamedTuple
 
+from app.constants.log_tags import LogTag
 from app.services.model_service import get_model_by_id
 from shared.py.wide_events import log
 
@@ -61,7 +62,7 @@ async def get_model_pricing(model_name: str) -> ModelPricing:
         return DEFAULT_PRICING
 
     except Exception as e:
-        log.error(f"Error fetching pricing for model {model_name}: {e}")
+        log.error(f"{LogTag.STARTUP} Error fetching pricing for model {model_name}: {e}")
         return DEFAULT_PRICING
 
 

--- a/apps/api/app/config/sentry.py
+++ b/apps/api/app/config/sentry.py
@@ -6,6 +6,7 @@ from loguru import logger as _loguru
 import sentry_sdk
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -51,10 +52,10 @@ def init_sentry():
     """Initialize Sentry error tracking if DSN is configured."""
 
     if not settings.SENTRY_DSN:
-        log.info("SENTRY_DSN is not configured, skipping Sentry initialization.")
+        log.info(f"{LogTag.STARTUP} SENTRY_DSN is not configured, skipping Sentry initialization.")
         return
 
-    log.info("SENTRY_DSN is configured, initializing Sentry.")
+    log.info(f"{LogTag.STARTUP} SENTRY_DSN is configured, initializing Sentry.")
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         # Add data like request headers and IP for users,

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -24,6 +24,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.config.secrets import inject_infisical_secrets
 from app.config.settings_validator import settings_validator
+from app.constants.log_tags import LogTag
 from app.constants.search import (
     CRAWL4AI_DEFAULT_MAX_BROWSERS,
     CRAWL4AI_MIN_MAX_BROWSERS,
@@ -53,7 +54,7 @@ class BaseAppSettings(BaseSettings):
         try:
             return cls(**kwargs)
         except Exception as e:
-            log.warning(f"Error creating settings: {e!s}")
+            log.warning(f"{LogTag.STARTUP} Error creating settings: {e!s}")
             # Create a minimal instance with empty strings for required fields,
             # but skip fields that already have env vars set or have defaults.
             fields = cls.model_fields
@@ -577,7 +578,9 @@ def _ensure_infisical_loaded():
     if not _infisical_secrets_loaded:
         infisical_start = time.time()
         inject_infisical_secrets()
-        log.info(f"Infisical secrets loaded in {(time.time() - infisical_start):.3f}s")
+        log.info(
+            f"{LogTag.STARTUP} Infisical secrets loaded in {(time.time() - infisical_start):.3f}s"
+        )
         _infisical_secrets_loaded = True
 
 
@@ -590,7 +593,7 @@ def get_settings():
     avoiding expensive Pydantic validation on every import.
     """
     log.set(service={"name": "gaia-api"})
-    log.info("Starting settings initialization...")
+    log.info(f"{LogTag.STARTUP} Starting settings initialization...")
 
     _ensure_infisical_loaded()
 
@@ -602,7 +605,7 @@ def get_settings():
             settings_obj = DevelopmentSettings.from_env()
         else:
             settings_obj = ProductionSettings.from_env()
-            log.info("Production settings initialized")
+            log.info(f"{LogTag.STARTUP} Production settings initialized")
 
         # Validate settings after full initialization
         settings_validator.configure(
@@ -617,12 +620,12 @@ def get_settings():
         return settings_obj
 
     except Exception as e:
-        log.error(f"Error initializing settings: {e!s}")
+        log.error(f"{LogTag.STARTUP} Error initializing settings: {e!s}")
         # In case of error, we still need to return a settings object
         # Use development settings with defaults as fallback
         if env == "development":
             return DevelopmentSettings.from_env(SHOW_MISSING_KEY_WARNINGS=True)
-        log.critical("Critical error initializing production settings!")
+        log.critical(f"{LogTag.STARTUP} Critical error initializing production settings!")
         raise
 
 

--- a/apps/api/app/config/settings_validator.py
+++ b/apps/api/app/config/settings_validator.py
@@ -19,6 +19,7 @@ Add env vars
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -375,7 +376,7 @@ class SettingsValidator:
             if group.affected_features:
                 warning_msg += f"\n  → Affected: {group.affected_features}"
 
-            log.warning(warning_msg)
+            log.warning(f"{LogTag.STARTUP} {warning_msg}")
 
 
 settings_validator = SettingsValidator()

--- a/apps/api/app/config/token_repository.py
+++ b/apps/api/app/config/token_repository.py
@@ -19,6 +19,7 @@ import httpx
 from sqlalchemy import select, update
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.db.postgresql import get_db_session
 from app.models.db_oauth import OAuthToken
 from shared.py.wide_events import log
@@ -40,7 +41,9 @@ class TokenRepository:
         # Initialize supported providers
         self._init_oauth_clients()
 
-        log.info("Token repository initialized for managing API tokens (Google, etc.)")
+        log.info(
+            f"{LogTag.STARTUP} Token repository initialized for managing API tokens (Google, etc.)"
+        )
 
     def _init_oauth_clients(self):
         """Initialize OAuth clients for all supported providers."""
@@ -56,9 +59,11 @@ class TokenRepository:
                     "prompt": "select_account",
                 },
             )
-            log.info("Google OAuth client registered")
+            log.info(f"{LogTag.STARTUP} Google OAuth client registered")
         else:
-            log.warning("Google OAuth credentials not found, client not registered")
+            log.warning(
+                f"{LogTag.STARTUP} Google OAuth credentials not found, client not registered"
+            )
 
     def _get_token_expiration(self, token_data: dict) -> datetime:
         """Get token expiration time with fallback logic."""
@@ -69,7 +74,7 @@ class TokenRepository:
             try:
                 return datetime.fromtimestamp(float(expires_at), UTC)
             except (ValueError, TypeError, OverflowError):
-                log.warning(f"Invalid expires_at: {expires_at}")
+                log.warning(f"{LogTag.STARTUP} Invalid expires_at: {expires_at}")
 
         # Fall back to expires_in
         expires_in = token_data.get("expires_in", 3500)  # Default about 1 hour
@@ -77,7 +82,7 @@ class TokenRepository:
             expires_in = float(expires_in)
             return datetime.now(UTC) + timedelta(seconds=expires_in)
         except (ValueError, TypeError):
-            log.warning(f"Invalid expires_in: {expires_in}, using default")
+            log.warning(f"{LogTag.STARTUP} Invalid expires_in: {expires_in}, using default")
             return datetime.now(UTC) + timedelta(seconds=3600)
 
     async def store_token(
@@ -231,7 +236,7 @@ class TokenRepository:
         """
 
         if not self.oauth.google:
-            log.error("Google OAuth client not properly initialized")
+            log.error(f"{LogTag.STARTUP} Google OAuth client not properly initialized")
             return None
 
         client = self.oauth.google
@@ -253,7 +258,7 @@ class TokenRepository:
                 )
 
             if response.status_code != 200:
-                log.error(f"Failed to refresh token: {response.text}")
+                log.error(f"{LogTag.STARTUP} Failed to refresh token: {response.text}")
                 return None
 
             token_data = response.json()
@@ -265,7 +270,7 @@ class TokenRepository:
             # Create OAuth2Token from response
             return OAuth2Token(token_data)
         except Exception as e:
-            log.error(f"Error refreshing Google token: {e!s}")
+            log.error(f"{LogTag.STARTUP} Error refreshing Google token: {e!s}")
             return None
 
     async def _refresh_provider_token(
@@ -284,7 +289,7 @@ class TokenRepository:
         if provider == "google":
             return await self._refresh_google_token(refresh_token)
         # Add more providers as needed
-        log.error(f"Provider {provider} not supported for token refresh")
+        log.error(f"{LogTag.STARTUP} Provider {provider} not supported for token refresh")
         return None
 
     async def refresh_token(self, user_id: str, provider: str) -> OAuth2Token | None:
@@ -307,24 +312,28 @@ class TokenRepository:
             token_record = result.scalar_one_or_none()
 
             if not token_record:
-                log.warning(f"Cannot refresh token: No {provider} token found for user {user_id}")
+                log.warning(
+                    f"{LogTag.STARTUP} Cannot refresh token: No {provider} token found for user {user_id}"
+                )
                 return None
 
             # Check if refresh token is available
             refresh_token = token_record.refresh_token
             if not refresh_token:
                 log.warning(
-                    f"Cannot refresh token: No refresh token for user {user_id} and provider {provider}"
+                    f"{LogTag.STARTUP} Cannot refresh token: No refresh token for user {user_id} and provider {provider}"
                 )
                 return None
 
             # Refresh the token using the appropriate provider handler
             try:
-                log.info(f"Refreshing {provider} token for user {user_id}")
+                log.info(f"{LogTag.STARTUP} Refreshing {provider} token for user {user_id}")
                 token = await self._refresh_provider_token(provider, refresh_token)
 
                 if not token:
-                    log.error(f"Failed to refresh {provider} token for user {user_id}")
+                    log.error(
+                        f"{LogTag.STARTUP} Failed to refresh {provider} token for user {user_id}"
+                    )
                     return None
 
                 # Convert OAuth2Token to a dictionary we can store
@@ -346,11 +355,13 @@ class TokenRepository:
                 # without querying the database again
                 refreshed_token = await self.store_token(user_id, provider, token_dict)
 
-                log.info(f"Successfully refreshed {provider} token for user {user_id}")
+                log.info(
+                    f"{LogTag.STARTUP} Successfully refreshed {provider} token for user {user_id}"
+                )
 
                 return refreshed_token
             except Exception as e:
-                log.error(f"Error refreshing {provider} token: {e!s}")
+                log.error(f"{LogTag.STARTUP} Error refreshing {provider} token: {e!s}")
                 return None
 
     async def revoke_token(self, user_id: str, provider: str) -> bool:
@@ -374,17 +385,21 @@ class TokenRepository:
             token_record = result.scalar_one_or_none()
 
             if not token_record:
-                log.warning(f"Cannot revoke token: No {provider} token found for user {user_id}")
+                log.warning(
+                    f"{LogTag.STARTUP} Cannot revoke token: No {provider} token found for user {user_id}"
+                )
                 return False
 
             try:
                 # Delete the token record
                 await session.delete(token_record)
                 await session.commit()
-                log.info(f"Successfully revoked {provider} token for user {user_id}")
+                log.info(
+                    f"{LogTag.STARTUP} Successfully revoked {provider} token for user {user_id}"
+                )
                 return True
             except Exception as e:
-                log.error(f"Error revoking token: {e!s}")
+                log.error(f"{LogTag.STARTUP} Error revoking token: {e!s}")
                 await session.rollback()
                 return False
 
@@ -423,7 +438,7 @@ class TokenRepository:
 
             # Log token status for debugging
             log.debug(
-                f"Token expiry status - is_expired: {oauth_token.is_expired()}, will_renew: {renew_if_expired}"
+                f"{LogTag.STARTUP} Token expiry status - is_expired: {oauth_token.is_expired()}, will_renew: {renew_if_expired}"
             )
 
             # Check if token is expired

--- a/apps/api/app/constants/log_tags.py
+++ b/apps/api/app/constants/log_tags.py
@@ -1,0 +1,59 @@
+"""Greppable log-line prefixes.
+
+A single registry of bracketed, uppercase tags prepended to real-time log
+messages (``log.info`` / ``log.warning`` / ``log.error`` / ``log.debug``) so one
+subsystem's activity can be filtered with a single token — ``grep '\\[SANDBOX\\]'``
+locally or ``|= "[SANDBOX]"`` in LogQL.
+
+This is the cross-cutting counterpart to ``FsOps`` (which centralizes latency-
+metric op names): one canonical home so prefixes never drift or collide across
+files. Add a subsystem's tag here, then prefix that subsystem's log lines with
+it — never inline a bare ``"[foo]"`` literal at the call site.
+
+A tag annotates the human-readable *message*. Structured business context still
+belongs in ``log.set(...)`` wide-event fields (see the ``*Context`` TypedDicts in
+``shared.py.wide_events``), not in the prefix.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+class LogTag:
+    """Stable, greppable prefixes for real-time log lines, one per subsystem."""
+
+    # --- Agent runtime ---
+    AGENT: Final[str] = "[AGENT]"  # agents/core, middleware, llm, prompts, workspace
+    TOOL: Final[str] = "[TOOL]"  # agents/tools/* (generic; specific tools below)
+    MEMORY: Final[str] = "[MEMORY]"  # agents/memory + memory tools/services
+    SKILLS: Final[str] = "[SKILLS]"  # agents/skills
+
+    # --- Coding sandbox subsystem ---
+    SANDBOX: Final[str] = "[SANDBOX]"
+    ARTIFACT_WATCHER: Final[str] = "[ARTIFACT-WATCHER]"
+
+    # --- External integrations ---
+    MCP: Final[str] = "[MCP]"  # services/mcp
+    INTEGRATION: Final[str] = "[INTEGRATION]"  # services/integrations
+    OAUTH: Final[str] = "[OAUTH]"  # services/oauth
+    COMPOSIO: Final[str] = "[COMPOSIO]"  # services/composio, utils/composio_hooks
+    TRIGGER: Final[str] = "[TRIGGER]"  # services/triggers
+    MAIL: Final[str] = "[MAIL]"  # services/mail
+
+    # --- Product domains ---
+    CHAT: Final[str] = "[CHAT]"  # services/chat
+    WORKFLOW: Final[str] = "[WORKFLOW]"  # services/workflow, system_workflows, utils
+    ONBOARDING: Final[str] = "[ONBOARDING]"  # services/onboarding
+    TODO: Final[str] = "[TODO]"  # services/todos
+    PAYMENT: Final[str] = "[PAYMENT]"  # services/payments
+    NOTIFICATION: Final[str] = "[NOTIFICATION]"  # utils/notification
+    DESKTOP: Final[str] = "[DESKTOP]"  # services/desktop
+
+    # --- Infra / platform ---
+    API: Final[str] = "[API]"  # api/v1 endpoints + middleware (HTTP layer)
+    WORKER: Final[str] = "[WORKER]"  # workers/tasks, workers/lifecycle
+    STORAGE: Final[str] = "[STORAGE]"  # services/storage (JuiceFS, sessions, vfs)
+    MONGO: Final[str] = "[MONGO]"  # db/mongodb
+    CHROMA: Final[str] = "[CHROMA]"  # db/chroma (vector store)
+    STARTUP: Final[str] = "[STARTUP]"  # app boot / provider registration / lifespan

--- a/apps/api/app/core/lazy_loader.py
+++ b/apps/api/app/core/lazy_loader.py
@@ -28,6 +28,7 @@ from typing import (
     cast,
 )
 
+from app.constants.log_tags import LogTag
 from app.utils.exceptions import ConfigurationError
 from shared.py.wide_events import log
 
@@ -104,17 +105,19 @@ class LazyLoader(Generic[T]):
                     # For async functions, we can't auto-initialize during __init__
                     # Log a message and defer initialization to first get() call
                     log.info(
-                        f"Async provider '{self.provider_name}' will be auto-initialized on first access"
+                        f"{LogTag.STARTUP} Async provider '{self.provider_name}' will be auto-initialized on first access"
                     )
                 else:
                     self._initialize_sync()
                     log.info(
-                        f"Auto-initialized provider '{self.provider_name}' at registration time"
+                        f"{LogTag.STARTUP} Auto-initialized provider '{self.provider_name}' at registration time"
                     )
             except Exception as e:
                 if self.strategy == MissingKeyStrategy.ERROR:
                     raise
-                log.warning(f"Auto-initialization failed for '{self.provider_name}': {e}")
+                log.warning(
+                    f"{LogTag.STARTUP} Auto-initialization failed for '{self.provider_name}': {e}"
+                )
 
     def _check_availability_and_warn(self):
         """Check availability at registration time and log warnings if needed."""
@@ -226,7 +229,9 @@ class LazyLoader(Generic[T]):
                 # For global context providers, call the function for side effects
                 self.loader_func()
                 self._is_configured = True
-                log.info(f"Successfully configured global provider: {self.provider_name}")
+                log.info(
+                    f"{LogTag.STARTUP} Successfully configured global provider: {self.provider_name}"
+                )
                 return True  # type: ignore[return-value]
             # For instance-based providers, store and return the instance
             result = self.loader_func()
@@ -235,12 +240,12 @@ class LazyLoader(Generic[T]):
                     f"Sync initialization called on async loader function for '{self.provider_name}'"
                 )
             self._instance = cast(T, result)
-            log.info(f"Successfully initialized provider: {self.provider_name}")
+            log.info(f"{LogTag.STARTUP} Successfully initialized provider: {self.provider_name}")
             return self._instance
 
         except Exception as e:
             error_msg = f"Failed to initialize provider '{self.provider_name}': {e!s}"
-            log.error(error_msg)
+            log.error(f"{LogTag.STARTUP} {error_msg}")
 
             if self.strategy == MissingKeyStrategy.ERROR:
                 raise ConfigurationError(error_msg) from e
@@ -276,7 +281,9 @@ class LazyLoader(Generic[T]):
                             f"Unexpected coroutine from sync loader function for '{self.provider_name}'"
                         )
                 self._is_configured = True
-                log.info(f"Successfully configured global provider: {self.provider_name}")
+                log.info(
+                    f"{LogTag.STARTUP} Successfully configured global provider: {self.provider_name}"
+                )
                 return True  # type: ignore[return-value]
             # For instance-based providers, store and return the instance
             if self.is_async:
@@ -294,12 +301,12 @@ class LazyLoader(Generic[T]):
                         f"Unexpected coroutine from sync loader function for '{self.provider_name}'"
                     )
                 self._instance = cast(T, result)
-            log.info(f"Successfully initialized provider: {self.provider_name}")
+            log.info(f"{LogTag.STARTUP} Successfully initialized provider: {self.provider_name}")
             return self._instance
 
         except Exception as e:
             error_msg = f"Failed to initialize provider '{self.provider_name}': {e!s}"
-            log.error(error_msg)
+            log.error(f"{LogTag.STARTUP} {error_msg}")
 
             if self.strategy == MissingKeyStrategy.ERROR:
                 raise ConfigurationError(error_msg) from e
@@ -345,7 +352,7 @@ class LazyLoader(Generic[T]):
 
     def _log_warning(self, message: str):
         """Log warning message."""
-        log.warning(f"[LazyLoader] {message}")
+        log.warning(f"{LogTag.STARTUP} [LazyLoader] {message}")
 
     def is_available(self) -> bool:
         """Check if the provider is available without initializing it."""
@@ -439,7 +446,7 @@ class ProviderRegistry:
         """Register a new provider."""
         with self._lock:
             if name in self._providers:
-                log.warning(f"Provider '{name}' is being re-registered")
+                log.warning(f"{LogTag.STARTUP} Provider '{name}' is being re-registered")
 
             provider = LazyLoader(
                 loader_func=loader_func,
@@ -493,7 +500,7 @@ class ProviderRegistry:
                         return
 
                     await self.aget(name)
-                    log.info(f"Auto-initialized provider '{name}'")
+                    log.info(f"{LogTag.STARTUP} Auto-initialized provider '{name}'")
                 except asyncio.CancelledError:
                     # Propagate cancellation so shutdown can stop warmup promptly.
                     raise
@@ -502,9 +509,11 @@ class ProviderRegistry:
                     provider = self._providers.get(name)
                     provider_strategy = provider.strategy if provider else MissingKeyStrategy.WARN
                     if provider_strategy == MissingKeyStrategy.ERROR:
-                        log.error(f"Auto-initialization failed for '{name}': {e}")
+                        log.error(f"{LogTag.STARTUP} Auto-initialization failed for '{name}': {e}")
                     else:
-                        log.warning(f"Auto-initialization failed for '{name}': {e}")
+                        log.warning(
+                            f"{LogTag.STARTUP} Auto-initialization failed for '{name}': {e}"
+                        )
 
         with self._lock:
             names = [name for name in self._auto_init_providers if name in self._providers]
@@ -512,7 +521,7 @@ class ProviderRegistry:
             return
 
         await asyncio.gather(*[_init_provider(name) for name in names])
-        log.info(f"Completed auto-initialization for {len(names)} providers")
+        log.info(f"{LogTag.STARTUP} Completed auto-initialization for {len(names)} providers")
 
         if strict and errors:
             failed = ", ".join(name for name, _ in errors)
@@ -566,7 +575,7 @@ class ProviderRegistry:
                     raise
                 except Exception as e:
                     errors.append((name, e))
-                    log.error(f"Provider warmup failed for '{name}': {e}")
+                    log.error(f"{LogTag.STARTUP} Provider warmup failed for '{name}': {e}")
 
         if not warmup_names:
             if strict and errors:
@@ -578,12 +587,12 @@ class ProviderRegistry:
 
         if errors:
             log.warning(
-                f"Provider warmup completed with {len(errors)} errors "
+                f"{LogTag.STARTUP} Provider warmup completed with {len(errors)} errors "
                 f"({skipped_unavailable} unavailable providers skipped)"
             )
         else:
             log.info(
-                f"Provider warmup completed for {len(warmup_names)} providers "
+                f"{LogTag.STARTUP} Provider warmup completed for {len(warmup_names)} providers "
                 f"({skipped_unavailable} unavailable providers skipped)"
             )
 

--- a/apps/api/app/core/lifespan.py
+++ b/apps/api/app/core/lifespan.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.constants.log_tags import LogTag
 from app.core.provider_registration import (
     unified_shutdown,
     unified_startup,
@@ -24,7 +25,7 @@ async def lifespan(app: FastAPI):
         yield
 
     except Exception as e:
-        log.error(f"Error during startup: {e}")
+        log.error(f"{LogTag.STARTUP} Error during startup: {e}")
         raise RuntimeError("Startup failed") from e
 
     finally:

--- a/apps/api/app/core/provider_registration.py
+++ b/apps/api/app/core/provider_registration.py
@@ -40,6 +40,7 @@ from app.config.cloudinary import init_cloudinary
 from app.config.langfuse import init_langfuse
 from app.config.posthog import init_posthog
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.constants.startup import (
     AUTO_PROVIDER_CONCURRENCY,
     PROD_PROVIDER_WARMUP_CONCURRENCY,
@@ -101,15 +102,15 @@ def _spawn_background_task(
     """
 
     async def _runner() -> None:
-        log.info(f"Background init started: {name}")
+        log.info(f"{LogTag.STARTUP} Background init started: {name}")
         try:
             await coro_factory()
-            log.info(f"Background init finished: {name}")
+            log.info(f"{LogTag.STARTUP} Background init finished: {name}")
         except asyncio.CancelledError:
-            log.info(f"Background init cancelled: {name}")
+            log.info(f"{LogTag.STARTUP} Background init cancelled: {name}")
             raise
         except Exception as e:
-            log.error(f"Background init failed: {name}: {e}")
+            log.error(f"{LogTag.STARTUP} Background init failed: {name}: {e}")
 
     task = asyncio.create_task(_runner(), name=f"warmup:{name}")
     _background_tasks.append(task)
@@ -140,24 +141,26 @@ def _spawn_background_services(
         for i, result in enumerate(results):
             if isinstance(result, Exception):
                 failed += 1
-                log.error(f"Background init failed ({service_names[i]}): {result}")
+                log.error(f"{LogTag.STARTUP} Background init failed ({service_names[i]}): {result}")
 
         if failed:
-            log.warning(f"Background init completed with {failed}/{len(services)} failures")
+            log.warning(
+                f"{LogTag.STARTUP} Background init completed with {failed}/{len(services)} failures"
+            )
         else:
-            log.info(f"Background init completed: {len(services)} services")
+            log.info(f"{LogTag.STARTUP} Background init completed: {len(services)} services")
 
         if after is not None:
             followup_name = after_name or "followup"
-            log.info(f"Background init started: {followup_name}")
+            log.info(f"{LogTag.STARTUP} Background init started: {followup_name}")
             try:
                 await after()
-                log.info(f"Background init finished: {followup_name}")
+                log.info(f"{LogTag.STARTUP} Background init finished: {followup_name}")
             except asyncio.CancelledError:
-                log.info(f"Background init cancelled: {followup_name}")
+                log.info(f"{LogTag.STARTUP} Background init cancelled: {followup_name}")
                 raise
             except Exception as e:
-                log.error(f"Background init failed: {followup_name}: {e}")
+                log.error(f"{LogTag.STARTUP} Background init failed: {followup_name}: {e}")
 
     _spawn_background_task(name, _run_all)
 
@@ -185,14 +188,14 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
     # RabbitMQ instead of delivering them straight to the held socket.
     settings.WORKER_TYPE = context
 
-    log.info(f"Starting {context} with unified provider system...")
+    log.info(f"{LogTag.STARTUP} Starting {context} with unified provider system...")
 
     # Register lazy providers (dormant until first access).
     #
     # Gotcha: many providers are authored as `async def` and decorated with
     # `@lazy_provider(...)`. The decorator replaces the async function with a
     # sync registration function, so these calls are intentionally NOT awaited.
-    log.info(f"Registering lazy providers for {context}...")
+    log.info(f"{LogTag.STARTUP} Registering lazy providers for {context}...")
 
     registrations: tuple[Callable[[], object], ...] = (
         init_postgresql_engine,
@@ -217,7 +220,7 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
 
     for register in registrations:
         register()
-    log.info(f"All lazy providers registered successfully for {context}")
+    log.info(f"{LogTag.STARTUP} All lazy providers registered successfully for {context}")
 
     # Services we typically want running in-process.
     #
@@ -264,7 +267,7 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
     # warm up in background.
     if context == "main_app" and not settings.ENABLE_LAZY_LOADING:
         log.info(
-            "Hot reloading disabled: scheduling warmup tasks in background (non-blocking startup)"
+            f"{LogTag.STARTUP} Hot reloading disabled: scheduling warmup tasks in background (non-blocking startup)"
         )
 
         _spawn_background_services(
@@ -286,11 +289,11 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
         results = await asyncio.gather(*startup_tasks, return_exceptions=True)
         _process_results(results, service_names)  # Validate results and handle failures
 
-        log.info(f"All {context} services initialized successfully")
-        log.info(f"{context.title().replace('_', ' ')} startup complete")
+        log.info(f"{LogTag.STARTUP} All {context} services initialized successfully")
+        log.info(f"{LogTag.STARTUP} {context.title().replace('_', ' ')} startup complete")
 
     except Exception as e:
-        log.error(f"Error during {context} startup: {e}")
+        log.error(f"{LogTag.STARTUP} Error during {context} startup: {e}")
         raise RuntimeError(f"{context} startup failed") from e
 
 
@@ -306,11 +309,11 @@ async def unified_shutdown(context: Literal["main_app", "arq_worker"]) -> None:
     Args:
         context: "main_app" for FastAPI, "arq_worker" for background tasks
     """
-    log.info(f"Shutting down {context}...")
+    log.info(f"{LogTag.STARTUP} Shutting down {context}...")
 
     # Cancel any background warmup tasks first.
     if _background_tasks:
-        log.info(f"Cancelling {len(_background_tasks)} background tasks")
+        log.info(f"{LogTag.STARTUP} Cancelling {len(_background_tasks)} background tasks")
         for task in _background_tasks:
             if not task.done():
                 task.cancel()
@@ -335,7 +338,7 @@ async def unified_shutdown(context: Literal["main_app", "arq_worker"]) -> None:
         shutdown_services.append((close_websocket_async, "websocket"))
 
     if not shutdown_services:
-        log.info(f"No shutdown tasks for {context}")
+        log.info(f"{LogTag.STARTUP} No shutdown tasks for {context}")
         return
 
     # Build parallel cleanup tasks (faster shutdown via concurrency)
@@ -350,11 +353,13 @@ async def unified_shutdown(context: Literal["main_app", "arq_worker"]) -> None:
         # Log failures without stopping other cleanup operations
         for i, result in enumerate(shutdown_results):
             if isinstance(result, Exception):
-                log.error(f"Error during {context} {shutdown_service_names[i]} shutdown: {result}")
+                log.error(
+                    f"{LogTag.STARTUP} Error during {context} {shutdown_service_names[i]} shutdown: {result}"
+                )
 
-        log.info(f"{context} services shutdown completed")
+        log.info(f"{LogTag.STARTUP} {context} services shutdown completed")
 
     except Exception as e:
-        log.error(f"Error during {context} shutdown: {e}")
+        log.error(f"{LogTag.STARTUP} Error during {context} shutdown: {e}")
 
-    log.info(f"{context} shutdown complete")
+    log.info(f"{LogTag.STARTUP} {context} shutdown complete")

--- a/apps/api/app/core/stream_manager.py
+++ b/apps/api/app/core/stream_manager.py
@@ -51,6 +51,7 @@ from app.constants.cache import (
     STREAM_SIGNAL_PREFIX,
     STREAM_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.constants.streaming import (
     STREAM_CANCELLED_SIGNAL,
     STREAM_DONE_SIGNAL,
@@ -126,7 +127,7 @@ class StreamManager:
             ttl=STREAM_TTL,
         )
 
-        log.debug(f"Stream {stream_id} started for conversation {conversation_id}")
+        log.debug(f"{LogTag.STARTUP} Stream {stream_id} started for conversation {conversation_id}")
 
     @classmethod
     async def complete_stream(cls, stream_id: str) -> None:
@@ -146,7 +147,7 @@ class StreamManager:
         # Notify subscribers that stream is done
         await cls._publish(stream_id, STREAM_DONE_SIGNAL)
 
-        log.debug(f"Stream {stream_id} completed")
+        log.debug(f"{LogTag.STARTUP} Stream {stream_id} completed")
 
     @classmethod
     async def cleanup(cls, stream_id: str) -> None:
@@ -158,7 +159,7 @@ class StreamManager:
         await redis_cache.delete(f"{STREAM_PROGRESS_PREFIX}{stream_id}")
         await redis_cache.delete(f"{STREAM_SIGNAL_PREFIX}{stream_id}")
 
-        log.debug(f"Stream {stream_id} cleaned up")
+        log.debug(f"{LogTag.STARTUP} Stream {stream_id} cleaned up")
 
     # -------------------------------------------------------------------------
     # Pub/Sub Communication
@@ -199,7 +200,7 @@ class StreamManager:
             interspersed with ``": keepalive\\n\\n"`` comments during idle periods.
         """
         if not redis_cache.redis:
-            log.error("Redis not available for stream subscription")
+            log.error(f"{LogTag.STARTUP} Redis not available for stream subscription")
             if start_event and not start_event.is_set():
                 start_event.set()
             return
@@ -210,7 +211,7 @@ class StreamManager:
 
         try:
             await pubsub.subscribe(channel)
-            log.debug(f"Subscribed to stream channel: {channel}")
+            log.debug(f"{LogTag.STARTUP} Subscribed to stream channel: {channel}")
 
             # Allow the background task to start publishing
             if start_event and not start_event.is_set():
@@ -241,17 +242,17 @@ class StreamManager:
                 # Handle control signals
                 if data == STREAM_DONE_SIGNAL:
                     log.debug(
-                        f"Stream {stream_id} completed successfully ({chunks_received} chunks)"
+                        f"{LogTag.STARTUP} Stream {stream_id} completed successfully ({chunks_received} chunks)"
                     )
                     break
 
                 if data == STREAM_CANCELLED_SIGNAL:
-                    log.info(f"Stream {stream_id} was cancelled by user")
+                    log.info(f"{LogTag.STARTUP} Stream {stream_id} was cancelled by user")
                     yield "data: [DONE]\n\n"
                     break
 
                 if data == STREAM_ERROR_SIGNAL:
-                    log.error(f"Stream {stream_id} encountered an error")
+                    log.error(f"{LogTag.STARTUP} Stream {stream_id} encountered an error")
                     progress = await cls.get_progress(stream_id)
                     error_msg = (
                         progress.get("error", "An unexpected error occurred")
@@ -266,10 +267,14 @@ class StreamManager:
                 yield data
 
             if chunks_received == 0:
-                log.warning(f"Stream {stream_id} ended without receiving any chunks")
+                log.warning(
+                    f"{LogTag.STARTUP} Stream {stream_id} ended without receiving any chunks"
+                )
 
         except Exception as e:
-            log.error(f"Error in stream subscription {stream_id}: {e}", exc_info=True)
+            log.error(
+                f"{LogTag.STARTUP} Error in stream subscription {stream_id}: {e}", exc_info=True
+            )
             yield f"data: {json.dumps({'error': 'Stream subscription failed'})}\n\n"
         finally:
             try:
@@ -318,7 +323,7 @@ class StreamManager:
         # Notify subscribers
         await cls._publish(stream_id, STREAM_CANCELLED_SIGNAL)
 
-        log.info(f"Stream {stream_id} cancelled")
+        log.info(f"{LogTag.STARTUP} Stream {stream_id} cancelled")
         return True
 
     @classmethod

--- a/apps/api/app/core/websocket_consumer.py
+++ b/apps/api/app/core/websocket_consumer.py
@@ -8,6 +8,7 @@ from aio_pika import connect_robust
 from aio_pika.abc import AbstractIncomingMessage
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.core.websocket_manager import websocket_manager
 from shared.py.wide_events import log
 
@@ -34,10 +35,12 @@ class WebSocketEventConsumer:
             # Start consuming
             await self.queue.consume(self._handle_websocket_message)
 
-            log.info("WebSocket event consumer started on queue: websocket-events")
+            log.info(
+                f"{LogTag.STARTUP} WebSocket event consumer started on queue: websocket-events"
+            )
 
         except Exception as e:
-            log.error(f"Failed to start WebSocket event consumer: {e}")
+            log.error(f"{LogTag.STARTUP} Failed to start WebSocket event consumer: {e}")
             raise
 
     async def stop(self) -> None:
@@ -52,10 +55,10 @@ class WebSocketEventConsumer:
             if self.connection:
                 await self.connection.close()
 
-            log.info("WebSocket event consumer stopped")
+            log.info(f"{LogTag.STARTUP} WebSocket event consumer stopped")
 
         except Exception as e:
-            log.error(f"Error stopping WebSocket event consumer: {e}")
+            log.error(f"{LogTag.STARTUP} Error stopping WebSocket event consumer: {e}")
 
     async def _handle_websocket_message(self, message: AbstractIncomingMessage) -> None:
         """Handle incoming WebSocket broadcast messages from RabbitMQ"""
@@ -65,7 +68,9 @@ class WebSocketEventConsumer:
                 data = json.loads(message.body.decode())
 
                 if data.get("type") != "websocket_broadcast":
-                    log.warning(f"Received unknown WebSocket message type: {data.get('type')}")
+                    log.warning(
+                        f"{LogTag.STARTUP} Received unknown WebSocket message type: {data.get('type')}"
+                    )
                     return
 
                 user_id = data.get("user_id")
@@ -75,7 +80,9 @@ class WebSocketEventConsumer:
                     log.set(websocket={"user_id": user_id})
 
                 if not user_id or not ws_message:
-                    log.error("Invalid WebSocket broadcast message: missing user_id or message")
+                    log.error(
+                        f"{LogTag.STARTUP} Invalid WebSocket broadcast message: missing user_id or message"
+                    )
                     return
 
                 # Broadcast to WebSocket connections in the main app
@@ -85,21 +92,23 @@ class WebSocketEventConsumer:
                         try:
                             await websocket.send_json(ws_message)
                         except Exception as e:
-                            log.warning(f"Failed to send WebSocket message to user {user_id}: {e}")
+                            log.warning(
+                                f"{LogTag.STARTUP} Failed to send WebSocket message to user {user_id}: {e}"
+                            )
                             disconnected.add(websocket)
 
                     # Remove disconnected websockets
                     for ws in disconnected:
                         websocket_manager.connections[user_id].discard(ws)
 
-                    log.debug(f"Broadcasted WebSocket message to user {user_id}")
+                    log.debug(f"{LogTag.STARTUP} Broadcasted WebSocket message to user {user_id}")
                 else:
-                    log.debug(f"No WebSocket connections found for user {user_id}")
+                    log.debug(f"{LogTag.STARTUP} No WebSocket connections found for user {user_id}")
 
             except json.JSONDecodeError as e:
-                log.error(f"Failed to decode WebSocket message JSON: {e}")
+                log.error(f"{LogTag.STARTUP} Failed to decode WebSocket message JSON: {e}")
             except Exception as e:
-                log.error(f"Failed to process WebSocket message: {e}")
+                log.error(f"{LogTag.STARTUP} Failed to process WebSocket message: {e}")
 
 
 # Global instance

--- a/apps/api/app/core/websocket_manager.py
+++ b/apps/api/app/core/websocket_manager.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, TypeVar, cast
 
 from fastapi import WebSocket
 
+from app.constants.log_tags import LogTag
 from app.db.rabbitmq import get_rabbitmq_publisher
 from app.utils.worker_detection import is_main_app
 from shared.py.wide_events import log
@@ -20,7 +21,7 @@ class WebSocketManager:
             cls._instance = super().__new__(cls)
             # Initialize the instance in __new__ for singleton pattern
             cls._instance.initialized = False
-            log.info("Created new WebSocketManager instance")
+            log.info(f"{LogTag.STARTUP} Created new WebSocketManager instance")
         return cast(T, cls._instance)
 
     def __init__(self) -> None:
@@ -35,7 +36,7 @@ class WebSocketManager:
             self.connections[user_id] = set()
         self.connections[user_id].add(websocket)
         log.set(websocket={"user_id": user_id, "connection_id": id(websocket)})
-        log.info(f"Added WebSocket connection for user {user_id}")
+        log.info(f"{LogTag.STARTUP} Added WebSocket connection for user {user_id}")
 
     def remove_connection(self, user_id: str, websocket: WebSocket) -> None:
         """Remove a WebSocket connection for a user"""
@@ -44,7 +45,7 @@ class WebSocketManager:
             if not self.connections[user_id]:
                 del self.connections[user_id]
         log.set(websocket={"user_id": user_id, "connection_id": id(websocket)})
-        log.info(f"Removed WebSocket connection for user {user_id}")
+        log.info(f"{LogTag.STARTUP} Removed WebSocket connection for user {user_id}")
 
     async def broadcast_to_user(self, user_id: str, message: dict[str, Any]) -> None:
         """Broadcast message to all connections for a user"""
@@ -62,7 +63,7 @@ class WebSocketManager:
             try:
                 await websocket.send_json(message)
             except Exception as e:
-                log.warning(f"Failed to send to WebSocket: {e}")
+                log.warning(f"{LogTag.STARTUP} Failed to send to WebSocket: {e}")
                 disconnected.add(websocket)
 
         # Remove disconnected websockets
@@ -85,10 +86,15 @@ class WebSocketManager:
             # Publisher now handles connection health automatically
             await publisher.publish("websocket-events", message_body)
 
-            log.debug(f"Published WebSocket message for user {user_id} to RabbitMQ")
+            log.debug(
+                f"{LogTag.STARTUP} Published WebSocket message for user {user_id} to RabbitMQ"
+            )
 
         except Exception as e:
-            log.error(f"Failed to publish WebSocket message to RabbitMQ: {e}", exc_info=True)
+            log.error(
+                f"{LogTag.STARTUP} Failed to publish WebSocket message to RabbitMQ: {e}",
+                exc_info=True,
+            )
 
 
 # Create a singleton instance of WebSocketManager

--- a/apps/api/app/db/chroma/chroma_cleanup.py
+++ b/apps/api/app/db/chroma/chroma_cleanup.py
@@ -1,11 +1,12 @@
 """ChromaDB cleanup utilities for integration lifecycle management."""
 
 from app.constants.cache import HANDOFF_NAME_CACHE_PREFIX, SUBAGENT_CACHE_PREFIX
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.chroma.chroma_tools_store import delete_tools_by_namespace
 from app.db.redis import delete_cache
 from app.helpers.namespace_utils import derive_integration_namespace
-from shared.py.wide_events import log
+from shared.py.wide_events import VectorContext, log
 
 
 async def cleanup_integration_chroma_data(
@@ -29,6 +30,8 @@ async def cleanup_integration_chroma_data(
         - "tools": Whether tools were deleted
         - "cache": Whether cache was invalidated
     """
+    log.set(vector=VectorContext(operation="delete", collection="langgraph_tools_store"))
+
     results = {"subagent": False, "tools": False, "cache": False}
 
     namespace = derive_integration_namespace(integration_id, server_url, is_custom=True)
@@ -39,17 +42,17 @@ async def cleanup_integration_chroma_data(
         if store:
             await store.adelete(namespace=("subagents",), key=integration_id)
             results["subagent"] = True
-            log.debug(f"Deleted subagent entry for {integration_id}")
+            log.debug(f"{LogTag.CHROMA} Deleted subagent entry for {integration_id}")
     except Exception as e:
-        log.warning(f"Failed to delete subagent entry for {integration_id}: {e}")
+        log.warning(f"{LogTag.CHROMA} Failed to delete subagent entry for {integration_id}: {e}")
 
     # 2. Delete indexed tools
     try:
         deleted_count = await delete_tools_by_namespace(namespace)
         results["tools"] = True
-        log.info(f"Deleted {deleted_count} tools for namespace '{namespace}'")
+        log.info(f"{LogTag.CHROMA} Deleted {deleted_count} tools for namespace '{namespace}'")
     except Exception as e:
-        log.warning(f"Failed to delete tools for namespace '{namespace}': {e}")
+        log.warning(f"{LogTag.CHROMA} Failed to delete tools for namespace '{namespace}': {e}")
 
     # 3. Invalidate caches: namespace hash + the per-integration name caches
     # (subagent_info and handoff_name both embed the display name).
@@ -59,6 +62,6 @@ async def cleanup_integration_chroma_data(
         await delete_cache(f"{HANDOFF_NAME_CACHE_PREFIX}:{integration_id}")
         results["cache"] = True
     except Exception as e:
-        log.warning(f"Failed to invalidate cache for namespace '{namespace}': {e}")
+        log.warning(f"{LogTag.CHROMA} Failed to invalidate cache for namespace '{namespace}': {e}")
 
     return results

--- a/apps/api/app/db/chroma/chroma_store.py
+++ b/apps/api/app/db/chroma/chroma_store.py
@@ -31,7 +31,8 @@ from langgraph.store.base import (
     tokenize_path,
 )
 
-from shared.py.wide_events import log
+from app.constants.log_tags import LogTag
+from shared.py.wide_events import VectorContext, log
 
 
 class _NoOpEmbeddingFunction(EmbeddingFunction):  # type: ignore[type-arg]
@@ -121,12 +122,12 @@ class ChromaStore(BaseStore):
 
             if self.collection_name not in collection_names:
                 log.set(
-                    db={
-                        "operation": "create_collection",
-                        "collection": self.collection_name,
-                    }
+                    vector=VectorContext(
+                        operation="create_collection",
+                        collection=self.collection_name,
+                    )
                 )
-                log.info(f"Creating ChromaDB collection: {self.collection_name}")
+                log.info(f"{LogTag.CHROMA} Creating ChromaDB collection: {self.collection_name}")
                 self._collection_cache = await self.client.create_collection(
                     name=self.collection_name,
                     metadata={"hnsw:space": "cosine"},
@@ -269,7 +270,7 @@ class ChromaStore(BaseStore):
                 else datetime.now(UTC),
             )
         except Exception as e:
-            log.error(f"Error getting item {doc_id}: {e}")
+            log.error(f"{LogTag.CHROMA} Error getting item {doc_id}: {e}")
             return None
 
     async def _filter_items(self, op: SearchOp, collection: AsyncCollection) -> list[str]:
@@ -303,7 +304,7 @@ class ChromaStore(BaseStore):
                 try:
                     value = pickle.loads(document.encode("latin1"))  # nosec B301 - Internal trusted data only
                 except Exception as e:
-                    log.debug(f"Failed to deserialize document at index {idx}: {e}")
+                    log.debug(f"{LogTag.CHROMA} Failed to deserialize document at index {idx}: {e}")
                     continue
                 if not isinstance(value, dict):
                     continue
@@ -312,7 +313,7 @@ class ChromaStore(BaseStore):
 
             return filtered_ids
         except Exception as e:
-            log.error(f"Error filtering items: {e}")
+            log.error(f"{LogTag.CHROMA} Error filtering items: {e}")
             return []
 
     def _matches_namespace_prefix(
@@ -454,7 +455,7 @@ class ChromaStore(BaseStore):
                     # Apply pagination
                     results[i] = items[op.offset : op.offset + op.limit]
                 except Exception as e:
-                    log.error(f"Error in vector search: {e}")
+                    log.error(f"{LogTag.CHROMA} Error in vector search: {e}")
                     results[i] = []
             else:
                 # No query, just return filtered items with pagination
@@ -510,14 +511,16 @@ class ChromaStore(BaseStore):
         ]
         succeeded = len(results) - len(failures)
         log.info(
-            f"_apply_put_ops completed: total={len(results)} succeeded={succeeded} "
+            f"{LogTag.CHROMA} _apply_put_ops completed: total={len(results)} succeeded={succeeded} "
             f"failed={len(failures)}"
         )
         if failures:
             # Show up to 3 distinct exception classes to make patterns obvious.
             sample = failures[: min(3, len(failures))]
             for d, exc in sample:
-                log.error(f"_apply_put_ops failure doc_id={d}: {type(exc).__name__}: {exc}")
+                log.error(
+                    f"{LogTag.CHROMA} _apply_put_ops failure doc_id={d}: {type(exc).__name__}: {exc}"
+                )
 
     async def _delete_item(self, doc_id: str, collection: AsyncCollection) -> None:
         """Delete a single item.
@@ -530,7 +533,7 @@ class ChromaStore(BaseStore):
         try:
             await collection.delete(ids=[doc_id])
         except Exception as e:
-            log.error(f"Error deleting item {doc_id}: {type(e).__name__}: {e}")
+            log.error(f"{LogTag.CHROMA} Error deleting item {doc_id}: {type(e).__name__}: {e}")
             raise
 
     async def _upsert_item(self, doc_id: str, op: PutOp, collection: AsyncCollection) -> None:
@@ -575,7 +578,7 @@ class ChromaStore(BaseStore):
                     embedding = await self.embeddings.aembed_query(" ".join(texts))
                 except Exception as embed_err:
                     log.error(
-                        f"_upsert_item embedding failed for doc_id={doc_id} "
+                        f"{LogTag.CHROMA} _upsert_item embedding failed for doc_id={doc_id} "
                         f"ns={namespace_str} text_len={sum(len(t) for t in texts)}: "
                         f"{type(embed_err).__name__}: {embed_err}"
                     )
@@ -591,7 +594,7 @@ class ChromaStore(BaseStore):
         except Exception as e:
             # Re-raise so _apply_put_ops's failure count is accurate.
             log.error(
-                f"Error upserting item {doc_id} (ns={namespace_str}): {type(e).__name__}: {e}"
+                f"{LogTag.CHROMA} Error upserting item {doc_id} (ns={namespace_str}): {type(e).__name__}: {e}"
             )
             raise
 
@@ -623,7 +626,7 @@ class ChromaStore(BaseStore):
             sorted_namespaces = sorted(namespaces)
             return sorted_namespaces[op.offset : op.offset + op.limit]
         except Exception as e:
-            log.error(f"Error listing namespaces: {e}")
+            log.error(f"{LogTag.CHROMA} Error listing namespaces: {e}")
             return []
 
     def _does_match(self, match_condition: MatchCondition, key: tuple[str, ...]) -> bool:

--- a/apps/api/app/db/chroma/chroma_tools_store.py
+++ b/apps/api/app/db/chroma/chroma_tools_store.py
@@ -8,10 +8,11 @@ from langgraph.store.base import PutOp
 
 from app.agents.core.subagents.registry import all_subagents
 from app.agents.tools.core.registry import get_tool_registry
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from app.db.chroma.chromadb import ChromaClient
 from app.db.redis import delete_cache, get_cache, set_cache
-from shared.py.wide_events import log
+from shared.py.wide_events import VectorContext, log
 
 from .chroma_store import ChromaStore
 
@@ -25,7 +26,7 @@ async def _compute_tool_hash(tool: Any) -> str:
         content = f"{tool.description}::{code_source}"
     except (OSError, TypeError, AttributeError):
         log.debug(
-            f"Source unavailable for {getattr(tool, 'name', 'unknown')}, using description hash"
+            f"{LogTag.CHROMA} Source unavailable for {getattr(tool, 'name', 'unknown')}, using description hash"
         )
         content = f"{tool.name}::{tool.description}"
 
@@ -145,7 +146,7 @@ async def _get_existing_tools_from_chroma(
                         "namespace": namespace,
                     }
     except Exception as e:
-        log.warning(f"Error fetching existing tools: {e}, will register all tools")
+        log.warning(f"{LogTag.CHROMA} Error fetching existing tools: {e}, will register all tools")
 
     return existing_tools
 
@@ -252,10 +253,10 @@ async def _execute_batch_operations(store, put_ops: list[PutOp], batch_size: int
         batch = put_ops[i : i + batch_size]
         await store.abatch(batch)
         log.info(
-            f"Processed batch {i // batch_size + 1}/{(total_ops + batch_size - 1) // batch_size}"
+            f"{LogTag.CHROMA} Processed batch {i // batch_size + 1}/{(total_ops + batch_size - 1) // batch_size}"
         )
 
-    log.info(f"Successfully updated {total_ops} tools in ChromaDB")
+    log.info(f"{LogTag.CHROMA} Successfully updated {total_ops} tools in ChromaDB")
 
 
 async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
@@ -274,17 +275,18 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
     namespace = tools_with_space[0][1] if tools_with_space else None
 
     log.set(
-        chroma_index={
-            "phase": "entry",
-            "namespace": namespace,
-            "input_tool_count": input_count,
-        }
+        vector=VectorContext(
+            operation="upsert",
+            collection="langgraph_tools_store",
+        )
     )
-    log.info(f"index_tools_to_store called: namespace='{namespace}' input_tools={input_count}")
+    log.info(
+        f"{LogTag.CHROMA} index_tools_to_store called: namespace='{namespace}' input_tools={input_count}"
+    )
 
     if not tools_with_space:
         log.warning(
-            "index_tools_to_store called with EMPTY tools_with_space — caller "
+            f"{LogTag.CHROMA} index_tools_to_store called with EMPTY tools_with_space — caller "
             "passed [], no indexing will occur. Verify category.tools is populated."
         )
         return
@@ -295,7 +297,7 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
     distinct_namespaces = {space for _, space in tools_with_space}
     if len(distinct_namespaces) > 1:
         log.error(
-            f"index_tools_to_store: mixed namespaces in single call "
+            f"{LogTag.CHROMA} index_tools_to_store: mixed namespaces in single call "
             f"({sorted(distinct_namespaces)}); aborting to prevent partial indexing. "
             f"Caller must batch per-namespace."
         )
@@ -303,7 +305,7 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
 
     if not namespace or len(namespace) > 512 or "::" in namespace:
         log.error(
-            f"index_tools_to_store: invalid namespace '{namespace}' "
+            f"{LogTag.CHROMA} index_tools_to_store: invalid namespace '{namespace}' "
             f"(empty/too-long/contains-::), aborting"
         )
         return
@@ -313,7 +315,6 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
         f"{t.name}:{getattr(t, 'description', '')[:200]}" for t, _ in tools_with_space
     )
     tools_hash = hashlib.sha256(tools_signature.encode()).hexdigest()[:16]
-    log.set(chroma_index={"tools_hash": tools_hash})
 
     # Check Redis cache BEFORE expensive ChromaDB operations
     # Single source of truth for cache keys: always namespace-based
@@ -321,7 +322,7 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
     cached_hash = await get_cache(cache_key)
     if cached_hash == tools_hash:
         log.info(
-            f"index_tools_to_store: namespace '{namespace}' Redis cache HIT "
+            f"{LogTag.CHROMA} index_tools_to_store: namespace '{namespace}' Redis cache HIT "
             f"(hash={tools_hash}), skipping reindex of {input_count} tools"
         )
         return
@@ -329,7 +330,7 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
     store = await providers.aget("chroma_tools_store")
     if store is None:
         log.warning(
-            f"index_tools_to_store: chroma_tools_store provider returned None "
+            f"{LogTag.CHROMA} index_tools_to_store: chroma_tools_store provider returned None "
             f"for namespace '{namespace}', skipping {input_count} tools"
         )
         return
@@ -346,21 +347,22 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
             "tool": tool,
         }
     log.info(
-        f"index_tools_to_store: built current_tools dict for '{namespace}': "
+        f"{LogTag.CHROMA} index_tools_to_store: built current_tools dict for '{namespace}': "
         f"{len(current_tools)} unique composite keys from {input_count} inputs"
     )
 
     existing_tools = await _get_existing_tools_from_chroma(collection, {namespace})
     log.info(
-        f"index_tools_to_store: fetched {len(existing_tools)} existing docs "
+        f"{LogTag.CHROMA} index_tools_to_store: fetched {len(existing_tools)} existing docs "
         f"for namespace '{namespace}'"
     )
 
     tools_to_upsert, tools_to_delete = _compute_tool_diff(current_tools, existing_tools)
+    log.set_ns("vector", embedded_count=len(tools_to_upsert))
 
     if not tools_to_upsert and not tools_to_delete:
         log.info(
-            f"index_tools_to_store: namespace '{namespace}' is up-to-date "
+            f"{LogTag.CHROMA} index_tools_to_store: namespace '{namespace}' is up-to-date "
             f"({len(current_tools)} tools, no diff)"
         )
         # Cache the hash even if no changes (first time seeing this namespace)
@@ -368,7 +370,7 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
         return
 
     log.info(
-        f"index_tools_to_store: Updating namespace '{namespace}': "
+        f"{LogTag.CHROMA} index_tools_to_store: Updating namespace '{namespace}': "
         f"{len(tools_to_upsert)} to upsert, {len(tools_to_delete)} to delete"
     )
 
@@ -377,7 +379,9 @@ async def index_tools_to_store(tools_with_space: list[tuple[Any, str]]):
 
     # Cache the hash after successful indexing (24 hour TTL)
     await set_cache(cache_key, tools_hash, ttl=86400)
-    log.info(f"index_tools_to_store: completed namespace '{namespace}', cache key set")
+    log.info(
+        f"{LogTag.CHROMA} index_tools_to_store: completed namespace '{namespace}', cache key set"
+    )
 
 
 async def delete_tools_by_namespace(namespace: str) -> int:
@@ -392,9 +396,11 @@ async def delete_tools_by_namespace(namespace: str) -> int:
         Number of tools deleted
     """
 
+    log.set(vector=VectorContext(operation="delete", collection="langgraph_tools_store"))
+
     store = await providers.aget("chroma_tools_store")
     if not store:
-        log.warning("ChromaDB store not available for cleanup")
+        log.warning(f"{LogTag.CHROMA} ChromaDB store not available for cleanup")
         return 0
 
     collection = await store._get_collection()
@@ -405,10 +411,11 @@ async def delete_tools_by_namespace(namespace: str) -> int:
         include=[],
     )
     ids_to_delete = results.get("ids", [])
+    log.set_ns("vector", result_count=len(ids_to_delete))
 
     if ids_to_delete:
         await collection.delete(ids=ids_to_delete)
-        log.info(f"Deleted {len(ids_to_delete)} tools from namespace '{namespace}'")
+        log.info(f"{LogTag.CHROMA} Deleted {len(ids_to_delete)} tools from namespace '{namespace}'")
 
     # Invalidate Redis cache for this namespace (unified format)
     await delete_cache(f"chroma:indexed:{namespace}")
@@ -456,19 +463,20 @@ async def initialize_chroma_tools_store():
     current_tools = await _get_current_tools_with_hashes(tool_registry)
 
     managed_namespaces = {tool_data["namespace"] for tool_data in current_tools.values()}
-    log.set(db={"operation": "init_tools_store", "collection": "langgraph_tools_store"})
-    log.info(f"Managing namespaces at init: {managed_namespaces}")
+    log.set(vector=VectorContext(operation="upsert", collection="langgraph_tools_store"))
+    log.info(f"{LogTag.CHROMA} Managing namespaces at init: {managed_namespaces}")
 
     existing_tools = await _get_existing_tools_from_chroma(collection, managed_namespaces)
 
     tools_to_upsert, tools_to_delete = _compute_tool_diff(current_tools, existing_tools)
+    log.set_ns("vector", embedded_count=len(tools_to_upsert))
 
     if not tools_to_upsert and not tools_to_delete:
-        log.info("ChromaDB tools store is up-to-date, no changes needed")
+        log.info(f"{LogTag.CHROMA} ChromaDB tools store is up-to-date, no changes needed")
         return store
 
     log.info(
-        f"Updating ChromaDB tools store: {len(tools_to_upsert)} to upsert, "
+        f"{LogTag.CHROMA} Updating ChromaDB tools store: {len(tools_to_upsert)} to upsert, "
         f"{len(tools_to_delete)} to delete"
     )
 

--- a/apps/api/app/db/chroma/chroma_triggers_store.py
+++ b/apps/api/app/db/chroma/chroma_triggers_store.py
@@ -11,9 +11,10 @@ from typing import Any
 from langgraph.store.base import PutOp
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from app.db.chroma.chromadb import ChromaClient
-from shared.py.wide_events import log
+from shared.py.wide_events import VectorContext, log
 
 from .chroma_store import ChromaStore
 
@@ -125,7 +126,9 @@ async def _get_existing_triggers_from_chroma(collection) -> dict[str, dict]:
                         "namespace": namespace,
                     }
     except Exception as e:
-        log.warning(f"Error fetching existing triggers: {e}, will register all triggers")
+        log.warning(
+            f"{LogTag.CHROMA} Error fetching existing triggers: {e}, will register all triggers"
+        )
 
     return existing_triggers
 
@@ -227,11 +230,11 @@ async def _execute_batch_operations(
         batch = put_ops[i : i + batch_size]
         await store.abatch(batch)
         log.info(
-            f"Processed triggers batch {i // batch_size + 1}/"
+            f"{LogTag.CHROMA} Processed triggers batch {i // batch_size + 1}/"
             f"{(total_ops + batch_size - 1) // batch_size}"
         )
 
-    log.info(f"Successfully updated {total_ops} triggers in ChromaDB")
+    log.info(f"{LogTag.CHROMA} Successfully updated {total_ops} triggers in ChromaDB")
 
 
 @lazy_provider(
@@ -271,25 +274,26 @@ async def initialize_chroma_triggers_store() -> ChromaStore:
 
     current_triggers = _get_current_triggers_with_hashes()
     log.set(
-        db={
-            "operation": "init_triggers_store",
-            "collection": "langgraph_triggers_store",
-        }
+        vector=VectorContext(
+            operation="upsert",
+            collection="langgraph_triggers_store",
+        )
     )
-    log.info(f"Found {len(current_triggers)} triggers to manage")
+    log.info(f"{LogTag.CHROMA} Found {len(current_triggers)} triggers to manage")
 
     existing_triggers = await _get_existing_triggers_from_chroma(collection)
 
     triggers_to_upsert, triggers_to_delete = _compute_trigger_diff(
         current_triggers, existing_triggers
     )
+    log.set_ns("vector", embedded_count=len(triggers_to_upsert))
 
     if not triggers_to_upsert and not triggers_to_delete:
-        log.info("ChromaDB triggers store is up-to-date, no changes needed")
+        log.info(f"{LogTag.CHROMA} ChromaDB triggers store is up-to-date, no changes needed")
         return store
 
     log.info(
-        f"Updating ChromaDB triggers store: {len(triggers_to_upsert)} to upsert, "
+        f"{LogTag.CHROMA} Updating ChromaDB triggers store: {len(triggers_to_upsert)} to upsert, "
         f"{len(triggers_to_delete)} to delete"
     )
 

--- a/apps/api/app/db/chroma/chromadb.py
+++ b/apps/api/app/db/chroma/chromadb.py
@@ -5,6 +5,7 @@ from fastapi import Request
 from langchain_chroma import Chroma
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from shared.py.wide_events import log
 
@@ -39,7 +40,7 @@ class ChromaClient:
                 raise RuntimeError("ChromaDB client could not be initialized")
             return client
         except Exception as e:
-            log.error(f"Failed to get ChromaDB client: {e}")
+            log.error(f"{LogTag.CHROMA} Failed to get ChromaDB client: {e}")
             raise RuntimeError("ChromaDB client not initialized") from e
 
     @classmethod
@@ -92,7 +93,7 @@ class ChromaClient:
         # Dynamically register a provider for this collection and auto-initialize it
         async def _loader() -> Chroma:
             log.debug(
-                f"Creating Langchain client for collection '{collection_name}' via provider '{provider_name}'"
+                f"{LogTag.CHROMA} Creating Langchain client for collection '{collection_name}' via provider '{provider_name}'"
             )
             constructor_client = await providers.aget("chromadb_constructor")
             if not constructor_client:
@@ -161,7 +162,7 @@ async def init_chromadb_client():
     )
 
     response = await client.heartbeat()
-    log.debug(f"ChromaDB heartbeat response: {response}")
+    log.debug(f"{LogTag.CHROMA} ChromaDB heartbeat response: {response}")
     log.set(
         db={
             "connection_status": "connected",
@@ -170,7 +171,7 @@ async def init_chromadb_client():
             "port": port,
         }
     )
-    log.info(f"Connected to ChromaDB at {host}:{port}")
+    log.info(f"{LogTag.CHROMA} Connected to ChromaDB at {host}:{port}")
 
     # Create default collections if they don't exist
     existing_collections = await client.list_collections()
@@ -180,11 +181,11 @@ async def init_chromadb_client():
     # Create collections if they don't exist
     for collection_name in collection_names:
         if collection_name not in existing_collection_names:
-            log.debug(f"Creating collection '{collection_name}'")
+            log.debug(f"{LogTag.CHROMA} Creating collection '{collection_name}'")
             await client.create_collection(name=collection_name, metadata={"hnsw:space": "cosine"})
-            log.debug(f"Collection '{collection_name}' created")
+            log.debug(f"{LogTag.CHROMA} Collection '{collection_name}' created")
         else:
-            log.debug(f"Collection '{collection_name}' exists")
+            log.debug(f"{LogTag.CHROMA} Collection '{collection_name}' exists")
 
     return client
 
@@ -207,7 +208,7 @@ def init_chromadb_constructor():
     Returns:
         ClientAPI: The ChromaDB constructor client
     """
-    log.debug("Initializing ChromaDB constructor client")
+    log.debug(f"{LogTag.CHROMA} Initializing ChromaDB constructor client")
 
     host: str = settings.CHROMADB_HOST  # type: ignore
     port: int = settings.CHROMADB_PORT  # type: ignore
@@ -239,7 +240,7 @@ def init_langchain_chroma():
     Returns:
         Chroma: The default Langchain Chroma client
     """
-    log.debug("Initializing default Langchain Chroma client")
+    log.debug(f"{LogTag.CHROMA} Initializing default Langchain Chroma client")
 
     # Get the constructor client
     constructor_client = providers.get("chromadb_constructor")
@@ -274,5 +275,5 @@ def init_chroma():
         init_langchain_chroma()
 
     except Exception as e:
-        log.error(f"Error in init_chroma compatibility function: {e}")
+        log.error(f"{LogTag.CHROMA} Error in init_chroma compatibility function: {e}")
         raise RuntimeError(f"ChromaDB connection failed: {e}") from e

--- a/apps/api/app/db/chroma/public_integrations_store.py
+++ b/apps/api/app/db/chroma/public_integrations_store.py
@@ -1,8 +1,9 @@
 """ChromaDB store for public integrations semantic search."""
 
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.chroma.chromadb import ChromaClient
-from shared.py.wide_events import log
+from shared.py.wide_events import VectorContext, log
 
 COLLECTION_NAME = "public_integrations"
 
@@ -14,6 +15,7 @@ async def index_public_integration(
     tools: list[dict],
 ) -> None:
     """Index a public integration in ChromaDB for semantic search."""
+    log.set(vector=VectorContext(operation="upsert", collection=COLLECTION_NAME))
     try:
         embedding_fn = await providers.aget("google_embeddings")
         chroma = await ChromaClient.get_langchain_client(
@@ -30,15 +32,16 @@ async def index_public_integration(
             ids=[integration_id],
             metadatas=[{"integration_id": integration_id}],
         )
-        log.info(f"Indexed public integration {integration_id} in ChromaDB")
+        log.info(f"{LogTag.CHROMA} Indexed public integration {integration_id} in ChromaDB")
 
     except Exception as e:
-        log.error(f"Failed to index public integration {integration_id}: {e}")
+        log.error(f"{LogTag.CHROMA} Failed to index public integration {integration_id}: {e}")
         raise
 
 
 async def remove_public_integration(integration_id: str) -> None:
     """Remove a public integration from ChromaDB index."""
+    log.set(vector=VectorContext(operation="delete", collection=COLLECTION_NAME))
     try:
         embedding_fn = await providers.aget("google_embeddings")
         chroma = await ChromaClient.get_langchain_client(
@@ -47,10 +50,10 @@ async def remove_public_integration(integration_id: str) -> None:
             create_if_not_exists=True,
         )
         await chroma.adelete(ids=[integration_id])
-        log.info(f"Removed public integration {integration_id} from ChromaDB")
+        log.info(f"{LogTag.CHROMA} Removed public integration {integration_id} from ChromaDB")
 
     except Exception as e:
-        log.error(f"Failed to remove public integration {integration_id}: {e}")
+        log.error(f"{LogTag.CHROMA} Failed to remove public integration {integration_id}: {e}")
 
 
 async def search_public_integrations(
@@ -59,6 +62,9 @@ async def search_public_integrations(
     category: str | None = None,
 ) -> list[dict]:
     """Search public integrations. Returns list of {integration_id, relevance_score}."""
+    log.set(
+        vector=VectorContext(operation="query", collection=COLLECTION_NAME, n_results=limit)
+    )
     try:
         embedding_fn = await providers.aget("google_embeddings")
         chroma = await ChromaClient.get_langchain_client(
@@ -72,7 +78,7 @@ async def search_public_integrations(
             k=limit,
         )
 
-        return [
+        matches = [
             {
                 "integration_id": doc.metadata.get("integration_id") or getattr(doc, "id", None),
                 "relevance_score": score,
@@ -80,7 +86,9 @@ async def search_public_integrations(
             for doc, score in results
             if doc.metadata.get("integration_id") or getattr(doc, "id", None)
         ]
+        log.set_ns("vector", result_count=len(matches))
+        return matches
 
     except Exception as e:
-        log.error(f"Failed to search public integrations: {e}")
+        log.error(f"{LogTag.CHROMA} Failed to search public integrations: {e}")
         return []

--- a/apps/api/app/db/chroma/public_integrations_store.py
+++ b/apps/api/app/db/chroma/public_integrations_store.py
@@ -62,9 +62,7 @@ async def search_public_integrations(
     category: str | None = None,
 ) -> list[dict]:
     """Search public integrations. Returns list of {integration_id, relevance_score}."""
-    log.set(
-        vector=VectorContext(operation="query", collection=COLLECTION_NAME, n_results=limit)
-    )
+    log.set(vector=VectorContext(operation="query", collection=COLLECTION_NAME, n_results=limit))
     try:
         embedding_fn = await providers.aget("google_embeddings")
         chroma = await ChromaClient.get_langchain_client(

--- a/apps/api/app/db/mongodb/collections.py
+++ b/apps/api/app/db/mongodb/collections.py
@@ -25,6 +25,7 @@ Performance:
 import pymongo
 from pymongo.server_api import ServerApi
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # Cache for async (Motor) collections
@@ -41,18 +42,18 @@ def _get_mongodb_instance():
     """Get or create async MongoDB instance (Motor)."""
     global _mongodb_instance
     if _mongodb_instance is None:
-        log.info("Initializing MongoDB instance (lazy loading)")
+        log.info(f"{LogTag.MONGO} Initializing MongoDB instance (lazy loading)")
         from app.db.mongodb.mongodb import init_mongodb
 
         _mongodb_instance = init_mongodb()
-        log.info("MongoDB instance initialized")
+        log.info(f"{LogTag.MONGO} MongoDB instance initialized")
     return _mongodb_instance
 
 
 def _get_collection(collection_name: str):
     """Get async collection with lazy loading and caching."""
     if collection_name not in _collections_cache:
-        log.info(f"Creating async collection '{collection_name}' (lazy loading)")
+        log.info(f"{LogTag.MONGO} Creating async collection '{collection_name}' (lazy loading)")
         mongodb_instance = _get_mongodb_instance()
         _collections_cache[collection_name] = mongodb_instance.get_collection(collection_name)
     return _collections_cache[collection_name]
@@ -64,10 +65,10 @@ def _get_sync_db():
     if _sync_db is None:
         from app.config.settings import settings
 
-        log.info("Initializing sync MongoDB client (PyMongo)")
+        log.info(f"{LogTag.MONGO} Initializing sync MongoDB client (PyMongo)")
         _sync_client = pymongo.MongoClient(settings.MONGO_DB, server_api=ServerApi("1"))
         _sync_db = _sync_client.get_database("GAIA")
-        log.info("Sync MongoDB client initialized")
+        log.info(f"{LogTag.MONGO} Sync MongoDB client initialized")
     return _sync_db
 
 
@@ -85,7 +86,7 @@ def get_sync_collection(collection_name: str):
         A PyMongo Collection object (sync)
     """
     if collection_name not in _sync_collections_cache:
-        log.info(f"Creating sync collection '{collection_name}' (lazy loading)")
+        log.info(f"{LogTag.MONGO} Creating sync collection '{collection_name}' (lazy loading)")
         db = _get_sync_db()
         _sync_collections_cache[collection_name] = db.get_collection(collection_name)
     return _sync_collections_cache[collection_name]

--- a/apps/api/app/db/mongodb/indexes.py
+++ b/apps/api/app/db/mongodb/indexes.py
@@ -14,6 +14,7 @@ import asyncio
 
 from pymongo.errors import OperationFailure
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     ai_models_collection,
     blog_collection,
@@ -52,7 +53,7 @@ async def create_all_indexes():
     """Create all database indexes. Called during application startup."""
     try:
         log.set(db={"operation": "create_indexes", "collection": "all"})
-        log.info("Starting comprehensive database index creation...")
+        log.info(f"{LogTag.MONGO} Starting comprehensive database index creation...")
 
         # Create all indexes concurrently for better performance
         index_tasks = [
@@ -117,7 +118,9 @@ async def create_all_indexes():
         index_results = {}
         for i, (collection_name, result) in enumerate(zip(collection_names, results)):
             if isinstance(result, Exception):
-                log.error(f"Failed to create indexes for {collection_name}: {result!s}")
+                log.error(
+                    f"{LogTag.MONGO} Failed to create indexes for {collection_name}: {result!s}"
+                )
                 index_results[collection_name] = f"FAILED: {result!s}"
             else:
                 index_results[collection_name] = "SUCCESS"
@@ -126,15 +129,19 @@ async def create_all_indexes():
         successful = sum(1 for result in index_results.values() if result == "SUCCESS")
         total = len(index_results)
 
-        log.info(f"Database index creation completed: {successful}/{total} collections successful")
+        log.info(
+            f"{LogTag.MONGO} Database index creation completed: {successful}/{total} collections successful"
+        )
 
         # Log any failures
         failed_collections = [name for name, result in index_results.items() if result != "SUCCESS"]
         if failed_collections:
-            log.warning(f"Failed to create indexes for collections: {failed_collections}")
+            log.warning(
+                f"{LogTag.MONGO} Failed to create indexes for collections: {failed_collections}"
+            )
 
     except Exception as e:
-        log.error(f"Critical error during database index creation: {e!s}")
+        log.error(f"{LogTag.MONGO} Critical error during database index creation: {e!s}")
         raise
 
 
@@ -162,7 +169,7 @@ async def create_user_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating user indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating user indexes: {e!s}")
         raise
 
 
@@ -186,7 +193,7 @@ async def create_conversation_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating conversation indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating conversation indexes: {e!s}")
         raise
 
 
@@ -251,7 +258,7 @@ async def create_todo_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating todo indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating todo indexes: {e!s}")
         raise
 
 
@@ -269,7 +276,7 @@ async def create_project_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating project indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating project indexes: {e!s}")
         raise
 
 
@@ -288,7 +295,7 @@ async def create_goal_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating goal indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating goal indexes: {e!s}")
         raise
 
 
@@ -308,7 +315,7 @@ async def create_note_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating note indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating note indexes: {e!s}")
         raise
 
 
@@ -328,7 +335,7 @@ async def create_file_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating file indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating file indexes: {e!s}")
         raise
 
 
@@ -344,7 +351,7 @@ async def create_mail_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating mail indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating mail indexes: {e!s}")
         raise
 
 
@@ -362,7 +369,7 @@ async def create_calendar_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating calendar indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating calendar indexes: {e!s}")
         raise
 
 
@@ -393,7 +400,7 @@ async def create_blog_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating blog indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating blog indexes: {e!s}")
         raise
 
 
@@ -413,7 +420,7 @@ async def create_notification_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating notification indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating notification indexes: {e!s}")
         raise
 
 
@@ -430,7 +437,7 @@ async def create_reminder_indexes():
             reminders_collection.create_index([("user_id", 1), ("type", 1)]),
         )
     except Exception as e:
-        log.error(f"Error creating reminder indexes: {e}")
+        log.error(f"{LogTag.MONGO} Error creating reminder indexes: {e}")
         raise
 
 
@@ -524,12 +531,12 @@ async def create_workflow_indexes():
             )
         except OperationFailure as e:
             log.warning(
-                f"Failed to create slug_public_unique_idx: {e}. "
+                f"{LogTag.MONGO} Failed to create slug_public_unique_idx: {e}. "
                 "Likely duplicate public slugs in workflows; de-dup and restart."
             )
 
     except Exception as e:
-        log.error(f"Error creating workflow indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating workflow indexes: {e!s}")
         raise
 
 
@@ -545,7 +552,7 @@ async def create_workflow_execution_indexes():
             workflow_executions_collection.create_index([("workflow_id", 1), ("status", 1)]),
         )
     except Exception as e:
-        log.error(f"Error creating workflow execution indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating workflow execution indexes: {e!s}")
         raise
 
 
@@ -577,7 +584,7 @@ async def create_payment_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating payment indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating payment indexes: {e!s}")
         raise
 
 
@@ -599,7 +606,7 @@ async def create_processed_webhook_indexes():
             ),
         )
     except Exception as e:
-        log.error(f"Error creating processed webhook indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating processed webhook indexes: {e!s}")
         raise
 
 
@@ -638,7 +645,7 @@ async def create_usage_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating usage indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating usage indexes: {e!s}")
         raise
 
 
@@ -674,7 +681,7 @@ async def create_ai_models_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating AI models indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating AI models indexes: {e!s}")
         raise
 
 
@@ -764,7 +771,7 @@ async def create_integration_indexes():
         await _backfill_integration_slugs()
 
     except Exception as e:
-        log.error(f"Error creating integration indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating integration indexes: {e!s}")
         raise
 
 
@@ -781,7 +788,7 @@ async def _backfill_integration_slugs() -> None:
             if not docs:
                 break
 
-            log.info(f"Backfilling slugs for {len(docs)} public integrations")
+            log.info(f"{LogTag.MONGO} Backfilling slugs for {len(docs)} public integrations")
             for doc in docs:
                 slug = await generate_unique_integration_slug(
                     name=doc.get("name", ""),
@@ -796,9 +803,11 @@ async def _backfill_integration_slugs() -> None:
             total_backfilled += len(docs)
 
         if total_backfilled:
-            log.info(f"Slug backfill complete: {total_backfilled} integrations updated")
+            log.info(
+                f"{LogTag.MONGO} Slug backfill complete: {total_backfilled} integrations updated"
+            )
     except Exception as e:
-        log.warning(f"Slug backfill failed (non-fatal): {e}")
+        log.warning(f"{LogTag.MONGO} Slug backfill failed (non-fatal): {e}")
 
 
 async def create_user_integration_indexes():
@@ -840,7 +849,7 @@ async def create_user_integration_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating user integration indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating user integration indexes: {e!s}")
         raise
 
 
@@ -861,7 +870,7 @@ async def create_integration_instructions_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating integration instructions indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating integration instructions indexes: {e!s}")
         raise
 
 
@@ -878,7 +887,7 @@ async def create_device_token_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating device token indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating device token indexes: {e!s}")
         raise
 
 
@@ -900,7 +909,7 @@ async def create_bot_session_indexes():
         )
 
     except Exception as e:
-        log.error(f"Error creating bot session indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating bot session indexes: {e!s}")
         raise
 
 
@@ -946,7 +955,7 @@ async def create_installed_skills_indexes() -> None:
         )
 
     except Exception as e:
-        log.error(f"Error creating installed_skills indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating installed_skills indexes: {e!s}")
         raise
 
 
@@ -973,5 +982,5 @@ async def create_e2b_sandbox_indexes() -> None:
             ),
         )
     except Exception as e:
-        log.error(f"Error creating e2b sandbox indexes: {e!s}")
+        log.error(f"{LogTag.MONGO} Error creating e2b sandbox indexes: {e!s}")
         raise

--- a/apps/api/app/db/mongodb/mongodb.py
+++ b/apps/api/app/db/mongodb/mongodb.py
@@ -7,6 +7,7 @@ import pymongo
 from pymongo.server_api import ServerApi
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -27,7 +28,7 @@ class MongoDB:
             db_name (str): Name of the database.
         """
         if not uri:
-            log.error("MongoDB URI is not found in the environment variables.")
+            log.error(f"{LogTag.MONGO} MongoDB URI is not found in the environment variables.")
             sys.exit(1)
 
         try:
@@ -48,7 +49,7 @@ class MongoDB:
 
         except Exception as e:
             log.set(db={"connection_status": "error", "backend": "mongodb"})
-            log.error(f"An error occurred while connecting to MongoDB: {e}")
+            log.error(f"{LogTag.MONGO} An error occurred while connecting to MongoDB: {e}")
             sys.exit(1)
 
     def ping(self):
@@ -58,18 +59,18 @@ class MongoDB:
             sync_client.admin.command("ping")
             sync_client.close()
         except Exception as e:
-            log.error(f"Ping failed: {e}")
+            log.error(f"{LogTag.MONGO} Ping failed: {e}")
 
     async def _initialize_indexes(self):
         try:
-            log.info("Initializing all indexes in MongoDB...")
+            log.info(f"{LogTag.MONGO} Initializing all indexes in MongoDB...")
             # Import here to avoid circular import
             from app.db.mongodb.indexes import create_all_indexes
 
             await create_all_indexes()
             # await log_index_summary()
         except Exception as e:
-            log.error(f"Error while initializing indexes: {e}")
+            log.error(f"{LogTag.MONGO} Error while initializing indexes: {e}")
 
     def get_collection(self, collection_name: str):
         return self.database.get_collection(collection_name)
@@ -83,9 +84,9 @@ def init_mongodb():
     Args:
         app (FastAPI): The FastAPI application instance.
     """
-    log.info("Initializing MongoDB...")
+    log.info(f"{LogTag.MONGO} Initializing MongoDB...")
     mongodb_instance = MongoDB(uri=settings.MONGO_DB, db_name="GAIA")
-    log.info("Created MongoDB instance")
+    log.info(f"{LogTag.MONGO} Created MongoDB instance")
     mongodb_instance.ping()
-    log.info("Successfully connected to MongoDB.")
+    log.info(f"{LogTag.MONGO} Successfully connected to MongoDB.")
     return mongodb_instance

--- a/apps/api/app/db/postgresql.py
+++ b/apps/api/app/db/postgresql.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engin
 from sqlalchemy.orm import declarative_base
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from shared.py.wide_events import log
 
@@ -61,7 +62,7 @@ def _ensure_timestamptz_columns(connection: Connection) -> None:
                 f"TYPE timestamptz USING {column} AT TIME ZONE 'UTC'"
             )
         )
-        log.info("Promoted column to timestamptz", table=table, column=column)
+        log.info(f"{LogTag.STARTUP} Promoted column to timestamptz", table=table, column=column)
 
 
 def _adapt_url_for_asyncpg(postgres_url: str) -> tuple[str, dict[str, Any]]:
@@ -108,7 +109,7 @@ async def init_postgresql_engine() -> AsyncEngine:
     Returns:
         AsyncEngine: The SQLAlchemy async engine
     """
-    log.debug("Initializing PostgreSQL async engine")
+    log.debug(f"{LogTag.STARTUP} Initializing PostgreSQL async engine")
 
     postgres_url: str = settings.POSTGRES_URL  # type: ignore
     url, connect_args = _adapt_url_for_asyncpg(postgres_url)
@@ -127,7 +128,7 @@ async def init_postgresql_engine() -> AsyncEngine:
         await conn.run_sync(_ensure_timestamptz_columns)
 
     log.set(db={"connection_status": "connected", "backend": "postgresql"})
-    log.info("PostgreSQL engine initialized for database")
+    log.info(f"{LogTag.STARTUP} PostgreSQL engine initialized for database")
     return engine
 
 
@@ -172,6 +173,6 @@ async def close_postgresql_db() -> None:
         if providers.is_initialized("postgresql_engine"):
             engine = await get_postgresql_engine()
             await engine.dispose()
-            log.info("PostgreSQL connections closed")
+            log.info(f"{LogTag.STARTUP} PostgreSQL connections closed")
     except Exception as e:
-        log.error(f"Error closing PostgreSQL connections: {e}")
+        log.error(f"{LogTag.STARTUP} Error closing PostgreSQL connections: {e}")

--- a/apps/api/app/db/rabbitmq.py
+++ b/apps/api/app/db/rabbitmq.py
@@ -4,6 +4,7 @@ from aio_pika.abc import AbstractChannel, AbstractRobustConnection
 from aio_pika.exceptions import ChannelPreconditionFailed
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.constants.outbound import (
     OUTBOUND_DLX,
     OUTBOUND_QUEUES,
@@ -25,18 +26,18 @@ class RabbitMQPublisher:
     async def connect(self):
         """Connect to RabbitMQ and create channel."""
         if self.connection is None:
-            log.debug("Establishing RabbitMQ connection")
+            log.debug(f"{LogTag.STARTUP} Establishing RabbitMQ connection")
             self.connection = await aio_pika.connect_robust(self.amqp_url)
             self.channel = await self.connection.channel()
             log.set(db={"connection_status": "connected", "backend": "rabbitmq"})
-            log.info("RabbitMQ connection established")
+            log.info(f"{LogTag.STARTUP} RabbitMQ connection established")
 
     async def declare_queue(self, queue_name: str):
         """Declare a queue if not already declared."""
         if queue_name not in self.declared_queues and self.channel:
             await self.channel.declare_queue(queue_name, durable=True)
             self.declared_queues.add(queue_name)
-            log.debug(f"RabbitMQ queue '{queue_name}' declared")
+            log.debug(f"{LogTag.STARTUP} RabbitMQ queue '{queue_name}' declared")
 
     async def is_connected(self) -> bool:
         """Check if the RabbitMQ connection is still active."""
@@ -58,7 +59,7 @@ class RabbitMQPublisher:
         the WebSocket consumer, but ARQ workers only publish sporadically.
         """
         if not await self.is_connected():
-            log.info("RabbitMQ connection not active, reconnecting...")
+            log.info(f"{LogTag.STARTUP} RabbitMQ connection not active, reconnecting...")
             # Reset connection state
             self.connection = None
             self.channel = None
@@ -66,7 +67,7 @@ class RabbitMQPublisher:
             self._outbound_topology_declared = False
             # Reconnect
             await self.connect()
-            log.info("RabbitMQ reconnected successfully")
+            log.info(f"{LogTag.STARTUP} RabbitMQ reconnected successfully")
 
     async def _publish_with_retry(self, queue_name: str, body: bytes, *, declare: bool) -> None:
         """Publish to the default exchange, reconnecting and retrying once.
@@ -89,9 +90,11 @@ class RabbitMQPublisher:
         try:
             await _attempt()
         except Exception as e:
-            log.error(f"Failed to publish to RabbitMQ: {e}. Attempting recovery...")
+            log.error(
+                f"{LogTag.STARTUP} Failed to publish to RabbitMQ: {e}. Attempting recovery..."
+            )
             await _attempt()
-            log.info("Successfully published after reconnection")
+            log.info(f"{LogTag.STARTUP} Successfully published after reconnection")
 
     async def publish(self, queue_name: str, body: bytes) -> None:
         """Publish to ``queue_name`` (declared on demand) with one retry."""
@@ -150,7 +153,7 @@ class RabbitMQPublisher:
                 # durable queues already exist.
                 self._outbound_topology_declared = True
                 log.error(
-                    "Outbound topology redeclare rejected (divergent queue arguments); "
+                    f"{LogTag.STARTUP} Outbound topology redeclare rejected (divergent queue arguments); "
                     "publishing to the existing queue. Delete or migrate it to reconcile.",
                     error=str(e),
                 )
@@ -160,10 +163,10 @@ class RabbitMQPublisher:
         """Close RabbitMQ connection and channel."""
         if self.channel:
             await self.channel.close()
-            log.debug("RabbitMQ channel closed")
+            log.debug(f"{LogTag.STARTUP} RabbitMQ channel closed")
         if self.connection:
             await self.connection.close()
-            log.info("RabbitMQ connection closed")
+            log.info(f"{LogTag.STARTUP} RabbitMQ connection closed")
 
 
 @lazy_provider(
@@ -180,7 +183,7 @@ async def init_rabbitmq_publisher() -> RabbitMQPublisher:
     Returns:
         RabbitMQPublisher: Connected RabbitMQ publisher instance
     """
-    log.debug("Initializing RabbitMQ publisher")
+    log.debug(f"{LogTag.STARTUP} Initializing RabbitMQ publisher")
 
     rabbitmq_url: str = settings.RABBITMQ_URL  # type: ignore
     publisher = RabbitMQPublisher(rabbitmq_url)
@@ -219,7 +222,7 @@ async def declare_outbound_topology_on_startup() -> None:
         # every outbound publish keeps failing until an operator deletes or
         # migrates the queue, so surface it loudly instead of as a warning.
         log.error(
-            "Outbound topology rejected: a queue exists with divergent arguments. "
+            f"{LogTag.STARTUP} Outbound topology rejected: a queue exists with divergent arguments. "
             "Delete or migrate it — outbound delivery will fail until resolved.",
             error=str(e),
         )
@@ -227,6 +230,6 @@ async def declare_outbound_topology_on_startup() -> None:
     except Exception as e:
         # Best-effort: a missing/unreachable broker must not crash-loop startup —
         # the first publish reconnects and re-declares the topology.
-        log.warning("Outbound topology not declared at startup", error=str(e))
+        log.warning(f"{LogTag.STARTUP} Outbound topology not declared at startup", error=str(e))
         return
-    log.info("Outbound message topology declared")
+    log.info(f"{LogTag.STARTUP} Outbound message topology declared")

--- a/apps/api/app/db/redis.py
+++ b/apps/api/app/db/redis.py
@@ -30,6 +30,7 @@ from app.constants.cache import (
     DEFAULT_CACHE_TTL,
     ONE_YEAR_TTL,
 )
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # Re-export for backwards compatibility
@@ -111,12 +112,14 @@ class RedisCache:
                 # connectivity is asserted by verify_connection() at startup.
                 self.redis = redis.from_url(self.redis_url, decode_responses=True)
                 log.set(db={"connection_status": "configured", "backend": "redis"})
-                log.info("Redis client configured (connection verified at startup).")
+                log.info(
+                    f"{LogTag.STORAGE} Redis client configured (connection verified at startup)."
+                )
             except Exception as e:
                 log.set(db={"connection_status": "error", "backend": "redis"})
-                log.error(f"Failed to create Redis client: {e}")
+                log.error(f"{LogTag.STORAGE} Failed to create Redis client: {e}")
         else:
-            log.warning("REDIS_URL is not set. Caching will be disabled.")
+            log.warning(f"{LogTag.STORAGE} REDIS_URL is not set. Caching will be disabled.")
 
     async def verify_connection(self) -> None:
         """Assert Redis is actually reachable, and scream if it is not.
@@ -130,7 +133,7 @@ class RedisCache:
         if self.redis is None:
             message = "Redis is UNAVAILABLE: REDIS_URL is not configured."
             log.set(db={"connection_status": "unavailable", "backend": "redis"})
-            log.error(message)
+            log.error(f"{LogTag.STORAGE} {message}")
             if settings.ENV == "production":
                 raise ConnectionError(message)
             return
@@ -138,11 +141,11 @@ class RedisCache:
         try:
             await self.redis.ping()
             log.set(db={"connection_status": "verified", "backend": "redis"})
-            log.info("Redis connection verified.")
+            log.info(f"{LogTag.STORAGE} Redis connection verified.")
         except Exception as e:
             message = f"Redis is UNAVAILABLE: ping failed ({type(e).__name__}: {e})"
             log.set(db={"connection_status": "error", "backend": "redis"})
-            log.error(message)
+            log.error(f"{LogTag.STORAGE} {message}")
             if settings.ENV == "production":
                 raise ConnectionError(message) from e
 
@@ -166,7 +169,7 @@ class RedisCache:
             user = await cache.get("user:123", model=User)
         """
         if not self.redis:
-            log.warning("Redis is not initialized. Skipping get operation.")
+            log.warning(f"{LogTag.STORAGE} Redis is not initialized. Skipping get operation.")
             return None
 
         try:
@@ -203,7 +206,7 @@ class RedisCache:
             await cache.set("user:123", user_obj, model=User, ttl=3600)
         """
         if not self.redis:
-            log.warning("Redis is not initialized. Skipping set operation.")
+            log.warning(f"{LogTag.STORAGE} Redis is not initialized. Skipping set operation.")
             return
 
         try:
@@ -226,12 +229,12 @@ class RedisCache:
         Delete a cached key.
         """
         if not self.redis:
-            log.warning("Redis is not initialized. Skipping delete operation.")
+            log.warning(f"{LogTag.STORAGE} Redis is not initialized. Skipping delete operation.")
             return
 
         try:
             await self.redis.delete(key)
-            log.info(f"Cache deleted for key: {key}")
+            log.info(f"{LogTag.STORAGE} Cache deleted for key: {key}")
         except Exception as e:
             log.error(
                 "redis_op_failed",
@@ -248,7 +251,7 @@ class RedisCache:
         """
         if not self.redis:
             self.redis = redis.from_url(self.redis_url, decode_responses=True)
-            log.info("Re-initialized Redis connection.")
+            log.info(f"{LogTag.STORAGE} Re-initialized Redis connection.")
 
         return self.redis
 
@@ -317,7 +320,9 @@ async def get_and_delete_cache(key: str) -> Any | None:
         Cached value (deserialized from JSON) or None if not found
     """
     if not redis_cache.redis:
-        log.warning("Redis is not initialized. Skipping get_and_delete operation.")
+        log.warning(
+            f"{LogTag.STORAGE} Redis is not initialized. Skipping get_and_delete operation."
+        )
         return None
 
     try:
@@ -326,7 +331,7 @@ async def get_and_delete_cache(key: str) -> Any | None:
             return deserialize_any(value)
         return None
     except Exception as e:
-        log.error(f"Error in get_and_delete for key {key}: {e}")
+        log.error(f"{LogTag.STORAGE} Error in get_and_delete for key {key}: {e}")
         return None
 
 
@@ -349,19 +354,19 @@ async def delete_cache_by_pattern(pattern: str):
         await delete_cache_by_pattern("temp:*")  # Delete temporary data
     """
     if not redis_cache.redis:
-        log.warning("Redis is not initialized. Skipping delete operation.")
+        log.warning(f"{LogTag.STORAGE} Redis is not initialized. Skipping delete operation.")
         return
 
     try:
         keys = await redis_cache.redis.keys(pattern)
         if not keys:
-            log.info(f"No keys found for pattern: {pattern}")
+            log.info(f"{LogTag.STORAGE} No keys found for pattern: {pattern}")
             return
         for key in keys:
             await redis_cache.delete(key)
-            log.info(f"Cache deleted for key: {key}")
+            log.info(f"{LogTag.STORAGE} Cache deleted for key: {key}")
     except Exception as e:
-        log.error(f"Error deleting Redis keys by pattern {pattern}: {e}")
+        log.error(f"{LogTag.STORAGE} Error deleting Redis keys by pattern {pattern}: {e}")
 
 
 # Caching decorators have been moved to app.decorators.caching

--- a/apps/api/app/decorators/caching.py
+++ b/apps/api/app/decorators/caching.py
@@ -30,6 +30,7 @@ import functools
 import inspect
 from typing import Any, Generic, TypeVar
 
+from app.constants.log_tags import LogTag
 from app.db.redis import ONE_YEAR_TTL, delete_cache, get_cache, set_cache
 from app.utils.cache_utils import create_cache_key_hash
 from shared.py.wide_events import log
@@ -197,7 +198,7 @@ class Cacheable(Generic[T]):
             # Check if the value is already cached
             cached_value = await get_cache(cache_key, self.model)
             if cached_value is not None:
-                log.debug(f"Cache hit for key: {cache_key}")
+                log.debug(f"{LogTag.API} Cache hit for key: {cache_key}")
                 if self.deserializer:
                     cached_value = self.deserializer(cached_value)
                 return cached_value
@@ -215,8 +216,8 @@ class Cacheable(Generic[T]):
             if self.serializer:
                 serialized_result = self.serializer(result)
 
-            log.debug(f"Cache miss for key: {cache_key}")
-            log.debug(f"Setting cache for key: {cache_key}")
+            log.debug(f"{LogTag.API} Cache miss for key: {cache_key}")
+            log.debug(f"{LogTag.API} Setting cache for key: {cache_key}")
 
             # Let set_cache handle Pydantic serialization
             await set_cache(key=cache_key, value=serialized_result, ttl=self.ttl, model=self.model)
@@ -328,7 +329,7 @@ class CacheInvalidator:
                     for pattern in self.key_patterns
                 ]
 
-            log.debug(f"Cache invalidation for keys: {cache_keys}")
+            log.debug(f"{LogTag.API} Cache invalidation for keys: {cache_keys}")
 
             # Invalidate the cache
             await asyncio.gather(*[delete_cache(key) for key in cache_keys])

--- a/apps/api/app/decorators/integration.py
+++ b/apps/api/app/decorators/integration.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.utils.integration_checker import check_and_prompt_integration
 from app.utils.oauth_utils import get_tokens_by_user_id
 from shared.py.wide_events import log
@@ -45,7 +46,9 @@ def require_integration(tool_category: str, tool_name: str | None = None):
                 config = kwargs.get("config")
 
             if not config:
-                log.warning(f"No RunnableConfig found for tool: {tool_name or func.__name__}")
+                log.warning(
+                    f"{LogTag.API} No RunnableConfig found for tool: {tool_name or func.__name__}"
+                )
                 return "Configuration error: Unable to verify integration permissions."
 
             # Extract access token from config
@@ -55,7 +58,9 @@ def require_integration(tool_category: str, tool_name: str | None = None):
             )
 
             if not access_token:
-                log.warning(f"No access token found for tool: {tool_name or func.__name__}")
+                log.warning(
+                    f"{LogTag.API} No access token found for tool: {tool_name or func.__name__}"
+                )
                 return "Authentication required: Please ensure you're logged in."
 
             # Check if user has required integration

--- a/apps/api/app/decorators/rate_limiting.py
+++ b/apps/api/app/decorators/rate_limiting.py
@@ -14,6 +14,7 @@ from app.api.v1.middleware.tiered_rate_limiter import (
     RateLimitExceededException,
     tiered_limiter,
 )
+from app.constants.log_tags import LogTag
 from app.models.payment_models import PlanType
 from app.models.usage_models import UsageInfo
 from app.services.payments.payment_service import payment_service
@@ -73,7 +74,9 @@ def with_rate_limiting(
 
                 # Skip rate limiting for system operations if configured
                 if bypass_for_system and initiator == "backend":
-                    log.debug(f"Bypassing rate limiting for system operation: {actual_feature_key}")
+                    log.debug(
+                        f"{LogTag.API} Bypassing rate limiting for system operation: {actual_feature_key}"
+                    )
                 else:
                     try:
                         user_plan = await payment_service.get_cached_plan_type(user_id)
@@ -99,13 +102,13 @@ def with_rate_limiting(
                         )
 
                         log.debug(
-                            f"Rate limit check passed for user {user_id}, feature {actual_feature_key}"
+                            f"{LogTag.API} Rate limit check passed for user {user_id}, feature {actual_feature_key}"
                         )
 
                     except RateLimitExceededException as e:
                         # Convert to agent-friendly exception
                         log.warning(
-                            f"Rate limit exceeded for user {user_id}, feature {actual_feature_key}"
+                            f"{LogTag.API} Rate limit exceeded for user {user_id}, feature {actual_feature_key}"
                         )
                         detail_dict = {}
                         reset_time = None
@@ -150,11 +153,13 @@ def with_rate_limiting(
                         )
                     except Exception as e:
                         log.error(
-                            f"Rate limiting failed for user {user_id}, feature {actual_feature_key}: {e!s}"
+                            f"{LogTag.API} Rate limiting failed for user {user_id}, feature {actual_feature_key}: {e!s}"
                         )
                         raise
             else:
-                log.warning(f"No user context for {actual_feature_key}, skipping rate limiting")
+                log.warning(
+                    f"{LogTag.API} No user context for {actual_feature_key}, skipping rate limiting"
+                )
 
             # Execute the original function
             result = await func(*args, **kwargs)
@@ -188,7 +193,7 @@ def with_rate_limiting(
                 tokens_used = result.get("tokens_used", 0)
                 if tokens_used > 0:
                     log.debug(
-                        f"Token usage recorded: {tokens_used} tokens for feature {actual_feature_key}"
+                        f"{LogTag.API} Token usage recorded: {tokens_used} tokens for feature {actual_feature_key}"
                     )
 
             return result
@@ -303,7 +308,7 @@ def set_user_context(user_id: str, initiator: str = "frontend", **kwargs):
     """Set user context to avoid parameter pollution."""
     context = {"user_id": user_id, "initiator": initiator, **kwargs}
     user_context.set(context)
-    log.debug(f"Set user context for {user_id} (initiator: {initiator})")
+    log.debug(f"{LogTag.API} Set user context for {user_id} (initiator: {initiator})")
     return context
 
 
@@ -311,7 +316,7 @@ def clear_user_context():
     """Clear user context."""
     user_context.set(None)
     rate_limit_context.set(None)
-    log.debug("Cleared user context")
+    log.debug(f"{LogTag.API} Cleared user context")
 
 
 def get_current_rate_limit_info() -> dict[str, Any] | None:

--- a/apps/api/app/decorators/timing.py
+++ b/apps/api/app/decorators/timing.py
@@ -8,6 +8,7 @@ import functools
 import inspect
 import time
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -20,7 +21,7 @@ def async_timer(func: Callable) -> Callable:
         try:
             result = await func(*args, **kwargs)
             execution_time = time.time() - start_time
-            log.info(f"⏱️  {func.__name__} completed in {execution_time:.3f}s")
+            log.info(f"{LogTag.API} ⏱️  {func.__name__} completed in {execution_time:.3f}s")
             if execution_time > 1.0:
                 log.warning(
                     "slow function",
@@ -30,7 +31,7 @@ def async_timer(func: Callable) -> Callable:
             return result
         except Exception as e:
             execution_time = time.time() - start_time
-            log.error(f"⏱️  {func.__name__} failed after {execution_time:.3f}s: {e}")
+            log.error(f"{LogTag.API} ⏱️  {func.__name__} failed after {execution_time:.3f}s: {e}")
             raise
 
     return wrapper
@@ -45,7 +46,7 @@ def sync_timer(func: Callable) -> Callable:
         try:
             result = func(*args, **kwargs)
             execution_time = time.time() - start_time
-            log.info(f"⏱️  {func.__name__} completed in {execution_time:.3f}s")
+            log.info(f"{LogTag.API} ⏱️  {func.__name__} completed in {execution_time:.3f}s")
             if execution_time > 1.0:
                 log.warning(
                     "slow function",
@@ -55,7 +56,7 @@ def sync_timer(func: Callable) -> Callable:
             return result
         except Exception as e:
             execution_time = time.time() - start_time
-            log.error(f"⏱️  {func.__name__} failed after {execution_time:.3f}s: {e}")
+            log.error(f"{LogTag.API} ⏱️  {func.__name__} failed after {execution_time:.3f}s: {e}")
             raise
 
     return wrapper

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -9,15 +9,18 @@ import time
 from fastapi import FastAPI  # noqa: F401
 
 from app.config.sentry import init_sentry
+from app.constants.log_tags import LogTag
 from app.core.app_factory import create_app
 import app.patches  # noqa: F401 to apply patches
 from shared.py.wide_events import log
 
 # Create the FastAPI application
 log.set(service={"name": "gaia-api"})
-log.info("Starting application initialization...")
+log.info(f"{LogTag.STARTUP} Starting application initialization...")
 app_creation_start = time.time()
 app: FastAPI = create_app()  # type: ignore[assignment, no-redef]
 init_sentry()
 
-log.info(f"Application setup completed in {(time.time() - app_creation_start):.3f}s")
+log.info(
+    f"{LogTag.STARTUP} Application setup completed in {(time.time() - app_creation_start):.3f}s"
+)

--- a/apps/api/app/services/chat/persistence.py
+++ b/apps/api/app/services/chat/persistence.py
@@ -21,6 +21,7 @@ from app.api.v1.middleware.tiered_rate_limiter import tiered_limiter
 from app.config.model_pricing import calculate_token_cost
 from app.config.settings import settings
 from app.constants.chat import ARTIFACT_REF_RE, WORKSPACE_ARTIFACT_RE
+from app.constants.log_tags import LogTag
 from app.models.chat_models import MessageModel, UpdateMessagesRequest
 from app.models.message_models import MessageRequestWithHistory
 from app.models.payment_models import PlanType
@@ -125,7 +126,7 @@ async def save_conversation_async(
         try:
             await process_token_usage_and_cost(user_id, metadata)
         except Exception as e:  # noqa: BLE001 — billing failure must not block save
-            log.error(f"Failed to process token usage: {e}")
+            log.error(f"{LogTag.CHAT} Failed to process token usage: {e}")
 
     bot_timestamp = bot_timestamp or datetime.now(UTC)
     user_timestamp = bot_timestamp - timedelta(milliseconds=100)
@@ -217,4 +218,4 @@ async def process_token_usage_and_cost(user_id: str, metadata: dict[str, Any]) -
         )
 
     except Exception as e:  # noqa: BLE001 — billing failure must not block save
-        log.debug(f"Token usage processing failed: {e}")
+        log.debug(f"{LogTag.CHAT} Token usage processing failed: {e}")

--- a/apps/api/app/services/chat/state.py
+++ b/apps/api/app/services/chat/state.py
@@ -9,6 +9,7 @@ cancellation paths where the ``nostream`` marker never arrives.
 from datetime import UTC, datetime
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from shared.py.wide_events import log
 
@@ -63,7 +64,7 @@ async def recover_stream_state(
         and not tool_data.get("tool_data")
     ):
         tool_data = progress_tool_data
-    log.debug(f"Recovered {len(complete_message)} chars from Redis progress")
+    log.debug(f"{LogTag.CHAT} Recovered {len(complete_message)} chars from Redis progress")
     return complete_message, tool_data
 
 

--- a/apps/api/app/services/chat/stream.py
+++ b/apps/api/app/services/chat/stream.py
@@ -27,6 +27,7 @@ from app.agents.core.background.executor_capture import (
     teardown_executor_capture,
 )
 from app.constants.cache import EXECUTOR_WAIT_TIMEOUT, VOICE_EXECUTOR_RESULT_TIMEOUT_S
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from app.db.mongodb.collections import conversations_collection
 from app.models.message_models import MessageRequestWithHistory
@@ -268,7 +269,7 @@ async def _publish_description_if_ready(
             f"""data: {json.dumps({"conversation_description": description})}\n\n""",
         )
     except Exception as e:  # noqa: BLE001 — description is non-critical
-        log.error(f"Failed to get conversation description: {e}")
+        log.error(f"{LogTag.CHAT} Failed to get conversation description: {e}")
     return None
 
 
@@ -283,7 +284,7 @@ async def _wait_for_http_subscriber(
     try:
         await asyncio.wait_for(start_event.wait(), timeout=5.0)
     except TimeoutError:
-        log.warning(f"Stream {stream_id} HTTP subscriber timeout, proceeding anyway")
+        log.warning(f"{LogTag.CHAT} Stream {stream_id} HTTP subscriber timeout, proceeding anyway")
 
 
 async def _publish_init_chunk(
@@ -344,7 +345,7 @@ async def _consume_agent_stream(
     ):
         if await stream_manager.is_cancelled(stream_id):
             state.is_cancelled = True
-            log.info(f"Stream {stream_id} cancelled by user")
+            log.info(f"{LogTag.CHAT} Stream {stream_id} cancelled by user")
             break
 
         # Skip [DONE] marker — we send it after description generation.
@@ -368,7 +369,7 @@ async def _consume_agent_stream(
                     state.follow_up_actions,
                 )
             except Exception as e:  # noqa: BLE001 — fall back to passthrough
-                log.error(f"Error processing chunk: {e}")
+                log.error(f"{LogTag.CHAT} Error processing chunk: {e}")
                 await stream_manager.publish_chunk(stream_id, chunk)
         else:
             await stream_manager.publish_chunk(stream_id, chunk)
@@ -428,7 +429,7 @@ async def _finalize_description(
             f"""data: {json.dumps({"conversation_description": description})}\n\n""",
         )
     except Exception as e:  # noqa: BLE001 — description is non-critical
-        log.error(f"Failed to get conversation description: {e}")
+        log.error(f"{LogTag.CHAT} Failed to get conversation description: {e}")
 
 
 async def _handle_stream_error(
@@ -441,7 +442,7 @@ async def _handle_stream_error(
     Order matters: ``set_error`` publishes the ``STREAM_ERROR_SIGNAL`` which
     breaks the subscriber loop, so the error chunk must go on the wire first.
     """
-    log.error(f"Background stream error for {stream_id}: {error}")
+    log.error(f"{LogTag.CHAT} Background stream error for {stream_id}: {error}")
     await _wait_for_http_subscriber(start_event, stream_id)
     await stream_manager.publish_chunk(stream_id, f"data: {json.dumps({'error': str(error)})}\n\n")
     await stream_manager.set_error(stream_id, str(error))
@@ -520,7 +521,7 @@ async def _attach_executor_tool_data(
             {"$push": {"messages.$.tool_data": {"$each": executor_td}}},
         )
     except Exception as e:  # noqa: BLE001 — executor tool_data attach is best-effort
-        log.error(f"Failed to update bot message tool_data: {e}")
+        log.error(f"{LogTag.CHAT} Failed to update bot message tool_data: {e}")
 
 
 async def _finalize_stream(
@@ -552,7 +553,7 @@ async def _finalize_stream(
             # happy/cancel path, which always runs the attach itself.
             await _attach_executor_tool_data(stream_id, body, user, conversation_id, state)
         except Exception as save_err:  # noqa: BLE001 — best-effort fallback save
-            log.error(f"Fallback save failed for stream {stream_id}: {save_err}")
+            log.error(f"{LogTag.CHAT} Fallback save failed for stream {stream_id}: {save_err}")
 
     # Teardown must come AFTER the fallback save: the backstop attach drains the
     # session's tool events — tearing down first would leave it nothing to drain.
@@ -572,4 +573,4 @@ async def _finalize_stream(
         # elided so events without FS activity stay clean.
         **({"fs": fs_metrics} if fs_metrics else {}),
     )
-    log.debug(f"Background stream {stream_id} completed and saved")
+    log.debug(f"{LogTag.CHAT} Background stream {stream_id} completed and saved")

--- a/apps/api/app/services/chat/workspace.py
+++ b/apps/api/app/services/chat/workspace.py
@@ -22,6 +22,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.constants.outbound import OUTBOUND_QUEUES
 from app.core.stream_manager import stream_manager
 from app.db.mongodb.collections import conversations_collection
@@ -73,7 +74,7 @@ def schedule_last_active_touch(user_id: str, conversation_id: str) -> None:
         except JuiceFSUnavailable:
             return  # dev mode — no mount, nothing to touch
         except Exception as e:  # noqa: BLE001 — last_active bump must not affect chat
-            log.warning(f"[chat] last_active touch failed: {e}")
+            log.warning(f"{LogTag.CHAT} last_active touch failed: {e}")
 
     task = loop.create_task(_touch())
     _last_active_tasks.add(task)
@@ -157,7 +158,7 @@ async def forward_artifact_events(
     except asyncio.CancelledError:
         raise
     except Exception as e:  # noqa: BLE001 — log and exit; orchestrator cleans up
-        log.warning(f"[chat] artifact forwarder error: {e}")
+        log.warning(f"{LogTag.CHAT} artifact forwarder error: {e}")
     finally:
         with contextlib.suppress(Exception):
             await pubsub.unsubscribe(channel)
@@ -202,11 +203,11 @@ async def _persist_artifact_entry(
                 return
             await asyncio.sleep(_PERSIST_RETRY_BASE_DELAY * (attempt + 1))
         log.warning(
-            "[chat] artifact persist matched no bot message after retries "
+            f"{LogTag.CHAT} artifact persist matched no bot message after retries "
             f"(conv={conversation_id}, msg={bot_message_id})"
         )
     except Exception as e:  # noqa: BLE001 — best-effort; live stream already delivered it
-        log.warning(f"[chat] failed to persist artifact entry: {e}")
+        log.warning(f"{LogTag.CHAT} failed to persist artifact entry: {e}")
 
 
 # JuiceFS default block size: reading in block-sized chunks pulls each block
@@ -242,7 +243,7 @@ async def _warm_artifact_cache(user_id: str, conversation_id: str, path: str) ->
             host_path = await resolve_session_path(user_id, conversation_id, "artifacts", path)
             await asyncio.to_thread(_warm_artifact_blocks, host_path)
     except Exception as e:  # noqa: BLE001 — best-effort cache warm
-        log.debug(f"[chat] artifact cache warm skipped: {e}")
+        log.debug(f"{LogTag.CHAT} artifact cache warm skipped: {e}")
 
 
 def _parse_artifact_message(message: dict[str, Any], conversation_id: str) -> dict[str, Any] | None:

--- a/apps/api/app/services/composio/composio_service.py
+++ b/apps/api/app/services/composio/composio_service.py
@@ -6,6 +6,7 @@ from composio.types import Tool
 
 from app.config.oauth_config import get_composio_social_configs
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from app.models.trigger_config import TriggerConfig
 
@@ -85,13 +86,13 @@ class ComposioService:
                 "connection_id": connection_request.id,
             }
         except Exception as e:
-            log.error(f"Error connecting {provider} for {user_id}: {e}")
+            log.error(f"{LogTag.COMPOSIO} Error connecting {provider} for {user_id}: {e}")
             raise
 
     async def get_tools(self, tool_kit: str, exclude_tools: list[str] | None = None):
         """Get tools for a toolkit with unified master hooks."""
         log.set(composio_toolkit=tool_kit)
-        log.info(f"Loading {tool_kit} toolkit...")
+        log.info(f"{LogTag.COMPOSIO} Loading {tool_kit} toolkit...")
 
         tools = await asyncio.to_thread(
             lambda: self.composio.tools.get(  # type: ignore[call-overload]
@@ -158,9 +159,13 @@ class ComposioService:
 
             store = get_mcp_tools_store()
             await store.store_tools(toolkit_name.lower(), tool_metadata)
-            log.debug(f"Stored {len(tool_metadata)} Composio tool metadata for {toolkit_name}")
+            log.debug(
+                f"{LogTag.COMPOSIO} Stored {len(tool_metadata)} Composio tool metadata for {toolkit_name}"
+            )
         except Exception as e:
-            log.warning(f"Failed to store Composio tool metadata for {toolkit_name}: {e}")
+            log.warning(
+                f"{LogTag.COMPOSIO} Failed to store Composio tool metadata for {toolkit_name}: {e}"
+            )
 
     async def get_tools_by_name(
         self,
@@ -195,7 +200,7 @@ class ComposioService:
         )
 
         tools_time = time.time() - start_time
-        log.info(f"Tools loaded: {len(result)} tools in {tools_time:.3f}s")
+        log.info(f"{LogTag.COMPOSIO} Tools loaded: {len(result)} tools in {tools_time:.3f}s")
         existing = log.get().get("composio", {})
         log.set(
             composio={
@@ -264,7 +269,7 @@ class ComposioService:
 
             return tools[0] if tools else None
         except Exception as e:
-            log.error(f"Error getting tool {tool_name}: {e}")
+            log.error(f"{LogTag.COMPOSIO} Error getting tool {tool_name}: {e}")
             return None
 
     async def check_connection_status(self, providers: list[str], user_id: str) -> dict[str, bool]:
@@ -305,7 +310,7 @@ class ComposioService:
 
         except Exception as e:
             log.error(
-                f"Error checking connection status for providers {providers} and user {user_id}: {e}"
+                f"{LogTag.COMPOSIO} Error checking connection status for providers {providers} and user {user_id}: {e}"
             )
             return result
 
@@ -316,7 +321,9 @@ class ComposioService:
             )
             return connected_account
         except Exception as e:
-            log.error(f"Error retrieving connected account {connected_account_id}: {e}")
+            log.error(
+                f"{LogTag.COMPOSIO} Error retrieving connected account {connected_account_id}: {e}"
+            )
             return None
 
     async def delete_connected_account(self, user_id: str, provider: str) -> dict[str, str]:
@@ -345,7 +352,7 @@ class ComposioService:
 
             if not active_accounts:
                 log.info(
-                    f"No active connected account found for {provider} and user {user_id}, nothing to delete"
+                    f"{LogTag.COMPOSIO} No active connected account found for {provider} and user {user_id}, nothing to delete"
                 )
                 return {
                     "status": "success",
@@ -363,7 +370,7 @@ class ComposioService:
             await asyncio.gather(*delete_tasks)
 
             log.info(
-                f"Deleted {len(active_accounts)} connected account(s) for {provider} and user {user_id}"
+                f"{LogTag.COMPOSIO} Deleted {len(active_accounts)} connected account(s) for {provider} and user {user_id}"
             )
             return {
                 "status": "success",
@@ -373,7 +380,9 @@ class ComposioService:
         except ValueError:
             raise
         except Exception as e:
-            log.error(f"Error deleting connected account for {provider} and user {user_id}: {e}")
+            log.error(
+                f"{LogTag.COMPOSIO} Error deleting connected account for {provider} and user {user_id}: {e}"
+            )
             raise
         finally:
             # Always flush the proxy connected_account_id cache: on success the
@@ -391,10 +400,12 @@ class ComposioService:
         active_triggers = [t for t in triggers if t.auto_activate]
 
         if not active_triggers:
-            log.info(f"No auto-active triggers to subscribe for user {user_id}")
+            log.info(f"{LogTag.COMPOSIO} No auto-active triggers to subscribe for user {user_id}")
             return []
 
-        log.info(f"Subscribing to {len(active_triggers)} auto-active triggers for user {user_id}")
+        log.info(
+            f"{LogTag.COMPOSIO} Subscribing to {len(active_triggers)} auto-active triggers for user {user_id}"
+        )
 
         try:
 
@@ -412,7 +423,7 @@ class ComposioService:
 
             return await asyncio.gather(*tasks)
         except Exception as e:
-            log.error(f"Error handling subscribe trigger for {user_id}: {e}")
+            log.error(f"{LogTag.COMPOSIO} Error handling subscribe trigger for {user_id}: {e}")
 
 
 @lazy_provider(

--- a/apps/api/app/services/composio/custom_tools/gmail_tools.py
+++ b/apps/api/app/services/composio/custom_tools/gmail_tools.py
@@ -11,6 +11,7 @@ from typing import Any
 from composio import Composio
 from pydantic import BaseModel, Field
 
+from app.constants.log_tags import LogTag
 from app.models.common_models import GatherContextInput
 from app.services.composio.proxy_client import proxy_request_sync
 from app.services.contact_service import build_contact_index
@@ -329,11 +330,11 @@ def register_gmail_custom_tools(composio: Composio):
                     messages.append(full)
             except Exception as exc:
                 fetch_failures += 1
-                log.warning(f"Gmail message fetch failed for {message_id}: {exc}")
+                log.warning(f"{LogTag.COMPOSIO} Gmail message fetch failed for {message_id}: {exc}")
 
         if message_ids and not messages:
             log.error(
-                f"Gmail contact list: all {len(message_ids)} message fetches failed "
+                f"{LogTag.COMPOSIO} Gmail contact list: all {len(message_ids)} message fetches failed "
                 f"for user {user_id}"
             )
             return {

--- a/apps/api/app/services/composio/custom_tools/registry.py
+++ b/apps/api/app/services/composio/custom_tools/registry.py
@@ -68,6 +68,7 @@ from app.agents.tools.integrations.twitter_tool import (
 from app.agents.tools.integrations.urgency_tool import (
     register_urgency_custom_tools,
 )
+from app.constants.log_tags import LogTag
 from app.services.composio.custom_tools.gmail_tools import (
     register_gmail_custom_tools,
 )
@@ -174,7 +175,9 @@ class CustomToolsRegistry:
             custom_tools_registered_count=len(tool_names),
             custom_tools_names=tool_names,
         )
-        log.info(f"Registered {len(tool_names)} custom tools for {normalized_toolkit} toolkit")
+        log.info(
+            f"{LogTag.COMPOSIO} Registered {len(tool_names)} custom tools for {normalized_toolkit} toolkit"
+        )
 
     def get_tool_names(self, toolkit: str) -> list[str]:
         """Get the custom tool names for a toolkit, or an empty list if none exist."""

--- a/apps/api/app/services/composio/langchain_composio_service.py
+++ b/apps/api/app/services/composio/langchain_composio_service.py
@@ -15,6 +15,7 @@ from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import StructuredTool as BaseStructuredTool
 import pydantic
 
+from app.constants.log_tags import LogTag
 from app.utils.errors import AppError
 from shared.py.wide_events import log
 
@@ -110,7 +111,7 @@ class LangchainProvider(
                 # which would silently route this call to the wrong (or no)
                 # connected account. Fail loudly instead of hitting "default".
                 log.warning(
-                    f"composio tool {tool} (toolkit={toolkit}) invoked without a "
+                    f"{LogTag.COMPOSIO} composio tool {tool} (toolkit={toolkit}) invoked without a "
                     "user_id in runnable metadata; refusing to fall back to the "
                     "Composio 'default' account."
                 )
@@ -156,16 +157,18 @@ class LangchainProvider(
                     )
                     if looks_like_dead_account:
                         log.warning(
-                            f"composio tool {tool} (toolkit={toolkit}) likely "
+                            f"{LogTag.COMPOSIO} composio tool {tool} (toolkit={toolkit}) likely "
                             f"dead account for user={user_id}: error={err_preview!r}"
                         )
                     else:
                         log.info(
-                            f"composio tool {tool} (toolkit={toolkit}) returned "
+                            f"{LogTag.COMPOSIO} composio tool {tool} (toolkit={toolkit}) returned "
                             f"successful=False for user={user_id}: error={err_preview!r}"
                         )
             except Exception as obs_err:  # noqa: BLE001 - observability must not break tool
-                log.debug(f"composio invocation log skipped for {tool}: {obs_err}")
+                log.debug(
+                    f"{LogTag.COMPOSIO} composio invocation log skipped for {tool}: {obs_err}"
+                )
 
             return result
 

--- a/apps/api/app/services/composio/proxy_client.py
+++ b/apps/api/app/services/composio/proxy_client.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 
 from app.config.oauth_config import get_composio_social_configs
 from app.constants.error_codes import INTEGRATION_NOT_CONNECTED
+from app.constants.log_tags import LogTag
 from app.utils.errors import AppError
 from shared.py.wide_events import log
 
@@ -89,7 +90,7 @@ def _resolve_connected_account_id(user_id: str, toolkit: str) -> str:
         raise
     except Exception as e:
         log.error(
-            f"composio.connected_accounts.list FAILED for user={user_id} "
+            f"{LogTag.COMPOSIO} composio.connected_accounts.list FAILED for user={user_id} "
             f"toolkit={toolkit}: {type(e).__name__}: {e}"
         )
         raise AppError(
@@ -121,7 +122,7 @@ def _resolve_connected_account_id(user_id: str, toolkit: str) -> str:
             for acc in accounts.items[:5]
         ]
         log.warning(
-            f"composio: no ACTIVE account for user={user_id} toolkit={toolkit} "
+            f"{LogTag.COMPOSIO} composio: no ACTIVE account for user={user_id} toolkit={toolkit} "
             f"(total_accounts={total_accounts}, sample={account_summary})"
         )
         # 403, not 401: the user's GAIA session is valid — they simply have no
@@ -142,7 +143,7 @@ def _resolve_connected_account_id(user_id: str, toolkit: str) -> str:
         )
 
     log.info(
-        f"composio: resolved connected_account_id for user={user_id} toolkit={toolkit} "
+        f"{LogTag.COMPOSIO} composio: resolved connected_account_id for user={user_id} toolkit={toolkit} "
         f"-> {active.id} (cached for {_CONNECTED_ACCOUNT_CACHE_TTL_SECONDS}s)"
     )
     with _cache_lock:
@@ -214,7 +215,7 @@ def _proxy_call(
         raise
     except Exception as e:
         log.error(
-            f"composio.tools.proxy raised for user={user_id} toolkit={toolkit} "
+            f"{LogTag.COMPOSIO} composio.tools.proxy raised for user={user_id} toolkit={toolkit} "
             f"{method} {endpoint}: {type(e).__name__}: {e}"
         )
         raise AppError(

--- a/apps/api/app/services/desktop/bridge.py
+++ b/apps/api/app/services/desktop/bridge.py
@@ -21,6 +21,7 @@ from app.constants.cache import (
     DESKTOP_REQUEST_TTL_GRACE_SECONDS,
     DESKTOP_RESULT_CHANNEL_PREFIX,
 )
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from app.db.redis import redis_cache
 from app.utils.errors import AppError
@@ -78,7 +79,7 @@ async def request_desktop_action(
     ``DESKTOP_TOOL_TIMEOUT_SECONDS``) on the per-request Redis result channel.
     """
     if not redis_cache.redis:
-        log.error("Desktop bridge: Redis unavailable")
+        log.error(f"{LogTag.DESKTOP} Desktop bridge: Redis unavailable")
         return DesktopToolOutcome(ok=False, error=ERROR_REDIS_UNAVAILABLE)
 
     request_id = str(uuid4())
@@ -121,7 +122,9 @@ async def request_desktop_action(
             async with asyncio.timeout(DESKTOP_TOOL_TIMEOUT_SECONDS):
                 outcome = await _await_result(pubsub)
         except TimeoutError:
-            log.warning(f"Desktop tool '{tool}' timed out after {DESKTOP_TOOL_TIMEOUT_SECONDS}s")
+            log.warning(
+                f"{LogTag.DESKTOP} Desktop tool '{tool}' timed out after {DESKTOP_TOOL_TIMEOUT_SECONDS}s"
+            )
             return DesktopToolOutcome(ok=False, error=ERROR_TIMEOUT)
 
         return outcome
@@ -157,7 +160,7 @@ async def _await_result(pubsub: Any) -> DesktopToolOutcome:
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError:
-            log.warning("Desktop bridge: discarding malformed result payload")
+            log.warning(f"{LogTag.DESKTOP} Desktop bridge: discarding malformed result payload")
             continue
 
         return DesktopToolOutcome(
@@ -176,7 +179,7 @@ async def publish_desktop_result(
 ) -> None:
     """Relay a result POSTed by the desktop app to the awaiting tool."""
     if not redis_cache.redis:
-        log.error("Desktop bridge: Redis unavailable, dropping result")
+        log.error(f"{LogTag.DESKTOP} Desktop bridge: Redis unavailable, dropping result")
         return
     await redis_cache.redis.publish(
         f"{DESKTOP_RESULT_CHANNEL_PREFIX}{request_id}",

--- a/apps/api/app/services/integrations/category_inference_service.py
+++ b/apps/api/app/services/integrations/category_inference_service.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from openai import AsyncOpenAI
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # Fixed list of valid integration categories
@@ -104,7 +105,7 @@ async def infer_integration_category(
         content = response.choices[0].message.content
         if content is None:
             log.warning(
-                f"LLM returned empty content for integration '{name}', falling back to 'other'"
+                f"{LogTag.INTEGRATION} LLM returned empty content for integration '{name}', falling back to 'other'"
             )
             return "other"
 
@@ -113,17 +114,17 @@ async def infer_integration_category(
         # Validate response is a known category
         if category not in INTEGRATION_CATEGORIES:
             log.warning(
-                f"LLM returned invalid category '{category}' for integration '{name}', "
+                f"{LogTag.INTEGRATION} LLM returned invalid category '{category}' for integration '{name}', "
                 f"falling back to 'other'"
             )
             return "other"
 
-        log.info(f"Inferred category '{category}' for integration '{name}'")
+        log.info(f"{LogTag.INTEGRATION} Inferred category '{category}' for integration '{name}'")
         return category
 
     except Exception as e:
         log.error(
-            f"Failed to infer category for integration '{name}': {e}",
+            f"{LogTag.INTEGRATION} Failed to infer category for integration '{name}': {e}",
             exc_info=True,
         )
         return "other"

--- a/apps/api/app/services/integrations/community_service.py
+++ b/apps/api/app/services/integrations/community_service.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from app.constants.cache import COMMUNITY_CACHE_TTL
+from app.constants.log_tags import LogTag
 from app.db.chroma.public_integrations_store import search_public_integrations
 from app.db.mongodb.collections import integrations_collection
 from app.db.redis import get_cache, set_cache
@@ -72,7 +73,9 @@ async def _search_community_integrations(
         )
 
     # Fallback to MongoDB regex search
-    log.info(f"ChromaDB returned no results for '{query}', falling back to MongoDB")
+    log.info(
+        f"{LogTag.INTEGRATION} ChromaDB returned no results for '{query}', falling back to MongoDB"
+    )
     search_regex = {"$regex": query, "$options": "i"}
     mongo_query: dict[str, Any] = {
         "is_public": True,

--- a/apps/api/app/services/integrations/custom_crud.py
+++ b/apps/api/app/services/integrations/custom_crud.py
@@ -7,6 +7,7 @@ import uuid
 from mcp_use.client.exceptions import OAuthAuthenticationError
 from sqlalchemy import delete
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chroma_cleanup import cleanup_integration_chroma_data
 from app.db.chroma.public_integrations_store import remove_public_integration
 from app.db.mongodb.collections import (
@@ -73,7 +74,7 @@ async def create_custom_integration(
     try:
         await add_user_integration(user_id, integration_id, initial_status="created")
     except Exception as e:
-        log.error(f"Failed to add user_integration, rolling back: {e}")
+        log.error(f"{LogTag.INTEGRATION} Failed to add user_integration, rolling back: {e}")
         await integrations_collection.delete_one({"integration_id": integration_id})
         raise
 
@@ -117,7 +118,9 @@ async def update_custom_integration(
                 try:
                     await cleanup_integration_chroma_data(integration_id, old_server_url)
                 except Exception as e:
-                    log.warning(f"Failed to clean old namespace for {integration_id}: {e}")
+                    log.warning(
+                        f"{LogTag.INTEGRATION} Failed to clean old namespace for {integration_id}: {e}"
+                    )
 
         if request.requires_auth is not None:
             current_config["requires_auth"] = request.requires_auth
@@ -164,7 +167,7 @@ async def delete_custom_integration(user_id: str, integration_id: str) -> bool:
             try:
                 await remove_public_integration(integration_id)
             except Exception as e:
-                log.warning(f"Failed to remove from public integrations: {e}")
+                log.warning(f"{LogTag.INTEGRATION} Failed to remove from public integrations: {e}")
 
         result = await integrations_collection.delete_one(
             {
@@ -186,7 +189,9 @@ async def delete_custom_integration(user_id: str, integration_id: str) -> bool:
                 try:
                     await remove_user_integration(affected_user_id, integration_id)
                 except Exception as e:
-                    log.debug(f"Failed to remove integration for user {affected_user_id}: {e}")
+                    log.debug(
+                        f"{LogTag.INTEGRATION} Failed to remove integration for user {affected_user_id}: {e}"
+                    )
 
             try:
                 async with get_db_session() as session:
@@ -195,19 +200,21 @@ async def delete_custom_integration(user_id: str, integration_id: str) -> bool:
                     )
                     await session.commit()
             except Exception as e:
-                log.warning(f"Failed to delete MCP credentials: {e}")
+                log.warning(f"{LogTag.INTEGRATION} Failed to delete MCP credentials: {e}")
 
             try:
                 await delete_cache("mcp:tools:all")
             except Exception as e:
-                log.debug(f"Cache deletion for mcp:tools:all failed: {e}")
+                log.debug(f"{LogTag.INTEGRATION} Cache deletion for mcp:tools:all failed: {e}")
 
             try:
                 mcp_config = doc.get("mcp_config", {})
                 server_url = mcp_config.get("server_url", "")
                 await cleanup_integration_chroma_data(integration_id, server_url)
             except Exception as e:
-                log.debug(f"Chroma store deletion failed for {integration_id}: {e}")
+                log.debug(
+                    f"{LogTag.INTEGRATION} Chroma store deletion failed for {integration_id}: {e}"
+                )
 
             return True
         return False
@@ -222,7 +229,9 @@ async def delete_custom_integration(user_id: str, integration_id: str) -> bool:
                 )
                 await session.commit()
         except Exception as e:
-            log.debug(f"MCP credential deletion failed for {integration_id}: {e}")
+            log.debug(
+                f"{LogTag.INTEGRATION} MCP credential deletion failed for {integration_id}: {e}"
+            )
 
         return True
     return False
@@ -339,7 +348,7 @@ async def _build_oauth_result(mcp_client: Any, integration_id: str) -> dict:
         )
         return {"status": "requires_oauth", "oauth_url": auth_url}
     except Exception as e:
-        log.error(f"OAuth discovery failed: {e}")
+        log.error(f"{LogTag.INTEGRATION} OAuth discovery failed: {e}")
         return {
             "status": "failed",
             "error": f"OAuth required but discovery failed: {e}",

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -14,6 +14,7 @@ from app.config.oauth_config import (
 )
 from app.config.token_repository import token_repository
 from app.constants.cache import OAUTH_STATUS_KEY
+from app.constants.log_tags import LogTag
 from app.db.redis import delete_cache
 from app.helpers.mcp_helpers import get_api_base_url, invalidate_mcp_status_cache
 from app.schemas.integrations.responses import (
@@ -147,7 +148,7 @@ async def _handle_connect_failure(
     """Surface a connection failure as a structured error, never a 500."""
     if not is_platform:
         await update_user_integration_status(user_id, integration_id, "created")
-    log.warning(f"MCP connection failed for {integration_id}: {error}")
+    log.warning(f"{LogTag.INTEGRATION} MCP connection failed for {integration_id}: {error}")
     log.set(integration={"provider": integration_name, "action": "connect_mcp", "status": "error"})
     return ConnectIntegrationResponse(
         status="error",
@@ -458,7 +459,7 @@ async def initiate_integration_connection(
             )
         return _error(f"Unsupported integration type: {resolved.managed_by}")
     except Exception as e:
-        log.error(f"Failed to initiate connection for {integration_id}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Failed to initiate connection for {integration_id}: {e}")
         return _error(str(e))
 
 
@@ -521,9 +522,9 @@ async def _invalidate_caches(user_id: str, integration_id: str, managed_by: str)
     try:
         cache_key = f"{OAUTH_STATUS_KEY}:{user_id}"
         await delete_cache(cache_key)
-        log.info(f"OAuth status cache invalidated for user {user_id}")
+        log.info(f"{LogTag.INTEGRATION} OAuth status cache invalidated for user {user_id}")
     except redis.RedisError as e:
-        log.warning(f"Failed to invalidate OAuth status cache: {e}")
+        log.warning(f"{LogTag.INTEGRATION} Failed to invalidate OAuth status cache: {e}")
 
     # Provider metadata cache (24h TTL) is keyed by integration.provider, not
     # integration_id. Without this clear, disconnected integrations keep
@@ -533,14 +534,16 @@ async def _invalidate_caches(user_id: str, integration_id: str, managed_by: str)
         try:
             metadata_key = f"provider_metadata:{user_id}:{integration.provider}"
             await delete_cache(metadata_key)
-            log.info(f"Provider metadata cache invalidated for {user_id}:{integration.provider}")
+            log.info(
+                f"{LogTag.INTEGRATION} Provider metadata cache invalidated for {user_id}:{integration.provider}"
+            )
         except redis.RedisError as e:
-            log.warning(f"Failed to invalidate provider metadata cache: {e}")
+            log.warning(f"{LogTag.INTEGRATION} Failed to invalidate provider metadata cache: {e}")
 
     # Determine whether to delete record or set status to "created"
     if managed_by == "mcp":
         # MCP integrations: record already deleted in main disconnect logic
-        log.info(f"MCP integration {integration_id} record removed")
+        log.info(f"{LogTag.INTEGRATION} MCP integration {integration_id} record removed")
     else:
         # Check if it's a platform integration (defined in oauth_config.py)
         # If get_integration_by_id returns a value, it's a platform integration
@@ -549,13 +552,17 @@ async def _invalidate_caches(user_id: str, integration_id: str, managed_by: str)
             # Platform integrations: delete the record entirely
             try:
                 await remove_user_integration(user_id, integration_id)
-                log.info(f"Removed platform integration {integration_id} record")
+                log.info(
+                    f"{LogTag.INTEGRATION} Removed platform integration {integration_id} record"
+                )
             except pymongo.errors.PyMongoError as e:
-                log.warning(f"Failed to remove integration record: {e}")
+                log.warning(f"{LogTag.INTEGRATION} Failed to remove integration record: {e}")
         else:
             # Custom integrations: preserve in workspace by setting status to "created"
             try:
                 await update_user_integration_status(user_id, integration_id, "created")
-                log.info(f"Updated status to 'created' for custom integration {integration_id}")
+                log.info(
+                    f"{LogTag.INTEGRATION} Updated status to 'created' for custom integration {integration_id}"
+                )
             except pymongo.errors.PyMongoError as e:
-                log.warning(f"Failed to update status: {e}")
+                log.warning(f"{LogTag.INTEGRATION} Failed to update status: {e}")

--- a/apps/api/app/services/integrations/integration_resolver.py
+++ b/apps/api/app/services/integrations/integration_resolver.py
@@ -9,6 +9,7 @@ across mcp_client.py, integrations.py, and integration_service.py.
 from dataclasses import dataclass
 
 from app.config.oauth_config import get_integration_by_id
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import integrations_collection
 from app.models.mcp_config import MCPConfig
 from app.models.oauth_models import OAuthIntegration
@@ -94,7 +95,7 @@ class IntegrationResolver:
                 # Warn about inconsistencies and fix them
                 if doc_requires_auth != mcp_requires_auth:
                     log.info(
-                        f"Integration {integration_id}: syncing requires_auth "
+                        f"{LogTag.INTEGRATION} Integration {integration_id}: syncing requires_auth "
                         f"from {doc_requires_auth} to {mcp_requires_auth} (mcp_config is authoritative)"
                     )
                     # Sync MongoDB document to match authoritative mcp_config
@@ -110,7 +111,7 @@ class IntegrationResolver:
                         )
                     except Exception as sync_err:
                         log.warning(
-                            f"Failed to sync requires_auth for {integration_id}: {sync_err}"
+                            f"{LogTag.INTEGRATION} Failed to sync requires_auth for {integration_id}: {sync_err}"
                         )
 
                 requires_auth = mcp_requires_auth

--- a/apps/api/app/services/integrations/marketplace.py
+++ b/apps/api/app/services/integrations/marketplace.py
@@ -5,6 +5,7 @@ import asyncio
 from bson import ObjectId
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import integrations_collection, users_collection
 from app.models.integration_models import (
     Integration,
@@ -44,7 +45,7 @@ async def get_all_integrations(
                 integration = Integration(**doc)
                 custom_integrations.append(IntegrationResponse.from_integration(integration))
             except Exception as e:
-                log.warning(f"Failed to parse custom integration: {e}")
+                log.warning(f"{LogTag.INTEGRATION} Failed to parse custom integration: {e}")
 
         return custom_integrations
 
@@ -106,7 +107,7 @@ def assemble_integration_response(
         try:
             response = IntegrationResponse.from_integration(Integration(**custom_doc))
         except Exception as e:
-            log.error(f"Failed to parse integration: {e}")
+            log.error(f"{LogTag.INTEGRATION} Failed to parse integration: {e}")
             return None
     else:
         return None
@@ -145,7 +146,7 @@ async def get_integration_details(integration_id: str) -> IntegrationResponse | 
                 {"name": 1, "picture": 1},
             )
         except Exception as e:
-            log.debug(f"Failed to fetch creator info for {created_by}: {e}")
+            log.debug(f"{LogTag.INTEGRATION} Failed to fetch creator info for {created_by}: {e}")
 
     return assemble_integration_response(
         resolved.platform_integration, resolved.custom_doc, stored_tools, creator_doc

--- a/apps/api/app/services/integrations/profanity.py
+++ b/apps/api/app/services/integrations/profanity.py
@@ -24,6 +24,7 @@ import re
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
 
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from shared.py.wide_events import log
 
@@ -157,7 +158,7 @@ async def contains_profanity(**fields: str | None) -> bool:
         return bool(result.is_offensive)
     except TimeoutError:
         log.warning(
-            "[profanity] LLM moderation timed out; falling back to wordlist",
+            f"{LogTag.INTEGRATION} LLM moderation timed out; falling back to wordlist",
             timeout_s=_MODERATION_TIMEOUT_SECONDS,
         )
         return _wordlist_any(non_empty.values())
@@ -166,7 +167,7 @@ async def contains_profanity(**fields: str | None) -> bool:
         # fixed message and attach only the exception type as context so we
         # don't leak user-submitted publish content into logs.
         log.warning(
-            "[profanity] LLM moderation failed; falling back to wordlist",
+            f"{LogTag.INTEGRATION} LLM moderation failed; falling back to wordlist",
             error_type=type(e).__name__,
         )
         return _wordlist_any(non_empty.values())

--- a/apps/api/app/services/integrations/publish_service.py
+++ b/apps/api/app/services/integrations/publish_service.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.public_integrations_store import (
     index_public_integration,
     remove_public_integration,
@@ -115,7 +116,7 @@ async def publish_custom_integration(
     )
 
     await delete_cache_by_pattern("marketplace:community:*")
-    log.info(f"Published integration {integration_id}")
+    log.info(f"{LogTag.INTEGRATION} Published integration {integration_id}")
 
     return {
         "integration_id": integration_id,
@@ -156,6 +157,6 @@ async def unpublish_custom_integration(
 
     await remove_public_integration(integration_id)
     await delete_cache_by_pattern("marketplace:community:*")
-    log.info(f"Unpublished integration {integration_id}")
+    log.info(f"{LogTag.INTEGRATION} Unpublished integration {integration_id}")
 
     return {"integration_id": integration_id}

--- a/apps/api/app/services/integrations/user_integration_status.py
+++ b/apps/api/app/services/integrations/user_integration_status.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal
 
 from app.constants.cache import USER_INTEGRATION_CACHE_PATTERNS
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import user_integrations_collection
 from app.decorators.caching import CacheInvalidator
 from app.services.integrations_fs import schedule_user_integrations_sync
@@ -56,7 +57,9 @@ async def update_user_integration_status(
     # Operation is successful if document was modified, inserted, or matched
     # (matched_count > 0 means document exists with same values - still success)
     if result.modified_count > 0 or result.upserted_id or result.matched_count > 0:
-        log.info(f"Updated user {user_id} integration {integration_id} status to {status}")
+        log.info(
+            f"{LogTag.INTEGRATION} Updated user {user_id} integration {integration_id} status to {status}"
+        )
         if status == "connected":
             # Reflect the new connected set in the user's workspace VFS.
             schedule_user_integrations_sync(user_id)

--- a/apps/api/app/services/integrations/user_integrations.py
+++ b/apps/api/app/services/integrations/user_integrations.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 from app.agents.tools.core.registry import get_tool_registry
 from app.config.oauth_config import get_integration_by_id
 from app.constants.cache import ONE_DAY_TTL, USER_INTEGRATION_CACHE_PATTERNS
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     integrations_collection,
     user_integrations_collection,
@@ -64,7 +65,7 @@ async def get_user_integrations(user_id: str) -> UserIntegrationsListResponse:
         try:
             parsed.append(UserIntegration(**doc))
         except Exception as e:
-            log.warning(f"Failed to parse user integration: {e}")
+            log.warning(f"{LogTag.INTEGRATION} Failed to parse user integration: {e}")
 
     ids = [ui.integration_id for ui in parsed]
 
@@ -236,7 +237,9 @@ async def add_user_integration(
     )
 
     await user_integrations_collection.insert_one(user_integration.model_dump())
-    log.info(f"User {user_id} added integration {integration_id} with status {status}")
+    log.info(
+        f"{LogTag.INTEGRATION} User {user_id} added integration {integration_id} with status {status}"
+    )
 
     return user_integration
 
@@ -253,7 +256,7 @@ async def remove_user_integration(user_id: str, integration_id: str) -> bool:
     )
 
     if result.deleted_count > 0:
-        log.info(f"User {user_id} removed integration {integration_id}")
+        log.info(f"{LogTag.INTEGRATION} User {user_id} removed integration {integration_id}")
         return True
 
     return False

--- a/apps/api/app/services/mail/email_importance_service.py
+++ b/apps/api/app/services/mail/email_importance_service.py
@@ -4,9 +4,10 @@ from typing import Any
 
 from langchain_core.output_parsers import PydanticOutputParser
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import mail_collection
 from app.models.mail_models import EmailComprehensiveAnalysis
-from shared.py.wide_events import log
+from shared.py.wide_events import MailContext, log
 
 email_comprehensive_parser = PydanticOutputParser(pydantic_object=EmailComprehensiveAnalysis)
 
@@ -15,7 +16,7 @@ async def get_email_importance_summaries(
     user_id: str, limit: int = 50, important_only: bool = False
 ) -> dict[str, Any]:
     """Get email importance summaries for a user."""
-    log.set(mail_user_id=user_id, mail_limit=limit, mail_important_only=important_only)
+    log.set(user={"id": user_id}, mail=MailContext(operation="summarize"))
     try:
         # Build query filter
         query_filter: dict[str, Any] = {"user_id": user_id}
@@ -33,6 +34,7 @@ async def get_email_importance_summaries(
             if "analyzed_at" in email:
                 email["analyzed_at"] = email["analyzed_at"].isoformat()
 
+        log.set_ns("mail", result_count=len(emails), success=True)
         return {
             "status": "success",
             "emails": emails,
@@ -40,7 +42,7 @@ async def get_email_importance_summaries(
             "filtered_by_importance": important_only,
         }
     except Exception as e:
-        log.error(f"Error retrieving email summaries for user {user_id}: {e}")
+        log.error(f"{LogTag.MAIL} Error retrieving email summaries for user {user_id}: {e}")
         raise
 
 
@@ -48,12 +50,13 @@ async def get_single_email_importance_summary(
     user_id: str, message_id: str
 ) -> dict[str, Any] | None:
     """Get the importance summary for a specific email."""
-    log.set(mail_user_id=user_id, mail_message_id=message_id)
+    log.set(user={"id": user_id}, mail=MailContext(operation="summarize"))
     try:
         # Find the email in database
         email = await mail_collection.find_one({"user_id": user_id, "message_id": message_id})
 
         if not email:
+            log.set_ns("mail", result_count=0, success=True)
             return None
 
         # Convert ObjectId to string for JSON serialization
@@ -62,9 +65,12 @@ async def get_single_email_importance_summary(
         if "analyzed_at" in email:
             email["analyzed_at"] = email["analyzed_at"].isoformat()
 
+        log.set_ns("mail", result_count=1, success=True)
         return {"status": "success", "email": email}
     except Exception as e:
-        log.error(f"Error retrieving email summary for user {user_id}, message {message_id}: {e}")
+        log.error(
+            f"{LogTag.MAIL} Error retrieving email summary for user {user_id}, message {message_id}: {e}"
+        )
         raise
 
 
@@ -73,8 +79,8 @@ async def get_bulk_email_importance_summaries(
 ) -> dict[str, Any]:
     """Get importance summaries for multiple emails in bulk, indexed by message_id."""
     log.set(
-        mail_user_id=user_id,
-        mail_bulk_message_count=len(message_ids),
+        user={"id": user_id},
+        mail=MailContext(operation="summarize", message_count=len(message_ids)),
     )
     try:
         # Query for all emails matching the message IDs
@@ -98,6 +104,7 @@ async def get_bulk_email_importance_summaries(
         found_message_ids = set(email_summaries.keys())
         missing_message_ids = set(message_ids) - found_message_ids
 
+        log.set_ns("mail", result_count=len(found_message_ids), success=True)
         return {
             "status": "success",
             "emails": email_summaries,
@@ -107,5 +114,5 @@ async def get_bulk_email_importance_summaries(
             "missing_message_ids": list(missing_message_ids),
         }
     except Exception as e:
-        log.error(f"Error retrieving bulk email summaries for user {user_id}: {e}")
+        log.error(f"{LogTag.MAIL} Error retrieving bulk email summaries for user {user_id}: {e}")
         raise

--- a/apps/api/app/services/mail/mail_service.py
+++ b/apps/api/app/services/mail/mail_service.py
@@ -4,16 +4,17 @@ from typing import Any
 
 from fastapi import UploadFile
 
+from app.constants.log_tags import LogTag
 from app.services.composio.composio_service import (
     get_composio_service,
 )
 from app.utils.general_utils import transform_gmail_message
-from shared.py.wide_events import log
+from shared.py.wide_events import MailContext, log
 
 
 def get_gmail_tool(tool_name: str, user_id: str):
     """Get a specific Gmail tool by name via ComposioService, or None if not found."""
-    log.set(mail_gmail_tool=tool_name, mail_user_id=user_id)
+    log.set(user={"id": user_id}, mail=MailContext(provider="gmail"))
     composio_service = get_composio_service()
 
     try:
@@ -21,7 +22,7 @@ def get_gmail_tool(tool_name: str, user_id: str):
             tool_name, use_before_hook=False, use_after_hook=False, user_id=user_id
         )
     except Exception as e:
-        log.error(f"Error getting Gmail tool {tool_name}: {e}")
+        log.error(f"{LogTag.MAIL} Error getting Gmail tool {tool_name}: {e}")
         return None
 
 
@@ -38,7 +39,7 @@ async def invoke_gmail_tool(
         result = await tool.ainvoke(parameters)
         return result
     except Exception as e:
-        log.error(f"Error invoking Gmail tool {tool_name} for user {user_id}: {e}")
+        log.error(f"{LogTag.MAIL} Error invoking Gmail tool {tool_name} for user {user_id}: {e}")
         return {"error": str(e), "successful": False}
 
 
@@ -76,12 +77,8 @@ async def send_email(
     so Gmail renders formatting instead of literal ``**`` / ``###``.
     """
     log.set(
-        mail_user_id=user_id,
-        mail_recipient=to,
-        mail_subject=subject,
-        mail_is_reply=bool(thread_id),
-        mail_thread_id=thread_id,
-        mail_has_attachments=bool(attachments),
+        user={"id": user_id},
+        mail=MailContext(operation="send", provider="gmail"),
     )
     try:
         # Determine tool and body parameter name
@@ -113,13 +110,16 @@ async def send_email(
             parameters["attachments"] = await asyncio.to_thread(_process_attachments, attachments)
 
         log.info(
-            f"Using {tool_name} to {'reply to thread ' + (thread_id or '') if is_reply else 'send new email to ' + to}"
+            f"{LogTag.MAIL} Using {tool_name} to {'reply to thread ' + (thread_id or '') if is_reply else 'send new email to ' + to}"
         )
 
-        return await invoke_gmail_tool(user_id, tool_name, parameters)
+        result = await invoke_gmail_tool(user_id, tool_name, parameters)
+        log.set_ns("mail", success=bool(result.get("successful", True)))
+        return result
 
     except Exception as e:
-        log.error(f"Error sending email for user {user_id}: {e}")
+        log.error(f"{LogTag.MAIL} Error sending email for user {user_id}: {e}")
+        log.set_ns("mail", success=False)
         return {"error": str(e), "successful": False}
 
 
@@ -148,7 +148,7 @@ async def modify_message_labels(
             if add_result.get("successful", True):
                 results.extend(add_result.get("messages", []))
         except Exception as e:
-            log.error(f"Error adding labels {add_labels} to messages: {e}")
+            log.error(f"{LogTag.MAIL} Error adding labels {add_labels} to messages: {e}")
 
     # Remove labels if specified
     if remove_labels:
@@ -163,7 +163,7 @@ async def modify_message_labels(
                 if not add_labels:
                     results.extend(remove_result.get("messages", []))
         except Exception as e:
-            log.error(f"Error removing labels {remove_labels} from messages: {e}")
+            log.error(f"{LogTag.MAIL} Error removing labels {remove_labels} from messages: {e}")
 
     return results
 
@@ -180,19 +180,19 @@ async def mark_messages_as_unread(user_id: str, message_ids: list[str]) -> list[
 
 async def star_messages(user_id: str, message_ids: list[str]) -> list[dict[str, Any]]:
     """Star Gmail messages by adding the STARRED label."""
-    log.info(f"Starring {len(message_ids)} messages")
+    log.info(f"{LogTag.MAIL} Starring {len(message_ids)} messages")
     return await modify_message_labels(user_id, message_ids, add_labels=["STARRED"])
 
 
 async def unstar_messages(user_id: str, message_ids: list[str]) -> list[dict[str, Any]]:
     """Unstar Gmail messages by removing the STARRED label."""
-    log.info(f"Unstarring {len(message_ids)} messages")
+    log.info(f"{LogTag.MAIL} Unstarring {len(message_ids)} messages")
     return await modify_message_labels(user_id, message_ids, remove_labels=["STARRED"])
 
 
 async def trash_messages(user_id: str, message_ids: list[str]) -> list[dict[str, Any]]:
     """Move Gmail messages to trash."""
-    log.info(f"Moving {len(message_ids)} messages to trash")
+    log.info(f"{LogTag.MAIL} Moving {len(message_ids)} messages to trash")
     results = []
 
     for message_id in message_ids:
@@ -202,16 +202,18 @@ async def trash_messages(user_id: str, message_ids: list[str]) -> list[dict[str,
             if result.get("successful", True):
                 results.append(result)
             else:
-                log.error(f"Error trashing message {message_id}: {result.get('error')}")
+                log.error(
+                    f"{LogTag.MAIL} Error trashing message {message_id}: {result.get('error')}"
+                )
         except Exception as e:
-            log.error(f"Error trashing message {message_id}: {e}")
+            log.error(f"{LogTag.MAIL} Error trashing message {message_id}: {e}")
 
     return results
 
 
 async def untrash_messages(user_id: str, message_ids: list[str]) -> list[dict[str, Any]]:
     """Restore Gmail messages from trash."""
-    log.info(f"Restoring {len(message_ids)} messages from trash")
+    log.info(f"{LogTag.MAIL} Restoring {len(message_ids)} messages from trash")
     results = []
 
     for message_id in message_ids:
@@ -221,28 +223,31 @@ async def untrash_messages(user_id: str, message_ids: list[str]) -> list[dict[st
             if result.get("successful", True):
                 results.append(result)
             else:
-                log.error(f"Error untrashing message {message_id}: {result.get('error')}")
+                log.error(
+                    f"{LogTag.MAIL} Error untrashing message {message_id}: {result.get('error')}"
+                )
         except Exception as e:
-            log.error(f"Error untrashing message {message_id}: {e}")
+            log.error(f"{LogTag.MAIL} Error untrashing message {message_id}: {e}")
 
     return results
 
 
 async def archive_messages(user_id: str, message_ids: list[str]) -> list[dict[str, Any]]:
     """Archive Gmail messages by removing the INBOX label."""
-    log.info(f"Archiving {len(message_ids)} messages")
+    log.info(f"{LogTag.MAIL} Archiving {len(message_ids)} messages")
     return await modify_message_labels(user_id, message_ids, remove_labels=["INBOX"])
 
 
 async def move_to_inbox(user_id: str, message_ids: list[str]) -> list[dict[str, Any]]:
     """Move Gmail messages to inbox by adding the INBOX label."""
-    log.info(f"Moving {len(message_ids)} messages to inbox")
+    log.info(f"{LogTag.MAIL} Moving {len(message_ids)} messages to inbox")
     return await modify_message_labels(user_id, message_ids, add_labels=["INBOX"])
 
 
 async def fetch_thread(user_id: str, thread_id: str) -> dict[str, Any]:
     """Fetch a complete email thread with all messages."""
-    log.info(f"Fetching thread with ID: {thread_id}")
+    log.set(user={"id": user_id}, mail=MailContext(operation="fetch", provider="gmail"))
+    log.info(f"{LogTag.MAIL} Fetching thread with ID: {thread_id}")
     try:
         parameters = {
             "thread_id": thread_id,
@@ -260,12 +265,17 @@ async def fetch_thread(user_id: str, thread_id: str) -> dict[str, Any]:
                 # Sort messages by date (oldest first)
                 thread["messages"].sort(key=lambda msg: int(msg.get("internalDate", 0)))
 
+            log.set_ns("mail", message_count=len(thread.get("messages", [])), success=True)
             return thread
-        log.error(f"Error from GMAIL_FETCH_MESSAGE_BY_THREAD_ID: {result.get('error')}")
+        log.error(
+            f"{LogTag.MAIL} Error from GMAIL_FETCH_MESSAGE_BY_THREAD_ID: {result.get('error')}"
+        )
+        log.set_ns("mail", success=False)
         return {"messages": []}
 
     except Exception as error:
-        log.error(f"Error fetching thread {thread_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error fetching thread {thread_id}: {error}")
+        log.set_ns("mail", success=False)
         return {"messages": []}
 
 
@@ -284,6 +294,7 @@ async def search_messages(
     Pass format="metadata" with include_payload=False and verbose=False to
     skip body decode and bypass GMAIL_FULL_FETCH_HARD_LIMIT.
     """
+    log.set(user={"id": user_id}, mail=MailContext(operation="fetch", provider="gmail"))
     try:
         parameters: dict[str, Any] = {
             "query": query or "",
@@ -304,13 +315,16 @@ async def search_messages(
             # Transform messages if needed
             data = result.get("data", {})
             messages = data.get("messages", [])
+            log.set_ns("mail", result_count=len(messages), success=True)
             return {
                 "messages": [transform_gmail_message(msg) for msg in messages],
                 "nextPageToken": data.get("nextPageToken"),
             }
+        log.set_ns("mail", success=False)
         return {"messages": [], "nextPageToken": None}
 
     except Exception:
+        log.set_ns("mail", success=False)
         return {"messages": [], "nextPageToken": None}
 
 
@@ -323,7 +337,7 @@ async def create_label(
     text_color: str | None = None,
 ) -> dict[str, Any]:
     """Create a new Gmail label."""
-    log.info(f"Creating new label: {name}")
+    log.info(f"{LogTag.MAIL} Creating new label: {name}")
     try:
         parameters = {
             "name": name,
@@ -343,7 +357,7 @@ async def create_label(
         result = await invoke_gmail_tool(user_id, "GMAIL_CREATE_LABEL", parameters)
         return result
     except Exception as error:
-        log.error(f"Error creating label {name}: {error}")
+        log.error(f"{LogTag.MAIL} Error creating label {name}: {error}")
         return {"error": str(error), "successful": False}
 
 
@@ -357,7 +371,7 @@ async def update_label(
     text_color: str | None = None,
 ) -> dict[str, Any]:
     """Update an existing Gmail label."""
-    log.info(f"Updating label {label_id}")
+    log.info(f"{LogTag.MAIL} Updating label {label_id}")
     try:
         parameters = {
             "label_id": label_id,
@@ -383,19 +397,19 @@ async def update_label(
         result = await invoke_gmail_tool(user_id, "GMAIL_PATCH_LABEL", parameters)
         return result
     except Exception as error:
-        log.error(f"Error updating label {label_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error updating label {label_id}: {error}")
         return {"error": str(error), "successful": False}
 
 
 async def delete_label(user_id: str, label_id: str) -> bool:
     """Delete a Gmail label."""
-    log.info(f"Deleting label {label_id}")
+    log.info(f"{LogTag.MAIL} Deleting label {label_id}")
     try:
         parameters = {"label_id": label_id}
         result = await invoke_gmail_tool(user_id, "GMAIL_DELETE_LABEL", parameters)
         return result.get("successful", True)
     except Exception as error:
-        log.error(f"Error deleting label {label_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error deleting label {label_id}: {error}")
         return False
 
 
@@ -403,7 +417,7 @@ async def apply_labels(
     user_id: str, message_ids: list[str], label_ids: list[str]
 ) -> list[dict[str, Any]]:
     """Apply one or more labels to the specified messages."""
-    log.info(f"Applying labels {label_ids} to {len(message_ids)} messages")
+    log.info(f"{LogTag.MAIL} Applying labels {label_ids} to {len(message_ids)} messages")
     return await modify_message_labels(user_id, message_ids, add_labels=label_ids)
 
 
@@ -411,7 +425,7 @@ async def remove_labels(
     user_id: str, message_ids: list[str], label_ids: list[str]
 ) -> list[dict[str, Any]]:
     """Remove one or more labels from the specified messages."""
-    log.info(f"Removing labels {label_ids} from {len(message_ids)} messages")
+    log.info(f"{LogTag.MAIL} Removing labels {label_ids} from {len(message_ids)} messages")
     return await modify_message_labels(user_id, message_ids, remove_labels=label_ids)
 
 
@@ -427,7 +441,7 @@ async def create_draft(
 
     Body is always sent as HTML; the Composio before-hook converts Markdown.
     """
-    log.info(f"Creating draft email to {to_list} with subject: {subject}")
+    log.info(f"{LogTag.MAIL} Creating draft email to {to_list} with subject: {subject}")
     try:
         parameters: dict[str, Any] = {
             "to": to_list,
@@ -444,7 +458,7 @@ async def create_draft(
         result = await invoke_gmail_tool(user_id, "GMAIL_CREATE_EMAIL_DRAFT", parameters)
         return result
     except Exception as error:
-        log.error(f"Error creating draft: {error}")
+        log.error(f"{LogTag.MAIL} Error creating draft: {error}")
         return {"error": str(error), "successful": False}
 
 
@@ -452,7 +466,7 @@ async def list_drafts(
     user_id: str, max_results: int = 20, page_token: str | None = None
 ) -> dict[str, Any]:
     """List Gmail draft messages."""
-    log.info(f"Listing drafts, max_results={max_results}")
+    log.info(f"{LogTag.MAIL} Listing drafts, max_results={max_results}")
     try:
         parameters: dict[str, Any] = {
             "max_results": max_results,
@@ -476,17 +490,17 @@ async def list_drafts(
                 "drafts": detailed_drafts,
                 "nextPageToken": result.get("nextPageToken"),
             }
-        log.error(f"Error from GMAIL_LIST_DRAFTS: {result.get('error')}")
+        log.error(f"{LogTag.MAIL} Error from GMAIL_LIST_DRAFTS: {result.get('error')}")
         return {"drafts": [], "nextPageToken": None}
 
     except Exception as error:
-        log.error(f"Error listing drafts: {error}")
+        log.error(f"{LogTag.MAIL} Error listing drafts: {error}")
         return {"drafts": [], "nextPageToken": None}
 
 
 async def get_draft(user_id: str, draft_id: str) -> dict[str, Any]:
     """Get a specific Gmail draft."""
-    log.info(f"Fetching draft {draft_id}")
+    log.info(f"{LogTag.MAIL} Fetching draft {draft_id}")
     try:
         parameters = {"draft_id": draft_id}
         result = await invoke_gmail_tool(user_id, "GMAIL_GET_DRAFT", parameters)
@@ -496,11 +510,11 @@ async def get_draft(user_id: str, draft_id: str) -> dict[str, Any]:
             if "message" in result:
                 result["message"] = transform_gmail_message(result["message"])
             return result
-        log.error(f"Error from GMAIL_GET_DRAFT: {result.get('error')}")
+        log.error(f"{LogTag.MAIL} Error from GMAIL_GET_DRAFT: {result.get('error')}")
         return {"error": result.get("error"), "successful": False}
 
     except Exception as error:
-        log.error(f"Error fetching draft {draft_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error fetching draft {draft_id}: {error}")
         return {"error": str(error), "successful": False}
 
 
@@ -517,7 +531,7 @@ async def update_draft(
 
     Body is always sent as HTML; the Composio before-hook converts Markdown.
     """
-    log.info(f"Updating draft {draft_id}")
+    log.info(f"{LogTag.MAIL} Updating draft {draft_id}")
     try:
         parameters = {
             "draft_id": draft_id,
@@ -536,46 +550,50 @@ async def update_draft(
 
         if result.get("successful", True):
             return result
-        log.error(f"Error from GMAIL_UPDATE_DRAFT: {result.get('error')}")
+        log.error(f"{LogTag.MAIL} Error from GMAIL_UPDATE_DRAFT: {result.get('error')}")
         return {"error": result.get("error"), "successful": False}
 
     except Exception as error:
-        log.error(f"Error updating draft {draft_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error updating draft {draft_id}: {error}")
         return {"error": str(error), "successful": False}
 
 
 async def delete_draft(user_id: str, draft_id: str) -> bool:
     """Delete a Gmail draft."""
-    log.info(f"Deleting draft {draft_id}")
+    log.info(f"{LogTag.MAIL} Deleting draft {draft_id}")
     try:
         parameters = {"draft_id": draft_id}
         result = await invoke_gmail_tool(user_id, "GMAIL_DELETE_DRAFT", parameters)
         return result.get("successful", True)
     except Exception as error:
-        log.error(f"Error deleting draft {draft_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error deleting draft {draft_id}: {error}")
         return False
 
 
 async def send_draft(user_id: str, draft_id: str) -> dict[str, Any]:
     """Send an existing Gmail draft."""
-    log.info(f"Sending draft {draft_id}")
+    log.set(user={"id": user_id}, mail=MailContext(operation="send", provider="gmail"))
+    log.info(f"{LogTag.MAIL} Sending draft {draft_id}")
     try:
         parameters = {"draft_id": draft_id}
         result = await invoke_gmail_tool(user_id, "GMAIL_SEND_DRAFT", parameters)
 
         if result.get("successful", True):
+            log.set_ns("mail", success=True)
             return result
-        log.error(f"Error from GMAIL_SEND_DRAFT: {result.get('error')}")
+        log.error(f"{LogTag.MAIL} Error from GMAIL_SEND_DRAFT: {result.get('error')}")
+        log.set_ns("mail", success=False)
         return {"error": result.get("error"), "successful": False}
 
     except Exception as error:
-        log.error(f"Error sending draft {draft_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error sending draft {draft_id}: {error}")
+        log.set_ns("mail", success=False)
         return {"error": str(error), "successful": False}
 
 
 async def list_labels(user_id: str) -> dict[str, Any]:
     """List all Gmail labels."""
-    log.info(f"Listing Gmail labels for user {user_id}")
+    log.info(f"{LogTag.MAIL} Listing Gmail labels for user {user_id}")
     try:
         parameters: dict[str, Any] = {}  # No parameters needed for listing labels
         result = await invoke_gmail_tool(user_id, "GMAIL_LIST_LABELS", parameters)
@@ -587,7 +605,7 @@ async def list_labels(user_id: str) -> dict[str, Any]:
                 "labels": labels,
                 "count": len(labels),
             }
-        log.error(f"Error from GMAIL_LIST_LABELS: {result.get('error')}")
+        log.error(f"{LogTag.MAIL} Error from GMAIL_LIST_LABELS: {result.get('error')}")
         return {
             "success": False,
             "error": result.get("error"),
@@ -595,7 +613,7 @@ async def list_labels(user_id: str) -> dict[str, Any]:
         }
 
     except Exception as error:
-        log.error(f"Error listing Gmail labels: {error}")
+        log.error(f"{LogTag.MAIL} Error listing Gmail labels: {error}")
         return {
             "success": False,
             "error": str(error),
@@ -605,7 +623,8 @@ async def list_labels(user_id: str) -> dict[str, Any]:
 
 async def get_email_by_id(user_id: str, message_id: str) -> dict[str, Any]:
     """Get a Gmail message by its ID."""
-    log.info(f"Fetching email with ID: {message_id}")
+    log.set(user={"id": user_id}, mail=MailContext(operation="fetch", provider="gmail"))
+    log.info(f"{LogTag.MAIL} Fetching email with ID: {message_id}")
     try:
         parameters = {"message_id": message_id}
         result = await invoke_gmail_tool(user_id, "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID", parameters)
@@ -613,11 +632,15 @@ async def get_email_by_id(user_id: str, message_id: str) -> dict[str, Any]:
         if result.get("successful", True):
             # Transform the message data for easier frontend processing
             transformed_message = transform_gmail_message(result)
+            log.set_ns("mail", result_count=1, success=True)
             return {
                 "success": True,
                 "message": transformed_message,
             }
-        log.error(f"Error from GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID: {result.get('error')}")
+        log.error(
+            f"{LogTag.MAIL} Error from GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID: {result.get('error')}"
+        )
+        log.set_ns("mail", success=False)
         return {
             "success": False,
             "error": result.get("error"),
@@ -625,7 +648,8 @@ async def get_email_by_id(user_id: str, message_id: str) -> dict[str, Any]:
         }
 
     except Exception as error:
-        log.error(f"Error fetching email {message_id}: {error}")
+        log.error(f"{LogTag.MAIL} Error fetching email {message_id}: {error}")
+        log.set_ns("mail", success=False)
         return {
             "success": False,
             "error": str(error),

--- a/apps/api/app/services/mcp/mcp_client.py
+++ b/apps/api/app/services/mcp/mcp_client.py
@@ -35,6 +35,7 @@ from pydantic import AnyHttpUrl, AnyUrl
 
 from app.config.settings import settings
 from app.constants.cache import MCP_TOOLS_CACHE_KEY, OAUTH_DISCOVERY_PREFIX
+from app.constants.log_tags import LogTag
 from app.constants.mcp import (
     COMPOSIO_MCP_HOST,
     GAIA_OAUTH_CLIENT_NAME,
@@ -99,7 +100,7 @@ from mcp.shared.auth import (
     OAuthMetadata,
     OAuthToken,
 )
-from shared.py.wide_events import log, log_context
+from shared.py.wide_events import McpContext, log, log_context
 
 
 class _ClientBranding(TypedDict, total=False):
@@ -153,7 +154,7 @@ def _extract_response_signal(exception: Exception) -> tuple[int | None, str | No
             if isinstance(raw, str):
                 error_code = raw.lower()
     except Exception as parse_err:
-        log.debug(f"_extract_response_signal: body parse skipped ({parse_err!r})")
+        log.debug(f"{LogTag.MCP} _extract_response_signal: body parse skipped ({parse_err!r})")
     return status, error_code
 
 
@@ -226,7 +227,9 @@ def _spawn_background(coro: Any, label: str) -> asyncio.Task | None:
             return
         exc = t.exception()
         if exc is not None:
-            log.warning(f"background mcp task '{label}' raised: {type(exc).__name__}: {exc}")
+            log.warning(
+                f"{LogTag.MCP} background mcp task '{label}' raised: {type(exc).__name__}: {exc}"
+            )
 
     task.add_done_callback(_on_done)
     return task
@@ -293,11 +296,11 @@ class MCPClient:
             )
             if result.modified_count > 0:
                 log.info(
-                    f"Updated auth status for {integration_id}: "
+                    f"{LogTag.MCP} Updated auth status for {integration_id}: "
                     f"requires_auth={requires_auth}, auth_type={auth_type}"
                 )
         except Exception as e:
-            log.warning(f"Failed to update auth status for {integration_id}: {e}")
+            log.warning(f"{LogTag.MCP} Failed to update auth status for {integration_id}: {e}")
 
     async def _discover_oauth_config(
         self,
@@ -345,24 +348,23 @@ class MCPClient:
         if not stored_token and mcp_config.requires_auth:
             # Check if OAuth token is expiring soon and try to refresh
             if await self.token_store.is_token_expiring_soon(integration_id):
-                log.info(f"Token expiring soon for {integration_id}, attempting refresh")
+                log.info(
+                    f"{LogTag.MCP} Token expiring soon for {integration_id}, attempting refresh"
+                )
                 await self._try_refresh_token(integration_id, mcp_config)
 
             stored_token = await self.token_store.get_oauth_token(integration_id)
             token_source = "oauth"  # nosec B105
 
         if stored_token:
-            log.set(
-                mcp_config_build={
-                    "integration_id": integration_id,
-                    "user_id": self.user_id,
-                    "token_source": token_source,
-                    "token_length": len(stored_token),
-                    "transport": server_config.get("transport"),
-                }
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                server_id=integration_id,
+                transport=server_config.get("transport"),
             )
             log.info(
-                f"[{integration_id}] Retrieved stored {token_source} token (length={len(stored_token)})"
+                f"{LogTag.MCP} [{integration_id}] Retrieved stored {token_source} token (length={len(stored_token)})"
             )
             # Strip Bearer prefix if present - mcp-use adds it automatically
             raw_token = stored_token
@@ -378,7 +380,7 @@ class MCPClient:
             server_config["headers"] = {"Authorization": f"Bearer {raw_token}"}
         elif mcp_config.requires_auth:
             log.warning(
-                f"[{integration_id}] _build_config: no stored token, but "
+                f"{LogTag.MCP} [{integration_id}] _build_config: no stored token, but "
                 f"requires_auth=True for user {self.user_id} — raising "
                 f"'OAuth authorization required'"
             )
@@ -389,7 +391,7 @@ class MCPClient:
         else:
             # No auth required and no bearer token - set auth to None
             log.info(
-                f"[{integration_id}] _build_config: no auth required, connecting unauthenticated"
+                f"{LogTag.MCP} [{integration_id}] _build_config: no auth required, connecting unauthenticated"
             )
             server_config["auth"] = None
 
@@ -422,7 +424,7 @@ class MCPClient:
 
         # If another coroutine is already connecting this integration, wait for it
         if integration_id in self._connecting:
-            log.info(f"[{integration_id}] Waiting for concurrent connect to finish")
+            log.info(f"{LogTag.MCP} [{integration_id}] Waiting for concurrent connect to finish")
             await self._connecting[integration_id].wait()
             if integration_id in self._tools:
                 return self._tools[integration_id]
@@ -452,17 +454,23 @@ class MCPClient:
         "Concurrent connect failed" when it checks `_tools` post-wait.
         """
         start = time.monotonic()
-        log.warning(f"[{integration_id}] transparent reconnect requested for tool '{tool_name}'")
+        log.warning(
+            f"{LogTag.MCP} [{integration_id}] transparent reconnect requested for tool '{tool_name}'"
+        )
 
         # If another caller (warmup, sibling reconnect) is already connecting,
         # wait on their event and reuse the result they produce.
         in_flight_event = self._connecting.get(integration_id)
         if in_flight_event is not None:
-            log.info(f"[{integration_id}] transparent reconnect waiting on in-flight connect")
+            log.info(
+                f"{LogTag.MCP} [{integration_id}] transparent reconnect waiting on in-flight connect"
+            )
             try:
                 await in_flight_event.wait()
             except Exception as wait_err:
-                log.warning(f"[{integration_id}] in-flight connect wait raised: {wait_err}")
+                log.warning(
+                    f"{LogTag.MCP} [{integration_id}] in-flight connect wait raised: {wait_err}"
+                )
 
         # Take the connecting lock ourselves before clearing caches so any
         # concurrent caller after this point waits on us instead of racing.
@@ -476,16 +484,13 @@ class MCPClient:
                 try:
                     await self._do_connect(integration_id)
                 except Exception as e:
-                    latency_ms = int((time.monotonic() - start) * 1000)
-                    log.set(
-                        mcp_reconnect={
-                            "integration_id": integration_id,
-                            "user_id": self.user_id,
-                            "tool_name": tool_name,
-                            "latency_ms": latency_ms,
-                            "outcome": "reconnect_failed",
-                            "error_type": type(e).__name__,
-                        }
+                    log.set_ns(
+                        "mcp",
+                        operation="connect",
+                        server_id=integration_id,
+                        tool_name=tool_name,
+                        success=False,
+                        error_type=type(e).__name__,
                     )
                     raise
             finally:
@@ -494,29 +499,25 @@ class MCPClient:
 
         fresh_tools = self._tools.get(integration_id, [])
         if not fresh_tools:
-            latency_ms = int((time.monotonic() - start) * 1000)
-            log.set(
-                mcp_reconnect={
-                    "integration_id": integration_id,
-                    "user_id": self.user_id,
-                    "tool_name": tool_name,
-                    "latency_ms": latency_ms,
-                    "outcome": "no_tools_after_reconnect",
-                }
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                server_id=integration_id,
+                tool_name=tool_name,
+                success=False,
+                error_type=RuntimeError.__name__,
             )
             raise RuntimeError(f"No tools available for {integration_id} after reconnect")
 
         fresh_tool = next((t for t in fresh_tools if t.name == tool_name), None)
         if fresh_tool is None:
-            latency_ms = int((time.monotonic() - start) * 1000)
-            log.set(
-                mcp_reconnect={
-                    "integration_id": integration_id,
-                    "user_id": self.user_id,
-                    "tool_name": tool_name,
-                    "latency_ms": latency_ms,
-                    "outcome": "tool_not_found_after_reconnect",
-                }
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                server_id=integration_id,
+                tool_name=tool_name,
+                success=False,
+                error_type=RuntimeError.__name__,
             )
             raise RuntimeError(f"Tool '{tool_name}' not found in {integration_id} after reconnect")
 
@@ -529,32 +530,27 @@ class MCPClient:
         try:
             result = await underlying(**kwargs)
         except Exception as e:
-            latency_ms = int((time.monotonic() - start) * 1000)
-            log.set(
-                mcp_reconnect={
-                    "integration_id": integration_id,
-                    "user_id": self.user_id,
-                    "tool_name": tool_name,
-                    "latency_ms": latency_ms,
-                    "outcome": "retry_call_failed",
-                    "error_type": type(e).__name__,
-                }
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                server_id=integration_id,
+                tool_name=tool_name,
+                success=False,
+                error_type=type(e).__name__,
             )
             raise
 
         latency_ms = int((time.monotonic() - start) * 1000)
         log.info(
-            f"[{integration_id}] transparent reconnect succeeded for tool "
+            f"{LogTag.MCP} [{integration_id}] transparent reconnect succeeded for tool "
             f"'{tool_name}' (latency_ms={latency_ms})"
         )
-        log.set(
-            mcp_reconnect={
-                "integration_id": integration_id,
-                "user_id": self.user_id,
-                "tool_name": tool_name,
-                "latency_ms": latency_ms,
-                "outcome": "success",
-            }
+        log.set_ns(
+            "mcp",
+            operation="connect",
+            server_id=integration_id,
+            tool_name=tool_name,
+            success=True,
         )
         return result
 
@@ -568,7 +564,7 @@ class MCPClient:
             try:
                 await coro
             except Exception as e:
-                log.warning(f"[{integration_id}] {what} failed during teardown: {e}")
+                log.warning(f"{LogTag.MCP} [{integration_id}] {what} failed during teardown: {e}")
 
         await _swallow(
             update_user_integration_status(self.user_id, integration_id, "created"),
@@ -605,20 +601,22 @@ class MCPClient:
 
         try:
             log.info(
-                f"[{integration_id}] Starting connection to MCP server. Config: {self._sanitize_config(config)}"
+                f"{LogTag.MCP} [{integration_id}] Starting connection to MCP server. Config: {self._sanitize_config(config)}"
             )
 
-            log.info(f"[{integration_id}] Creating BaseMCPClient instance")
+            log.info(f"{LogTag.MCP} [{integration_id}] Creating BaseMCPClient instance")
             client = BaseMCPClient(config)
 
-            log.info(f"[{integration_id}] Creating session with integration_id={integration_id}")
+            log.info(
+                f"{LogTag.MCP} [{integration_id}] Creating session with integration_id={integration_id}"
+            )
             await client.create_session(integration_id)
-            log.info(f"[{integration_id}] Session created successfully")
+            log.info(f"{LogTag.MCP} [{integration_id}] Session created successfully")
 
             # Use resilient adapter that handles invalid schemas gracefully
             # It will skip tools with bad schemas and return the ones that work
             adapter = ResilientLangChainAdapter()
-            log.info(f"[{integration_id}] Converting MCP tools to LangChain format")
+            log.info(f"{LogTag.MCP} [{integration_id}] Converting MCP tools to LangChain format")
             try:
                 raw_tools = await adapter.create_tools(client)
             except Exception:
@@ -626,10 +624,12 @@ class MCPClient:
                 try:
                     await client.close_all_sessions()
                 except Exception as close_err:
-                    log.warning(f"[{integration_id}] Failed to close leaked session: {close_err}")
+                    log.warning(
+                        f"{LogTag.MCP} [{integration_id}] Failed to close leaked session: {close_err}"
+                    )
                 raise
             log.info(
-                f"[{integration_id}] Successfully converted {len(raw_tools)} tools to LangChain format"
+                f"{LogTag.MCP} [{integration_id}] Successfully converted {len(raw_tools)} tools to LangChain format"
             )
 
             # CRITICAL: Wrap tools to filter None values before MCP invocation.
@@ -653,7 +653,7 @@ class MCPClient:
                             self._safe_close_client(stale_client),
                             f"evict_close_{iid}",
                         )
-                    log.info(f"[{iid}] Evicted stale session after connection error")
+                    log.info(f"{LogTag.MCP} [{iid}] Evicted stale session after connection error")
 
                 return _evict
 
@@ -688,18 +688,15 @@ class MCPClient:
             self._tools[integration_id] = tools
 
             tool_names_sample = [t.name for t in tools[:5]]
-            log.set(
-                mcp_connect={
-                    "integration_id": integration_id,
-                    "user_id": self.user_id,
-                    "tools_count": len(tools),
-                    "is_custom": is_custom,
-                    "requires_auth": mcp_config.requires_auth,
-                    "tool_names_sample": tool_names_sample,
-                }
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                server_id=integration_id,
+                tool_count=len(tools),
+                success=True,
             )
             log.info(
-                f"[{integration_id}] Connected to MCP, got {len(tools)} tools "
+                f"{LogTag.MCP} [{integration_id}] Connected to MCP, got {len(tools)} tools "
                 f"for user {self.user_id} (is_custom={is_custom}, "
                 f"sample_names={tool_names_sample})"
             )
@@ -713,7 +710,9 @@ class MCPClient:
 
             # 2. Store tool metadata to MongoDB for frontend visibility
             tool_metadata = [{"name": t.name, "description": t.description} for t in tools]
-            log.info(f"[{integration_id}] Storing {len(tool_metadata)} tools to MongoDB")
+            log.info(
+                f"{LogTag.MCP} [{integration_id}] Storing {len(tool_metadata)} tools to MongoDB"
+            )
             global_store = get_mcp_tools_store()
             post_tasks.append(global_store.store_tools(integration_id, tool_metadata))
 
@@ -754,30 +753,27 @@ class MCPClient:
             for label, result in zip(post_task_labels, results):
                 if isinstance(result, Exception):
                     log.warning(
-                        f"[{integration_id}] post-connect task '{label}' failed: "
+                        f"{LogTag.MCP} [{integration_id}] post-connect task '{label}' failed: "
                         f"{type(result).__name__}: {result}"
                     )
                 else:
-                    log.info(f"[{integration_id}] post-connect task '{label}' ok")
+                    log.info(f"{LogTag.MCP} [{integration_id}] post-connect task '{label}' ok")
 
             return tools
 
         except Exception as e:
             error_str = str(e).lower()
 
-            log.set(
-                mcp_connect_error={
-                    "integration_id": integration_id,
-                    "user_id": self.user_id,
-                    "error_type": type(e).__name__,
-                    "error_message": str(e)[:500],
-                    "requires_auth": mcp_config.requires_auth,
-                    "is_custom": is_custom,
-                }
+            log.set_ns(
+                "mcp",
+                operation="connect",
+                server_id=integration_id,
+                success=False,
+                error_type=type(e).__name__,
             )
             # Log comprehensive error details for debugging
             log.error(
-                f"[{integration_id}] Connection failed with exception:\n"
+                f"{LogTag.MCP} [{integration_id}] Connection failed with exception:\n"
                 f"  Error type: {type(e).__name__}\n"
                 f"  Error message: {e!s}\n"
                 f"  Error repr: {e!r}\n"
@@ -793,7 +789,9 @@ class MCPClient:
                 required_scopes: list[str] = []
                 if scope_match:
                     required_scopes = scope_match.group(1).split()
-                log.info(f"Step-up auth required for {integration_id}, scopes: {required_scopes}")
+                log.info(
+                    f"{LogTag.MCP} Step-up auth required for {integration_id}, scopes: {required_scopes}"
+                )
                 raise StepUpAuthRequired(integration_id, required_scopes) from e
 
             # Retry once on auth-related failures: 401 (expired token) or
@@ -808,7 +806,7 @@ class MCPClient:
             refresh_attempted = getattr(self, retry_flag, False)
             if is_auth_error and mcp_config.requires_auth and not refresh_attempted:
                 log.info(
-                    f"[{integration_id}] Auth-related connection failure, "
+                    f"{LogTag.MCP} [{integration_id}] Auth-related connection failure, "
                     "attempting token refresh and retry"
                 )
                 setattr(self, retry_flag, True)
@@ -816,10 +814,12 @@ class MCPClient:
                 try:
                     refreshed = await self._try_refresh_token(integration_id, mcp_config)
                     if refreshed:
-                        log.info(f"[{integration_id}] Token refreshed, retrying connection")
+                        log.info(
+                            f"{LogTag.MCP} [{integration_id}] Token refreshed, retrying connection"
+                        )
                         return await self._do_connect(integration_id)
                     log.warning(
-                        f"[{integration_id}] Token refresh failed, user may need to re-authorize"
+                        f"{LogTag.MCP} [{integration_id}] Token refresh failed, user may need to re-authorize"
                     )
                 finally:
                     try:
@@ -827,7 +827,7 @@ class MCPClient:
                     except AttributeError:
                         pass
 
-            log.error(f"Failed to connect to MCP {integration_id}: {e}")
+            log.error(f"{LogTag.MCP} Failed to connect to MCP {integration_id}: {e}")
 
             # Only reset on demonstrably dead credentials — transient errors
             # (5xx, network blip, transport mismatch) keep the existing tokens.
@@ -835,7 +835,7 @@ class MCPClient:
                 await self._reset_to_disconnected(integration_id)
             else:
                 log.warning(
-                    f"[{integration_id}] Transient connection failure — keeping "
+                    f"{LogTag.MCP} [{integration_id}] Transient connection failure — keeping "
                     f"connected status so next attempt retries with current tokens. "
                     f"Error: {type(e).__name__}: {e}"
                 )
@@ -862,7 +862,7 @@ class MCPClient:
         )
         if not namespace:
             log.warning(
-                f"[{integration_id}] platform integration has no subagent_config.tool_space; "
+                f"{LogTag.MCP} [{integration_id}] platform integration has no subagent_config.tool_space; "
                 f"skipping Chroma indexing to avoid namespace collisions"
             )
             return
@@ -871,12 +871,12 @@ class MCPClient:
             tools_with_space = [(tool, namespace) for tool in tools]
             await index_tools_to_store(tools_with_space)
             log.info(
-                f"[{integration_id}] indexed {len(tools)} platform MCP tools to "
+                f"{LogTag.MCP} [{integration_id}] indexed {len(tools)} platform MCP tools to "
                 f"Chroma namespace='{namespace}'"
             )
         except Exception as e:
             log.error(
-                f"[{integration_id}] _index_platform_mcp_tools failed for "
+                f"{LogTag.MCP} [{integration_id}] _index_platform_mcp_tools failed for "
                 f"namespace='{namespace}': {type(e).__name__}: {e}"
             )
 
@@ -890,17 +890,14 @@ class MCPClient:
     ) -> None:
         """Handle custom integration: index tools and register as subagent."""
         namespace = derive_integration_namespace(integration_id, server_url, is_custom=True)
-        log.set(
-            custom_mcp_connect={
-                "integration_id": integration_id,
-                "user_id": self.user_id,
-                "namespace": namespace,
-                "tools_count": len(tools),
-                "server_url": server_url,
-            }
+        log.set_ns(
+            "mcp",
+            operation="connect",
+            server_id=integration_id,
+            tool_count=len(tools),
         )
         log.info(
-            f"[{integration_id}] _handle_custom_integration_connect: namespace='{namespace}' "
+            f"{LogTag.MCP} [{integration_id}] _handle_custom_integration_connect: namespace='{namespace}' "
             f"tools={len(tools)}"
         )
 
@@ -912,7 +909,7 @@ class MCPClient:
             await index_tools_to_store(tools_with_space)
         except Exception as e:
             log.error(
-                f"[{integration_id}] index_tools_to_store failed for namespace "
+                f"{LogTag.MCP} [{integration_id}] index_tools_to_store failed for namespace "
                 f"'{namespace}': {type(e).__name__}: {e}"
             )
 
@@ -944,22 +941,22 @@ class MCPClient:
                         tools=tools,
                     )
                     log.info(
-                        f"Indexed custom MCP {integration_id} ({resolved_name}) "
+                        f"{LogTag.MCP} Indexed custom MCP {integration_id} ({resolved_name}) "
                         f"as subagent in namespace ('subagents',)"
                     )
                 else:
                     log.warning(
-                        f"[{integration_id}] no resolved_name; skipping subagent index "
+                        f"{LogTag.MCP} [{integration_id}] no resolved_name; skipping subagent index "
                         f"(name will not be discoverable via retrieve_tools)"
                     )
             else:
                 log.warning(
-                    f"[{integration_id}] chroma_tools_store provider unavailable; "
+                    f"{LogTag.MCP} [{integration_id}] chroma_tools_store provider unavailable; "
                     f"cannot index as subagent"
                 )
         except Exception as e:
             log.warning(
-                f"[{integration_id}] index_custom_mcp_as_subagent failed: {type(e).__name__}: {e}"
+                f"{LogTag.MCP} [{integration_id}] index_custom_mcp_as_subagent failed: {type(e).__name__}: {e}"
             )
 
     async def _try_refresh_token(self, integration_id: str, mcp_config: MCPConfig) -> bool:
@@ -1016,7 +1013,7 @@ class MCPClient:
             dcr_data = await self.token_store.get_dcr_client(integration_id)
             if dcr_data:
                 client_id = dcr_data.get("client_id")
-                log.debug(f"Using stored DCR client for {integration_id}")
+                log.debug(f"{LogTag.MCP} Using stored DCR client for {integration_id}")
 
         if not client_id:
             # Priority 3: Use Client ID Metadata Document if supported.
@@ -1032,7 +1029,7 @@ class MCPClient:
             if oauth_config.as_metadata.client_id_metadata_document_supported and not is_localhost:
                 client_id = get_client_metadata_document_url(api_base)
                 log.info(
-                    f"Using client metadata document URL as client_id for {integration_id}: {client_id}"
+                    f"{LogTag.MCP} Using client metadata document URL as client_id for {integration_id}: {client_id}"
                 )
             # Priority 4: Fall back to Dynamic Client Registration (DCR).
             # Also required when running locally since the auth server
@@ -1043,7 +1040,7 @@ class MCPClient:
                     oauth_config.as_metadata,
                     redirect_uri,
                 )
-                log.info(f"Registered new client via DCR for {integration_id}")
+                log.info(f"{LogTag.MCP} Registered new client via DCR for {integration_id}")
 
         if not client_id:
             raise ValueError(
@@ -1053,7 +1050,7 @@ class MCPClient:
                 "The authorization server may require manual client pre-registration."
             )
 
-        log.info(f"[{integration_id}] client_id resolved for auth URL")
+        log.info(f"{LogTag.MCP} [{integration_id}] client_id resolved for auth URL")
 
         # Verify PKCE support per MCP spec using centralized validation
         validate_pkce_support(oauth_config.as_metadata, integration_id)
@@ -1094,7 +1091,9 @@ class MCPClient:
         scope_parts = scope_str.split() if scope_str else []
         if "offline_access" in scopes_supported and "offline_access" not in scope_parts:
             scope_parts.append("offline_access")
-            log.info(f"[{integration_id}] Added offline_access scope for long-lived refresh token")
+            log.info(
+                f"{LogTag.MCP} [{integration_id}] Added offline_access scope for long-lived refresh token"
+            )
 
         # Drop scopes the auth server previously rejected with invalid_scope so a
         # re-authorization retry can converge. Some servers advertise scopes in
@@ -1105,7 +1104,7 @@ class MCPClient:
             if dropped:
                 scope_parts = [s for s in scope_parts if s not in excluded_scopes]
                 log.info(
-                    f"[{integration_id}] Dropping previously-rejected scopes on retry: {dropped}"
+                    f"{LogTag.MCP} [{integration_id}] Dropping previously-rejected scopes on retry: {dropped}"
                 )
 
         scope_str = " ".join(scope_parts)
@@ -1132,7 +1131,7 @@ class MCPClient:
             params["nonce"] = nonce
             # Store nonce for validation in callback
             await self.token_store.store_oauth_nonce(integration_id, nonce)
-            log.debug(f"Added OIDC nonce for {integration_id}")
+            log.debug(f"{LogTag.MCP} Added OIDC nonce for {integration_id}")
 
         return f"{auth_endpoint}?{urllib.parse.urlencode(params)}"
 
@@ -1159,7 +1158,7 @@ class MCPClient:
 
         excluded = await self.token_store.add_excluded_scopes(integration_id, rejected)
         log.info(
-            f"[{integration_id}] invalid_scope — retrying authorization without {sorted(excluded)}"
+            f"{LogTag.MCP} [{integration_id}] invalid_scope — retrying authorization without {sorted(excluded)}"
         )
         return await self.build_oauth_auth_url(
             integration_id, redirect_uri, redirect_path, excluded_scopes=excluded
@@ -1221,12 +1220,16 @@ class MCPClient:
                 await self.token_store.store_dcr_client(
                     integration_id, client_info.model_dump(mode="json", exclude_none=True)
                 )
-                log.info(f"DCR successful for {integration_id} at {registration_endpoint}")
+                log.info(
+                    f"{LogTag.MCP} DCR successful for {integration_id} at {registration_endpoint}"
+                )
                 return client_info.client_id
         except DCRNotSupportedException:
             raise  # Re-raise without wrapping
         except Exception as e:
-            log.error(f"DCR failed for {integration_id} at {registration_endpoint}: {e}")
+            log.error(
+                f"{LogTag.MCP} DCR failed for {integration_id} at {registration_endpoint}: {e}"
+            )
             raise ValueError(f"Dynamic Client Registration failed: {e}")
 
     async def handle_oauth_callback(
@@ -1265,7 +1268,7 @@ class MCPClient:
         try:
             validate_https_url(token_endpoint)
         except OAuthSecurityError as e:
-            log.warning(f"Token endpoint security warning: {e}")
+            log.warning(f"{LogTag.MCP} Token endpoint security warning: {e}")
 
         # Resolve client credentials using same priority as build_oauth_auth_url
         # to ensure the same client_id is used for both authorization and token exchange.
@@ -1298,7 +1301,7 @@ class MCPClient:
             if oauth_config.as_metadata.client_id_metadata_document_supported and not is_localhost:
                 client_id = get_client_metadata_document_url(api_base)
                 log.info(
-                    f"Using client metadata document URL as client_id "
+                    f"{LogTag.MCP} Using client metadata document URL as client_id "
                     f"for token exchange: {client_id}"
                 )
 
@@ -1310,7 +1313,7 @@ class MCPClient:
             )
 
         log.info(
-            f"[{integration_id}] client_id resolved for token exchange: "
+            f"{LogTag.MCP} [{integration_id}] client_id resolved for token exchange: "
             f"client_id={client_id[:50]}{'...' if len(client_id) > 50 else ''}, "
             f"has_secret={client_secret is not None}"
         )
@@ -1354,7 +1357,7 @@ class MCPClient:
             if not (200 <= response.status_code < 300):
                 error_info = parse_oauth_error_response(response)
                 log.error(
-                    f"Token exchange failed for {integration_id}: "
+                    f"{LogTag.MCP} Token exchange failed for {integration_id}: "
                     f"{error_info['error']} - {error_info.get('error_description')}"
                 )
                 raise ValueError(
@@ -1372,7 +1375,7 @@ class MCPClient:
         # Validate JWT issuer if applicable
         issuer = str(oauth_config.as_metadata.issuer)
         if not validate_jwt_issuer(access_token, issuer, integration_id):
-            log.warning(f"JWT issuer validation failed for {integration_id}")
+            log.warning(f"{LogTag.MCP} JWT issuer validation failed for {integration_id}")
             # Continue anyway - some tokens are opaque, not JWTs
 
         # Validate OIDC nonce if one was stored during auth URL build
@@ -1389,7 +1392,7 @@ class MCPClient:
                     token_nonce = payload.get("nonce")
                 except Exception as e:
                     log.warning(
-                        f"Could not decode id_token for nonce validation ({integration_id}): {e}"
+                        f"{LogTag.MCP} Could not decode id_token for nonce validation ({integration_id}): {e}"
                     )
                     token_nonce = None
                 if token_nonce is not None and token_nonce != stored_nonce:
@@ -1397,9 +1400,11 @@ class MCPClient:
                         f"OIDC nonce mismatch for {integration_id}: possible replay attack"
                     )
                 if token_nonce is not None:
-                    log.debug(f"OIDC nonce validated for {integration_id}")
+                    log.debug(f"{LogTag.MCP} OIDC nonce validated for {integration_id}")
             else:
-                log.warning(f"OIDC nonce stored but no id_token in response for {integration_id}")
+                log.warning(
+                    f"{LogTag.MCP} OIDC nonce stored but no id_token in response for {integration_id}"
+                )
 
         expires_at = oauth_token_expiry(token.expires_in)
 
@@ -1407,14 +1412,14 @@ class MCPClient:
         new_refresh_token = token.refresh_token
 
         log.info(
-            f"[{integration_id}] OAuth callback - token exchange successful. "
+            f"{LogTag.MCP} [{integration_id}] OAuth callback - token exchange successful. "
             f"access_token length={len(access_token)}, "
             f"has_refresh_token={new_refresh_token is not None}, "
             f"expires_at={expires_at}"
         )
 
         # Store tokens (~20ms) — required before redirect so reconnect can use them.
-        log.info(f"[{integration_id}] Storing OAuth tokens to PostgreSQL")
+        log.info(f"{LogTag.MCP} [{integration_id}] Storing OAuth tokens to PostgreSQL")
         await self.token_store.store_oauth_tokens(
             integration_id=integration_id,
             access_token=access_token,
@@ -1430,7 +1435,7 @@ class MCPClient:
             await update_user_integration_status(self.user_id, integration_id, "connected")
         except Exception as status_err:
             log.warning(
-                f"[{integration_id}] optimistic status flip failed (will retry in "
+                f"{LogTag.MCP} [{integration_id}] optimistic status flip failed (will retry in "
                 f"background connect): {status_err}"
             )
 
@@ -1442,12 +1447,14 @@ class MCPClient:
         async def _bg_connect_after_oauth() -> None:
             try:
                 await self.connect(integration_id)
-                log.info(f"[{integration_id}] background connect after OAuth succeeded")
+                log.info(
+                    f"{LogTag.MCP} [{integration_id}] background connect after OAuth succeeded"
+                )
             except Exception as e:
                 is_auth_error = "401" in str(e) or "authentication" in str(e).lower()
                 terminal = _is_terminal_auth_failure(e, refresh_attempted=False) or is_auth_error
                 log.error(
-                    f"[{integration_id}] background connect after OAuth failed: "
+                    f"{LogTag.MCP} [{integration_id}] background connect after OAuth failed: "
                     f"{type(e).__name__}: {e} (terminal={terminal})"
                 )
                 if terminal:
@@ -1495,11 +1502,11 @@ class MCPClient:
                 )
             except TimeoutError:
                 log.warning(
-                    f"[{integration_id}] close_all_sessions timed out; proceeding with "
+                    f"{LogTag.MCP} [{integration_id}] close_all_sessions timed out; proceeding with "
                     f"local cleanup. Upstream session may linger until server-side timeout."
                 )
             except Exception as e:
-                log.warning(f"Error closing MCP session: {e}")
+                log.warning(f"{LogTag.MCP} Error closing MCP session: {e}")
             del self._clients[integration_id]
 
         if integration_id in self._tools:
@@ -1514,7 +1521,7 @@ class MCPClient:
             # Invalidate the global MCP tools Redis cache
             await delete_cache(MCP_TOOLS_CACHE_KEY)
         except Exception as e:
-            log.warning(f"Failed to clear MongoDB tools for {integration_id}: {e}")
+            log.warning(f"{LogTag.MCP} Failed to clear MongoDB tools for {integration_id}: {e}")
 
         # Invalidate ChromaDB namespace cache so tools are re-indexed on reconnect
         try:
@@ -1527,13 +1534,13 @@ class MCPClient:
                 )
                 await delete_cache(f"chroma:indexed:{namespace}")
         except Exception as e:
-            log.warning(f"Failed to invalidate ChromaDB cache: {e}")
+            log.warning(f"{LogTag.MCP} Failed to invalidate ChromaDB cache: {e}")
 
         # Wipe persistent auth artifacts (Mongo status, PG creds, DCR client,
         # Redis OAuth cache) via the shared teardown helper.
         await self._reset_to_disconnected(integration_id)
 
-        log.info(f"Disconnected MCP {integration_id}")
+        log.info(f"{LogTag.MCP} Disconnected MCP {integration_id}")
 
     async def _revoke_tokens(self, integration_id: str) -> None:
         """Revoke OAuth tokens at authorization server per RFC 7009."""
@@ -1547,7 +1554,7 @@ class MCPClient:
             if mcp_config:
                 await revoke_tokens(self.token_store, integration_id, mcp_config, oauth_config)
         except Exception as e:
-            log.warning(f"Token revocation failed for {integration_id}: {e}")
+            log.warning(f"{LogTag.MCP} Token revocation failed for {integration_id}: {e}")
 
     async def get_tools(self, integration_id: str) -> list[BaseTool]:
         """Get tools for a connected integration."""
@@ -1605,7 +1612,7 @@ class MCPClient:
         try:
             await client.close_all_sessions()
         except Exception as e:
-            log.warning(f"Error closing MCP client session: {e}")
+            log.warning(f"{LogTag.MCP} Error closing MCP client session: {e}")
 
     async def close_all_client_sessions(self) -> None:
         """Close all active MCP client sessions.
@@ -1616,7 +1623,7 @@ class MCPClient:
             try:
                 await self._clients[integration_id].close_all_sessions()
             except Exception as e:
-                log.warning(f"Error closing MCP session for {integration_id}: {e}")
+                log.warning(f"{LogTag.MCP} Error closing MCP session for {integration_id}: {e}")
 
     @staticmethod
     def _normalize_server_url(server_url: str) -> str:
@@ -1653,7 +1660,7 @@ class MCPClient:
             user_integrations = await get_user_integration_records(self.user_id)
         except Exception as e:
             log.warning(
-                f"Failed to load user integrations while matching server_url {server_url}: {e}",
+                f"{LogTag.MCP} Failed to load user integrations while matching server_url {server_url}: {e}",
             )
             return None
 
@@ -1712,7 +1719,13 @@ class MCPClient:
         if matching_integration_id is None:
             raise ValueError(f"No connected MCP integration found for server_url: {server_url}")
 
-        log.set(mcp={"server": server_url, "tool": tool_name})
+        log.set(
+            mcp=McpContext(
+                operation="call_tool",
+                server_id=matching_integration_id,
+                tool_name=tool_name,
+            )
+        )
 
         # Rehydrate a previously-connected integration if its in-memory session was evicted.
         await self.ensure_connected(matching_integration_id)
@@ -1724,9 +1737,7 @@ class MCPClient:
             )
         session = client.get_session(matching_integration_id)
 
-        start_time = time.monotonic()
         result = await session.call_tool(name=tool_name, arguments=arguments)
-        elapsed_ms = int((time.monotonic() - start_time) * 1000)
 
         # Normalise the mcp CallToolResult to a plain dict
         if hasattr(result, "model_dump"):
@@ -1737,14 +1748,7 @@ class MCPClient:
             raw = dict(result)
 
         is_error = raw.get("isError") or raw.get("is_error", False)
-        log.set(
-            mcp={
-                "server": server_url,
-                "tool": tool_name,
-                "latency_ms": elapsed_ms,
-                "success": not is_error,
-            }
-        )
+        log.set_ns("mcp", success=not is_error)
 
         return raw
 
@@ -1833,14 +1837,16 @@ class MCPClient:
         try:
             matching_integration_id = await self._find_integration_id_by_server_url(server_url)
             if matching_integration_id is None:
-                log.warning(f"No active MCP session found for server_url: {server_url}")
+                log.warning(
+                    f"{LogTag.MCP} No active MCP session found for server_url: {server_url}"
+                )
                 return None
 
             await self.ensure_connected(matching_integration_id)
 
             matching_client = self._clients.get(matching_integration_id)
             if matching_client is None:
-                log.warning(f"No active MCP client found for server_url: {server_url}")
+                log.warning(f"{LogTag.MCP} No active MCP client found for server_url: {server_url}")
                 return None
 
             session = matching_client.get_session(matching_integration_id)
@@ -1866,10 +1872,14 @@ class MCPClient:
             return None
 
         except TimeoutError:
-            log.warning(f"Timeout reading UI resource {resource_uri} from {server_url} (10s)")
+            log.warning(
+                f"{LogTag.MCP} Timeout reading UI resource {resource_uri} from {server_url} (10s)"
+            )
             return None
         except Exception as e:
-            log.warning(f"Failed to read UI resource {resource_uri} from {server_url}: {e}")
+            log.warning(
+                f"{LogTag.MCP} Failed to read UI resource {resource_uri} from {server_url}: {e}"
+            )
             return None
 
 

--- a/apps/api/app/services/mcp/mcp_client_pool.py
+++ b/apps/api/app/services/mcp/mcp_client_pool.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from shared.py.wide_events import log
 
@@ -48,7 +49,7 @@ class MCPClientPool:
                 # Move to end (most recently used) so LRU eviction picks the
                 # truly oldest entry when we hit the cap.
                 self._clients.move_to_end(user_id)
-                log.debug(f"Reusing pooled MCPClient for {user_id}")
+                log.debug(f"{LogTag.MCP} Reusing pooled MCPClient for {user_id}")
                 return pooled.client
 
             # Pop oldest if at capacity (close outside lock)
@@ -56,7 +57,7 @@ class MCPClientPool:
                 oldest_key = next(iter(self._clients))
                 evicted = self._clients.pop(oldest_key)
                 log.info(
-                    f"MCPClientPool at capacity ({self._max_clients}); LRU-evicting {oldest_key}"
+                    f"{LogTag.MCP} MCPClientPool at capacity ({self._max_clients}); LRU-evicting {oldest_key}"
                 )
 
             # Create new client (local import to avoid circular dependency)
@@ -64,14 +65,14 @@ class MCPClientPool:
 
             client = MCPClient(user_id=user_id)
             self._clients[user_id] = PooledClient(client=client)
-            log.debug(f"Created new pooled MCPClient for {user_id}")
+            log.debug(f"{LogTag.MCP} Created new pooled MCPClient for {user_id}")
 
         # Close evicted sessions outside the lock to avoid blocking
         if evicted:
             try:
                 await evicted.client.close_all_client_sessions()
             except Exception as e:
-                log.warning(f"Error closing evicted MCP sessions: {e}")
+                log.warning(f"{LogTag.MCP} Error closing evicted MCP sessions: {e}")
 
         return client
 
@@ -84,8 +85,8 @@ class MCPClientPool:
         try:
             await pooled.client.close_all_client_sessions()
         except Exception as e:
-            log.warning(f"Error closing MCP sessions for user {user_id}: {e}")
-        log.debug(f"Evicted MCPClient for {user_id}")
+            log.warning(f"{LogTag.MCP} Error closing MCP sessions for user {user_id}: {e}")
+        log.debug(f"{LogTag.MCP} Evicted MCPClient for {user_id}")
 
     async def shutdown(self):
         """Graceful shutdown of all clients."""
@@ -93,7 +94,7 @@ class MCPClientPool:
             for user_id in list(self._clients.keys()):
                 await self._evict(user_id)
 
-        log.info("MCPClientPool shutdown complete")
+        log.info(f"{LogTag.MCP} MCPClientPool shutdown complete")
 
     @property
     def size(self) -> int:

--- a/apps/api/app/services/mcp/mcp_resource_fetcher.py
+++ b/apps/api/app/services/mcp/mcp_resource_fetcher.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.services.mcp.mcp_client import get_mcp_client
-from shared.py.wide_events import log
+from shared.py.wide_events import McpContext, log
 
 
 async def fetch_mcp_ui_resource(
@@ -40,11 +41,12 @@ async def fetch_mcp_ui_resource(
             server_url=server_url,
             resource_uri=resource_uri,
         )
-        log.set(mcp_ui={"fetch_success": True})
+        log.set(mcp=McpContext(success=True))
         return details
     except Exception as e:
+        log.set(mcp=McpContext(success=False, error_type=type(e).__name__))
         log.warning(
-            "Failed to fetch MCP UI resource",
+            f"{LogTag.MCP} Failed to fetch MCP UI resource",
             resource_uri=resource_uri,
             server_url=server_url,
             error=str(e),

--- a/apps/api/app/services/mcp/mcp_token_store.py
+++ b/apps/api/app/services/mcp/mcp_token_store.py
@@ -20,6 +20,7 @@ from app.constants.cache import (
     OAUTH_STATE_PREFIX,
     OAUTH_STATE_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.db.postgresql import get_db_session
 from app.db.redis import get_and_delete_cache, get_cache, set_cache
 from app.models.db_oauth import MCPAuthType, MCPCredential, MCPCredentialStatus
@@ -85,26 +86,26 @@ class MCPTokenStore:
         """Get decrypted OAuth access token if not expired."""
         cred = await self.get_credential(integration_id)
         if not cred:
-            log.debug(f"[{integration_id}] No credential record found in DB")
+            log.debug(f"{LogTag.MCP} [{integration_id}] No credential record found in DB")
             return None
 
         if not cred.access_token:
-            log.debug(f"[{integration_id}] Credential exists but no access_token")
+            log.debug(f"{LogTag.MCP} [{integration_id}] Credential exists but no access_token")
             return None
 
         if cred.status != MCPCredentialStatus.CONNECTED:
             log.debug(
-                f"[{integration_id}] Credential status is '{cred.status}', expected 'connected'"
+                f"{LogTag.MCP} [{integration_id}] Credential status is '{cred.status}', expected 'connected'"
             )
             return None
 
         # token_expires_at is a timezone-aware column (DateTime(timezone=True)),
         # so compare against timezone-aware UTC.
         if cred.token_expires_at and cred.token_expires_at < datetime.now(UTC):
-            log.warning(f"OAuth token expired for {integration_id}")
+            log.warning(f"{LogTag.MCP} OAuth token expired for {integration_id}")
             return None
 
-        log.debug(f"[{integration_id}] Returning decrypted OAuth token")
+        log.debug(f"{LogTag.MCP} [{integration_id}] Returning decrypted OAuth token")
         return self._decrypt(cred.access_token)
 
     async def get_refresh_token(self, integration_id: str) -> str | None:
@@ -176,7 +177,7 @@ class MCPTokenStore:
                 )
                 session.add(cred)
             await session.commit()
-            log.info(f"Stored bearer token for {integration_id}")
+            log.info(f"{LogTag.MCP} Stored bearer token for {integration_id}")
 
     async def store_oauth_tokens(
         self,
@@ -221,7 +222,7 @@ class MCPTokenStore:
                 )
                 session.add(cred)
             await session.commit()
-            log.info(f"Stored OAuth tokens for {integration_id}")
+            log.info(f"{LogTag.MCP} Stored OAuth tokens for {integration_id}")
 
     async def store_unauthenticated(self, integration_id: str) -> None:
         """Store connection for unauthenticated MCP.
@@ -249,7 +250,9 @@ class MCPTokenStore:
                 )
                 session.add(cred)
                 await session.commit()
-                log.info(f"Created credential record for unauthenticated {integration_id}")
+                log.info(
+                    f"{LogTag.MCP} Created credential record for unauthenticated {integration_id}"
+                )
 
     async def create_oauth_state(self, integration_id: str, code_verifier: str) -> str:
         """
@@ -316,7 +319,7 @@ class MCPTokenStore:
             if cred:
                 await session.delete(cred)
                 await session.commit()
-                log.info(f"Deleted MCP credentials for {integration_id}")
+                log.info(f"{LogTag.MCP} Deleted MCP credentials for {integration_id}")
 
     async def is_connected(self, integration_id: str) -> bool:
         """Check if user has a connected credential for this integration.
@@ -355,7 +358,7 @@ class MCPTokenStore:
                 cred.client_registration = None
                 session.add(cred)
                 await session.commit()
-                log.info(f"Deleted DCR client for {integration_id}")
+                log.info(f"{LogTag.MCP} Deleted DCR client for {integration_id}")
 
     async def store_dcr_client(self, integration_id: str, dcr_data: dict) -> None:
         """Store DCR client registration from dynamic registration."""
@@ -381,7 +384,7 @@ class MCPTokenStore:
                 )
                 session.add(cred)
             await session.commit()
-            log.info(f"Stored DCR client for {integration_id}")
+            log.info(f"{LogTag.MCP} Stored DCR client for {integration_id}")
 
     async def store_oauth_discovery(self, integration_id: str, discovery: OAuthDiscovery) -> None:
         """
@@ -399,7 +402,7 @@ class MCPTokenStore:
         """
         cache_key = f"{OAUTH_DISCOVERY_PREFIX}:{integration_id}"
         await set_cache(cache_key, discovery.model_dump(mode="json"), ttl=OAUTH_DISCOVERY_TTL)
-        log.info(f"Cached OAuth discovery for {integration_id}")
+        log.info(f"{LogTag.MCP} Cached OAuth discovery for {integration_id}")
 
     async def get_oauth_discovery(self, integration_id: str) -> OAuthDiscovery | None:
         """Get cached OAuth discovery data from Redis."""
@@ -420,7 +423,7 @@ class MCPTokenStore:
         """
         cache_key = f"mcp_oauth_nonce:{self.user_id}:{integration_id}"
         await set_cache(cache_key, nonce, ttl=OAUTH_STATE_TTL)
-        log.debug(f"Stored OIDC nonce for {integration_id}")
+        log.debug(f"{LogTag.MCP} Stored OIDC nonce for {integration_id}")
 
     async def get_and_delete_oauth_nonce(self, integration_id: str) -> str | None:
         """

--- a/apps/api/app/services/mcp/mcp_tools_store.py
+++ b/apps/api/app/services/mcp/mcp_tools_store.py
@@ -5,6 +5,7 @@ import asyncio
 from pymongo import UpdateOne
 
 from app.constants.cache import MCP_TOOLS_CACHE_KEY, MCP_TOOLS_CACHE_TTL
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import integrations_collection
 from app.db.redis import delete_cache, get_cache, set_cache
 from shared.py.wide_events import log
@@ -49,7 +50,7 @@ class MCPToolsStore:
             _background_tasks.add(_task)
             _task.add_done_callback(_background_tasks.discard)
         except Exception as e:
-            log.error(f"[{integration_id}] Error storing tools: {e}")
+            log.error(f"{LogTag.MCP} [{integration_id}] Error storing tools: {e}")
             raise
 
     async def store_tools_batch(self, items: list[tuple[str, list[dict]]]) -> None:
@@ -77,7 +78,7 @@ class MCPToolsStore:
             _background_tasks.add(_task)
             _task.add_done_callback(_background_tasks.discard)
         except Exception as e:
-            log.error(f"Error storing tools batch: {e}")
+            log.error(f"{LogTag.MCP} Error storing tools batch: {e}")
             raise
 
     async def get_tools(self, integration_id: str) -> list[dict] | None:
@@ -89,7 +90,7 @@ class MCPToolsStore:
             )
             return doc.get("tools") if doc else None
         except Exception as e:
-            log.error(f"Error getting tools for {integration_id}: {e}")
+            log.error(f"{LogTag.MCP} Error getting tools for {integration_id}: {e}")
             return None
 
     async def get_all_mcp_tools(self) -> dict[str, dict]:
@@ -118,7 +119,7 @@ class MCPToolsStore:
             await set_cache(MCP_TOOLS_CACHE_KEY, grouped, ttl=MCP_TOOLS_CACHE_TTL)
             return grouped
         except Exception as e:
-            log.error(f"Error getting all MCP tools: {e}")
+            log.error(f"{LogTag.MCP} Error getting all MCP tools: {e}")
             return {}
 
     async def _refresh_cache(self) -> None:
@@ -126,7 +127,7 @@ class MCPToolsStore:
         try:
             await self.get_all_mcp_tools()
         except Exception as e:
-            log.warning(f"Failed to refresh MCP tools cache: {e}")
+            log.warning(f"{LogTag.MCP} Failed to refresh MCP tools cache: {e}")
 
 
 def get_mcp_tools_store() -> MCPToolsStore:

--- a/apps/api/app/services/mcp/oauth_discovery.py
+++ b/apps/api/app/services/mcp/oauth_discovery.py
@@ -6,6 +6,7 @@ Handles OAuth 2.1 discovery flow per MCP specification:
 - RFC 8414 Authorization Server Metadata discovery
 """
 
+from app.constants.log_tags import LogTag
 from app.constants.mcp import COMPOSIO_MCP_HOST
 from app.models.mcp_config import MCPConfig, OAuthDiscovery
 from app.services.mcp.mcp_token_store import MCPTokenStore
@@ -49,7 +50,7 @@ async def discover_oauth_config(
     try:
         validate_https_url(server_url)
     except OAuthSecurityError as e:
-        log.warning(f"Server URL security warning for {integration_id}: {e}")
+        log.warning(f"{LogTag.MCP} Server URL security warning for {integration_id}: {e}")
 
     challenge = challenge_data or await extract_auth_challenge(server_url)
     initial_scope = challenge.get("scope")
@@ -87,7 +88,7 @@ async def discover_oauth_config(
         try:
             validate_oauth_endpoints(as_metadata)
         except OAuthSecurityError as e:
-            log.warning(f"OAuth endpoint security warning: {e}")
+            log.warning(f"{LogTag.MCP} OAuth endpoint security warning: {e}")
 
         await token_store.store_oauth_discovery(integration_id, discovery)
         return discovery
@@ -106,7 +107,7 @@ async def discover_oauth_config(
         try:
             validate_oauth_endpoints(as_metadata)
         except OAuthSecurityError as e:
-            log.warning(f"OAuth endpoint security warning: {e}")
+            log.warning(f"{LogTag.MCP} OAuth endpoint security warning: {e}")
 
         await token_store.store_oauth_discovery(integration_id, discovery)
         return discovery

--- a/apps/api/app/services/mcp/resilient_adapter.py
+++ b/apps/api/app/services/mcp/resilient_adapter.py
@@ -19,6 +19,7 @@ from langchain_core.tools import BaseTool
 import mcp_use.agents.adapters.langchain_adapter as _mcp_use_lc_adapter
 from pydantic import BaseModel
 
+from app.constants.log_tags import LogTag
 from app.services.mcp.langchain_adapter import SanitizingLangChainAdapter
 from app.utils.schema_fixes import patch_tool_schema
 from shared.py.wide_events import log
@@ -75,7 +76,7 @@ class ResilientLangChainAdapter(SanitizingLangChainAdapter):
         # Get connectors from active sessions
         sessions = client.get_all_active_sessions()
         if not sessions:
-            log.warning("No active sessions found in client")
+            log.warning(f"{LogTag.MCP} No active sessions found in client")
             return []
 
         # Get first session (we typically only have one per integration)
@@ -86,13 +87,13 @@ class ResilientLangChainAdapter(SanitizingLangChainAdapter):
         # Get tools from MCP server
         try:
             mcp_tools = await connector.list_tools()
-            log.info(f"[{integration_id}] MCP server returned {len(mcp_tools)} tools")
+            log.info(f"{LogTag.MCP} [{integration_id}] MCP server returned {len(mcp_tools)} tools")
         except Exception as e:
-            log.error(f"[{integration_id}] Failed to list tools: {e}")
+            log.error(f"{LogTag.MCP} [{integration_id}] Failed to list tools: {e}")
             raise
 
         if not mcp_tools:
-            log.warning(f"[{integration_id}] No tools returned from MCP server")
+            log.warning(f"{LogTag.MCP} [{integration_id}] No tools returned from MCP server")
             return []
 
         # Normalize schemas before conversion
@@ -102,7 +103,9 @@ class ResilientLangChainAdapter(SanitizingLangChainAdapter):
                 normalized_tool = patch_tool_schema(tool)
                 normalized_tools.append(normalized_tool)
             except Exception as e:
-                log.warning(f"[{integration_id}] Could not normalize schema for {tool.name}: {e}")
+                log.warning(
+                    f"{LogTag.MCP} [{integration_id}] Could not normalize schema for {tool.name}: {e}"
+                )
                 # Still try to use the original tool
                 normalized_tools.append(tool)
 
@@ -137,15 +140,15 @@ class ResilientLangChainAdapter(SanitizingLangChainAdapter):
                             "permissions": ui_meta.get("permissions", []),
                         }
                         log.debug(
-                            f"[{integration_id}] Attached mcp_ui metadata to tool: {tool.name}"
+                            f"{LogTag.MCP} [{integration_id}] Attached mcp_ui metadata to tool: {tool.name}"
                         )
 
                 successfully_converted.append(langchain_tool)
-                log.debug(f"[{integration_id}] ✓ Converted tool: {tool.name}")
+                log.debug(f"{LogTag.MCP} [{integration_id}] Converted tool: {tool.name}")
             except Exception as e:
                 failed_tools.append((tool.name, str(e)))
                 log.warning(
-                    f"[{integration_id}] ✗ Failed to convert tool '{tool.name}': "
+                    f"{LogTag.MCP} [{integration_id}] Failed to convert tool '{tool.name}': "
                     f"{type(e).__name__}: {e}"
                 )
                 # Continue with other tools
@@ -153,12 +156,12 @@ class ResilientLangChainAdapter(SanitizingLangChainAdapter):
         # Log summary
         if successfully_converted:
             log.info(
-                f"[{integration_id}] Successfully converted {len(successfully_converted)}/{len(mcp_tools)} tools"
+                f"{LogTag.MCP} [{integration_id}] Successfully converted {len(successfully_converted)}/{len(mcp_tools)} tools"
             )
 
         if failed_tools:
             log.warning(
-                f"[{integration_id}] Skipped {len(failed_tools)} tools with invalid schemas:\n"
+                f"{LogTag.MCP} [{integration_id}] Skipped {len(failed_tools)} tools with invalid schemas:\n"
                 + "\n".join(f"  - {name}: {error}" for name, error in failed_tools)
             )
 

--- a/apps/api/app/services/mcp/token_management.py
+++ b/apps/api/app/services/mcp/token_management.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from app.constants.log_tags import LogTag
 from app.models.mcp_config import MCPConfig, OAuthDiscovery
 from app.services.mcp.mcp_token_store import MCPTokenStore
 from app.utils.mcp_oauth_utils import oauth_token_expiry
@@ -59,7 +60,7 @@ async def try_refresh_token(
     refresh_token = await token_store.get_refresh_token(integration_id)
     if not refresh_token:
         log.warning(
-            f"try_refresh_token: no refresh_token stored for {integration_id} "
+            f"{LogTag.MCP} try_refresh_token: no refresh_token stored for {integration_id} "
             f"user={token_store.user_id}; user must re-OAuth"
         )
         return False
@@ -76,7 +77,7 @@ async def try_refresh_token(
 
         if not client_id:
             log.warning(
-                f"try_refresh_token: no client_id resolved for {integration_id} "
+                f"{LogTag.MCP} try_refresh_token: no client_id resolved for {integration_id} "
                 f"user={token_store.user_id} (no pre-configured creds, no DCR "
                 f"registration); user must re-authorize"
             )
@@ -116,7 +117,7 @@ async def try_refresh_token(
                     pass
 
                 log.warning(
-                    f"try_refresh_token: token endpoint returned "
+                    f"{LogTag.MCP} try_refresh_token: token endpoint returned "
                     f"{response.status_code} for {integration_id} "
                     f"user={token_store.user_id} "
                     f"(oauth_error={error_code!r}, desc={error_description!r}) "
@@ -130,7 +131,7 @@ async def try_refresh_token(
             # as a failure rather than storing a blank credential.
             if not token.access_token:
                 log.warning(
-                    f"try_refresh_token: token endpoint returned an empty "
+                    f"{LogTag.MCP} try_refresh_token: token endpoint returned an empty "
                     f"access_token for {integration_id} user={token_store.user_id}"
                 )
                 return False
@@ -145,7 +146,7 @@ async def try_refresh_token(
             )
 
             log.info(
-                f"try_refresh_token: refreshed token for {integration_id} "
+                f"{LogTag.MCP} try_refresh_token: refreshed token for {integration_id} "
                 f"user={token_store.user_id} "
                 f"(new_access_token_length={len(token.access_token)}, "
                 f"refresh_token_rotated={token.refresh_token is not None}, "
@@ -155,7 +156,7 @@ async def try_refresh_token(
 
     except Exception as e:
         log.warning(
-            f"try_refresh_token: exception during refresh for "
+            f"{LogTag.MCP} try_refresh_token: exception during refresh for "
             f"{integration_id} user={token_store.user_id}: "
             f"{type(e).__name__}: {e}"
         )
@@ -205,4 +206,4 @@ async def revoke_tokens(
 
                 await http_client.post(revocation_endpoint, data=data, headers=headers, timeout=10)
     except Exception as e:
-        log.warning(f"Token revocation failed for {integration_id}: {e}")
+        log.warning(f"{LogTag.MCP} Token revocation failed for {integration_id}: {e}")

--- a/apps/api/app/services/oauth/oauth_service.py
+++ b/apps/api/app/services/oauth/oauth_service.py
@@ -19,6 +19,7 @@ from app.constants.integrations import (
     MANAGED_BY_MCP,
     MANAGED_BY_SELF,
 )
+from app.constants.log_tags import LogTag
 from app.core.websocket_manager import websocket_manager
 from app.db.mongodb.collections import user_integrations_collection, users_collection
 from app.db.redis import delete_cache
@@ -36,7 +37,7 @@ from app.services.system_workflows.provisioner import provision_system_workflows
 from app.services.workspace_sync import schedule_user_provision
 from app.utils.email_utils import add_contact_to_resend, send_welcome_email
 from app.utils.redis_utils import RedisPoolManager
-from shared.py.wide_events import log
+from shared.py.wide_events import OAuthContext, log
 
 
 async def store_user_info(
@@ -90,7 +91,7 @@ async def store_user_info(
                 login_method=LOGIN_METHOD_WORKOS,
             )
         except Exception as e:
-            log.error(f"Failed to track login in PostHog for {email}: {e!s}")
+            log.error(f"{LogTag.OAUTH} Failed to track login in PostHog for {email}: {e!s}")
 
         return existing_user["_id"], False
     user_data = {
@@ -111,24 +112,24 @@ async def store_user_info(
             name=name,
             signup_method=LOGIN_METHOD_WORKOS,
         )
-        log.info(f"Signup tracked in PostHog for new user: {email}")
+        log.info(f"{LogTag.OAUTH} Signup tracked in PostHog for new user: {email}")
     except Exception as e:
-        log.error(f"Failed to track signup in PostHog for {email}: {e!s}")
+        log.error(f"{LogTag.OAUTH} Failed to track signup in PostHog for {email}: {e!s}")
 
     # Send welcome email to new user
     try:
         await send_welcome_email(email, name)
-        log.info(f"Welcome email sent to new user: {email}")
+        log.info(f"{LogTag.OAUTH} Welcome email sent to new user: {email}")
     except Exception as e:
-        log.error(f"Failed to send welcome email to {email}: {e!s}")
+        log.error(f"{LogTag.OAUTH} Failed to send welcome email to {email}: {e!s}")
         # Don't raise exception - user creation should still succeed
 
     # Add contact to Resend audience
     try:
         await add_contact_to_resend(email, name)
-        log.info(f"Contact added to Resend audience for new user: {email}")
+        log.info(f"{LogTag.OAUTH} Contact added to Resend audience for new user: {email}")
     except Exception as e:
-        log.error(f"Failed to add contact to Resend audience for {email}: {e!s}")
+        log.error(f"{LogTag.OAUTH} Failed to add contact to Resend audience for {email}: {e!s}")
         # Don't raise exception - user creation should still succeed
 
     # Provision the user's workspace (system files + skills catalog) now, instead
@@ -197,7 +198,7 @@ async def get_all_integrations_status(user_id: str) -> dict[str, bool]:
                     scope in authorized_scopes for scope in required_scopes
                 )
             except Exception as e:
-                log.debug(f"Token not found for {integration.provider}: {e}")
+                log.debug(f"{LogTag.OAUTH} Token not found for {integration.provider}: {e}")
                 result[integration.id] = False
 
     # Step 2: Batch check Composio integrations not in MongoDB
@@ -208,7 +209,7 @@ async def get_all_integrations_status(user_id: str) -> dict[str, bool]:
             for integration_id, provider in composio_id_to_provider.items():
                 result[integration_id] = status_map.get(provider, False)
         except Exception as e:
-            log.error(f"Error batch checking Composio integrations: {e}")
+            log.error(f"{LogTag.OAUTH} Error batch checking Composio integrations: {e}")
             for integration_id in composio_id_to_provider.keys():
                 result[integration_id] = False
 
@@ -217,6 +218,7 @@ async def get_all_integrations_status(user_id: str) -> dict[str, bool]:
         if integration_id not in result:
             result[integration_id] = is_connected
 
+    log.set(oauth=OAuthContext(operation="status"), result_count=len(result))
     return result
 
 
@@ -238,7 +240,7 @@ async def check_integration_status(integration_id: str, user_id: str) -> bool:
         all_statuses = await get_all_integrations_status(user_id)
         return all_statuses.get(integration_id, False)
     except Exception as e:
-        log.error(f"Error checking integration status for {integration_id}: {e}")
+        log.error(f"{LogTag.OAUTH} Error checking integration status for {integration_id}: {e}")
         return False
 
 
@@ -265,7 +267,7 @@ async def check_multiple_integrations_status(
             for integration_id in integration_ids
         }
     except Exception as e:
-        log.error(f"Error checking multiple integrations status: {e}")
+        log.error(f"{LogTag.OAUTH} Error checking multiple integrations status: {e}")
         return dict.fromkeys(integration_ids, False)
 
 
@@ -285,12 +287,18 @@ async def handle_oauth_connection(
         background_tasks: FastAPI background tasks
     """
     log.set(auth={"user_id": user_id, "provider": integration_config.id})
+    log.set_ns(
+        "oauth",
+        operation="connect",
+        provider=integration_config.provider,
+        integration_id=integration_config.id,
+    )
 
     # Setup triggers if available
     if integration_config.associated_triggers:
         composio_service = get_composio_service()
         log.info(
-            f"Setting up {len(integration_config.associated_triggers)} triggers "
+            f"{LogTag.OAUTH} Setting up {len(integration_config.associated_triggers)} triggers "
             f"for user {user_id} and integration {integration_config.id}"
         )
         background_tasks.add_task(
@@ -301,13 +309,13 @@ async def handle_oauth_connection(
 
     # Process Gmail emails to memory if this is a Gmail connection
     if integration_config.id == GMAIL_INTEGRATION_ID:
-        log.info(f"Starting Gmail email processing for user {user_id}")
+        log.info(f"{LogTag.OAUTH} Starting Gmail email processing for user {user_id}")
 
         user_doc = None
         try:
             user_doc = await users_collection.find_one({"_id": ObjectId(user_id)})
         except Exception as e:
-            log.error(f"Failed to load user_doc for {user_id}: {e}", exc_info=True)
+            log.error(f"{LogTag.OAUTH} Failed to load user_doc for {user_id}: {e}", exc_info=True)
 
         onboarding_completed = bool(user_doc and user_doc.get("onboarding", {}).get("completed"))
 
@@ -327,7 +335,7 @@ async def handle_oauth_connection(
                         },
                     )
                     log.info(
-                        f"Updated bio_status to processing for user {user_id} "
+                        f"{LogTag.OAUTH} Updated bio_status to processing for user {user_id} "
                         f"(was {current_bio_status})"
                     )
                     try:
@@ -340,10 +348,10 @@ async def handle_oauth_connection(
                                 },
                             )
                     except Exception as ws_error:
-                        log.warning(f"Failed to send WebSocket update: {ws_error}")
+                        log.warning(f"{LogTag.OAUTH} Failed to send WebSocket update: {ws_error}")
             except Exception as e:
                 log.error(
-                    f"Error updating bio_status for user {user_id}: {e}",
+                    f"{LogTag.OAUTH} Error updating bio_status for user {user_id}: {e}",
                     exc_info=True,
                 )
 
@@ -353,12 +361,12 @@ async def handle_oauth_connection(
             try:
                 pool = await RedisPoolManager.get_pool()
                 await pool.enqueue_job("process_gmail_emails_to_memory", user_id)
-                log.info(f"Queued Gmail processing job for user {user_id}")
+                log.info(f"{LogTag.OAUTH} Queued Gmail processing job for user {user_id}")
             except Exception as e:
-                log.error(f"Failed to queue Gmail processing: {e}", exc_info=True)
+                log.error(f"{LogTag.OAUTH} Failed to queue Gmail processing: {e}", exc_info=True)
         else:
             log.info(
-                "Deferring Gmail->memory ingestion until onboarding pipeline "
+                f"{LogTag.OAUTH} Deferring Gmail->memory ingestion until onboarding pipeline "
                 f"completes for user {user_id}"
             )
 
@@ -366,9 +374,9 @@ async def handle_oauth_connection(
     try:
         cache_key = f"{OAUTH_STATUS_KEY}:{user_id}"
         await delete_cache(cache_key)
-        log.info(f"OAuth status cache invalidated for user {user_id}")
+        log.info(f"{LogTag.OAUTH} OAuth status cache invalidated for user {user_id}")
     except Exception as e:
-        log.warning(f"Failed to invalidate OAuth status cache: {e}")
+        log.warning(f"{LogTag.OAUTH} Failed to invalidate OAuth status cache: {e}")
 
     # Update user_integrations status in MongoDB
     # The @CacheInvalidator on update_user_integration_status invalidates
@@ -377,9 +385,9 @@ async def handle_oauth_connection(
         await update_user_integration_status(
             user_id, integration_config.id, INTEGRATION_STATUS_CONNECTED
         )
-        log.info(f"Updated user_integrations status for {integration_config.id}")
+        log.info(f"{LogTag.OAUTH} Updated user_integrations status for {integration_config.id}")
     except Exception as e:
-        log.warning(f"Failed to update user_integrations status: {e}")
+        log.warning(f"{LogTag.OAUTH} Failed to update user_integrations status: {e}")
 
     if integration_config.metadata_config:
         background_tasks.add_task(
@@ -388,7 +396,7 @@ async def handle_oauth_connection(
             integration_id=integration_config.id,
         )
         log.info(
-            f"Queued metadata fetch for user {user_id} and integration {integration_config.id}"
+            f"{LogTag.OAUTH} Queued metadata fetch for user {user_id} and integration {integration_config.id}"
         )
 
     # Auto-provision system workflows for supported integrations
@@ -400,6 +408,6 @@ async def handle_oauth_connection(
             integration_display_name=integration_config.name,
         )
         log.info(
-            f"Queued system workflow provisioning for user {user_id}, "
+            f"{LogTag.OAUTH} Queued system workflow provisioning for user {user_id}, "
             f"integration {integration_config.id}"
         )

--- a/apps/api/app/services/oauth/oauth_state_service.py
+++ b/apps/api/app/services/oauth/oauth_state_service.py
@@ -12,8 +12,9 @@ Uses Redis for temporary state storage with automatic expiration.
 import secrets
 
 from app.constants.cache import STATE_KEY_PREFIX, STATE_TOKEN_TTL
+from app.constants.log_tags import LogTag
 from app.db.redis import redis_cache
-from shared.py.wide_events import log
+from shared.py.wide_events import OAuthContext, log
 
 
 async def create_oauth_state(user_id: str, redirect_path: str, integration_id: str) -> str:
@@ -33,11 +34,16 @@ async def create_oauth_state(user_id: str, redirect_path: str, integration_id: s
         - Stores state server-side with automatic expiration
         - Validates redirect path against allowlist
     """
-    log.set(auth={"user_id": user_id, "provider": integration_id})
+    log.set(
+        auth={"user_id": user_id, "provider": integration_id},
+        oauth=OAuthContext(operation="authorize", integration_id=integration_id),
+    )
 
     # Validate redirect path - only allow safe paths
     if not is_safe_redirect_path(redirect_path):
-        log.warning(f"Unsafe redirect path rejected for user {user_id}: {redirect_path}")
+        log.warning(
+            f"{LogTag.OAUTH} Unsafe redirect path rejected for user {user_id}: {redirect_path}"
+        )
         # Default to safe path
         redirect_path = "/c"
 
@@ -57,7 +63,9 @@ async def create_oauth_state(user_id: str, redirect_path: str, integration_id: s
     await redis_client.hset(state_key, mapping=state_data)  # type: ignore[arg-type]
     await redis_client.expire(state_key, STATE_TOKEN_TTL)
 
-    log.info(f"Created OAuth state token for user {user_id}, integration {integration_id}")
+    log.info(
+        f"{LogTag.OAUTH} Created OAuth state token for user {user_id}, integration {integration_id}"
+    )
     return state_token
 
 
@@ -86,7 +94,7 @@ async def validate_and_consume_oauth_state(
         state_data = await redis_client.hgetall(state_key)
 
         if not state_data:
-            log.warning(f"Invalid or expired OAuth state token: {state_token}")
+            log.warning(f"{LogTag.OAUTH} Invalid or expired OAuth state token: {state_token}")
             return None
 
         # Decode bytes to strings
@@ -97,23 +105,24 @@ async def validate_and_consume_oauth_state(
         }
 
         log.set(auth={"user_id": result["user_id"], "provider": result["integration_id"]})
+        log.set_ns("oauth", operation="callback", integration_id=result["integration_id"])
 
         # Validate that we have all required fields
         if not all([result["user_id"], result["redirect_path"], result["integration_id"]]):
-            log.warning(f"Incomplete OAuth state data for token: {state_token}")
+            log.warning(f"{LogTag.OAUTH} Incomplete OAuth state data for token: {state_token}")
             return None
 
         # Delete the token to prevent replay attacks
         await redis_client.delete(state_key)
 
         log.info(
-            f"OAuth state validated and consumed for user {result['user_id']}, "
+            f"{LogTag.OAUTH} OAuth state validated and consumed for user {result['user_id']}, "
             f"integration {result['integration_id']}"
         )
         return result
 
     except Exception as e:
-        log.error(f"Error validating OAuth state: {e}")
+        log.error(f"{LogTag.OAUTH} Error validating OAuth state: {e}")
         return None
 
 

--- a/apps/api/app/services/onboarding/clarify_service.py
+++ b/apps/api/app/services/onboarding/clarify_service.py
@@ -20,6 +20,7 @@ from langchain_core.messages import HumanMessage
 from pydantic import BaseModel, Field
 
 from app.agents.prompts.onboarding_prompts import CLARIFY_QUESTIONS_PROMPT
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from shared.py.wide_events import log
 
@@ -123,20 +124,20 @@ async def generate_clarify_questions(
 
         if len(questions) < 3:
             log.warning(
-                "[clarify] LLM returned incomplete set, falling back",
+                f"{LogTag.ONBOARDING} LLM returned incomplete set, falling back",
                 received=len(questions),
             )
             return _fallback_questions()
 
         log.info(
-            "[clarify] questions generated",
+            f"{LogTag.ONBOARDING} questions generated",
             duration_s=round(time.monotonic() - t0, 2),
         )
         return questions
 
     except Exception as e:
         log.warning(
-            "[clarify] generation failed, using fallback",
+            f"{LogTag.ONBOARDING} generation failed, using fallback",
             error=str(e)[:200],
             error_type=type(e).__name__,
             duration_s=round(time.monotonic() - t0, 2),

--- a/apps/api/app/services/onboarding/first_message_service.py
+++ b/apps/api/app/services/onboarding/first_message_service.py
@@ -8,6 +8,7 @@ from app.agents.prompts.onboarding_prompts import (
     FIRST_MESSAGE_GENERATION_PROMPT_GMAIL,
     FIRST_MESSAGE_GENERATION_PROMPT_NO_GMAIL,
 )
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.models.onboarding_models import (
     InboxTriage,
@@ -98,7 +99,7 @@ async def generate_first_message(
         message = content.strip()
 
         log.info(
-            "[first_message] generated",
+            f"{LogTag.ONBOARDING} first_message generated",
             user_id=user_id,
             step="first_message",
             outcome="ok",
@@ -115,7 +116,7 @@ async def generate_first_message(
 
     except Exception as e:
         log.error(
-            "[first_message] failed",
+            f"{LogTag.ONBOARDING} first_message failed",
             user_id=user_id,
             step="first_message",
             outcome="failed",

--- a/apps/api/app/services/onboarding/inbox_triage_service.py
+++ b/apps/api/app/services/onboarding/inbox_triage_service.py
@@ -5,6 +5,7 @@ import time
 from langchain_core.messages import HumanMessage
 
 from app.agents.prompts.onboarding_prompts import INBOX_TRIAGE_PROMPT
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.models.onboarding_models import InboxTriage, InboxTriageOutput
 from shared.py.wide_events import log
@@ -102,7 +103,7 @@ async def triage_inbox(
         )
 
         log.info(
-            "[inbox_triage] done",
+            f"{LogTag.ONBOARDING} inbox_triage done",
             user_id=user_id,
             step="triage_llm",
             outcome="ok",
@@ -121,7 +122,7 @@ async def triage_inbox(
 
     except Exception as e:
         log.error(
-            "[inbox_triage] failed",
+            f"{LogTag.ONBOARDING} inbox_triage failed",
             user_id=user_id,
             step="triage_llm",
             outcome="failed",

--- a/apps/api/app/services/onboarding/intelligence_job.py
+++ b/apps/api/app/services/onboarding/intelligence_job.py
@@ -13,6 +13,7 @@ from arq.jobs import Job, JobStatus
 from arq.utils import timestamp_ms
 from bson import ObjectId
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import todos_collection, users_collection
 from app.utils.redis_utils import RedisPoolManager
 from shared.py.wide_events import log
@@ -64,7 +65,7 @@ async def is_intelligence_job_live(user_id: str) -> bool:
         status = await job.status()
     except Exception as e:
         log.warning(
-            "[intelligence_job] status check failed, treating as dead",
+            f"{LogTag.ONBOARDING} intelligence_job status check failed, treating as dead",
             user_id=user_id,
             job_id=job_id,
             error=str(e)[:200],
@@ -88,7 +89,7 @@ async def abort_active_intelligence_job(user_id: str) -> bool:
         await pool.zadd(abort_jobs_ss, {job_id: timestamp_ms()})
         aborted = True
         log.info(
-            "[intelligence_job] aborted",
+            f"{LogTag.ONBOARDING} intelligence_job aborted",
             user_id=user_id,
             job_id=job_id,
             prev_status=status.value,
@@ -104,7 +105,7 @@ async def _purge_stale_onboarding_todos(user_id: str) -> int:
         return result.deleted_count
     except Exception as e:
         log.warning(
-            "[intelligence_job] failed to purge stale onboarding todos",
+            f"{LogTag.ONBOARDING} intelligence_job failed to purge stale onboarding todos",
             user_id=user_id,
             error=str(e)[:200],
         )
@@ -118,7 +119,7 @@ async def enqueue_intelligence_job(user_id: str) -> str | None:
     purged = await _purge_stale_onboarding_todos(user_id)
     if purged:
         log.info(
-            "[intelligence_job] purged stale onboarding todos",
+            f"{LogTag.ONBOARDING} intelligence_job purged stale onboarding todos",
             user_id=user_id,
             purged=purged,
         )
@@ -126,12 +127,12 @@ async def enqueue_intelligence_job(user_id: str) -> str | None:
     pool = await RedisPoolManager.get_pool()
     job = await pool.enqueue_job(_INTELLIGENCE_TASK, user_id)
     if job is None:
-        log.error("[intelligence_job] enqueue returned no job", user_id=user_id)
+        log.error(f"{LogTag.ONBOARDING} intelligence_job enqueue returned no job", user_id=user_id)
         return None
 
     await _set_active_job_id(user_id, job.job_id)
     log.info(
-        "[intelligence_job] enqueued",
+        f"{LogTag.ONBOARDING} intelligence_job enqueued",
         user_id=user_id,
         job_id=job.job_id,
     )

--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -37,6 +37,7 @@ from app.agents.prompts.onboarding_prompts import (
 )
 from app.config.oauth_config import OAUTH_INTEGRATIONS
 from app.constants.email import ONBOARDING_EMAIL_SCAN_LIMIT
+from app.constants.log_tags import LogTag
 from app.constants.todos import ONBOARDING_TODO_LIMIT
 from app.core.lazy_loader import providers
 from app.core.websocket_manager import websocket_manager
@@ -108,11 +109,11 @@ async def _emit_stage(
         )
         status_text = (payload or {}).get("status_text")
         if status_text:
-            log.info(f"[intelligence:stage] {stage.value} — {status_text}")
+            log.info(f"{LogTag.ONBOARDING} stage {stage.value} — {status_text}")
         else:
-            log.info(f"[intelligence:stage] {stage.value}")
+            log.info(f"{LogTag.ONBOARDING} stage {stage.value}")
     except Exception as e:
-        log.warning(f"[intelligence] Failed to emit stage {stage.value}: {e}")
+        log.warning(f"{LogTag.ONBOARDING} Failed to emit stage {stage.value}: {e}")
 
 
 T = TypeVar("T")
@@ -122,7 +123,7 @@ async def _safe_run(name: str, coro: Awaitable[T], default: T) -> T:
     try:
         return await coro
     except Exception as e:
-        log.error(f"[intelligence] Node '{name}' failed: {e}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Node '{name}' failed: {e}", exc_info=True)
         return default
 
 
@@ -202,12 +203,12 @@ async def _scan_then_enqueue_memory(user_id: str, ctx: InboxScanContext) -> None
         pool = await RedisPoolManager.get_pool()
         await pool.enqueue_job("process_gmail_emails_to_memory", user_id)
         log.info(
-            "[intelligence] queued gmail->memory ingestion",
+            f"{LogTag.ONBOARDING} queued gmail->memory ingestion",
             user_id=user_id,
         )
     except Exception as e:
         log.warning(
-            "[intelligence] failed to queue gmail->memory ingestion",
+            f"{LogTag.ONBOARDING} failed to queue gmail->memory ingestion",
             user_id=user_id,
             error=str(e)[:200],
             error_type=type(e).__name__,
@@ -283,7 +284,7 @@ async def process_onboarding_intelligence(user_id: str) -> None:
     log.set(user={"id": user_id})
     pipeline_start = time.monotonic()
     log.info(
-        "[intelligence] pipeline start",
+        f"{LogTag.ONBOARDING} pipeline start",
         user_id=user_id,
         phase="start",
     )
@@ -306,7 +307,7 @@ async def process_onboarding_intelligence(user_id: str) -> None:
     user_doc = await users_collection.find_one({"_id": ObjectId(user_id)})
     if not user_doc:
         log.error(
-            "[intelligence] user not found",
+            f"{LogTag.ONBOARDING} user not found",
             user_id=user_id,
             outcome="aborted",
             reason="user_not_found",
@@ -325,13 +326,13 @@ async def process_onboarding_intelligence(user_id: str) -> None:
     connection_status = await composio_service.check_connection_status(["gmail"], user_id)
     has_gmail: bool = connection_status.get("gmail", False)
     log.info(
-        "[intelligence] gmail check",
+        f"{LogTag.ONBOARDING} gmail check",
         user_id=user_id,
         has_gmail=has_gmail,
         duration_s=round(time.monotonic() - t_gmail_check, 2),
     )
     log.info(
-        "[intelligence] inputs",
+        f"{LogTag.ONBOARDING} inputs",
         user_id=user_id,
         has_gmail=has_gmail,
         profession_set=bool(profession),
@@ -382,7 +383,7 @@ async def process_onboarding_intelligence(user_id: str) -> None:
         writing_style_future,
     )
     log.info(
-        "[intelligence] critical_path gathered",
+        f"{LogTag.ONBOARDING} critical_path gathered",
         user_id=user_id,
         phase="critical_path_gather",
         duration_s=round(time.monotonic() - t_gather, 2),
@@ -406,7 +407,7 @@ async def process_onboarding_intelligence(user_id: str) -> None:
         default="Welcome to GAIA. I'm here to help — what's on your mind?",
     )
     log.info(
-        "[intelligence] first_message generated",
+        f"{LogTag.ONBOARDING} first_message generated",
         user_id=user_id,
         message_chars=len(first_message),
         duration_s=round(time.monotonic() - t_msg, 2),
@@ -436,7 +437,7 @@ async def process_onboarding_intelligence(user_id: str) -> None:
         ),
     )
     log.info(
-        "[intelligence] finalize gathered",
+        f"{LogTag.ONBOARDING} finalize gathered",
         user_id=user_id,
         phase="finalize_gather",
         duration_s=round(time.monotonic() - t_final, 2),
@@ -453,7 +454,7 @@ async def process_onboarding_intelligence(user_id: str) -> None:
     )
 
     log.info(
-        "[intelligence] pipeline done",
+        f"{LogTag.ONBOARDING} pipeline done",
         user_id=user_id,
         phase="done",
         has_gmail=has_gmail,
@@ -483,7 +484,7 @@ async def _run_inbox_scanning(user_id: str, ctx: InboxScanContext) -> None:
             {"status_text": f"Loaded {len(cached)} cached emails"},
         )
         log.info(
-            "[intelligence] inbox_scanning cache_hit",
+            f"{LogTag.ONBOARDING} inbox_scanning cache_hit",
             user_id=user_id,
             step="inbox_scanning",
             outcome="ok",
@@ -525,7 +526,7 @@ async def _run_inbox_scanning(user_id: str, ctx: InboxScanContext) -> None:
         fetch_ok = True
     except Exception as e:
         log.error(
-            "[intelligence] inbox_scanning failed",
+            f"{LogTag.ONBOARDING} inbox_scanning failed",
             user_id=user_id,
             step="inbox_scanning",
             outcome="failed",
@@ -541,7 +542,7 @@ async def _run_inbox_scanning(user_id: str, ctx: InboxScanContext) -> None:
             await inbox_scan_cache.put(user_id, "metadata", list(ctx.emails))
 
     log.info(
-        "[intelligence] inbox_scanning done",
+        f"{LogTag.ONBOARDING} inbox_scanning done",
         user_id=user_id,
         step="inbox_scanning",
         outcome="ok",
@@ -555,7 +556,7 @@ async def _run_provision_gmail(user_id: str) -> None:
     try:
         await provision_system_workflows(user_id, "gmail", "Gmail", notify=False)
         log.info(
-            "[intelligence] provision_gmail done",
+            f"{LogTag.ONBOARDING} provision_gmail done",
             user_id=user_id,
             step="provision_gmail",
             outcome="ok",
@@ -563,7 +564,7 @@ async def _run_provision_gmail(user_id: str) -> None:
         )
     except Exception as e:
         log.warning(
-            "[intelligence] provision_gmail failed",
+            f"{LogTag.ONBOARDING} provision_gmail failed",
             user_id=user_id,
             step="provision_gmail",
             outcome="failed",
@@ -581,7 +582,7 @@ async def _run_writing_style(
     """Learn writing style from the user's last 50 sent emails. Gmail-only."""
     if not has_gmail:
         log.info(
-            "[intelligence] writing_style skipped",
+            f"{LogTag.ONBOARDING} writing_style skipped",
             user_id=user_id,
             step="writing_style",
             outcome="skipped",
@@ -602,7 +603,7 @@ async def _run_writing_style(
         result = await learn_writing_style(user_id, profession=profession, on_status=_on_status)
     except Exception as e:
         log.error(
-            "[intelligence] writing_style failed",
+            f"{LogTag.ONBOARDING} writing_style failed",
             user_id=user_id,
             step="writing_style",
             outcome="failed",
@@ -614,7 +615,7 @@ async def _run_writing_style(
         result = None
 
     log.info(
-        "[intelligence] writing_style done",
+        f"{LogTag.ONBOARDING} writing_style done",
         user_id=user_id,
         step="writing_style",
         outcome="ok" if result else "empty",
@@ -641,7 +642,7 @@ async def _run_triage(
 ) -> InboxTriage | None:
     if inbox_ctx is None:
         log.info(
-            "[intelligence] triage skipped",
+            f"{LogTag.ONBOARDING} triage skipped",
             user_id=user_id,
             step="triage",
             outcome="skipped",
@@ -652,7 +653,7 @@ async def _run_triage(
     emails = list(inbox_ctx.emails)
     if not emails:
         log.info(
-            "[intelligence] triage skipped",
+            f"{LogTag.ONBOARDING} triage skipped",
             user_id=user_id,
             step="triage",
             outcome="skipped",
@@ -671,7 +672,7 @@ async def _run_triage(
         result = await triage_inbox(user_id, emails, profession=profession, focus=focus)
     except Exception as e:
         log.error(
-            "[intelligence] triage failed",
+            f"{LogTag.ONBOARDING} triage failed",
             user_id=user_id,
             step="triage",
             outcome="failed",
@@ -682,7 +683,7 @@ async def _run_triage(
         )
         result = None
     log.info(
-        "[intelligence] triage done",
+        f"{LogTag.ONBOARDING} triage done",
         user_id=user_id,
         step="triage",
         outcome="ok" if result else "empty",
@@ -750,7 +751,7 @@ async def _run_social_profiles_background(
             profiles = dedup_profiles_by_platform(raw)
             await _persist_social_profiles(user_id, profiles)
             log.info(
-                "[intelligence] social_profiles done",
+                f"{LogTag.ONBOARDING} social_profiles done",
                 user_id=user_id,
                 step="social_profiles",
                 outcome="ok",
@@ -761,7 +762,7 @@ async def _run_social_profiles_background(
             )
     except Exception as e:
         log.error(
-            "[intelligence] social_profiles failed",
+            f"{LogTag.ONBOARDING} social_profiles failed",
             user_id=user_id,
             step="social_profiles",
             outcome="failed",
@@ -817,7 +818,7 @@ async def _run_todos(
             todos = await _create_focus_todos(user_id, name, profession, focus, clarify_answers)
     except Exception as e:
         log.error(
-            "[intelligence] todos failed",
+            f"{LogTag.ONBOARDING} todos failed",
             user_id=user_id,
             step="todos",
             outcome="failed",
@@ -830,7 +831,7 @@ async def _run_todos(
         todos = []
 
     log.info(
-        "[intelligence] todos done",
+        f"{LogTag.ONBOARDING} todos done",
         user_id=user_id,
         step="todos",
         outcome="ok" if todos else "empty",
@@ -884,7 +885,7 @@ async def _run_workflows(
         )
     except Exception as e:
         log.error(
-            "[intelligence] workflows failed",
+            f"{LogTag.ONBOARDING} workflows failed",
             user_id=user_id,
             step="workflows",
             outcome="failed",
@@ -896,7 +897,7 @@ async def _run_workflows(
         workflows = []
 
     log.info(
-        "[intelligence] workflows done",
+        f"{LogTag.ONBOARDING} workflows done",
         user_id=user_id,
         step="workflows",
         outcome="ok" if workflows else "empty",
@@ -915,7 +916,7 @@ async def _run_workflows(
             )
     except Exception as e:
         log.warning(
-            "[intelligence] persist suggested_workflows failed",
+            f"{LogTag.ONBOARDING} persist suggested_workflows failed",
             user_id=user_id,
             step="workflows",
             error=str(e)[:200],
@@ -993,7 +994,7 @@ async def _run_holo_card(
             card_design["overlay_opacity"],
         )
         log.info(
-            "[intelligence] holo_card done",
+            f"{LogTag.ONBOARDING} holo_card done",
             user_id=user_id,
             step="holo_card",
             outcome="ok",
@@ -1007,7 +1008,7 @@ async def _run_holo_card(
         )
     except Exception as e:
         log.error(
-            "[intelligence] holo_card failed",
+            f"{LogTag.ONBOARDING} holo_card failed",
             user_id=user_id,
             step="holo_card",
             outcome="failed",
@@ -1026,7 +1027,7 @@ async def _seed_conversation(user_id: str) -> str | None:
         cid = await seed_onboarding_conversation(user_id=user_id)
     except Exception as e:
         log.error(
-            "[intelligence] seed_conversation failed",
+            f"{LogTag.ONBOARDING} seed_conversation failed",
             user_id=user_id,
             step="seed_conversation",
             outcome="failed",
@@ -1037,7 +1038,7 @@ async def _seed_conversation(user_id: str) -> str | None:
         )
         return None
     log.info(
-        "[intelligence] seed_conversation done",
+        f"{LogTag.ONBOARDING} seed_conversation done",
         user_id=user_id,
         step="seed_conversation",
         outcome="ok",
@@ -1065,7 +1066,7 @@ async def _persist_social_profiles(user_id: str, social_profiles: list[SocialPro
             {"$set": {"onboarding.social_profiles": [p.model_dump() for p in social_profiles]}},
         )
     except Exception as e:
-        log.error(f"[intelligence] persist social_profiles failed: {e}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} persist social_profiles failed: {e}", exc_info=True)
 
 
 async def _persist_profiles(
@@ -1100,10 +1101,10 @@ async def _persist_profiles(
         try:
             await users_collection.update_one({"_id": ObjectId(user_id)}, {"$set": update_fields})
         except Exception as e:
-            log.error(f"[intelligence] persist update_fields failed: {e}", exc_info=True)
+            log.error(f"{LogTag.ONBOARDING} persist update_fields failed: {e}", exc_info=True)
 
     log.info(
-        "[intelligence] persist_profiles done",
+        f"{LogTag.ONBOARDING} persist_profiles done",
         user_id=user_id,
         step="persist_profiles",
         writing_style_persisted=writing_style is not None,
@@ -1152,7 +1153,7 @@ async def _create_focus_todos(
                 return {"id": str(result.id), "title": safe_title}
             except Exception as e:
                 log.warning(
-                    "[intelligence] focus todo create failed",
+                    f"{LogTag.ONBOARDING} focus todo create failed",
                     user_id=user_id,
                     step="todos_focus_create_one",
                     title=title[:60],
@@ -1167,7 +1168,7 @@ async def _create_focus_todos(
         )
         created = [r for r in results if r is not None]
         log.info(
-            "[intelligence] focus_todos done",
+            f"{LogTag.ONBOARDING} focus_todos done",
             user_id=user_id,
             step="todos_focus",
             outcome="ok",
@@ -1181,7 +1182,7 @@ async def _create_focus_todos(
 
     except Exception as e:
         log.warning(
-            "[intelligence] focus_todos failed",
+            f"{LogTag.ONBOARDING} focus_todos failed",
             user_id=user_id,
             step="todos_focus",
             outcome="failed",
@@ -1246,12 +1247,12 @@ async def _create_todos_from_triage(
                     }
                 elif spec.source_sender or spec.source_subject:
                     log.warning(
-                        "[intelligence] Dropped hallucinated source_email "
+                        f"{LogTag.ONBOARDING} Dropped hallucinated source_email "
                         f"sender={spec.source_sender!r} subject={spec.source_subject!r}"
                     )
                 return todo_dict
             except Exception as e:
-                log.warning(f"[intelligence] Failed to create todo: {e}")
+                log.warning(f"{LogTag.ONBOARDING} Failed to create todo: {e}")
                 return None
 
         t_create = time.monotonic()
@@ -1260,7 +1261,7 @@ async def _create_todos_from_triage(
         )
         created = [r for r in results if r is not None]
         log.info(
-            "[intelligence] triage_todos done",
+            f"{LogTag.ONBOARDING} triage_todos done",
             user_id=user_id,
             step="todos_triage",
             outcome="ok",
@@ -1274,7 +1275,7 @@ async def _create_todos_from_triage(
 
     except Exception as e:
         log.warning(
-            "[intelligence] triage_todos failed",
+            f"{LogTag.ONBOARDING} triage_todos failed",
             user_id=user_id,
             step="todos_triage",
             outcome="failed",
@@ -1382,7 +1383,7 @@ async def _generate_workflow_specs(user_id: str, prompt: str) -> _WorkflowList:
             if len(candidate.workflows) == 4:
                 return candidate
             log.warning(
-                "[intelligence] workflow specs wrong count, retrying",
+                f"{LogTag.ONBOARDING} workflow specs wrong count, retrying",
                 user_id=user_id,
                 step="workflows_specs_llm",
                 attempt=attempt,
@@ -1391,7 +1392,7 @@ async def _generate_workflow_specs(user_id: str, prompt: str) -> _WorkflowList:
         except Exception as e:
             last_error = e
             log.warning(
-                "[intelligence] workflow specs llm failed, retrying",
+                f"{LogTag.ONBOARDING} workflow specs llm failed, retrying",
                 user_id=user_id,
                 step="workflows_specs_llm",
                 attempt=attempt,
@@ -1436,7 +1437,7 @@ async def _build_one_workflow(
         )
         create_duration_s = round(time.monotonic() - t_create, 2)
         log.info(
-            "[intelligence] workflow spec done",
+            f"{LogTag.ONBOARDING} workflow spec done",
             user_id=user_id,
             step="workflows_spec",
             spec_index=idx,
@@ -1456,7 +1457,7 @@ async def _build_one_workflow(
         }
     except Exception as e:
         log.warning(
-            "[intelligence] workflow spec failed",
+            f"{LogTag.ONBOARDING} workflow spec failed",
             user_id=user_id,
             step="workflows_spec",
             spec_index=idx,
@@ -1494,7 +1495,7 @@ async def _create_onboarding_workflows(
         parsed = await _generate_workflow_specs(user_id, prompt)
         specs_llm_duration_s = round(time.monotonic() - t_specs_llm, 2)
         log.info(
-            "[intelligence] workflow specs generated",
+            f"{LogTag.ONBOARDING} workflow specs generated",
             user_id=user_id,
             step="workflows_specs_llm",
             specs_count=len(parsed.workflows),
@@ -1511,7 +1512,7 @@ async def _create_onboarding_workflows(
         created: list[dict] = [r for r in results if r is not None]
         specs_failed = specs_total - len(created)
         log.info(
-            "[intelligence] workflows specs done",
+            f"{LogTag.ONBOARDING} workflows specs done",
             user_id=user_id,
             step="workflows_specs",
             specs_total=specs_total,
@@ -1524,7 +1525,7 @@ async def _create_onboarding_workflows(
         return created
     except Exception as e:
         log.warning(
-            "[intelligence] workflow LLM failed, using fallback",
+            f"{LogTag.ONBOARDING} workflow LLM failed, using fallback",
             user_id=user_id,
             step="workflows",
             error=str(e)[:200],
@@ -1568,5 +1569,5 @@ async def _create_fallback_workflow(
             }
         ]
     except Exception as e:
-        log.warning(f"[intelligence] Fallback workflow creation failed: {e}")
+        log.warning(f"{LogTag.ONBOARDING} Fallback workflow creation failed: {e}")
         return []

--- a/apps/api/app/services/onboarding/onboarding_service.py
+++ b/apps/api/app/services/onboarding/onboarding_service.py
@@ -5,6 +5,7 @@ from bson import ObjectId
 from fastapi import BackgroundTasks, HTTPException
 from pymongo import ReturnDocument
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     conversations_collection,
     todos_collection,
@@ -98,7 +99,7 @@ async def complete_onboarding(
             if not existing:
                 raise HTTPException(status_code=404, detail="User not found")
             log.info(
-                "[complete_onboarding] replay — onboarding already submitted",
+                f"{LogTag.ONBOARDING} complete_onboarding replay — onboarding already submitted",
                 user_id=user_id,
                 phase=(existing.get("onboarding") or {}).get("phase"),
             )
@@ -110,7 +111,7 @@ async def complete_onboarding(
             await enqueue_intelligence_job(user_id)
         except Exception as e:
             log.error(
-                f"Enqueue failed, rolling back onboarding state for user {user_id}: {e}",
+                f"{LogTag.ONBOARDING} Enqueue failed, rolling back onboarding state for user {user_id}: {e}",
                 exc_info=True,
             )
             try:
@@ -120,7 +121,7 @@ async def complete_onboarding(
                 )
             except Exception as rollback_error:
                 log.error(
-                    f"Rollback also failed for user {user_id}: {rollback_error}",
+                    f"{LogTag.ONBOARDING} Rollback also failed for user {user_id}: {rollback_error}",
                     exc_info=True,
                 )
             raise HTTPException(
@@ -130,13 +131,16 @@ async def complete_onboarding(
 
         background_tasks.add_task(seed_initial_user_data, user_id)
 
-        log.info(f"Onboarding completed successfully for user {user_id}")
+        log.info(f"{LogTag.ONBOARDING} Onboarding completed successfully for user {user_id}")
         return _serialize_user(updated_user)
 
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error completing onboarding for user {user_id}: {e!s}", exc_info=True)
+        log.error(
+            f"{LogTag.ONBOARDING} Error completing onboarding for user {user_id}: {e!s}",
+            exc_info=True,
+        )
         raise HTTPException(status_code=500, detail="Failed to complete onboarding")
 
 
@@ -171,7 +175,7 @@ async def get_user_onboarding_status(user_id: str) -> dict[str, Any]:
         raise
     except Exception as e:
         log.error(
-            f"Error getting onboarding status for user {user_id}: {e!s}",
+            f"{LogTag.ONBOARDING} Error getting onboarding status for user {user_id}: {e!s}",
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="An internal error occurred")
@@ -223,7 +227,9 @@ async def update_onboarding_preferences(
         updated_user["_id"] = str(updated_user["_id"])
         updated_user["user_id"] = updated_user["_id"]
 
-        log.info(f"Onboarding preferences updated successfully for user {user_id}")
+        log.info(
+            f"{LogTag.ONBOARDING} Onboarding preferences updated successfully for user {user_id}"
+        )
 
         return updated_user
 
@@ -231,7 +237,7 @@ async def update_onboarding_preferences(
         raise
     except Exception as e:
         log.error(
-            f"Error updating onboarding preferences for user {user_id}: {e!s}",
+            f"{LogTag.ONBOARDING} Error updating onboarding preferences for user {user_id}: {e!s}",
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="Failed to update preferences")
@@ -256,7 +262,7 @@ async def reset_onboarding(user_id: str) -> dict[str, int]:
     try:
         await abort_active_intelligence_job(user_id)
     except Exception as e:
-        log.warning(f"[reset_onboarding] failed to abort intelligence job: {e}")
+        log.warning(f"{LogTag.ONBOARDING} reset_onboarding failed to abort intelligence job: {e}")
 
     onboarding = user_doc.get("onboarding", {}) or {}
     workflow_ids: list[Any] = onboarding.get("suggested_workflows", []) or []
@@ -271,7 +277,9 @@ async def reset_onboarding(user_id: str) -> dict[str, int]:
             if deleted:
                 workflows_deleted += 1
         except Exception as e:
-            log.warning(f"[reset_onboarding] failed to delete workflow {wf_id}: {e}")
+            log.warning(
+                f"{LogTag.ONBOARDING} reset_onboarding failed to delete workflow {wf_id}: {e}"
+            )
 
     todos_deleted = 0
     try:
@@ -280,7 +288,7 @@ async def reset_onboarding(user_id: str) -> dict[str, int]:
         )
         todos_deleted = todo_result.deleted_count
     except Exception as e:
-        log.warning(f"[reset_onboarding] failed to delete todos: {e}")
+        log.warning(f"{LogTag.ONBOARDING} reset_onboarding failed to delete todos: {e}")
 
     conversation_deleted = 0
     if first_conversation_id:
@@ -290,7 +298,7 @@ async def reset_onboarding(user_id: str) -> dict[str, int]:
             )
             conversation_deleted = convo_result.deleted_count
         except Exception as e:
-            log.warning(f"[reset_onboarding] failed to delete conversation: {e}")
+            log.warning(f"{LogTag.ONBOARDING} reset_onboarding failed to delete conversation: {e}")
 
     demo_conversations_deleted = 0
     try:
@@ -299,7 +307,9 @@ async def reset_onboarding(user_id: str) -> dict[str, int]:
         )
         demo_conversations_deleted = demo_result.deleted_count
     except Exception as e:
-        log.warning(f"[reset_onboarding] failed to delete demo conversations: {e}")
+        log.warning(
+            f"{LogTag.ONBOARDING} reset_onboarding failed to delete demo conversations: {e}"
+        )
 
     integrations_disconnected = await _disconnect_user_integrations(user_id)
     memories_cleared = await _clear_user_memories(user_id)
@@ -321,7 +331,7 @@ async def reset_onboarding(user_id: str) -> dict[str, int]:
         "memories_cleared": memories_cleared,
     }
     log.set(onboarding={"operation": "reset", **counts})
-    log.info(f"Onboarding reset complete for user {user_id}")
+    log.info(f"{LogTag.ONBOARDING} Onboarding reset complete for user {user_id}")
     return counts
 
 
@@ -330,7 +340,7 @@ async def _disconnect_user_integrations(user_id: str) -> int:
         cursor = user_integrations_collection.find({"user_id": user_id}, {"integration_id": 1})
         integration_ids = [doc["integration_id"] async for doc in cursor]
     except Exception as e:
-        log.warning(f"[reset_onboarding] failed to list user integrations: {e}")
+        log.warning(f"{LogTag.ONBOARDING} reset_onboarding failed to list user integrations: {e}")
         return 0
 
     disconnected = 0
@@ -339,7 +349,9 @@ async def _disconnect_user_integrations(user_id: str) -> int:
             await disconnect_integration(user_id, integration_id)
             disconnected += 1
         except Exception as e:
-            log.warning(f"[reset_onboarding] failed to disconnect {integration_id}: {e}")
+            log.warning(
+                f"{LogTag.ONBOARDING} reset_onboarding failed to disconnect {integration_id}: {e}"
+            )
     return disconnected
 
 
@@ -347,5 +359,5 @@ async def _clear_user_memories(user_id: str) -> int:
     try:
         return await memory_engine.delete_all(user_id)
     except Exception as e:
-        log.warning(f"[reset_onboarding] failed to clear memories: {e}")
+        log.warning(f"{LogTag.ONBOARDING} reset_onboarding failed to clear memories: {e}")
         return 0

--- a/apps/api/app/services/onboarding/post_onboarding_service.py
+++ b/apps/api/app/services/onboarding/post_onboarding_service.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from bson import ObjectId
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.models.user_models import BioStatus, OnboardingPhase
 from app.utils.seeding_utils import seed_onboarding_todo
@@ -57,19 +58,19 @@ async def save_personalization_data(
             {"_id": ObjectId(user_id)},
             {"$set": update_fields},
         )
-        log.info(f"Saved personalization data for user {user_id}")
+        log.info(f"{LogTag.ONBOARDING} Saved personalization data for user {user_id}")
 
     except Exception as e:
-        log.error(f"Error saving personalization data: {e}", exc_info=True)
+        log.error(f"{LogTag.ONBOARDING} Error saving personalization data: {e}", exc_info=True)
 
 
 async def seed_initial_user_data(user_id: str) -> None:
     """Seed the onboarding todo. The welcome conversation is seeded by the
     intelligence pipeline, not here."""
     try:
-        log.info(f"Starting data seeding for user {user_id}")
+        log.info(f"{LogTag.ONBOARDING} Starting data seeding for user {user_id}")
         await seed_onboarding_todo(user_id)
-        log.info(f"Completed data seeding for user {user_id}")
+        log.info(f"{LogTag.ONBOARDING} Completed data seeding for user {user_id}")
 
     except Exception as e:
-        log.error(f"Error in seed_initial_user_data for user {user_id}: {e}")
+        log.error(f"{LogTag.ONBOARDING} Error in seed_initial_user_data for user {user_id}: {e}")

--- a/apps/api/app/services/onboarding/social_profile_service.py
+++ b/apps/api/app/services/onboarding/social_profile_service.py
@@ -6,6 +6,7 @@ from bson import ObjectId
 from langchain_core.messages import HumanMessage
 
 from app.agents.prompts.onboarding_prompts import SOCIAL_PROFILE_FILTER_PROMPT
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.mongodb.collections import users_collection
 from app.models.onboarding_models import SocialProfile, SocialProfileFilterOutput
@@ -187,7 +188,7 @@ async def extract_social_profiles_from_emails(
                 )
 
     if not candidates:
-        log.info("[social_profiles_smart] No social URL candidates found in emails")
+        log.info(f"{LogTag.ONBOARDING} No social URL candidates found in emails")
         return []
 
     by_platform: dict[str, list[dict]] = {}
@@ -207,14 +208,14 @@ async def extract_social_profiles_from_emails(
         capped.extend(sorted_entries[:8])
 
     log.info(
-        f"[social_profiles_smart] Harvested {len(capped)} candidates "
+        f"{LogTag.ONBOARDING} Harvested {len(capped)} social URL candidates "
         f"across {len(by_platform)} platforms from {len(emails)} emails"
     )
 
     for entry in capped:
         sent_label = "SENT" if entry["is_sent"] else "recv"
         log.info(
-            f"[social_profiles_smart] candidate: {entry['platform']}/{entry['handle']} "
+            f"{LogTag.ONBOARDING} social profile candidate: {entry['platform']}/{entry['handle']} "
             f"freq={entry['frequency']} {sent_label}"
         )
 
@@ -246,7 +247,9 @@ async def extract_social_profiles_from_emails(
     try:
         llm = await providers.aget("gemini_llm")
         if llm is None:
-            log.warning("[social_profiles_smart] LLM not available, using sent-email fallback")
+            log.warning(
+                f"{LogTag.ONBOARDING} social_profiles LLM not available, using sent-email fallback"
+            )
             return dedup_profiles_by_platform(sent_fallback)
 
         structured_llm = llm.with_structured_output(SocialProfileFilterOutput)
@@ -272,22 +275,22 @@ async def extract_social_profiles_from_emails(
                 owned.append(SocialProfile(platform=item_platform, url=canonical_url))
 
         log.info(
-            f"[social_profiles_smart] LLM filtered to {len(owned)} owned profiles "
+            f"{LogTag.ONBOARDING} social_profiles LLM filtered to {len(owned)} owned profiles "
             f"from {len(capped)} candidates"
         )
         if owned:
             for p in owned:
-                log.info(f"[social_profiles_smart] accepted: {p.platform} → {p.url}")
+                log.info(f"{LogTag.ONBOARDING} social_profiles accepted: {p.platform} -> {p.url}")
         else:
             log.info(
-                f"[social_profiles_smart] LLM returned 0 owned. "
+                f"{LogTag.ONBOARDING} social_profiles LLM returned 0 owned. "
                 f"Raw output: {result.owned_profiles!r}"
             )
         return dedup_profiles_by_platform(owned)
 
     except Exception as e:
         log.error(
-            f"[social_profiles_smart] LLM filter failed, using sent-email fallback: {e}",
+            f"{LogTag.ONBOARDING} social_profiles LLM filter failed, using sent-email fallback: {e}",
             exc_info=True,
         )
         return dedup_profiles_by_platform(sent_fallback)
@@ -309,4 +312,4 @@ async def save_confirmed_profiles(user_id: str, profiles: list[dict]) -> None:
         {"_id": ObjectId(user_id)},
         {"$set": {"onboarding.social_profiles": profiles}},
     )
-    log.info(f"[social_profiles] Saved {len(profiles)} confirmed profiles for {user_id}")
+    log.info(f"{LogTag.ONBOARDING} Saved {len(profiles)} confirmed social profiles for {user_id}")

--- a/apps/api/app/services/onboarding/writing_style_service.py
+++ b/apps/api/app/services/onboarding/writing_style_service.py
@@ -10,6 +10,7 @@ from app.agents.prompts.onboarding_prompts import (
     WRITING_STYLE_EXAMPLE_PROMPT,
     WRITING_STYLE_PROMPT,
 )
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.mongodb.collections import users_collection
 from app.models.onboarding_models import (
@@ -50,7 +51,7 @@ async def learn_writing_style(
 
         if sent_count < _MIN_SENT_EMAILS:
             log.info(
-                "[writing_style] skipped",
+                f"{LogTag.ONBOARDING} writing_style skipped",
                 user_id=user_id,
                 outcome="skipped",
                 skip_reason="insufficient_sent",
@@ -77,7 +78,7 @@ async def learn_writing_style(
 
         if len(samples) < _MIN_SENT_EMAILS:
             log.info(
-                "[writing_style] skipped",
+                f"{LogTag.ONBOARDING} writing_style skipped",
                 user_id=user_id,
                 outcome="skipped",
                 skip_reason="insufficient_samples",
@@ -113,7 +114,7 @@ async def learn_writing_style(
         )
 
         log.info(
-            "[writing_style] learned",
+            f"{LogTag.ONBOARDING} writing_style learned",
             user_id=user_id,
             outcome="ok",
             sent_count=sent_count,
@@ -128,7 +129,7 @@ async def learn_writing_style(
 
     except Exception as e:
         log.error(
-            "[writing_style] failed",
+            f"{LogTag.ONBOARDING} writing_style failed",
             user_id=user_id,
             outcome="failed",
             error=str(e)[:200],
@@ -161,7 +162,7 @@ async def regenerate_example_for_style(
 
     except Exception as e:
         log.error(
-            f"[writing_style] Failed to regenerate example: {e}",
+            f"{LogTag.ONBOARDING} writing_style Failed to regenerate example: {e}",
             exc_info=True,
         )
         return None
@@ -173,7 +174,7 @@ async def save_user_edited_summary(user_id: str, edited_summary: str) -> None:
         {"_id": ObjectId(user_id)},
         {"$set": {"onboarding.writing_style.user_edited_summary": edited_summary}},
     )
-    log.info(f"[writing_style] Saved user-edited summary for {user_id}")
+    log.info(f"{LogTag.ONBOARDING} writing_style Saved user-edited summary for {user_id}")
 
 
 async def save_generated_example(user_id: str, example: WritingStyleExampleBlocks) -> None:
@@ -182,4 +183,4 @@ async def save_generated_example(user_id: str, example: WritingStyleExampleBlock
         {"_id": ObjectId(user_id)},
         {"$set": {"onboarding.writing_style.example": example.model_dump()}},
     )
-    log.info(f"[writing_style] Saved regenerated example for {user_id}")
+    log.info(f"{LogTag.ONBOARDING} writing_style Saved regenerated example for {user_id}")

--- a/apps/api/app/services/payments/payment_service.py
+++ b/apps/api/app/services/payments/payment_service.py
@@ -14,6 +14,7 @@ from app.constants.cache import (
     SUBSCRIPTION_PLAN_CACHE_PREFIX,
     SUBSCRIPTION_PLAN_CACHE_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     plans_collection,
     subscriptions_collection,
@@ -43,7 +44,7 @@ class DodoPaymentService:
                 environment=environment,
             )
         except Exception as e:
-            log.error(f"Failed to instantiate dodo payments: {e}")
+            log.error(f"{LogTag.PAYMENT} Failed to instantiate dodo payments: {e}")
 
     async def get_plans(self, active_only: bool = True) -> list[PlanResponse]:
         """Get subscription plans with caching."""
@@ -142,7 +143,7 @@ class DodoPaymentService:
 
             checkout_session = self.client.checkout_sessions.create(**params)
         except Exception as e:
-            log.error(f"Error creating Dodo checkout session: {e}")
+            log.error(f"{LogTag.PAYMENT} Error creating Dodo checkout session: {e}")
             raise HTTPException(502, f"Payment service error: {e!s}")
 
         # Look up plan name for richer logging
@@ -153,7 +154,7 @@ class DodoPaymentService:
             if matched_plan:
                 plan_name = matched_plan.name
         except Exception as e:  # nosec B110
-            log.warning("Failed to resolve plan name for logging", error=str(e))
+            log.warning(f"{LogTag.PAYMENT} Failed to resolve plan name for logging", error=str(e))
 
         log.set(
             payment={
@@ -191,7 +192,7 @@ class DodoPaymentService:
                     user_email=user["email"],
                 )
         except Exception as e:
-            log.debug(f"Failed to send welcome email: {e}")
+            log.debug(f"{LogTag.PAYMENT} Failed to send welcome email: {e}")
 
         return {
             "payment_completed": True,

--- a/apps/api/app/services/payments/payment_webhook_service.py
+++ b/apps/api/app/services/payments/payment_webhook_service.py
@@ -10,6 +10,7 @@ from bson import ObjectId
 from standardwebhooks.webhooks import Webhook
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     processed_webhooks_collection,
     subscriptions_collection,
@@ -41,7 +42,7 @@ class PaymentWebhookService:
                 # The secret should be base64 encoded for Standard Webhooks
                 self.webhook_verifier = Webhook(self.webhook_secret)
             except Exception as e:
-                log.error(f"Failed to initialize webhook verifier: {e}")
+                log.error(f"{LogTag.PAYMENT} Failed to initialize webhook verifier: {e}")
                 self.webhook_verifier = None
         else:
             self.webhook_verifier = None
@@ -69,16 +70,20 @@ class PaymentWebhookService:
             headers: Dictionary of headers from the webhook request
         """
         if not self.webhook_verifier:
-            log.warning("No webhook verifier configured - skipping signature verification")
+            log.warning(
+                f"{LogTag.PAYMENT} No webhook verifier configured - skipping signature verification"
+            )
             return True
 
         # Skip verification in development
         if settings.ENV != "production":
-            log.info("Development mode - skipping webhook signature verification")
+            log.info(f"{LogTag.PAYMENT} Development mode - skipping webhook signature verification")
             return True
 
         try:
-            log.info("Verifying webhook signature using Standard Webhooks library")
+            log.info(
+                f"{LogTag.PAYMENT} Verifying webhook signature using Standard Webhooks library"
+            )
 
             # The Standard Webhooks library expects headers in the correct format
             # Convert headers to the expected format (lowercase with dashes)
@@ -95,11 +100,11 @@ class PaymentWebhookService:
             # Verify using Standard Webhooks library
             self.webhook_verifier.verify(payload.encode("utf-8"), webhook_headers)
 
-            log.info("Webhook signature verification successful!")
+            log.info(f"{LogTag.PAYMENT} Webhook signature verification successful!")
             return True
 
         except Exception as e:
-            log.warning(f"Webhook signature verification failed: {e}")
+            log.warning(f"{LogTag.PAYMENT} Webhook signature verification failed: {e}")
             return False
 
     async def _is_webhook_processed(self, webhook_id: str) -> bool:
@@ -124,7 +129,7 @@ class PaymentWebhookService:
                 }
             )
         except Exception as e:
-            log.error(f"Failed to store processed webhook ID: {e}")
+            log.error(f"{LogTag.PAYMENT} Failed to store processed webhook ID: {e}")
 
     async def process_webhook(
         self, webhook_data: dict[str, Any], webhook_id: str
@@ -164,7 +169,7 @@ class PaymentWebhookService:
 
             # Check if webhook has already been processed
             if await self._is_webhook_processed(webhook_id):
-                log.info(f"Webhook {webhook_id} already processed, skipping")
+                log.info(f"{LogTag.PAYMENT} Webhook {webhook_id} already processed, skipping")
                 return DodoWebhookProcessingResult(
                     event_type=webhook_data.get("type", "unknown"),
                     status="ignored",
@@ -185,7 +190,7 @@ class PaymentWebhookService:
                 return result
 
             result = await handler(event)
-            log.info(f"Webhook processed: {event.type} - {result.status}")
+            log.info(f"{LogTag.PAYMENT} Webhook processed: {event.type} - {result.status}")
 
             # Bust the cached plan tier so a plan change applies immediately.
             if result.subscription_id:
@@ -196,7 +201,7 @@ class PaymentWebhookService:
             return result
 
         except Exception as e:
-            log.error(f"Webhook processing failed: {e}")
+            log.error(f"{LogTag.PAYMENT} Webhook processing failed: {e}")
             return DodoWebhookProcessingResult(
                 event_type=webhook_data.get("type", "unknown"),
                 status="failed",
@@ -221,7 +226,7 @@ class PaymentWebhookService:
         if not payment_data:
             raise ValueError("Invalid payment data")
 
-        log.info(f"Payment succeeded: {payment_data.payment_id}")
+        log.info(f"{LogTag.PAYMENT} Payment succeeded: {payment_data.payment_id}")
 
         # Track payment success in PostHog
         user_email = await self._get_user_email_from_metadata(payment_data.metadata)
@@ -248,7 +253,7 @@ class PaymentWebhookService:
         if not payment_data:
             raise ValueError("Invalid payment data")
 
-        log.warning(f"Payment failed: {payment_data.payment_id}")
+        log.warning(f"{LogTag.PAYMENT} Payment failed: {payment_data.payment_id}")
 
         # Track payment failure in PostHog
         user_email = await self._get_user_email_from_metadata(payment_data.metadata)
@@ -316,7 +321,7 @@ class PaymentWebhookService:
         )
 
         if existing:
-            log.info(f"Subscription already exists: {sub_data.subscription_id}")
+            log.info(f"{LogTag.PAYMENT} Subscription already exists: {sub_data.subscription_id}")
             return DodoWebhookProcessingResult(
                 event_type=event.type.value,
                 status="processed",
@@ -330,7 +335,9 @@ class PaymentWebhookService:
         if not user_id:
             user = await users_collection.find_one({"email": user_email})
             if not user:
-                log.error(f"User not found for subscription: {sub_data.subscription_id}")
+                log.error(
+                    f"{LogTag.PAYMENT} User not found for subscription: {sub_data.subscription_id}"
+                )
                 return DodoWebhookProcessingResult(
                     event_type=event.type.value,
                     status="failed",
@@ -379,7 +386,7 @@ class PaymentWebhookService:
         # Send welcome email
         await self._send_welcome_email(user_id)
 
-        log.info(f"Subscription activated: {sub_data.subscription_id}")
+        log.info(f"{LogTag.PAYMENT} Subscription activated: {sub_data.subscription_id}")
         return DodoWebhookProcessingResult(
             event_type=event.type.value,
             status="processed",
@@ -409,7 +416,9 @@ class PaymentWebhookService:
         )
 
         if result.matched_count == 0:
-            log.warning(f"Subscription not found for renewal: {sub_data.subscription_id}")
+            log.warning(
+                f"{LogTag.PAYMENT} Subscription not found for renewal: {sub_data.subscription_id}"
+            )
         else:
             # Track subscription renewal in PostHog
             user_email = sub_data.customer.email if sub_data.customer else None
@@ -585,9 +594,9 @@ class PaymentWebhookService:
                     user_name=user.get("first_name", "User"),
                     user_email=user["email"],
                 )
-                log.info(f"Welcome email sent to {user['email']}")
+                log.info(f"{LogTag.PAYMENT} Welcome email sent to {user['email']}")
         except Exception as e:
-            log.error(f"Failed to send welcome email: {e}")
+            log.error(f"{LogTag.PAYMENT} Failed to send welcome email: {e}")
 
 
 # Single instance

--- a/apps/api/app/services/sandbox/artifact_watcher.py
+++ b/apps/api/app/services/sandbox/artifact_watcher.py
@@ -38,6 +38,7 @@ from app.agents.workspace.paths import (
     session_artifacts,
 )
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.constants.sandbox import WORKSPACE_TMP_SUFFIX
 from app.services.artifact_events import (
     publish_artifact_event,
@@ -124,9 +125,9 @@ class ArtifactWatcher:
             else:
                 await self._start_watch_dir()
             self._stopped = False
-            log.set(sandbox_artifact_mode=self._mode)
+            log.set_ns("sandbox", artifact_mode=self._mode)
             log.info(
-                "[artifact-watcher] started",
+                f"{LogTag.ARTIFACT_WATCHER} started",
                 user_id=self.user_id,
                 mode=self._mode,
             )
@@ -134,7 +135,7 @@ class ArtifactWatcher:
             # Watcher is a latency optimization; never block sandbox acquire.
             self._stopped = True
             log.warning(
-                "[artifact-watcher] start failed",
+                f"{LogTag.ARTIFACT_WATCHER} start failed",
                 user_id=self.user_id,
                 mode=self._mode,
                 error=str(e),
@@ -218,7 +219,7 @@ class ArtifactWatcher:
         except JuiceFSUnavailable:
             return
         except Exception as e:
-            log.debug(f"[artifact-watcher] event dispatch failed: {e}")
+            log.debug(f"{LogTag.ARTIFACT_WATCHER} event dispatch failed: {e}")
 
     # -- accesslog mode ---------------------------------------------------
 
@@ -269,7 +270,7 @@ class ArtifactWatcher:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            log.debug(f"[artifact-watcher] rescan failed: {e}")
+            log.debug(f"{LogTag.ARTIFACT_WATCHER} rescan failed: {e}")
 
     async def _rescan_all(self) -> None:
         async with fs_timer(FsOps.WATCHER_RESCAN):

--- a/apps/api/app/services/sandbox/lifecycle.py
+++ b/apps/api/app/services/sandbox/lifecycle.py
@@ -33,6 +33,7 @@ from e2b import AsyncSandbox
 
 from app.api.v1.middleware.tiered_rate_limiter import RateLimitExceededException
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.constants.sandbox import (
     HEALTH_PROBE_REQUEST_TIMEOUT_SECONDS,
     HEALTH_PROBE_WAIT_TIMEOUT_SECONDS,
@@ -75,6 +76,16 @@ class SandboxRateLimitError(SandboxAcquisitionError):
 
 def _now() -> datetime:
     return datetime.now(UTC)
+
+
+def _record(**fields: Any) -> None:
+    """Merge ``fields`` into the wide event's ``sandbox`` namespace.
+
+    Thin wrapper over ``log.set_ns`` so the multi-step acquire path accumulates
+    into one ``sandbox`` dict instead of clobbering it. Valid keys are the
+    ``SandboxContext`` schema in ``shared.py.wide_events``.
+    """
+    log.set_ns("sandbox", **fields)
 
 
 def _split_meta_url(url: str) -> tuple[str, str]:
@@ -150,12 +161,12 @@ async def _enforce_creation_limit(user_id: str) -> None:
         await enforce_rate_limit(user_id, SANDBOX_CREATION_FEATURE_KEY)
     except RateLimitExceededException as e:
         detail: dict[str, Any] = e.detail if isinstance(e.detail, dict) else {}
-        log.set(
-            sandbox_rate_limited=True,
-            sandbox_rate_limit_reset=detail.get("reset_time"),
-            sandbox_rate_limit_plan=detail.get("plan_required"),
+        _record(
+            rate_limited=True,
+            rate_limit_reset=detail.get("reset_time"),
+            rate_limit_plan=detail.get("plan_required"),
         )
-        log.warning(f"[sandbox] creation rate limit hit for user {user_id}")
+        log.warning(f"{LogTag.SANDBOX} creation rate limit hit user={user_id}")
         message = "sandbox creation limit reached"
         if detail.get("reset_time"):
             message += f"; resets at {detail['reset_time']}"
@@ -163,7 +174,7 @@ async def _enforce_creation_limit(user_id: str) -> None:
             message += f" (upgrade to {detail['plan_required'].upper()} for higher limits)"
         raise SandboxRateLimitError(message) from e
     except Exception as e:
-        log.error(f"[sandbox] creation limit check failed for user {user_id}: {e}")
+        log.error(f"{LogTag.SANDBOX} creation limit check failed user={user_id}: {e}")
         raise SandboxAcquisitionError(f"sandbox creation limit check failed: {e}") from e
 
 
@@ -179,17 +190,25 @@ async def _create_fresh_sandbox(user_id: str, shard_id: int) -> Any:
     # Sandbox-wide env is deliberately empty of credentials — see _mount_env
     # docstring. USER_ID is not a secret but we still scope it per-call so
     # there's no implicit reliance on sandbox-wide identity for security.
+    log.info(
+        f"{LogTag.SANDBOX} creating fresh sandbox user={user_id} shard={shard_id} "
+        f"template={settings.E2B_TEMPLATE_ID}"
+    )
     async with fs_timer(FsOps.SBX_CREATE):
         sbx = await async_sandbox_cls.create(
             template=settings.E2B_TEMPLATE_ID,
             timeout=SANDBOX_LIFETIME_SECONDS,
             metadata={"user_id": user_id, "shard_id": str(shard_id)},
         )
-    log.set(
-        sandbox_created=True,
-        sandbox_id=getattr(sbx, "sandbox_id", None),
-        sandbox_template_id=settings.E2B_TEMPLATE_ID,
-        sandbox_shard_id=shard_id,
+    sandbox_id = getattr(sbx, "sandbox_id", None)
+    _record(
+        created=True,
+        sandbox_id=sandbox_id,
+        template_id=settings.E2B_TEMPLATE_ID,
+        shard_id=shard_id,
+    )
+    log.info(
+        f"{LogTag.SANDBOX} provisioned sandbox {sandbox_id} user={user_id}; mounting workspace"
     )
     await _run_mount_script(sbx, _mount_env(user_id, shard_id))
     return sbx
@@ -237,10 +256,11 @@ async def _run_mount_script(sbx: Any, mount_env: dict[str, str]) -> None:
     # surface that so we know the sandbox FS isn't durable.
     stderr = getattr(result, "stderr", "") or ""
     if "WARN:" in stderr:
-        log.set(sandbox_mount_status="ephemeral_fallback")
-        log.warning(f"[sandbox] ephemeral /workspace fallback: {stderr.strip()}")
+        _record(mount_status="ephemeral_fallback")
+        log.warning(f"{LogTag.SANDBOX} ephemeral /workspace fallback: {stderr.strip()}")
     else:
-        log.set(sandbox_mount_status="mounted")
+        _record(mount_status="mounted")
+        log.info(f"{LogTag.SANDBOX} workspace mounted")
 
 
 # NOSONAR python:S7483 — `timeout` is the E2B server-side command-stream
@@ -333,7 +353,7 @@ async def _connect_sandbox(sandbox_id: str) -> Any | None:
                 timeout=SANDBOX_CONNECT_TIMEOUT_SECONDS,
             )
         except Exception as e:
-            log.info(f"AsyncSandbox.connect({sandbox_id}) failed: {e}")
+            log.info(f"{LogTag.SANDBOX} connect failed sandbox={sandbox_id}: {e}")
             return None
 
 
@@ -365,7 +385,7 @@ async def _ensure_watcher(user_id: str, entry: PooledSandbox) -> None:
         return
     with contextlib.suppress(Exception):
         entry.watcher = await start_watcher_for(user_id, entry.sandbox)
-    log.set(sandbox_watcher_active=entry.watcher is not None)
+    _record(watcher_active=entry.watcher is not None)
 
 
 async def _stop_watcher(entry: PooledSandbox) -> None:
@@ -414,8 +434,8 @@ async def _reuse_cached_entry(user_id: str, mount_env: dict[str, str]) -> Pooled
     # was paused / killed since we last touched it), evict and create
     # fresh. Otherwise we'd hang for the full command timeout below.
     if not await _health_probe(entry.sandbox):
-        log.set(sandbox_cache_evicted="unhealthy")
-        log.info(f"[sandbox] cached handle unhealthy for {user_id}; evicting")
+        _record(cache_evicted="unhealthy")
+        log.info(f"{LogTag.SANDBOX} cached sandbox unhealthy user={user_id}; evicting")
         await _hard_evict(user_id, entry)
         return None
 
@@ -431,8 +451,8 @@ async def _reuse_cached_entry(user_id: str, mount_env: dict[str, str]) -> Pooled
 
     await _ensure_mounted(entry.sandbox, mount_env)
     if not await _verify_canary_or_die(entry):
-        log.set(sandbox_cache_evicted="canary_stale")
-        log.warning(f"Canary stale for user {user_id}; recreating sandbox")
+        _record(cache_evicted="canary_stale")
+        log.warning(f"{LogTag.SANDBOX} canary stale user={user_id}; recreating sandbox")
         await _hard_evict(user_id, entry)
         return None
 
@@ -442,19 +462,22 @@ async def _reuse_cached_entry(user_id: str, mount_env: dict[str, str]) -> Pooled
 
 async def _resume_existing_sandbox(doc: dict[str, Any], mount_env: dict[str, str]) -> Any | None:
     """Connect to a recorded sandbox (auto-resuming if paused); None if unusable."""
-    sbx = await _connect_sandbox(doc["sandbox_id"])
+    sandbox_id = doc["sandbox_id"]
+    log.info(f"{LogTag.SANDBOX} resuming sandbox {sandbox_id}")
+    sbx = await _connect_sandbox(sandbox_id)
     if sbx is None:
-        log.set(sandbox_resume_status="failed")
+        _record(resume_status="failed")
         return None
     if not await _health_probe(sbx):
-        log.set(sandbox_resume_status="unhealthy")
+        _record(resume_status="unhealthy")
         log.info(
-            f"[sandbox] resumed sandbox {doc['sandbox_id']} still unhealthy "
+            f"{LogTag.SANDBOX} resumed sandbox {sandbox_id} still unhealthy "
             f"after connect; falling through to fresh create"
         )
         return None
-    log.set(sandbox_resume_status="ok")
+    _record(resume_status="ok")
     await _ensure_mounted(sbx, mount_env)
+    log.info(f"{LogTag.SANDBOX} resumed sandbox {sandbox_id}")
     return sbx
 
 
@@ -462,15 +485,15 @@ async def _acquire_or_create(user_id: str) -> PooledSandbox:
     """Return a PooledSandbox for the user, creating/resuming as needed."""
     pool = get_sandbox_pool()
     shard_id = shard_for(user_id)
-    log.set(sandbox_shard_id=shard_id)
+    _record(operation="acquire", shard_id=shard_id)
     # Built once per acquire so _ensure_mounted can re-run mount.sh on a
     # stale FUSE without resorting to sandbox-wide credential env vars.
     mount_env = _mount_env(user_id, shard_id)
 
     cached = await _reuse_cached_entry(user_id, mount_env)
     if cached is not None:
-        log.set(
-            sandbox_source="cache",
+        _record(
+            source="cache",
             sandbox_id=getattr(cached.sandbox, "sandbox_id", None),
         )
         return cached
@@ -497,10 +520,10 @@ async def _acquire_or_create(user_id: str) -> PooledSandbox:
         sbx = await _create_fresh_sandbox(user_id, shard_id)
         workspace_version += 1
 
-    log.set(
-        sandbox_source=source,
+    _record(
+        source=source,
         sandbox_id=getattr(sbx, "sandbox_id", None),
-        sandbox_workspace_version=workspace_version,
+        workspace_version=workspace_version,
     )
 
     canary_ts = await _write_canary(sbx)
@@ -557,9 +580,10 @@ async def _pause_sandbox(user_id: str, entry: PooledSandbox) -> bool:
             {"user_id": user_id},
             {"$set": {"state": "paused", "paused_at": _now()}},
         )
+        log.info(f"{LogTag.SANDBOX} paused idle sandbox user={user_id}")
         return True
     except Exception as e:
-        log.warning(f"Pause failed for user {user_id}: {e}")
+        log.warning(f"{LogTag.SANDBOX} pause failed user={user_id}: {e}")
         return False
 
 
@@ -584,6 +608,7 @@ def _schedule_pause(user_id: str, entry: PooledSandbox) -> None:
 
 async def _hard_evict(user_id: str, entry: PooledSandbox) -> None:
     """Drop a sandbox from the pool and best-effort kill it."""
+    log.info(f"{LogTag.SANDBOX} evicting sandbox user={user_id}")
     get_sandbox_pool().evict(user_id)
     await _cancel_pause_task(entry)
     await _stop_watcher(entry)
@@ -595,7 +620,8 @@ async def _hard_evict(user_id: str, entry: PooledSandbox) -> None:
 async def mark_sandbox_dead(user_id: str) -> None:
     """Forcibly drop the cached sandbox and mark it dead in Mongo. Caller's
     next acquire will create a fresh one."""
-    log.set(sandbox_marked_dead=True)
+    _record(marked_dead=True)
+    log.info(f"{LogTag.SANDBOX} marking sandbox dead user={user_id}")
     entry = get_sandbox_pool().get(user_id)
     if entry is not None:
         await _hard_evict(user_id, entry)
@@ -632,6 +658,7 @@ async def acquire_sandbox(user_id: str) -> AsyncIterator[Any]:
         async with fs_timer(FsOps.SBX_ACQUIRE):
             entry = await _acquire_or_create(user_id)
         entry.refcount += 1
+        _record(refcount=entry.refcount)
         sandbox_dead = False
         try:
             yield entry.sandbox
@@ -643,6 +670,8 @@ async def acquire_sandbox(user_id: str) -> AsyncIterator[Any]:
             # here means every tool (bash/read/write/edit) gets death-eviction
             # uniformly; none need their own detection.
             sandbox_dead = not await _health_probe(entry.sandbox)
+            if sandbox_dead:
+                _record(health_ok=False)
             raise
         finally:
             entry.refcount -= 1

--- a/apps/api/app/services/sandbox/pool.py
+++ b/apps/api/app/services/sandbox/pool.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider
 from app.services.sandbox.shard_router import shard_for
 from app.services.storage.metrics import set_sandbox_pool_size
@@ -139,7 +140,7 @@ def init_sandbox_pool() -> SandboxPool:
     """
     global _pool_singleton
     if _pool_singleton is None:
-        log.info("Initializing E2B sandbox pool")
+        log.info(f"{LogTag.SANDBOX} initializing pool")
         _pool_singleton = SandboxPool()
     return _pool_singleton
 
@@ -152,6 +153,6 @@ def get_sandbox_pool() -> SandboxPool:
     """
     global _pool_singleton
     if _pool_singleton is None:
-        log.info("Initializing E2B sandbox pool")
+        log.info(f"{LogTag.SANDBOX} initializing pool")
         _pool_singleton = SandboxPool()
     return _pool_singleton

--- a/apps/api/app/services/storage/bootstrap.py
+++ b/apps/api/app/services/storage/bootstrap.py
@@ -38,6 +38,7 @@ import threading
 import time
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider
 from app.services.storage.metrics import FsOps, record_fs_op  # noqa: F401
 from shared.py.wide_events import log
@@ -199,11 +200,11 @@ def _format_if_needed(meta_url: str, encrypt_key: Path | None) -> str:
         outcome="ok" if status.returncode == 0 else "miss",
     )
     if status.returncode == 0:
-        log.info("[juicefs] filesystem already formatted")
+        log.info(f"{LogTag.STORAGE} filesystem already formatted")
         return "ok"
     if _classify(status.stderr) == "fatal":
         log.warning(
-            "[juicefs] permanent error during status",
+            f"{LogTag.STORAGE} permanent error during status",
             meta=_mask_meta(meta_url),
             detail=status.stderr.strip()[:300],
         )
@@ -213,7 +214,7 @@ def _format_if_needed(meta_url: str, encrypt_key: Path | None) -> str:
     # R2 credentials ride in env (the JuiceFS CLI honours the standard AWS
     # variables when --access-key/--secret-key are absent), so they do not
     # appear in argv visible to `ps auxww` during the format window.
-    log.info(f"[juicefs] formatting filesystem against {_bucket_url()}")
+    log.info(f"{LogTag.STORAGE} formatting filesystem against {_bucket_url()}")
     cmd: list[str] = [
         "juicefs",
         "format",
@@ -243,16 +244,16 @@ def _format_if_needed(meta_url: str, encrypt_key: Path | None) -> str:
     # Shared volume already initialized (the normal case: E2B/prod formatted
     # it) or a concurrent-format race — the volume is usable.
     if any(m in low for m in ("is not empty", "already exists", "already formatted")):
-        log.info("[juicefs] volume already initialized; proceeding to mount")
+        log.info(f"{LogTag.STORAGE} volume already initialized; proceeding to mount")
         return "ok"
     if _classify(err) == "fatal":
         log.warning(
-            "[juicefs] permanent error during format",
+            f"{LogTag.STORAGE} permanent error during format",
             meta=_mask_meta(meta_url),
             detail=err[:300],
         )
         return "fatal"
-    log.warning(f"[juicefs] format failed (transient; will retry): {err[:300]}")
+    log.warning(f"{LogTag.STORAGE} format failed (transient; will retry): {err[:300]}")
     return "transient"
 
 
@@ -269,7 +270,7 @@ def _mount(meta_url: str, mount_path: Path) -> str:
     Returns "ok" | "transient" | "fatal".
     """
     if _is_mounted(mount_path):
-        log.info(f"[juicefs] already mounted at {mount_path}")
+        log.info(f"{LogTag.STORAGE} already mounted at {mount_path}")
         return "ok"
 
     _CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -295,7 +296,7 @@ def _mount(meta_url: str, mount_path: Path) -> str:
             elapsed_ms = (time.monotonic() - started) * 1000.0
             record_fs_op(FsOps.JUICEFS_MOUNT, duration_ms=elapsed_ms, outcome="ok")
             log.info(
-                "[juicefs] mounted",
+                f"{LogTag.STORAGE} mounted",
                 mount=str(mount_path),
                 elapsed_s=round(elapsed_ms / 1000.0, 1),
             )
@@ -307,7 +308,7 @@ def _mount(meta_url: str, mount_path: Path) -> str:
     kind = _classify(detail)  # transient unless an explicit permanent error
     record_fs_op(FsOps.JUICEFS_MOUNT, duration_ms=elapsed_ms, outcome=kind)
     log.warning(
-        f"[juicefs] mount not ready within {timeout}s ({kind})",
+        f"{LogTag.STORAGE} mount not ready within {timeout}s ({kind})",
         meta=_mask_meta(meta_url),
         detail=detail.strip()[:300],
     )
@@ -318,7 +319,7 @@ def _bootstrap_once() -> str:
     """One full attempt. Returns "ok" | "transient" | "skip" | "fatal"."""
     mount_path = Path(settings.JUICEFS_HOST_MOUNT_PATH)
     if _is_mounted(mount_path):
-        log.info(f"[juicefs] mount already healthy at {mount_path}")
+        log.info(f"{LogTag.STORAGE} mount already healthy at {mount_path}")
         return "ok"
     encrypt_key = _materialize_encryption_key()
     meta_url = _meta_url()
@@ -336,26 +337,26 @@ def _bootstrap_loop() -> None:
         try:
             result = _bootstrap_once()
         except Exception as e:  # noqa: BLE001 - never let the thread die silently
-            log.warning(f"[juicefs] bootstrap attempt errored: {e}")
+            log.warning(f"{LogTag.STORAGE} bootstrap attempt errored: {e}")
             result = "transient"
         if result in ("ok", "skip", "fatal"):
             if result == "fatal":
                 log.warning(
-                    "[juicefs] bootstrap gave up (non-transient failure); "
+                    f"{LogTag.STORAGE} bootstrap gave up (non-transient failure); "
                     "storage helpers will soft-fail until reconfigured"
                 )
             return
         if attempt < attempts:
             delay = min(base_backoff * (2 ** (attempt - 1)), 15)
             log.info(
-                "[juicefs] transient mount failure; backing off",
+                f"{LogTag.STORAGE} transient mount failure; backing off",
                 attempt=attempt,
                 of=attempts,
                 retry_in_s=delay,
             )
             time.sleep(delay)
     log.warning(
-        f"[juicefs] mount still unavailable after {attempts} attempts; "
+        f"{LogTag.STORAGE} mount still unavailable after {attempts} attempts; "
         "storage helpers will soft-fail (next app start retries)"
     )
 
@@ -375,12 +376,12 @@ async def init_juicefs_mount() -> str:
     global _bootstrap_thread
 
     if shutil.which("juicefs") is None:
-        log.warning("[juicefs] CLI not found on PATH — skipping bootstrap")
+        log.warning(f"{LogTag.STORAGE} CLI not found on PATH — skipping bootstrap")
         return settings.JUICEFS_HOST_MOUNT_PATH
 
     missing = _missing_settings()
     if missing:
-        log.info("[juicefs] skipping bootstrap; missing settings: " + ", ".join(missing))
+        log.info(f"{LogTag.STORAGE} skipping bootstrap; missing settings: " + ", ".join(missing))
         return settings.JUICEFS_HOST_MOUNT_PATH
 
     # Probe off the event loop with a timeout — a wedged FUSE mount blocks forever
@@ -393,13 +394,13 @@ async def init_juicefs_mount() -> str:
         )
     except TimeoutError:
         log.warning(
-            f"[juicefs] mount probe timed out after {_MOUNT_PROBE_TIMEOUT_SECONDS}s — "
+            f"{LogTag.STORAGE} mount probe timed out after {_MOUNT_PROBE_TIMEOUT_SECONDS}s — "
             "mount likely unresponsive; (re)starting bootstrap"
         )
         already_mounted = False
 
     if already_mounted:
-        log.info("[juicefs] mount already healthy")
+        log.info(f"{LogTag.STORAGE} mount already healthy")
         return settings.JUICEFS_HOST_MOUNT_PATH
 
     with _bootstrap_lock:

--- a/apps/api/app/services/storage/juicefs.py
+++ b/apps/api/app/services/storage/juicefs.py
@@ -8,6 +8,7 @@ import re
 import shutil
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.services.storage.metrics import FsOps, add_fs_bytes, fs_timer
 from shared.py.wide_events import log
 
@@ -267,7 +268,7 @@ async def delete_user_workspace(user_id: str) -> None:
     def _delete() -> None:
         if not _is_mounted():
             log.warning(
-                "delete_user_workspace called but JuiceFS mount missing",
+                f"{LogTag.STORAGE} delete_user_workspace called but JuiceFS mount missing",
                 user_id=user_id,
             )
             return

--- a/apps/api/app/services/storage/sessions/skills.py
+++ b/apps/api/app/services/storage/sessions/skills.py
@@ -23,6 +23,7 @@ from app.agents.workspace.skill_loader import (
 from app.agents.workspace.system_docs import (
     INTEGRATIONS_GUIDE_MD,
 )
+from app.constants.log_tags import LogTag
 from app.constants.skills import EXECUTOR_SUBAGENT_ID, SKILL_BODY_FILENAME
 from app.services.storage._vfs_common import matches_text
 from app.services.storage.juicefs import ensure_safe_path_id
@@ -159,7 +160,9 @@ def materialize_instructions(user_root: Path, instructions: dict[str, str]) -> i
         try:
             ensure_safe_path_id(iid, label="integration_id")
         except ValueError:
-            log.warning(f"Skipping unsafe integration_id in instructions projection: {iid!r}")
+            log.warning(
+                f"{LogTag.STORAGE} Skipping unsafe integration_id in instructions projection: {iid!r}"
+            )
             continue
         agent_dir = integrations_root / iid / "agent"
         agent_dir.mkdir(parents=True, exist_ok=True)

--- a/apps/api/app/services/storage/system_workspace.py
+++ b/apps/api/app/services/storage/system_workspace.py
@@ -36,6 +36,7 @@ import hashlib
 from pathlib import Path
 
 from app.agents.workspace.system_files import SystemFile, system_files
+from app.constants.log_tags import LogTag
 from app.services.storage.juicefs import (
     JuiceFSUnavailable,
     _host_base_and_rel,
@@ -176,7 +177,7 @@ async def link_system_files_into_workspace(user_id: str) -> int:
 
     count = await asyncio.to_thread(_link)
     if count:
-        log.info(f"linked {count} system files for {user_id}")
+        log.info(f"{LogTag.STORAGE} linked {count} system files for {user_id}")
     return count
 
 

--- a/apps/api/app/services/system_workflows/provisioner.py
+++ b/apps/api/app/services/system_workflows/provisioner.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 from pymongo.errors import DuplicateKeyError
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.notification.notification_models import (
     ActionConfig,
@@ -71,11 +72,13 @@ async def provision_system_workflows(
     )
     entries = SYSTEM_WORKFLOWS_BY_INTEGRATION.get(integration_id)
     if not entries:
-        log.debug(f"No system workflows defined for integration '{integration_id}'")
+        log.debug(
+            f"{LogTag.WORKFLOW} No system workflows defined for integration '{integration_id}'"
+        )
         return
 
     log.info(
-        f"Provisioning {len(entries)} system workflow(s) for user {user_id}, "
+        f"{LogTag.WORKFLOW} Provisioning {len(entries)} system workflow(s) for user {user_id}, "
         f"integration {integration_id}"
     )
 
@@ -87,17 +90,19 @@ async def provision_system_workflows(
             {"user_id": user_id, "system_workflow_key": key, "is_system_workflow": True}
         )
         if existing:
-            log.info(f"System workflow '{key}' already exists for user {user_id}, skipping")
+            log.info(
+                f"{LogTag.WORKFLOW} System workflow '{key}' already exists for user {user_id}, skipping"
+            )
             continue
 
         try:
             request = factory()
             await WorkflowService.create_workflow(request, user_id)
             created.append(request)
-            log.info(f"Provisioned system workflow '{key}' for user {user_id}")
+            log.info(f"{LogTag.WORKFLOW} Provisioned system workflow '{key}' for user {user_id}")
         except DuplicateKeyError:
             log.info(
-                f"System workflow '{key}' already exists for user {user_id} "
+                f"{LogTag.WORKFLOW} System workflow '{key}' already exists for user {user_id} "
                 "(concurrent creation), skipping"
             )
         except Exception as e:
@@ -162,12 +167,12 @@ async def _notify_workflows_provisioned(
             )
         )
         log.info(
-            f"Sent system workflow provisioning notification to user {user_id} "
+            f"{LogTag.WORKFLOW} Sent system workflow provisioning notification to user {user_id} "
             f"for integration '{integration_display_name}'"
         )
     except Exception as e:
         log.error(
-            f"Failed to send provisioning notification for user {user_id}: {e}",
+            f"{LogTag.WORKFLOW} Failed to send provisioning notification for user {user_id}: {e}",
             exc_info=True,
         )
 
@@ -195,7 +200,7 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
     factory = SYSTEM_WORKFLOW_REGISTRY.get(key) if key else None
     if not factory:
         log.warning(
-            f"No definition found for system_workflow_key '{key}' on workflow {workflow_id}"
+            f"{LogTag.WORKFLOW} No definition found for system_workflow_key '{key}' on workflow {workflow_id}"
         )
         return False
 
@@ -219,12 +224,14 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
                 raise_on_failure=False,
             )
         except Exception as e:
-            log.error(f"Failed to re-register triggers, aborting reset of {workflow_id}: {e}")
+            log.error(
+                f"{LogTag.WORKFLOW} Failed to re-register triggers, aborting reset of {workflow_id}: {e}"
+            )
             return False
 
         if not new_trigger_ids:
             log.error(
-                f"New trigger registration returned empty result for {workflow_id}, "
+                f"{LogTag.WORKFLOW} New trigger registration returned empty result for {workflow_id}, "
                 "aborting reset to avoid leaving workflow without triggers"
             )
             return False
@@ -240,7 +247,7 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
             )
         except Exception as e:
             log.warning(
-                f"Failed to unregister old triggers during reset of {workflow_id} (non-fatal): {e}"
+                f"{LogTag.WORKFLOW} Failed to unregister old triggers during reset of {workflow_id} (non-fatal): {e}"
             )
 
     # Python mode keeps trigger_config.next_run a native datetime (BSON date),
@@ -261,5 +268,7 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
         },
     )
 
-    log.info(f"Reset system workflow '{key}' ({workflow_id}) to default for user {user_id}")
+    log.info(
+        f"{LogTag.WORKFLOW} Reset system workflow '{key}' ({workflow_id}) to default for user {user_id}"
+    )
     return True

--- a/apps/api/app/services/todos/sync_service.py
+++ b/apps/api/app/services/todos/sync_service.py
@@ -8,6 +8,7 @@ import uuid
 
 from bson import ObjectId
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     goals_collection,
     projects_collection,
@@ -84,7 +85,9 @@ async def sync_goal_node_completion(
         )
 
         if result.modified_count == 0:
-            log.warning(f"No subtask updated for subtask_id {subtask_id} in todo {todo_id}")
+            log.warning(
+                f"{LogTag.TODO} No subtask updated for subtask_id {subtask_id} in todo {todo_id}"
+            )
             return False
 
         # Get project_id for cache invalidation
@@ -98,12 +101,12 @@ async def sync_goal_node_completion(
         await _invalidate_goal_caches(user_id, goal_id)
 
         log.info(
-            f"Synced completion status for node {node_id} <-> subtask {subtask_id}: {is_complete}"
+            f"{LogTag.TODO} Synced completion status for node {node_id} <-> subtask {subtask_id}: {is_complete}"
         )
         return True
 
     except Exception as e:
-        log.error(f"Error syncing goal node completion: {e!s}")
+        log.error(f"{LogTag.TODO} Error syncing goal node completion: {e!s}")
         return False
 
 
@@ -153,7 +156,9 @@ async def sync_subtask_to_goal_completion(
         )
 
         if result.modified_count == 0:
-            log.warning(f"No node updated for subtask_id {subtask_id} in goal {goal_id}")
+            log.warning(
+                f"{LogTag.TODO} No node updated for subtask_id {subtask_id} in goal {goal_id}"
+            )
             return False
 
         # Invalidate goal caches
@@ -162,11 +167,13 @@ async def sync_subtask_to_goal_completion(
         # Also invalidate todo caches since this sync was triggered by a todo change
         await _invalidate_todo_caches(user_id, todo_project_id, todo_id)
 
-        log.info(f"Synced subtask {subtask_id} completion back to goal {goal_id}: {is_complete}")
+        log.info(
+            f"{LogTag.TODO} Synced subtask {subtask_id} completion back to goal {goal_id}: {is_complete}"
+        )
         return True
 
     except Exception as e:
-        log.error(f"Error syncing subtask to goal completion: {e!s}")
+        log.error(f"{LogTag.TODO} Error syncing subtask to goal completion: {e!s}")
         return False
 
 
@@ -265,12 +272,12 @@ async def create_goal_project_and_todo(
         await _invalidate_project_caches(user_id, project_id)
 
         log.info(
-            f"Added goal todo {created_todo.id} with {len(subtasks)} subtasks to Goals project {project_id} for goal {goal_id}"
+            f"{LogTag.TODO} Added goal todo {created_todo.id} with {len(subtasks)} subtasks to Goals project {project_id} for goal {goal_id}"
         )
         return project_id
 
     except Exception as e:
-        log.error(f"Error creating goal todo in Goals project: {e!s}")
+        log.error(f"{LogTag.TODO} Error creating goal todo in Goals project: {e!s}")
         raise
 
 
@@ -329,11 +336,11 @@ async def _invalidate_todo_caches(
         await delete_cache_by_pattern(f"todo:{user_id}:*")
 
         log.info(
-            f"Todo caches invalidated for user {user_id}, project {project_id}, todo {todo_id}"
+            f"{LogTag.TODO} Todo caches invalidated for user {user_id}, project {project_id}, todo {todo_id}"
         )
 
     except Exception as e:
-        log.error(f"Error invalidating todo caches: {e!s}")
+        log.error(f"{LogTag.TODO} Error invalidating todo caches: {e!s}")
 
 
 async def _invalidate_goal_caches(user_id: str, goal_id: str | None = None):
@@ -354,10 +361,10 @@ async def _invalidate_goal_caches(user_id: str, goal_id: str | None = None):
             cache_key_goal = f"goal_cache:{goal_id}"
             await delete_cache(cache_key_goal)
 
-        log.info(f"Goal caches invalidated for user {user_id}, goal {goal_id}")
+        log.info(f"{LogTag.TODO} Goal caches invalidated for user {user_id}, goal {goal_id}")
 
     except Exception as e:
-        log.error(f"Error invalidating goal caches: {e!s}")
+        log.error(f"{LogTag.TODO} Error invalidating goal caches: {e!s}")
 
 
 async def _invalidate_project_caches(user_id: str, project_id: str | None = None):
@@ -372,7 +379,9 @@ async def _invalidate_project_caches(user_id: str, project_id: str | None = None
         if project_id:
             await delete_cache_by_pattern(f"*:project:{project_id}*")
 
-        log.info(f"Project caches invalidated for user {user_id}, project {project_id}")
+        log.info(
+            f"{LogTag.TODO} Project caches invalidated for user {user_id}, project {project_id}"
+        )
 
     except Exception as e:
-        log.error(f"Error invalidating project caches: {e!s}")
+        log.error(f"{LogTag.TODO} Error invalidating project caches: {e!s}")

--- a/apps/api/app/services/todos/todo_bulk_service.py
+++ b/apps/api/app/services/todos/todo_bulk_service.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from bson import ObjectId
 from fastapi import HTTPException, status
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import todos_collection
 from app.db.redis import delete_cache
 from app.db.utils import serialize_document
@@ -100,14 +101,14 @@ async def bulk_complete_todos(todo_ids: list[str], user_id: str) -> list[TodoRes
             if todo.get("project_id"):
                 await delete_cache(f"todos:{user_id}:project:{todo['project_id']}")
 
-        log.info(f"Bulk completed {total_modified} todos for user {user_id}")
+        log.info(f"{LogTag.TODO} Bulk completed {total_modified} todos for user {user_id}")
 
         return [TodoResponse(**serialize_document(todo)) for todo in todos]
 
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error bulk completing todos: {e!s}")
+        log.error(f"{LogTag.TODO} Error bulk completing todos: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to bulk complete todos: {e!s}",
@@ -188,7 +189,7 @@ async def bulk_move_todos(todo_ids: list[str], project_id: str, user_id: str) ->
             await delete_cache(f"todo:{user_id}:{todo_id}")
 
         log.info(
-            f"Bulk moved {result.modified_count} todos to project {project_id} for user {user_id}"
+            f"{LogTag.TODO} Bulk moved {result.modified_count} todos to project {project_id} for user {user_id}"
         )
 
         return [TodoResponse(**serialize_document(todo)) for todo in todos]
@@ -196,7 +197,7 @@ async def bulk_move_todos(todo_ids: list[str], project_id: str, user_id: str) ->
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error bulk moving todos: {e!s}")
+        log.error(f"{LogTag.TODO} Error bulk moving todos: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to bulk move todos: {e!s}",
@@ -271,12 +272,12 @@ async def bulk_delete_todos(todo_ids: list[str], user_id: str) -> None:
         for todo_id in todo_ids:
             await delete_cache(f"todo:{user_id}:{todo_id}")
 
-        log.info(f"Bulk deleted {result.deleted_count} todos for user {user_id}")
+        log.info(f"{LogTag.TODO} Bulk deleted {result.deleted_count} todos for user {user_id}")
 
     except HTTPException:
         raise
     except Exception as e:
-        log.error(f"Error bulk deleting todos: {e!s}")
+        log.error(f"{LogTag.TODO} Error bulk deleting todos: {e!s}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to bulk delete todos: {e!s}",

--- a/apps/api/app/services/tools/tools_service.py
+++ b/apps/api/app/services/tools/tools_service.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from app.agents.tools.core.registry import get_tool_registry
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import user_integrations_collection
 from app.models.tools_models import ToolInfo, ToolsCategoryResponse, ToolsListResponse
 from app.services.mcp.mcp_tools_store import get_mcp_tools_store
@@ -64,7 +65,7 @@ async def _fetch_user_mcp_integrations(user_id: str | None) -> list[dict]:
         ]
         return await user_integrations_collection.aggregate(pipeline).to_list(None)
     except Exception as e:
-        log.warning(f"Failed to fetch user MCP integrations: {e}")
+        log.warning(f"{LogTag.TOOL} Failed to fetch user MCP integrations: {e}")
         return []
 
 
@@ -84,7 +85,7 @@ async def _build_tools_response(user_id: str | None = None) -> ToolsListResponse
             seen_integrations.add(category_obj.integration_name)
         for tool in category_obj.tools:
             if tool.name in seen_tool_names:
-                log.debug(f"Skipping duplicate tool from registry: {tool.name}")
+                log.debug(f"{LogTag.TOOL} Skipping duplicate tool from registry: {tool.name}")
                 continue
             seen_tool_names.add(tool.name)
 
@@ -110,7 +111,7 @@ async def _build_tools_response(user_id: str | None = None) -> ToolsListResponse
             _fetch_user_mcp_integrations(user_id),
         )
     except Exception as e:
-        log.warning(f"Failed to fetch MCP tools: {e}")
+        log.warning(f"{LogTag.TOOL} Failed to fetch MCP tools: {e}")
 
     # Process custom integrations first for proper metadata
     for custom in custom_integrations:
@@ -128,10 +129,14 @@ async def _build_tools_response(user_id: str | None = None) -> ToolsListResponse
         for tool_dict in custom_tools:
             tool_name = tool_dict.get("name")
             if not tool_name:
-                log.warning(f"Skipping tool with missing 'name' from custom MCP {integration_id}")
+                log.warning(
+                    f"{LogTag.TOOL} Skipping tool with missing 'name' from custom MCP {integration_id}"
+                )
                 continue
             if tool_name in seen_tool_names:
-                log.debug(f"Skipping duplicate tool from custom MCP {integration_id}: {tool_name}")
+                log.debug(
+                    f"{LogTag.TOOL} Skipping duplicate tool from custom MCP {integration_id}: {tool_name}"
+                )
                 continue
             seen_tool_names.add(tool_name)
 
@@ -145,7 +150,7 @@ async def _build_tools_response(user_id: str | None = None) -> ToolsListResponse
             )
             categories.add(integration_id)
 
-        log.info(f"Added {len(custom_tools)} tools from custom MCP {integration_id}")
+        log.info(f"{LogTag.TOOL} Added {len(custom_tools)} tools from custom MCP {integration_id}")
         seen_integrations.add(integration_id)
 
     # SECURITY: global_mcp_tools is keyed by integration_id only — it holds
@@ -302,10 +307,12 @@ async def get_user_mcp_tools(user_id: str) -> list[ToolInfo]:
                     )
                 )
 
-            log.debug(f"Fetched {len(integration_tools)} tools from MCP {integration_id}")
+            log.debug(
+                f"{LogTag.TOOL} Fetched {len(integration_tools)} tools from MCP {integration_id}"
+            )
 
     except Exception as e:
-        log.warning(f"Failed to fetch user MCP tools: {e}")
+        log.warning(f"{LogTag.TOOL} Failed to fetch user MCP tools: {e}")
 
     return tool_infos
 

--- a/apps/api/app/services/tools/tools_warmup.py
+++ b/apps/api/app/services/tools/tools_warmup.py
@@ -7,6 +7,7 @@ eliminating cold-start latency for the /tools endpoint.
 
 from app.agents.tools.core.registry import get_tool_registry
 from app.constants.cache import GLOBAL_TOOLS_CACHE_KEY, GLOBAL_TOOLS_CACHE_TTL
+from app.constants.log_tags import LogTag
 from app.db.redis import set_cache
 from app.services.tools.tools_service import get_available_tools
 from shared.py.wide_events import log
@@ -23,7 +24,7 @@ async def warmup_tools_cache() -> None:
     Called from lifespan to ensure tools are ready before serving requests.
     """
     log.set(service="tools_warmup", operation="warmup_tools_cache")
-    log.info("Warming up tools cache...")
+    log.info(f"{LogTag.TOOL} Warming up tools cache...")
 
     try:
         # 1. Index provider-tool METADATA (name + description) for retrieval and
@@ -34,7 +35,9 @@ async def warmup_tools_cache() -> None:
         #    first created (register_provider_tools).
         tool_registry = await get_tool_registry()
         await tool_registry.populate_provider_catalog()
-        log.info("Provider catalog metadata indexed (tools materialized lazily on use)")
+        log.info(
+            f"{LogTag.TOOL} Provider catalog metadata indexed (tools materialized lazily on use)"
+        )
 
         # 2. Build and cache global tools response
         # Pass None for user_id to get only global tools (no user-specific overlays)
@@ -48,10 +51,10 @@ async def warmup_tools_cache() -> None:
         )
 
         log.info(
-            f"Tools cache warmed with {global_tools.total_count} tools "
+            f"{LogTag.TOOL} Tools cache warmed with {global_tools.total_count} tools "
             f"across {len(global_tools.categories)} categories"
         )
 
     except Exception as e:
         # Don't fail startup if warmup fails - tools will be loaded on first request
-        log.warning(f"Tools cache warmup failed (non-fatal): {e}")
+        log.warning(f"{LogTag.TOOL} Tools cache warmup failed (non-fatal): {e}")

--- a/apps/api/app/services/triggers/base.py
+++ b/apps/api/app/services/triggers/base.py
@@ -10,13 +10,14 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.workflow_models import TriggerConfig, Workflow
 from app.services.composio.composio_service import get_composio_service
 from app.services.tracked_todo_service import tracked_todo_service
 from app.services.workflow.queue_service import WorkflowQueueService
 from app.utils.exceptions import TriggerRegistrationError
-from shared.py.wide_events import log
+from shared.py.wide_events import TriggerContext, log
 
 
 def _parse_event_start_utc(data: dict[str, Any]) -> datetime | None:
@@ -60,7 +61,7 @@ def _log_event_timing(data: dict[str, Any], now_utc: datetime) -> None:
     )
     if abs(webhook_lag) > 300:
         log.warning(
-            "webhook fired far from expected time — "
+            f"{LogTag.TRIGGER} webhook fired far from expected time — "
             f"lag={webhook_lag}s (positive = late, negative = early)",
         )
 
@@ -129,6 +130,7 @@ class TriggerHandler(ABC):
             operation="unregister",
             user_id=user_id,
             trigger_count=len(trigger_ids),
+            trigger=TriggerContext(operation="delete", result_count=len(trigger_ids)),
         )
         if not trigger_ids:
             return True
@@ -142,9 +144,9 @@ class TriggerHandler(ABC):
                     composio.composio.triggers.delete,
                     trigger_id=trigger_id,
                 )
-                log.debug(f"Deleted trigger: {trigger_id}")
+                log.debug(f"{LogTag.TRIGGER} Deleted trigger: {trigger_id}")
             except Exception as e:
-                log.error(f"Failed to delete trigger {trigger_id}: {e}")
+                log.error(f"{LogTag.TRIGGER} Failed to delete trigger {trigger_id}: {e}")
                 success = False
 
         return success
@@ -211,18 +213,22 @@ class TriggerHandler(ABC):
                 config_desc = (
                     config_description_fn(configs[i]) if config_description_fn else str(configs[i])
                 )
-                log.error(f"Trigger registration failed for {config_desc}: {result}")
+                log.error(
+                    f"{LogTag.TRIGGER} Trigger registration failed for {config_desc}: {result}"
+                )
             elif result is not None:
                 successful_ids.append(result)
 
         # If any failed, rollback all successful ones
         if has_failure:
             if successful_ids:
-                log.warning(f"Rolling back {len(successful_ids)} triggers due to partial failure")
+                log.warning(
+                    f"{LogTag.TRIGGER} Rolling back {len(successful_ids)} triggers due to partial failure"
+                )
                 rollback_ok = await self.unregister(user_id, successful_ids)
                 if not rollback_ok:
                     log.error(
-                        f"Rollback FAILED — orphaned Composio triggers: {successful_ids}. "
+                        f"{LogTag.TRIGGER} Rollback FAILED — orphaned Composio triggers: {successful_ids}. "
                         "Manual cleanup may be required."
                     )
 
@@ -247,7 +253,9 @@ class TriggerHandler(ABC):
                     del workflow_doc["_id"]
                 workflows.append(Workflow(**workflow_doc))
             except Exception as e:
-                log.error(f"Error processing workflow document ({log_context}): {e}")
+                log.error(
+                    f"{LogTag.TRIGGER} Error processing workflow document ({log_context}): {e}"
+                )
 
         return workflows
 
@@ -324,6 +332,9 @@ class TriggerHandler(ABC):
             Dict with 'status' and 'message' keys
         """
         now_utc = datetime.now(UTC)
+        trigger_ctx = TriggerContext(operation="dispatch", trigger_type=event_type)
+        if trigger_id:
+            trigger_ctx["trigger_id"] = trigger_id
         log.set(
             service="trigger_handler",
             operation="process_event",
@@ -331,6 +342,7 @@ class TriggerHandler(ABC):
             trigger_id=trigger_id,
             user_id=user_id,
             now_utc=now_utc.isoformat(),
+            trigger=trigger_ctx,
         )
 
         _log_event_timing(data, now_utc)
@@ -338,8 +350,10 @@ class TriggerHandler(ABC):
         # Find matching workflows using handler's find_workflows method
         # Each handler decides what identifiers it needs (trigger_id, user_id, etc.)
         workflows = await self.find_workflows(event_type, trigger_id or "", data)
+        log.set_ns("trigger", matched_count=len(workflows))
 
         if not workflows:
+            log.set_ns("trigger", fired=False)
             log.info(
                 "trigger_no_matching_workflows",
                 outcome="no_match",
@@ -359,6 +373,8 @@ class TriggerHandler(ABC):
                 workflow, data, signal_context_by_user, event_type, trigger_id
             ):
                 queued_count += 1
+
+        log.set_ns("trigger", fired=queued_count > 0, result_count=queued_count)
 
         return {
             "status": "success",

--- a/apps/api/app/services/triggers/handlers/asana.py
+++ b/apps/api/app/services/triggers/handlers/asana.py
@@ -4,6 +4,7 @@ Asana trigger handler.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.trigger_configs import AsanaTaskTriggerConfig
 from app.models.workflow_models import TriggerConfig, TriggerType, Workflow
@@ -79,7 +80,7 @@ class AsanaTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching an Asana trigger event."""
-        log.set(trigger={"provider": "asana", "event": event_type})
+        log.set_ns("trigger", integration_id="asana", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -99,13 +100,13 @@ class AsanaTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/calendar.py
+++ b/apps/api/app/services/triggers/handlers/calendar.py
@@ -9,6 +9,7 @@ Handles all calendar-specific trigger logic including:
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import (
     GoogleCalendarEventCreatedPayload,
@@ -21,7 +22,7 @@ from app.models.trigger_configs import (
 from app.models.workflow_models import TriggerConfig, TriggerType, Workflow
 from app.services.triggers.base import TriggerHandler
 from app.utils.exceptions import TriggerRegistrationError
-from shared.py.wide_events import log
+from shared.py.wide_events import TriggerContext, log
 
 
 class CalendarTriggerHandler(TriggerHandler):
@@ -129,6 +130,11 @@ class CalendarTriggerHandler(TriggerHandler):
                 if isinstance(trigger_data, CalendarEventStartingSoonConfig)
                 else None
             ),
+            trigger=TriggerContext(
+                operation="register",
+                trigger_type=trigger_name,
+                integration_id="google_calendar",
+            ),
         )
 
         # Use the base class helper for parallel registration with rollback
@@ -139,13 +145,14 @@ class CalendarTriggerHandler(TriggerHandler):
             composio_slug=composio_slug,
         )
         log.set(composio_trigger_ids=trigger_ids, trigger_ids_count=len(trigger_ids))
+        log.set_ns("trigger", result_count=len(trigger_ids))
         return trigger_ids
 
     async def find_workflows(
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a calendar trigger event."""
-        log.set(trigger={"provider": "google_calendar", "event": event_type})
+        log.set_ns("trigger", integration_id="google_calendar", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -160,12 +167,16 @@ class CalendarTriggerHandler(TriggerHandler):
                 try:
                     GoogleCalendarEventCreatedPayload.model_validate(data)
                 except Exception as e:
-                    log.debug(f"Calendar event created payload validation failed: {e}")
+                    log.debug(
+                        f"{LogTag.TRIGGER} Calendar event created payload validation failed: {e}"
+                    )
             elif "event_starting_soon" in event_type.lower():
                 try:
                     GoogleCalendarEventStartingSoonPayload.model_validate(data)
                 except Exception as e:
-                    log.debug(f"Calendar event starting soon payload validation failed: {e}")
+                    log.debug(
+                        f"{LogTag.TRIGGER} Calendar event starting soon payload validation failed: {e}"
+                    )
 
             cursor = workflows_collection.find(query)
             workflows: list[Workflow] = []
@@ -180,13 +191,13 @@ class CalendarTriggerHandler(TriggerHandler):
                     workflows.append(workflow)
 
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
     async def _fetch_user_calendars(self, user_id: str) -> list[str]:
@@ -205,7 +216,7 @@ class CalendarTriggerHandler(TriggerHandler):
             return ["primary"]
 
         except Exception as e:
-            log.error(f"Failed to fetch calendars for user {user_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Failed to fetch calendars for user {user_id}: {e}")
             return ["primary"]  # Fallback to primary calendar
 
 

--- a/apps/api/app/services/triggers/handlers/github.py
+++ b/apps/api/app/services/triggers/handlers/github.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from composio.types import ToolExecutionResponse
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import (
     GitHubCommitEventPayload,
@@ -83,7 +84,7 @@ class GitHubTriggerHandler(TriggerHandler):
             user_id=user_id,
         )
         if not tool:
-            log.error("GitHub list repositories tool not found")
+            log.error(f"{LogTag.TRIGGER} GitHub list repositories tool not found")
             return []
 
         # Invoke tool with typed input
@@ -103,7 +104,7 @@ class GitHubTriggerHandler(TriggerHandler):
 
         # Check response status
         if not result["successful"]:
-            log.error(f"GitHub API error: {result['error']}")
+            log.error(f"{LogTag.TRIGGER} GitHub API error: {result['error']}")
             return []
 
         # Extract and parse data
@@ -121,7 +122,7 @@ class GitHubTriggerHandler(TriggerHandler):
             if repo.full_name:
                 options.append({"value": repo.full_name, "label": repo.full_name})
 
-        log.info(f"Returning {len(options)} GitHub repository options")
+        log.info(f"{LogTag.TRIGGER} Returning {len(options)} GitHub repository options")
         return options
 
     async def register(
@@ -205,7 +206,7 @@ class GitHubTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a GitHub trigger event."""
-        log.set(trigger={"provider": "github", "event": event_type})
+        log.set_ns("trigger", integration_id="github", trigger_type=event_type)
         try:
             # Validate payload based on event type
             try:
@@ -218,7 +219,7 @@ class GitHubTriggerHandler(TriggerHandler):
                 elif "issue_added" in event_type.lower():
                     GitHubIssueAddedEventPayload.model_validate(data)
             except Exception as e:
-                log.debug(f"GitHub payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} GitHub payload validation failed: {e}")
 
             query = {
                 "activated": True,
@@ -238,13 +239,13 @@ class GitHubTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/gmail.py
+++ b/apps/api/app/services/triggers/handlers/gmail.py
@@ -6,6 +6,7 @@ Handles Gmail new message trigger processing.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import GmailNewMessagePayload
 from app.models.trigger_configs import GmailNewMessageConfig
@@ -54,7 +55,7 @@ class GmailTriggerHandler(TriggerHandler):
                 f"but got {type(trigger_data).__name__}"
             )
 
-        log.info(f"Gmail trigger enabled for workflow {workflow_id}")
+        log.info(f"{LogTag.TRIGGER} Gmail trigger enabled for workflow {workflow_id}")
         return []  # No explicit trigger IDs for Gmail
 
     async def find_workflows(
@@ -68,16 +69,16 @@ class GmailTriggerHandler(TriggerHandler):
 
         Both are routed here because they share the GMAIL_NEW_GMAIL_MESSAGE Composio event.
         """
-        log.set(trigger={"provider": "gmail", "event": event_type})
+        log.set_ns("trigger", integration_id="gmail", trigger_type=event_type)
         try:
             try:
                 GmailNewMessagePayload.model_validate(data)
             except Exception as e:
-                log.debug(f"Gmail payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} Gmail payload validation failed: {e}")
 
             user_id = data.get("user_id")
             if not user_id:
-                log.error("No user_id in Gmail webhook data")
+                log.error(f"{LogTag.TRIGGER} No user_id in Gmail webhook data")
                 return []
 
             workflows: list[Workflow] = []
@@ -109,12 +110,12 @@ class GmailTriggerHandler(TriggerHandler):
                             del workflow_doc["_id"]
                         workflows.append(Workflow(**workflow_doc))
                     except Exception as e:
-                        log.error(f"Error processing workflow: {e}")
+                        log.error(f"{LogTag.TRIGGER} Error processing workflow: {e}")
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding Gmail workflows: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding Gmail workflows: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/gmail_poll.py
+++ b/apps/api/app/services/triggers/handlers/gmail_poll.py
@@ -13,6 +13,7 @@ rather than fire on every single incoming email.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.models.trigger_configs import GmailPollInboxConfig
 from app.models.workflow_models import TriggerConfig, TriggerType, Workflow
 from app.services.triggers.base import TriggerHandler
@@ -92,7 +93,7 @@ class GmailPollTriggerHandler(TriggerHandler):
 
         Matches by composio trigger_id, same pattern as CalendarTriggerHandler.
         """
-        log.set(trigger={"provider": "gmail", "event": event_type})
+        log.set_ns("trigger", integration_id="gmail", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -106,7 +107,9 @@ class GmailPollTriggerHandler(TriggerHandler):
             )
 
         except Exception as e:
-            log.error(f"Error finding workflows for gmail_poll trigger {trigger_id}: {e}")
+            log.error(
+                f"{LogTag.TRIGGER} Error finding workflows for gmail_poll trigger {trigger_id}: {e}"
+            )
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/google_docs.py
+++ b/apps/api/app/services/triggers/handlers/google_docs.py
@@ -4,6 +4,7 @@ Google Docs trigger handler.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import GoogleDocsPageAddedPayload
 from app.models.trigger_configs import (
@@ -93,7 +94,7 @@ class GoogleDocsTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a Google Docs trigger event."""
-        log.set(trigger={"provider": "google_docs", "event": event_type})
+        log.set_ns("trigger", integration_id="google_docs", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -106,7 +107,7 @@ class GoogleDocsTriggerHandler(TriggerHandler):
             try:
                 GoogleDocsPageAddedPayload.model_validate(data)
             except Exception as e:
-                log.debug(f"Google Docs payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} Google Docs payload validation failed: {e}")
 
             cursor = workflows_collection.find(query)
             workflows: list[Workflow] = []
@@ -119,13 +120,13 @@ class GoogleDocsTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/google_sheets.py
+++ b/apps/api/app/services/triggers/handlers/google_sheets.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from composio.types import ToolExecutionResponse
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import (
     GoogleSheetsGetSheetNamesData,
@@ -75,7 +76,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
                     user_id=user_id,
                 )
                 if not tool:
-                    log.error("Google Sheets search spreadsheets tool not found")
+                    log.error(f"{LogTag.TRIGGER} Google Sheets search spreadsheets tool not found")
                     return []
 
                 # Invoke tool with typed input
@@ -93,7 +94,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
 
                 # Check response status
                 if not result["successful"]:
-                    log.error(f"Google Sheets API error: {result['error']}")
+                    log.error(f"{LogTag.TRIGGER} Google Sheets API error: {result['error']}")
                     return []
 
                 # Extract and parse data
@@ -116,7 +117,9 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
 
                     options.append({"value": sheet.id, "label": label})
 
-                log.info(f"Returning {len(options)} Google Sheets spreadsheet options")
+                log.info(
+                    f"{LogTag.TRIGGER} Returning {len(options)} Google Sheets spreadsheet options"
+                )
                 return options
 
             # Get sheets grouped by spreadsheet (cascading)
@@ -126,7 +129,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
                     user_id=user_id,
                 )
                 if not tool:
-                    log.error("Google Sheets get sheet names tool not found")
+                    log.error(f"{LogTag.TRIGGER} Google Sheets get sheet names tool not found")
                     return []
 
                 # Fetch sheet names for all spreadsheets in parallel
@@ -142,7 +145,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
 
                     if not sheets_result["successful"]:
                         log.error(
-                            f"Failed to get sheet names for {spreadsheet_id}: "
+                            f"{LogTag.TRIGGER} Failed to get sheet names for {spreadsheet_id}: "
                             f"{sheets_result['error']}"
                         )
                         return None
@@ -170,13 +173,13 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
                 # Filter out None/errors and collect results
                 grouped_results = [r for r in results if isinstance(r, dict) and r is not None]
 
-                log.info(f"Returning {len(grouped_results)} grouped sheet options")
+                log.info(f"{LogTag.TRIGGER} Returning {len(grouped_results)} grouped sheet options")
                 return grouped_results
 
             return []
 
         except Exception as e:
-            log.error(f"Failed to get Google Sheets options for {field_name}: {e}")
+            log.error(f"{LogTag.TRIGGER} Failed to get Google Sheets options for {field_name}: {e}")
             return []
 
     async def register(
@@ -196,7 +199,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
         """
         composio_slug = self.TRIGGER_TO_COMPOSIO.get(trigger_name)
         if not composio_slug:
-            log.error(f"Unknown Google Sheets trigger: {trigger_name}")
+            log.error(f"{LogTag.TRIGGER} Unknown Google Sheets trigger: {trigger_name}")
             raise TriggerRegistrationError(
                 f"Unknown Google Sheets trigger: {trigger_name}",
                 trigger_name,
@@ -264,7 +267,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a Google Sheets trigger event."""
-        log.set(trigger={"provider": "google_sheets", "event": event_type})
+        log.set_ns("trigger", integration_id="google_sheets", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -281,7 +284,7 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
                 elif "new_sheet" in event_type.lower():
                     GoogleSheetsNewSheetAddedPayload.model_validate(data)
             except Exception as e:
-                log.debug(f"Google Sheets payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} Google Sheets payload validation failed: {e}")
 
             cursor = workflows_collection.find(query)
             workflows: list[Workflow] = []
@@ -294,13 +297,13 @@ class GoogleSheetsTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/linear.py
+++ b/apps/api/app/services/triggers/handlers/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from composio.types import ToolExecutionResponse
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import (
     LinearCommentAddedPayload,
@@ -69,7 +70,7 @@ class LinearTriggerHandler(TriggerHandler):
         if field_name == "team_id":
             tool = composio_service.get_tool("LINEAR_GET_ALL_LINEAR_TEAMS", user_id=user_id)
             if not tool:
-                log.error("Linear get all teams tool not found")
+                log.error(f"{LogTag.TRIGGER} Linear get all teams tool not found")
                 return []
 
             # Invoke the tool
@@ -77,7 +78,7 @@ class LinearTriggerHandler(TriggerHandler):
 
             # Check response status
             if not result["successful"]:
-                log.error(f"Linear API error: {result['error']}")
+                log.error(f"{LogTag.TRIGGER} Linear API error: {result['error']}")
                 return []
 
             # Extract and parse data
@@ -93,7 +94,7 @@ class LinearTriggerHandler(TriggerHandler):
                     continue
                 options.append({"value": team.id, "label": team.name})
 
-            log.info(f"Returning {len(options)} Linear team options")
+            log.info(f"{LogTag.TRIGGER} Returning {len(options)} Linear team options")
             return options
 
         return []
@@ -160,7 +161,7 @@ class LinearTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a Linear trigger event."""
-        log.set(trigger={"provider": "linear", "event": event_type})
+        log.set_ns("trigger", integration_id="linear", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -176,7 +177,7 @@ class LinearTriggerHandler(TriggerHandler):
                 elif "comment_added" in event_type.lower():
                     LinearCommentAddedPayload.model_validate(data)
             except Exception as e:
-                log.debug(f"Linear payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} Linear payload validation failed: {e}")
 
             cursor = workflows_collection.find(query)
             workflows: list[Workflow] = []
@@ -189,13 +190,13 @@ class LinearTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/notion.py
+++ b/apps/api/app/services/triggers/handlers/notion.py
@@ -7,6 +7,7 @@ Handles Notion-specific trigger logic.
 import asyncio
 from typing import Any, Literal
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import (
     NotionAllPageEventsPayload,
@@ -72,7 +73,7 @@ class NotionTriggerHandler(TriggerHandler):
             # Use NOTION_FETCH_DATA tool
             tool = composio_service.get_tool("NOTION_FETCH_DATA", user_id=user_id)
             if not tool:
-                log.error("Notion FETCH_DATA tool not found")
+                log.error(f"{LogTag.TRIGGER} Notion FETCH_DATA tool not found")
                 return []
 
             # Determine fetch_type based on field_name
@@ -82,7 +83,7 @@ class NotionTriggerHandler(TriggerHandler):
             elif field_name == "page_id":
                 fetch_type = "pages"
             else:
-                log.warning(f"Unknown Notion field '{field_name}', fetching all")
+                log.warning(f"{LogTag.TRIGGER} Unknown Notion field '{field_name}', fetching all")
                 fetch_type = "all"
 
             # Invoke tool with typed input
@@ -92,12 +93,12 @@ class NotionTriggerHandler(TriggerHandler):
                 query=kwargs.get("search"),
             )
 
-            log.debug(f"Notion fetch input: {input_model.model_dump()}")
+            log.debug(f"{LogTag.TRIGGER} Notion fetch input: {input_model.model_dump()}")
 
             result = await asyncio.to_thread(tool.invoke, input_model.model_dump(exclude_none=True))
 
             if not result["successful"]:
-                log.error(f"Notion API error: {result['error']}")
+                log.error(f"{LogTag.TRIGGER} Notion API error: {result['error']}")
                 return []
 
             # Extract and parse data
@@ -112,11 +113,11 @@ class NotionTriggerHandler(TriggerHandler):
                 label = item.title or "Untitled"
                 options.append({"value": item.id, "label": label})
 
-            log.info(f"Returning {len(options)} Notion {field_name} options")
+            log.info(f"{LogTag.TRIGGER} Returning {len(options)} Notion {field_name} options")
             return options
 
         except Exception as e:
-            log.error(f"Failed to get Notion options for {field_name}: {e}")
+            log.error(f"{LogTag.TRIGGER} Failed to get Notion options for {field_name}: {e}")
             return []
 
     async def register(
@@ -155,7 +156,7 @@ class NotionTriggerHandler(TriggerHandler):
             database_ids = trigger_data.database_ids
 
             if not database_ids:
-                log.warning("No database IDs provided for notion_new_page_in_db")
+                log.warning(f"{LogTag.TRIGGER} No database IDs provided for notion_new_page_in_db")
                 return []
 
             for database_id in database_ids:
@@ -170,7 +171,7 @@ class NotionTriggerHandler(TriggerHandler):
             page_ids = trigger_data.page_ids
 
             if not page_ids:
-                log.warning("No page IDs provided for notion_page_updated")
+                log.warning(f"{LogTag.TRIGGER} No page IDs provided for notion_page_updated")
                 return []
 
             for page_id in page_ids:
@@ -202,7 +203,7 @@ class NotionTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a Notion trigger event."""
-        log.set(trigger={"provider": "notion", "event": event_type})
+        log.set_ns("trigger", integration_id="notion", trigger_type=event_type)
         try:
             # Match by specific trigger ID since these are manually registered
             query = {
@@ -222,7 +223,7 @@ class NotionTriggerHandler(TriggerHandler):
                 elif "all_page_events" in event_type.lower():
                     NotionAllPageEventsPayload.model_validate(data)
             except Exception as e:
-                log.debug(f"Notion payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} Notion payload validation failed: {e}")
 
             cursor = workflows_collection.find(query)
             workflows: list[Workflow] = []
@@ -235,13 +236,13 @@ class NotionTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/handlers/slack.py
+++ b/apps/api/app/services/triggers/handlers/slack.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from composio.types import ToolExecutionResponse
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.composio_schemas import (
     SlackChannelCreatedPayload,
@@ -154,7 +155,7 @@ class SlackTriggerHandler(TriggerHandler):
             if isinstance(result, Exception):
                 has_failure = True
                 failure_message = str(result)
-                log.error(f"Slack trigger registration failed: {result}")
+                log.error(f"{LogTag.TRIGGER} Slack trigger registration failed: {result}")
             elif isinstance(result, list):
                 successful_ids.extend(result)
 
@@ -162,7 +163,7 @@ class SlackTriggerHandler(TriggerHandler):
         if has_failure:
             if successful_ids:
                 log.warning(
-                    f"Rolling back {len(successful_ids)} Slack triggers due to partial failure"
+                    f"{LogTag.TRIGGER} Rolling back {len(successful_ids)} Slack triggers due to partial failure"
                 )
                 await self.unregister(user_id, successful_ids)
 
@@ -187,18 +188,20 @@ class SlackTriggerHandler(TriggerHandler):
             )
 
             if result and hasattr(result, "trigger_id"):
-                log.info(f"Registered {composio_slug} for user {user_id}: {result.trigger_id}")
+                log.info(
+                    f"{LogTag.TRIGGER} Registered {composio_slug} for user {user_id}: {result.trigger_id}"
+                )
                 return [result.trigger_id]
             return []
         except Exception as e:
-            log.error(f"Failed to register Slack trigger {composio_slug}: {e}")
+            log.error(f"{LogTag.TRIGGER} Failed to register Slack trigger {composio_slug}: {e}")
             return []
 
     async def find_workflows(
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a Slack trigger event."""
-        log.set(trigger={"provider": "slack", "event": event_type})
+        log.set_ns("trigger", integration_id="slack", trigger_type=event_type)
         try:
             # Validate payload based on event/trigger type
             try:
@@ -207,7 +210,7 @@ class SlackTriggerHandler(TriggerHandler):
                 elif "message" in event_type.lower() or "message" in trigger_id:
                     SlackReceiveMessagePayload.model_validate(data)
             except Exception as e:
-                log.debug(f"Slack payload validation failed: {e}")
+                log.debug(f"{LogTag.TRIGGER} Slack payload validation failed: {e}")
 
             query = {
                 "activated": True,
@@ -254,19 +257,19 @@ class SlackTriggerHandler(TriggerHandler):
                         # If channels specified and message not in list, skip
                         if selected_channels and message_channel not in selected_channels:
                             log.debug(
-                                f"Message channel {message_channel} not in selected channels for workflow {workflow.id}"
+                                f"{LogTag.TRIGGER} Message channel {message_channel} not in selected channels for workflow {workflow.id}"
                             )
                             continue
 
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
     async def get_config_options(
@@ -287,7 +290,7 @@ class SlackTriggerHandler(TriggerHandler):
                 # Use SLACK_LIST_ALL_CHANNELS with pagination support
                 tool = composio_service.get_tool("SLACK_LIST_ALL_CHANNELS", user_id=user_id)
                 if not tool:
-                    log.error("Slack list all channels tool not found")
+                    log.error(f"{LogTag.TRIGGER} Slack list all channels tool not found")
                     return []
 
                 all_channels = []
@@ -311,7 +314,7 @@ class SlackTriggerHandler(TriggerHandler):
 
                     # Check response status
                     if not result["successful"]:
-                        log.error(f"Slack API error: {result['error']}")
+                        log.error(f"{LogTag.TRIGGER} Slack API error: {result['error']}")
                         break
 
                     data = SlackListAllChannelsData.model_validate(result["data"])
@@ -346,11 +349,11 @@ class SlackTriggerHandler(TriggerHandler):
 
                     page_count += 1
 
-                log.info(f"Returning {len(all_channels)} Slack channel options")
+                log.info(f"{LogTag.TRIGGER} Returning {len(all_channels)} Slack channel options")
                 return all_channels
 
             except Exception as e:
-                log.error(f"Failed to fetch Slack channels: {e}")
+                log.error(f"{LogTag.TRIGGER} Failed to fetch Slack channels: {e}")
                 return []
 
         return []

--- a/apps/api/app/services/triggers/handlers/todoist.py
+++ b/apps/api/app/services/triggers/handlers/todoist.py
@@ -4,6 +4,7 @@ Todoist trigger handler.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.trigger_configs import TodoistNewTaskCreatedConfig
 from app.models.workflow_models import TriggerConfig, TriggerType, Workflow
@@ -74,7 +75,7 @@ class TodoistTriggerHandler(TriggerHandler):
         self, event_type: str, trigger_id: str, data: dict[str, Any]
     ) -> list[Workflow]:
         """Find workflows matching a Todoist trigger event."""
-        log.set(trigger={"provider": "todoist", "event": event_type})
+        log.set_ns("trigger", integration_id="todoist", trigger_type=event_type)
         try:
             query = {
                 "activated": True,
@@ -94,13 +95,13 @@ class TodoistTriggerHandler(TriggerHandler):
                     workflow = Workflow(**workflow_doc)
                     workflows.append(workflow)
                 except Exception as e:
-                    log.error(f"Error processing workflow document: {e}")
+                    log.error(f"{LogTag.TRIGGER} Error processing workflow document: {e}")
                     continue
 
             return workflows
 
         except Exception as e:
-            log.error(f"Error finding workflows for trigger {trigger_id}: {e}")
+            log.error(f"{LogTag.TRIGGER} Error finding workflows for trigger {trigger_id}: {e}")
             return []
 
 

--- a/apps/api/app/services/triggers/registry.py
+++ b/apps/api/app/services/triggers/registry.py
@@ -5,8 +5,9 @@ Maps trigger names and event types to their handlers.
 Provides plug-and-play registration for new trigger handlers.
 """
 
+from app.constants.log_tags import LogTag
 from app.services.triggers.base import TriggerHandler
-from shared.py.wide_events import log
+from shared.py.wide_events import TriggerContext, log
 
 
 class TriggerRegistry:
@@ -29,20 +30,24 @@ class TriggerRegistry:
             operation="register",
             handler=type(handler).__name__,
             trigger_names=list(handler.trigger_names),
+            trigger=TriggerContext(
+                operation="register",
+                result_count=len(handler.trigger_names),
+            ),
         )
         # Register by trigger names
         for name in handler.trigger_names:
             if name in self._name_handlers:
-                log.warning(f"Overwriting handler for trigger: {name}")
+                log.warning(f"{LogTag.TRIGGER} Overwriting handler for trigger: {name}")
             self._name_handlers[name] = handler
-            log.info(f"Registered handler for trigger: {name}")
+            log.info(f"{LogTag.TRIGGER} Registered handler for trigger: {name}")
 
         # Register by event types
         for event_type in handler.event_types:
             if event_type in self._event_handlers:
-                log.warning(f"Overwriting handler for event: {event_type}")
+                log.warning(f"{LogTag.TRIGGER} Overwriting handler for event: {event_type}")
             self._event_handlers[event_type] = handler
-            log.info(f"Registered handler for event: {event_type}")
+            log.info(f"{LogTag.TRIGGER} Registered handler for event: {event_type}")
 
     def get_by_trigger_name(self, trigger_name: str) -> TriggerHandler | None:
         """Get handler by trigger name (for registration)."""

--- a/apps/api/app/services/workflow/context_extractor.py
+++ b/apps/api/app/services/workflow/context_extractor.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from app.agents.core.subagents.registry import get_subagent_by_id, resolve_subagent_id
 from app.config.oauth_config import get_toolkit_to_integration_map
+from app.constants.log_tags import LogTag
 from app.utils.agent_utils import parse_subagent_id
 from shared.py.wide_events import log
 
@@ -74,13 +75,13 @@ class WorkflowContextExtractor:
         try:
             messages = await cls._fetch_messages(thread_id)
             if not messages:
-                log.warning(f"No messages found for thread {thread_id}")
+                log.warning(f"{LogTag.WORKFLOW} No messages found for thread {thread_id}")
                 return None
 
             return cls._build_context(messages, max_output_chars)
 
         except Exception as e:
-            log.error(f"Error extracting from thread {thread_id}: {e}")
+            log.error(f"{LogTag.WORKFLOW} Error extracting from thread {thread_id}: {e}")
             return None
 
     @classmethod

--- a/apps/api/app/services/workflow/conversation_service.py
+++ b/apps/api/app/services/workflow/conversation_service.py
@@ -2,6 +2,7 @@
 Workflow conversation service for managing single conversations per workflow.
 """
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import conversations_collection
 from app.models.chat_models import MessageModel, SystemPurpose, UpdateMessagesRequest
 from app.services.conversation_service import (
@@ -88,5 +89,7 @@ async def add_workflow_execution_messages(
         await update_messages(messages_request, user_dict)
 
     except Exception as e:
-        log.error(f"Failed to store messages in conversation {conversation_id}: {e!s}")
+        log.error(
+            f"{LogTag.WORKFLOW} Failed to store messages in conversation {conversation_id}: {e!s}"
+        )
         raise

--- a/apps/api/app/services/workflow/execution_service.py
+++ b/apps/api/app/services/workflow/execution_service.py
@@ -7,6 +7,7 @@ Service functions for tracking workflow execution history.
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflow_executions_collection
 from app.models.workflow_execution_models import (
     WorkflowExecution,
@@ -52,7 +53,9 @@ async def create_execution(
             "trigger_type": trigger_type,
         }
     )
-    log.info(f"Created execution {execution.execution_id} for workflow {workflow_id}")
+    log.info(
+        f"{LogTag.WORKFLOW} Created execution {execution.execution_id} for workflow {workflow_id}"
+    )
 
     return execution
 
@@ -82,7 +85,7 @@ async def complete_execution(
     # Calculate duration
     execution = await workflow_executions_collection.find_one({"execution_id": execution_id})
     if not execution:
-        log.warning(f"Execution {execution_id} not found for completion")
+        log.warning(f"{LogTag.WORKFLOW} Execution {execution_id} not found for completion")
         return False
 
     started_at = execution.get("started_at")
@@ -118,7 +121,7 @@ async def complete_execution(
         }
     )
     log.info(
-        f"Completed execution {execution_id} with status {status}, duration {duration_seconds}s"
+        f"{LogTag.WORKFLOW} Completed execution {execution_id} with status {status}, duration {duration_seconds}s"
     )
 
     return result.modified_count > 0

--- a/apps/api/app/services/workflow/generation_service.py
+++ b/apps/api/app/services/workflow/generation_service.py
@@ -12,6 +12,7 @@ from app.agents.prompts.workflow_prompts import (
 from app.agents.templates.workflow_template import WORKFLOW_GENERATION_TEMPLATE
 from app.agents.tools.core.registry import get_tool_registry
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.models.workflow_models import (
     GeneratedPromptOutput,
     GeneratedStep,
@@ -155,9 +156,9 @@ class WorkflowGenerationService:
         Raises:
             RuntimeError: If generation fails after all retry attempts.
         """
-        log.info(f"[WorkflowGen] ========== START: {title} ==========")
+        log.info(f"{LogTag.WORKFLOW} ========== START: {title} ==========")
 
-        log.info("[WorkflowGen] Getting tool registry...")
+        log.info(f"{LogTag.WORKFLOW} Getting tool registry...")
         tool_registry = await get_tool_registry()
 
         normalized_slugs = _normalize_slugs(selected_integrations)
@@ -199,7 +200,7 @@ class WorkflowGenerationService:
         )
 
         log.info(
-            f"[WorkflowGen] Categories: {len(category_names)} "
+            f"{LogTag.WORKFLOW} Categories: {len(category_names)} "
             f"(filtered={filter_active}, slugs={normalized_slugs})"
         )
 
@@ -217,11 +218,11 @@ class WorkflowGenerationService:
                 structured_llm = llm.with_structured_output(GeneratedWorkflow)
             except (NotImplementedError, TypeError):
                 log.info(
-                    "[WorkflowGen] LLM does not support with_structured_output, "
+                    f"{LogTag.WORKFLOW} LLM does not support with_structured_output, "
                     "using text parsing fallback"
                 )
 
-        log.info("[WorkflowGen] Formatting prompt...")
+        log.info(f"{LogTag.WORKFLOW} Formatting prompt...")
         prompt_context = prompt
         if description:
             prompt_context = (
@@ -243,15 +244,15 @@ class WorkflowGenerationService:
             tools="\n".join(tools_with_categories),
             categories=", ".join(category_names),
         )
-        log.info(f"[WorkflowGen] Prompt: {len(formatted_prompt)} chars")
+        log.info(f"{LogTag.WORKFLOW} Prompt: {len(formatted_prompt)} chars")
 
         last_error: Exception | None = None
         for attempt in range(_MAX_GENERATION_ATTEMPTS):
             try:
                 if attempt > 0:
-                    log.info(f"[WorkflowGen] Retry attempt {attempt} for: {title}")
+                    log.info(f"{LogTag.WORKFLOW} Retry attempt {attempt} for: {title}")
 
-                log.info("[WorkflowGen] === CALLING LLM ===")
+                log.info(f"{LogTag.WORKFLOW} === CALLING LLM ===")
 
                 if structured_llm:
                     result = await structured_llm.ainvoke(formatted_prompt)
@@ -268,10 +269,10 @@ class WorkflowGenerationService:
                     )
                     llm_response = await llm.ainvoke(fallback_prompt)
                     response_content = getattr(llm_response, "content", str(llm_response))
-                    log.debug(f"[WorkflowGen] Raw response ({len(response_content)} chars)")
+                    log.debug(f"{LogTag.WORKFLOW} Raw response ({len(response_content)} chars)")
                     result = _parse_workflow_response(response_content)
 
-                log.info("[WorkflowGen] === LLM RESPONDED ===")
+                log.info(f"{LogTag.WORKFLOW} === LLM RESPONDED ===")
 
                 if not result or not result.steps:
                     raise ValueError(
@@ -281,17 +282,17 @@ class WorkflowGenerationService:
 
                 steps_data = enrich_steps(result.steps)
 
-                log.info(f"[WorkflowGen] ========== DONE: {len(steps_data)} steps ==========")
+                log.info(f"{LogTag.WORKFLOW} ========== DONE: {len(steps_data)} steps ==========")
                 return steps_data
 
             except Exception as e:
                 last_error = e
                 log.warning(
-                    f"[WorkflowGen] Attempt {attempt + 1}/{_MAX_GENERATION_ATTEMPTS} failed: {e}"
+                    f"{LogTag.WORKFLOW} Attempt {attempt + 1}/{_MAX_GENERATION_ATTEMPTS} failed: {e}"
                 )
 
         log.error(
-            f"[WorkflowGen] ========== FAILED after {_MAX_GENERATION_ATTEMPTS} "
+            f"{LogTag.WORKFLOW} ========== FAILED after {_MAX_GENERATION_ATTEMPTS} "
             f"attempts: {last_error} =========="
         )
         raise RuntimeError(

--- a/apps/api/app/services/workflow/notifications.py
+++ b/apps/api/app/services/workflow/notifications.py
@@ -10,6 +10,7 @@ their own module to keep the executor runner free of a circular import on
 from datetime import UTC, datetime
 
 from app.constants.general import NEW_MESSAGE_BREAKER
+from app.constants.log_tags import LogTag
 from app.constants.notifications import pick_workflow_done_copy
 from app.models.notification.notification_models import (
     ActionConfig,
@@ -86,9 +87,11 @@ async def send_workflow_completion_notification(
                 metadata={"workflow_id": workflow_id, "conversation_id": conversation_id},
             )
         )
-        log.info(f"Workflow completion notification sent for {workflow_id}")
+        log.info(f"{LogTag.WORKFLOW} Workflow completion notification sent for {workflow_id}")
     except Exception as e:
-        log.error(f"Failed to send workflow completion notification for {workflow_id}: {e}")
+        log.error(
+            f"{LogTag.WORKFLOW} Failed to send workflow completion notification for {workflow_id}: {e}"
+        )
 
 
 async def send_workflow_failure_notification(
@@ -114,6 +117,8 @@ async def send_workflow_failure_notification(
                 metadata={"workflow_id": workflow_id},
             )
         )
-        log.info(f"Workflow failure notification sent for {workflow_id}")
+        log.info(f"{LogTag.WORKFLOW} Workflow failure notification sent for {workflow_id}")
     except Exception as e:
-        log.error(f"Failed to send workflow failure notification for {workflow_id}: {e}")
+        log.error(
+            f"{LogTag.WORKFLOW} Failed to send workflow failure notification for {workflow_id}: {e}"
+        )

--- a/apps/api/app/services/workflow/queue_service.py
+++ b/apps/api/app/services/workflow/queue_service.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 
+from app.constants.log_tags import LogTag
 from app.utils.redis_utils import RedisPoolManager
 from shared.py.wide_events import log
 
@@ -20,13 +21,17 @@ class WorkflowQueueService:
 
             if job:
                 log.set(workflow={"id": workflow_id, "status": "generation_queued"})
-                log.info(f"Queued workflow generation for {workflow_id} with job ID {job.job_id}")
+                log.info(
+                    f"{LogTag.WORKFLOW} Queued workflow generation for {workflow_id} with job ID {job.job_id}"
+                )
                 return True
-            log.error(f"Failed to queue workflow generation for {workflow_id}")
+            log.error(f"{LogTag.WORKFLOW} Failed to queue workflow generation for {workflow_id}")
             return False
 
         except Exception as e:
-            log.error(f"Error queuing workflow generation for {workflow_id}: {e!s}")
+            log.error(
+                f"{LogTag.WORKFLOW} Error queuing workflow generation for {workflow_id}: {e!s}"
+            )
             return False
 
     @staticmethod
@@ -60,7 +65,7 @@ class WorkflowQueueService:
                 # A job with this id is already queued or running — the duplicate
                 # enqueue was deduped. That's the intended outcome, not a failure.
                 log.info(
-                    f"Workflow execution already queued for {workflow_id}; "
+                    f"{LogTag.WORKFLOW} Workflow execution already queued for {workflow_id}; "
                     f"deduped duplicate enqueue (job ID {job_id})"
                 )
                 return True
@@ -71,11 +76,15 @@ class WorkflowQueueService:
                 queue_mode="immediate",
                 defer_seconds=0,
             )
-            log.info(f"Queued workflow execution for {workflow_id} with job ID {job.job_id}")
+            log.info(
+                f"{LogTag.WORKFLOW} Queued workflow execution for {workflow_id} with job ID {job.job_id}"
+            )
             return True
 
         except Exception as e:
-            log.error(f"Error queuing workflow execution for {workflow_id}: {e!s}")
+            log.error(
+                f"{LogTag.WORKFLOW} Error queuing workflow execution for {workflow_id}: {e!s}"
+            )
             return False
 
     @staticmethod
@@ -110,13 +119,17 @@ class WorkflowQueueService:
                     ex=300,  # 5 minute TTL
                 )
 
-                log.info(f"Queued todo workflow generation for {todo_id} with job ID {job.job_id}")
+                log.info(
+                    f"{LogTag.WORKFLOW} Queued todo workflow generation for {todo_id} with job ID {job.job_id}"
+                )
                 return True
-            log.error(f"Failed to queue todo workflow generation for {todo_id}")
+            log.error(f"{LogTag.WORKFLOW} Failed to queue todo workflow generation for {todo_id}")
             return False
 
         except Exception as e:
-            log.error(f"Error queuing todo workflow generation for {todo_id}: {e!s}")
+            log.error(
+                f"{LogTag.WORKFLOW} Error queuing todo workflow generation for {todo_id}: {e!s}"
+            )
             return False
 
     @staticmethod
@@ -136,4 +149,4 @@ class WorkflowQueueService:
             pool = await RedisPoolManager.get_pool()
             await pool.delete(f"todo_workflow_generating:{todo_id}")
         except Exception as e:
-            log.warning(f"Failed to clear generating flag for {todo_id}: {e}")
+            log.warning(f"{LogTag.WORKFLOW} Failed to clear generating flag for {todo_id}: {e}")

--- a/apps/api/app/services/workflow/scheduler.py
+++ b/apps/api/app/services/workflow/scheduler.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from arq.connections import RedisSettings
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.scheduler_models import (
     BaseScheduledTask,
@@ -106,7 +107,7 @@ class WorkflowScheduler(BaseSchedulerService):
 
             workflow_doc = await workflows_collection.find_one(query)
             if not workflow_doc:
-                log.warning(f"Workflow {task_id} not found")
+                log.warning(f"{LogTag.WORKFLOW} Workflow {task_id} not found")
                 return None
 
             # Transform MongoDB document to Workflow object
@@ -116,7 +117,7 @@ class WorkflowScheduler(BaseSchedulerService):
 
             return Workflow(**workflow_doc)
         except Exception as e:
-            log.error(f"Error fetching workflow {task_id}: {e}")
+            log.error(f"{LogTag.WORKFLOW} Error fetching workflow {task_id}: {e}")
             return None
 
     async def execute_task(self, task: BaseScheduledTask) -> TaskExecutionResult:
@@ -134,7 +135,7 @@ class WorkflowScheduler(BaseSchedulerService):
             from app.workers.tasks import execute_workflow_as_chat
 
             log.set(workflow={"id": workflow.id, "status": "executing"})
-            log.info(f"Executing workflow {workflow.id}")
+            log.info(f"{LogTag.WORKFLOW} Executing workflow {workflow.id}")
 
             if not workflow.id:
                 raise ValueError("Workflow ID is required for execution")
@@ -148,7 +149,7 @@ class WorkflowScheduler(BaseSchedulerService):
                 message="Workflow executed via scheduler",
             )
         except Exception as e:
-            log.error(f"Error executing workflow {task.id}: {e}")
+            log.error(f"{LogTag.WORKFLOW} Error executing workflow {task.id}: {e}")
             return TaskExecutionResult(success=False, message=f"Workflow execution failed: {e!s}")
 
     async def update_task_status(
@@ -184,13 +185,13 @@ class WorkflowScheduler(BaseSchedulerService):
 
             if result.modified_count > 0:
                 log.set(workflow={"id": task_id, "status": status.value})
-                log.info(f"Updated workflow {task_id} status to {status.value}")
+                log.info(f"{LogTag.WORKFLOW} Updated workflow {task_id} status to {status.value}")
                 return True
-            log.warning(f"No workflow updated for {task_id}")
+            log.warning(f"{LogTag.WORKFLOW} No workflow updated for {task_id}")
             return False
 
         except Exception as e:
-            log.error(f"Error updating workflow {task_id}: {e}")
+            log.error(f"{LogTag.WORKFLOW} Error updating workflow {task_id}: {e}")
             return False
 
     async def get_pending_task(self, current_time: datetime) -> list[BaseScheduledTask]:
@@ -242,16 +243,16 @@ class WorkflowScheduler(BaseSchedulerService):
 
             if success:
                 log.info(
-                    f"Scheduled workflow {workflow_id} for execution at {scheduled_at}"
+                    f"{LogTag.WORKFLOW} Scheduled workflow {workflow_id} for execution at {scheduled_at}"
                     + (f" with repeat '{repeat}'" if repeat else "")
                 )
             else:
-                log.error(f"Failed to schedule workflow {workflow_id}")
+                log.error(f"{LogTag.WORKFLOW} Failed to schedule workflow {workflow_id}")
 
             return success
 
         except Exception as e:
-            log.error(f"Error scheduling workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error scheduling workflow {workflow_id}: {e!s}")
             return False
 
     async def reschedule_workflow(
@@ -274,21 +275,25 @@ class WorkflowScheduler(BaseSchedulerService):
             )
 
             if not db_success:
-                log.error(f"Failed to update workflow {workflow_id} in database")
+                log.error(f"{LogTag.WORKFLOW} Failed to update workflow {workflow_id} in database")
                 return False
 
             # Actually reschedule in ARQ queue
             arq_success = await self.reschedule_task(workflow_id, new_scheduled_at)
 
             if arq_success:
-                log.info(f"Rescheduled workflow {workflow_id} for {new_scheduled_at}")
+                log.info(
+                    f"{LogTag.WORKFLOW} Rescheduled workflow {workflow_id} for {new_scheduled_at}"
+                )
             else:
-                log.error(f"Failed to reschedule workflow {workflow_id} in ARQ queue")
+                log.error(
+                    f"{LogTag.WORKFLOW} Failed to reschedule workflow {workflow_id} in ARQ queue"
+                )
 
             return arq_success
 
         except Exception as e:
-            log.error(f"Error rescheduling workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error rescheduling workflow {workflow_id}: {e!s}")
             return False
 
     async def reap_stale_executing(self) -> int:
@@ -333,7 +338,7 @@ class WorkflowScheduler(BaseSchedulerService):
                 await self.reschedule_task(workflow_id, next_run)
 
             log.warning(
-                f"Reaped workflow {workflow_id} stuck in EXECUTING for {stuck_seconds}s; "
+                f"{LogTag.WORKFLOW} Reaped workflow {workflow_id} stuck in EXECUTING for {stuck_seconds}s; "
                 f"reset to SCHEDULED (next run {next_run})"
             )
             reaped += 1

--- a/apps/api/app/services/workflow/service.py
+++ b/apps/api/app/services/workflow/service.py
@@ -10,6 +10,7 @@ import uuid
 
 from pymongo.errors import DuplicateKeyError
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chromadb import ChromaClient
 from app.db.mongodb.collections import workflows_collection
 from app.decorators.caching import Cacheable
@@ -132,7 +133,7 @@ class WorkflowService:
         # Only handle integration type triggers
         if trigger_config.type != TriggerType.INTEGRATION:
             log.debug(
-                f"Skipping trigger registration: type={trigger_config.type} is not INTEGRATION"
+                f"{LogTag.WORKFLOW} Skipping trigger registration: type={trigger_config.type} is not INTEGRATION"
             )
             return [], True
 
@@ -152,7 +153,7 @@ class WorkflowService:
             connected = await check_integration_status(integration_id, user_id)
             if not connected:
                 log.info(
-                    f"Skipping trigger registration: integration "
+                    f"{LogTag.WORKFLOW} Skipping trigger registration: integration "
                     f"'{integration_id}' not connected for user {user_id}"
                 )
                 return [], False
@@ -197,7 +198,7 @@ class WorkflowService:
                 # request-resolved user timezone only when the schedule didn't carry
                 # one (e.g. the agent-created path), then UTC.
                 timezone_to_use = trigger_config.timezone or user_timezone or "UTC"
-                log.info(f"Creating workflow with timezone: {timezone_to_use}")
+                log.info(f"{LogTag.WORKFLOW} Creating workflow with timezone: {timezone_to_use}")
                 trigger_config.timezone = timezone_to_use
                 if trigger_config.cron_expression:
                     trigger_config.update_next_run(user_timezone=timezone_to_use)
@@ -262,7 +263,7 @@ class WorkflowService:
                     "step_count": len(workflow_steps),
                 }
             )
-            log.info(f"Created pending workflow {workflow_id} for user {user_id}")
+            log.info(f"{LogTag.WORKFLOW} Created pending workflow {workflow_id} for user {user_id}")
 
             # Store in ChromaDB for semantic search (non-critical, don't fail on error)
             try:
@@ -287,7 +288,7 @@ class WorkflowService:
                     ids=[str(workflow.id)],
                 )
             except Exception as e:
-                log.warning(f"Failed to store workflow in ChromaDB: {e}")
+                log.warning(f"{LogTag.WORKFLOW} Failed to store workflow in ChromaDB: {e}")
 
             if not workflow.id:
                 raise ValueError("Workflow ID is required")
@@ -318,7 +319,7 @@ class WorkflowService:
                     }
                 )
                 log.info(
-                    f"Workflow {workflow.id} created inactive — integration for "
+                    f"{LogTag.WORKFLOW} Workflow {workflow.id} created inactive — integration for "
                     f"trigger '{trigger_config.trigger_name}' not connected"
                 )
             else:
@@ -351,7 +352,9 @@ class WorkflowService:
                         "step_count": len(workflow_steps),
                     }
                 )
-                log.info(f"Activated workflow {workflow.id} with {len(trigger_ids)} triggers")
+                log.info(
+                    f"{LogTag.WORKFLOW} Activated workflow {workflow.id} with {len(trigger_ids)} triggers"
+                )
 
                 # Schedule the workflow if it's a scheduled type (activated here).
                 if trigger_config.type == "schedule" and trigger_config.next_run:
@@ -376,27 +379,31 @@ class WorkflowService:
                     return updated_workflow or workflow
                 success = await WorkflowQueueService.queue_workflow_generation(workflow.id, user_id)
                 if not success:
-                    log.error(f"Failed to queue workflow generation for {workflow.id}")
+                    log.error(
+                        f"{LogTag.WORKFLOW} Failed to queue workflow generation for {workflow.id}"
+                    )
             else:
                 log.info(
-                    f"Workflow {workflow.id} created with {len(request.steps)} pre-existing steps, skipping generation"
+                    f"{LogTag.WORKFLOW} Workflow {workflow.id} created with {len(request.steps)} pre-existing steps, skipping generation"
                 )
 
             return workflow
 
         except TriggerRegistrationError as e:
             # Saga compensation: delete the pending workflow
-            log.error(f"Trigger registration failed, rolling back workflow: {e}")
+            log.error(f"{LogTag.WORKFLOW} Trigger registration failed, rolling back workflow: {e}")
             if workflow_id:
                 try:
                     await workflows_collection.delete_one({"_id": workflow_id})
-                    log.info(f"Rolled back workflow {workflow_id}")
+                    log.info(f"{LogTag.WORKFLOW} Rolled back workflow {workflow_id}")
                 except Exception as delete_error:
-                    log.error(f"Failed to rollback workflow {workflow_id}: {delete_error}")
+                    log.error(
+                        f"{LogTag.WORKFLOW} Failed to rollback workflow {workflow_id}: {delete_error}"
+                    )
             raise
 
         except Exception as e:
-            log.error(f"Error creating workflow: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error creating workflow: {e!s}")
             # For other errors, still try to cleanup if workflow was created
             if workflow_id:
                 try:
@@ -408,9 +415,11 @@ class WorkflowService:
                                 user_id, trigger_name, trigger_ids, workflow_id
                             )
                     await workflows_collection.delete_one({"_id": workflow_id})
-                    log.info(f"Rolled back workflow {workflow_id} after error")
+                    log.info(f"{LogTag.WORKFLOW} Rolled back workflow {workflow_id} after error")
                 except Exception as cleanup_error:
-                    log.error(f"Cleanup failed for {workflow_id}: {cleanup_error}")
+                    log.error(
+                        f"{LogTag.WORKFLOW} Cleanup failed for {workflow_id}: {cleanup_error}"
+                    )
             raise
 
     @staticmethod
@@ -430,7 +439,7 @@ class WorkflowService:
             return Workflow(**transformed_doc)
 
         except Exception as e:
-            log.error(f"Error getting workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error getting workflow {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -456,14 +465,16 @@ class WorkflowService:
                     transformed_doc = transform_workflow_document(doc)
                     workflows.append(Workflow(**transformed_doc))
                 except Exception as e:
-                    log.warning(f"Skipping malformed workflow document {doc.get('_id')}: {e}")
+                    log.warning(
+                        f"{LogTag.WORKFLOW} Skipping malformed workflow document {doc.get('_id')}: {e}"
+                    )
                     continue
 
-            log.debug(f"Retrieved {len(workflows)} workflows for user {user_id}")
+            log.debug(f"{LogTag.WORKFLOW} Retrieved {len(workflows)} workflows for user {user_id}")
             return workflows
 
         except Exception as e:
-            log.error(f"Error listing workflows for user {user_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error listing workflows for user {user_id}: {e!s}")
             raise
 
     @staticmethod
@@ -506,7 +517,9 @@ class WorkflowService:
                 # the request-resolved user timezone, then UTC.
                 if new_trigger_config.type == "schedule":
                     timezone_to_use = new_trigger_config.timezone or user_timezone or "UTC"
-                    log.info(f"Updating workflow {workflow_id} with timezone: {timezone_to_use}")
+                    log.info(
+                        f"{LogTag.WORKFLOW} Updating workflow {workflow_id} with timezone: {timezone_to_use}"
+                    )
                     new_trigger_config.timezone = timezone_to_use
                     if new_trigger_config.cron_expression:
                         new_trigger_config.update_next_run(user_timezone=timezone_to_use)
@@ -586,7 +599,7 @@ class WorkflowService:
                 # Compensate: unregister newly created triggers so they don't become orphaned
                 if registered_trigger_ids is not None:
                     log.error(
-                        f"MongoDB update failed for workflow {workflow_id}; "
+                        f"{LogTag.WORKFLOW} MongoDB update failed for workflow {workflow_id}; "
                         f"unregistering {len(registered_trigger_ids)} newly registered triggers"
                     )
                     await TriggerService.unregister_triggers(
@@ -600,11 +613,11 @@ class WorkflowService:
             if result.matched_count == 0:
                 return None
 
-            log.info(f"Updated workflow {workflow_id} for user {user_id}")
+            log.info(f"{LogTag.WORKFLOW} Updated workflow {workflow_id} for user {user_id}")
             return await WorkflowService.get_workflow(workflow_id, user_id)
 
         except Exception as e:
-            log.error(f"Error updating workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error updating workflow {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -629,7 +642,7 @@ class WorkflowService:
                         )
                     else:
                         log.warning(
-                            f"No trigger_name found for workflow {workflow_id}, cannot unregister triggers"
+                            f"{LogTag.WORKFLOW} No trigger_name found for workflow {workflow_id}, cannot unregister triggers"
                         )
 
             result = await workflows_collection.delete_one({"_id": workflow_id, "user_id": user_id})
@@ -638,11 +651,11 @@ class WorkflowService:
                 return False
 
             log.set(workflow={"id": workflow_id, "status": "deleted"})
-            log.info(f"Deleted workflow {workflow_id} for user {user_id}")
+            log.info(f"{LogTag.WORKFLOW} Deleted workflow {workflow_id} for user {user_id}")
             return True
 
         except Exception as e:
-            log.error(f"Error deleting workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error deleting workflow {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -687,7 +700,9 @@ class WorkflowService:
                     "title": workflow.title,
                 }
             )
-            log.info(f"Started execution {execution_id} for workflow {workflow_id}")
+            log.info(
+                f"{LogTag.WORKFLOW} Started execution {execution_id} for workflow {workflow_id}"
+            )
 
             return WorkflowExecutionResponse(
                 execution_id=execution_id,
@@ -695,7 +710,7 @@ class WorkflowService:
             )
 
         except Exception as e:
-            log.error(f"Error executing workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error executing workflow {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -724,7 +739,7 @@ class WorkflowService:
             )
 
         except Exception as e:
-            log.error(f"Error getting workflow status {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error getting workflow status {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -777,7 +792,7 @@ class WorkflowService:
 
             if trigger_ids:
                 log.info(
-                    f"Registered {len(trigger_ids)} Composio triggers for workflow {workflow_id}"
+                    f"{LogTag.WORKFLOW} Registered {len(trigger_ids)} Composio triggers for workflow {workflow_id}"
                 )
 
             # Get trigger_name for potential rollback
@@ -828,16 +843,16 @@ class WorkflowService:
                 )
 
             log.set(workflow={"id": workflow_id, "status": "activated"})
-            log.info(f"Activated workflow {workflow_id} for user {user_id}")
+            log.info(f"{LogTag.WORKFLOW} Activated workflow {workflow_id} for user {user_id}")
             return updated_workflow
 
         except TriggerRegistrationError as e:
             # Trigger registration failed - workflow remains inactive
-            log.error(f"Failed to activate workflow {workflow_id}: {e}")
+            log.error(f"{LogTag.WORKFLOW} Failed to activate workflow {workflow_id}: {e}")
             raise
 
         except Exception as e:
-            log.error(f"Error activating workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error activating workflow {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -864,11 +879,11 @@ class WorkflowService:
                         user_id, trigger_name, trigger_ids, workflow_id
                     )
                     log.info(
-                        f"Unregistered {len(trigger_ids)} Composio triggers for workflow {workflow_id}"
+                        f"{LogTag.WORKFLOW} Unregistered {len(trigger_ids)} Composio triggers for workflow {workflow_id}"
                     )
                 else:
                     log.warning(
-                        f"No trigger_name found for workflow {workflow_id}, cannot unregister triggers"
+                        f"{LogTag.WORKFLOW} No trigger_name found for workflow {workflow_id}, cannot unregister triggers"
                     )
 
             # Update trigger to disabled and clear trigger IDs
@@ -887,11 +902,11 @@ class WorkflowService:
                 return None
 
             log.set(workflow={"id": workflow_id, "status": "deactivated"})
-            log.info(f"Deactivated workflow {workflow_id} for user {user_id}")
+            log.info(f"{LogTag.WORKFLOW} Deactivated workflow {workflow_id} for user {user_id}")
             return await WorkflowService.get_workflow(workflow_id, user_id)
 
         except Exception as e:
-            log.error(f"Error deactivating workflow {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error deactivating workflow {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -941,7 +956,7 @@ class WorkflowService:
             return None
 
         except Exception as e:
-            log.error(f"Error regenerating workflow steps {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error regenerating workflow steps {workflow_id}: {e!s}")
             raise
 
     @staticmethod
@@ -966,15 +981,19 @@ class WorkflowService:
             success = result.matched_count > 0
             if success:
                 log.debug(
-                    f"Updated execution count for workflow {workflow_id}: total +1, successful +{1 if is_successful else 0}"
+                    f"{LogTag.WORKFLOW} Updated execution count for workflow {workflow_id}: total +1, successful +{1 if is_successful else 0}"
                 )
             else:
-                log.warning(f"Failed to update execution count - workflow not found: {workflow_id}")
+                log.warning(
+                    f"{LogTag.WORKFLOW} Failed to update execution count - workflow not found: {workflow_id}"
+                )
 
             return success
 
         except Exception as e:
-            log.error(f"Error updating execution count for workflow {workflow_id}: {e!s}")
+            log.error(
+                f"{LogTag.WORKFLOW} Error updating execution count for workflow {workflow_id}: {e!s}"
+            )
             return False
 
     @staticmethod
@@ -1067,7 +1086,7 @@ class WorkflowService:
             return PublicWorkflowsResponse(workflows=formatted_workflows, total=total)
 
         except Exception as e:
-            log.error(f"Error fetching community workflows: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error fetching community workflows: {e!s}")
             raise
 
     @staticmethod
@@ -1138,7 +1157,7 @@ class WorkflowService:
             return PublicWorkflowsResponse(workflows=formatted_workflows, total=total)
 
         except Exception as e:
-            log.error(f"Error fetching explore workflows: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error fetching explore workflows: {e!s}")
             raise
 
     @staticmethod
@@ -1179,7 +1198,7 @@ class WorkflowService:
             )
 
         except Exception as e:
-            log.error(f"Error generating workflow steps for {workflow_id}: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Error generating workflow steps for {workflow_id}: {e!s}")
             # Persist the error message so the status endpoint can report why it failed
             try:
                 await workflows_collection.find_one_and_update(
@@ -1192,5 +1211,7 @@ class WorkflowService:
                     },
                 )
             except Exception as db_err:
-                log.error(f"Failed to persist error_message for {workflow_id}: {db_err}")
+                log.error(
+                    f"{LogTag.WORKFLOW} Failed to persist error_message for {workflow_id}: {db_err}"
+                )
             await handle_workflow_error(workflow_id, user_id, e)

--- a/apps/api/app/services/workflow/subagent_output.py
+++ b/apps/api/app/services/workflow/subagent_output.py
@@ -15,6 +15,7 @@ from typing import Literal
 from langchain_core.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # =============================================================================
@@ -175,7 +176,7 @@ def parse_subagent_response(response: str) -> ParseResult:
                     try:
                         draft = FinalizedOutput(**data)
                     except Exception as e:
-                        log.warning(f"Failed to parse finalized output: {e}")
+                        log.warning(f"{LogTag.WORKFLOW} Failed to parse finalized output: {e}")
                         return ParseResult(
                             mode="parse_error",
                             parse_error=f"Invalid finalized output: {e!s}",
@@ -197,7 +198,9 @@ def parse_subagent_response(response: str) -> ParseResult:
                             raw_response=response,
                         )
 
-                    log.info(f"Successfully parsed finalized workflow: {draft.title}")
+                    log.info(
+                        f"{LogTag.WORKFLOW} Successfully parsed finalized workflow: {draft.title}"
+                    )
                     return ParseResult(
                         mode="finalized",
                         draft=draft,
@@ -207,7 +210,7 @@ def parse_subagent_response(response: str) -> ParseResult:
                 if output_type == "clarifying":
                     try:
                         clarifying = ClarifyingOutput(**data)
-                        log.info("Successfully parsed clarifying response")
+                        log.info(f"{LogTag.WORKFLOW} Successfully parsed clarifying response")
                         return ParseResult(
                             mode="clarifying",
                             message=clarifying.message,
@@ -226,7 +229,9 @@ def parse_subagent_response(response: str) -> ParseResult:
             continue
 
     # No structured output found - treat as conversational message
-    log.debug("No structured JSON found in subagent response, treating as message")
+    log.debug(
+        f"{LogTag.WORKFLOW} No structured JSON found in subagent response, treating as message"
+    )
     return ParseResult(
         mode="clarifying",
         message=response,

--- a/apps/api/app/services/workflow/trigger_search.py
+++ b/apps/api/app/services/workflow/trigger_search.py
@@ -12,6 +12,7 @@ Triggers are indexed in ChromaDB by chroma_triggers_store.py at startup.
 from typing import Any
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.db.chroma.chroma_triggers_store import (
     TRIGGERS_NAMESPACE,
     get_triggers_store,
@@ -59,7 +60,9 @@ class TriggerSearchService:
                     is_connected = await check_integration_status(integration_id, user_id)
                     checked_integrations[integration_id] = is_connected
                 except Exception as e:
-                    log.warning(f"Failed to check connection for {integration_id}: {e}")
+                    log.warning(
+                        f"{LogTag.WORKFLOW} Failed to check connection for {integration_id}: {e}"
+                    )
                     checked_integrations[integration_id] = False
 
             # Get config schema for this trigger (embedded in results)

--- a/apps/api/app/services/workflow/trigger_service.py
+++ b/apps/api/app/services/workflow/trigger_service.py
@@ -8,6 +8,7 @@ Handles Composio trigger reference counting to prevent premature deletion.
 from typing import Any
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.models.workflow_models import TriggerConfig
 from app.services.triggers import get_handler_by_name
@@ -86,10 +87,12 @@ class TriggerService:
                     safe_to_delete.append(trigger_id)
                 else:
                     log.debug(
-                        f"Trigger {trigger_id} still referenced by {count} other workflow(s), skipping deletion"
+                        f"{LogTag.WORKFLOW} Trigger {trigger_id} still referenced by {count} other workflow(s), skipping deletion"
                     )
             except Exception as e:
-                log.error(f"Error checking trigger references for {trigger_id}: {e}")
+                log.error(
+                    f"{LogTag.WORKFLOW} Error checking trigger references for {trigger_id}: {e}"
+                )
                 # Don't delete if we can't verify - safer to leave orphaned triggers
                 continue
 
@@ -112,7 +115,7 @@ class TriggerService:
         handler = get_handler_by_name(trigger_name)
         if not handler:
             error_msg = f"No handler found for trigger: {trigger_name}"
-            log.error(error_msg)
+            log.error(f"{LogTag.WORKFLOW} {error_msg}")
             if raise_on_failure:
                 raise TriggerRegistrationError(error_msg, trigger_name)
             return []
@@ -123,15 +126,15 @@ class TriggerService:
             return trigger_ids
         except TypeError as e:
             # Re-raise TypeError for type validation failures
-            log.error(f"Type validation error registering triggers: {e!s}")
+            log.error(f"{LogTag.WORKFLOW} Type validation error registering triggers: {e!s}")
             raise
         except TriggerRegistrationError:
             # Re-raise our custom exception
             raise
         except Exception as e:
             error_msg = f"Error registering triggers: {type(e).__name__}: {e!s}"
-            log.error(error_msg)
-            log.exception("Full traceback:")
+            log.error(f"{LogTag.WORKFLOW} {error_msg}")
+            log.exception(f"{LogTag.WORKFLOW} Full traceback:")
             if raise_on_failure:
                 raise TriggerRegistrationError(error_msg, trigger_name)
             return []
@@ -155,7 +158,7 @@ class TriggerService:
 
         handler = get_handler_by_name(trigger_name)
         if not handler:
-            log.error(f"No handler found for trigger: {trigger_name}")
+            log.error(f"{LogTag.WORKFLOW} No handler found for trigger: {trigger_name}")
             return False
 
         try:
@@ -166,18 +169,18 @@ class TriggerService:
 
             if not safe_to_delete:
                 log.info(
-                    f"No triggers safe to delete - all {len(trigger_ids)} trigger(s) "
+                    f"{LogTag.WORKFLOW} No triggers safe to delete - all {len(trigger_ids)} trigger(s) "
                     "are still referenced by other workflows"
                 )
                 return True
 
             if len(safe_to_delete) < len(trigger_ids):
                 log.info(
-                    f"Only {len(safe_to_delete)} of {len(trigger_ids)} triggers "
+                    f"{LogTag.WORKFLOW} Only {len(safe_to_delete)} of {len(trigger_ids)} triggers "
                     "are safe to delete (others still referenced)"
                 )
 
             return await handler.unregister(user_id, safe_to_delete)
         except Exception as e:
-            log.error(f"Error unregistering triggers: {e}")
+            log.error(f"{LogTag.WORKFLOW} Error unregistering triggers: {e}")
             return False

--- a/apps/api/app/services/workflow/workflow_subagent.py
+++ b/apps/api/app/services/workflow/workflow_subagent.py
@@ -25,6 +25,7 @@ from app.agents.core.subagents.subagent_helpers import create_agent_context_mess
 from app.agents.llm.client import init_llm
 from app.agents.prompts.subagent_prompts import WORKFLOW_AGENT_SYSTEM_PROMPT
 from app.agents.tools.workflow_shared_tools import SUBAGENT_WORKFLOW_TOOLS
+from app.constants.log_tags import LogTag
 from app.helpers.agent_helpers import build_agent_config
 from shared.py.wide_events import log
 
@@ -44,7 +45,7 @@ async def get_workflow_subagent():
     if _workflow_subagent_graph is not None:
         return _workflow_subagent_graph
 
-    log.info("Creating workflow subagent graph")
+    log.info(f"{LogTag.WORKFLOW} Creating workflow subagent graph")
 
     # Register workflow tools in the registry under 'workflow_subagent' space
     from app.agents.tools.core.registry import get_tool_registry
@@ -70,7 +71,7 @@ async def get_workflow_subagent():
         disable_retrieve_tools=True,
     )
 
-    log.info("Workflow subagent graph created successfully")
+    log.info(f"{LogTag.WORKFLOW} Workflow subagent graph created successfully")
     return _workflow_subagent_graph
 
 
@@ -137,7 +138,7 @@ class WorkflowSubagentRunner:
             "integration_usernames": {},
         }
 
-        log.info(f"[WorkflowSubagent] Executing with task: {task[:100]}...")
+        log.info(f"{LogTag.WORKFLOW} Executing with task: {task[:100]}...")
 
         complete_message = ""
         emitted_tool_calls: set[str] = set()
@@ -193,5 +194,5 @@ class WorkflowSubagentRunner:
                 if stream_writer:
                     stream_writer(payload)
 
-        log.info(f"[WorkflowSubagent] Completed. Response: {len(complete_message)} chars")
+        log.info(f"{LogTag.WORKFLOW} Completed. Response: {len(complete_message)} chars")
         return complete_message if complete_message else "Task completed"

--- a/apps/api/app/utils/agent_utils.py
+++ b/apps/api/app/utils/agent_utils.py
@@ -10,6 +10,7 @@ from app.agents.core.subagents.registry import get_subagent_by_id
 from app.agents.tools.core.registry import get_tool_registry
 from app.constants.agents import INTERNAL_AGENT_MARKERS
 from app.constants.cache import HANDOFF_NAME_CACHE_PREFIX
+from app.constants.log_tags import LogTag
 from app.constants.tool_labels import TOOL_DISPLAY_NAMES, humanize_tool_name
 from app.db.mongodb.collections import integrations_collection
 from app.decorators.caching import Cacheable
@@ -306,7 +307,7 @@ async def _resolve_mcp_integration_id(tool_name: str, user_id: str) -> str | Non
         mcp_client = await get_mcp_client(user_id)
         return mcp_client.find_integration(tool_name)
     except Exception as e:
-        log.warning(f"MCP integration lookup failed for {tool_name}: {e}")
+        log.warning(f"{LogTag.AGENT} MCP integration lookup failed for {tool_name}: {e}")
         return None
 
 
@@ -324,7 +325,7 @@ async def _resolve_mcp_ui_metadata(tool_name: str, user_id: str) -> tuple[dict |
                         return meta.get("mcp_ui"), meta.get("mcp_server_url")
                     return None, None
     except Exception as e:
-        log.warning(f"MCP UI metadata lookup failed for {tool_name}: {e}")
+        log.warning(f"{LogTag.AGENT} MCP UI metadata lookup failed for {tool_name}: {e}")
     return None, None
 
 
@@ -356,7 +357,7 @@ async def _resolve_mcp_icon_name(integration_id: str) -> tuple[str | None, str |
         await set_cache(cache_key, metadata, ttl=CUSTOM_INT_METADATA_TTL)
         return metadata["icon_url"], metadata["integration_name"]
     except Exception as e:
-        log.warning(f"MCP icon/name lookup failed for {integration_id}: {e}")
+        log.warning(f"{LogTag.AGENT} MCP icon/name lookup failed for {integration_id}: {e}")
         return None, None
 
 
@@ -380,5 +381,5 @@ def process_custom_event_for_tools(payload) -> dict:
         new_data = extract_tool_data(serialized)
         return new_data if new_data else {}
     except Exception as e:
-        log.error(f"Error extracting tool data: {e}")
+        log.error(f"{LogTag.AGENT} Error extracting tool data: {e}")
         return {}

--- a/apps/api/app/utils/auth_utils.py
+++ b/apps/api/app/utils/auth_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 from workos import AsyncWorkOSClient
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from shared.py.wide_events import log
 
@@ -84,7 +85,7 @@ async def authenticate_workos_session(
                 if not refresh_result.authenticated:
                     # Authentication failed, even after refresh
                     log.warning(
-                        f"Authentication failed even after refresh with reason: {refresh_result.reason}"  # type: ignore[reportOptionalMemberAccess]
+                        f"{LogTag.AGENT} Authentication failed even after refresh with reason: {refresh_result.reason}"  # type: ignore[reportOptionalMemberAccess]
                     )
                     return {}, None
 
@@ -94,19 +95,21 @@ async def authenticate_workos_session(
                     workos_user = refresh_dict.get("user")
                     new_session = refresh_dict.get("sealed_session")
                     if not workos_user:
-                        log.error("Refresh successful but no user data in refresh result")
+                        log.error(
+                            f"{LogTag.AGENT} Refresh successful but no user data in refresh result"
+                        )
                         return {}, new_session
                 else:
-                    log.error("Refresh result doesn't have expected structure")
+                    log.error(f"{LogTag.AGENT} Refresh result doesn't have expected structure")
                     return {}, None
 
             except Exception as e:
-                log.error(f"Session refresh error: {e}")
+                log.error(f"{LogTag.AGENT} Session refresh error: {e}")
                 return {}, None
 
         # Make sure we have a valid user before continuing
         if not workos_user:
-            log.error("Invalid user data from WorkOS")
+            log.error(f"{LogTag.AGENT} Invalid user data from WorkOS")
             return {}, new_session
 
         # Retrieve user from database
@@ -117,7 +120,9 @@ async def authenticate_workos_session(
 
             if not user_data:
                 # User doesn't exist in our database
-                log.warning(f"User {user_email} authenticated but not found in database")
+                log.warning(
+                    f"{LogTag.AGENT} User {user_email} authenticated but not found in database"
+                )
                 return {}, new_session
 
             # Prepare user info for return
@@ -125,9 +130,9 @@ async def authenticate_workos_session(
             return user_info, new_session
 
         except Exception as e:
-            log.error(f"Error processing user data: {e}")
+            log.error(f"{LogTag.AGENT} Error processing user data: {e}")
             return {}, new_session
 
     except Exception as e:
-        log.error(f"Error in authenticate_workos_session: {e}")
+        log.error(f"{LogTag.AGENT} Error in authenticate_workos_session: {e}")
         return {}, None

--- a/apps/api/app/utils/browser_reaper.py
+++ b/apps/api/app/utils/browser_reaper.py
@@ -20,6 +20,7 @@ import time
 
 import psutil
 
+from app.constants.log_tags import LogTag
 from app.constants.search import (
     BROWSER_REAPER_INTERVAL_SECONDS,
     BROWSER_REAPER_MAX_AGE_SECONDS,
@@ -73,11 +74,11 @@ async def _reaper_loop() -> None:
         try:
             reaped = await asyncio.to_thread(reap_leaked_browsers)
             if reaped:
-                log.warning(f"Reaped {reaped} leaked browser driver process(es)")
+                log.warning(f"{LogTag.TOOL} Reaped {reaped} leaked browser driver process(es)")
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            log.warning(f"Browser reaper sweep failed: {e}")
+            log.warning(f"{LogTag.TOOL} Browser reaper sweep failed: {e}")
 
 
 def start_browser_reaper() -> None:
@@ -87,7 +88,7 @@ def start_browser_reaper() -> None:
         return
     _reaper_task = asyncio.get_running_loop().create_task(_reaper_loop())
     log.info(
-        f"Browser reaper started (interval={BROWSER_REAPER_INTERVAL_SECONDS:.0f}s, "
+        f"{LogTag.TOOL} Browser reaper started (interval={BROWSER_REAPER_INTERVAL_SECONDS:.0f}s, "
         f"max_age={BROWSER_REAPER_MAX_AGE_SECONDS:.0f}s)"
     )
 

--- a/apps/api/app/utils/canvas_vector_utils.py
+++ b/apps/api/app/utils/canvas_vector_utils.py
@@ -7,6 +7,7 @@ tracked todos. Follows the same pattern as todo_vector_utils.py.
 
 from datetime import UTC, datetime
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chromadb import ChromaClient
 from shared.py.wide_events import log
 
@@ -43,7 +44,7 @@ async def store_canvas_embedding(
         )
         return True
     except Exception as e:
-        log.error(f"Failed to index canvas for todo {todo_id}: {e}")
+        log.error(f"{LogTag.CHROMA} Failed to index canvas for todo {todo_id}: {e}")
         return False
 
 
@@ -89,7 +90,7 @@ async def delete_canvas_embedding(todo_id: str) -> bool:
         await chroma_collection.adelete(ids=[f"canvas_{todo_id}"])
         return True
     except Exception as e:
-        log.error(f"Failed to delete canvas index for todo {todo_id}: {e}")
+        log.error(f"{LogTag.CHROMA} Failed to delete canvas index for todo {todo_id}: {e}")
         return False
 
 
@@ -164,5 +165,5 @@ async def search_canvas_context(
             )
         return matches
     except Exception as e:
-        log.error(f"Canvas search failed for user {user_id}: {e}")
+        log.error(f"{LogTag.CHROMA} Canvas search failed for user {user_id}: {e}")
         return []

--- a/apps/api/app/utils/chat_utils.py
+++ b/apps/api/app/utils/chat_utils.py
@@ -6,6 +6,7 @@ from uuid_extensions import uuid7str
 from app.agents.core.state import State
 from app.agents.llm.chatbot import chatbot
 from app.agents.prompts.convo_prompts import CONVERSATION_DESCRIPTION_GENERATOR
+from app.constants.log_tags import LogTag
 from app.models.message_models import MessageDict, SelectedWorkflowData
 from app.services.conversation_service import (
     ConversationModel,
@@ -39,12 +40,12 @@ async def _generate_description_from_message(
         )
 
         if not isinstance(response, dict) or "response" not in response:
-            log.error("Invalid response from LLM for description generation")
+            log.error(f"{LogTag.CHAT} Invalid response from LLM for description generation")
             return "New Chat"
 
         return response.get("response", "New Chat").replace('"', "").strip()
     except Exception as e:
-        log.error(f"Failed to generate description: {e}")
+        log.error(f"{LogTag.CHAT} Failed to generate description: {e}")
         return "New Chat"
 
 
@@ -124,7 +125,7 @@ async def generate_and_update_description(
     try:
         await update_conversation_description(conversation_id, description, user)
     except Exception as e:
-        log.error(f"Failed to persist description to DB for {conversation_id}: {e}")
+        log.error(f"{LogTag.CHAT} Failed to persist description to DB for {conversation_id}: {e}")
 
     return description
 
@@ -157,13 +158,13 @@ async def do_prompt_no_stream(
 def get_user_id_from_config(config: RunnableConfig) -> str:
     """Extract user ID from the config."""
     if not config:
-        log.error("Tool called without config")
+        log.error(f"{LogTag.CHAT} Tool called without config")
         return ""
 
     metadata = config.get("metadata", {})
     user_id = metadata.get("user_id", "")
 
     if not user_id:
-        log.error("No user_id found in config metadata")
+        log.error(f"{LogTag.CHAT} No user_id found in config metadata")
 
     return user_id

--- a/apps/api/app/utils/composio_hooks/gmail_hooks.py
+++ b/apps/api/app/utils/composio_hooks/gmail_hooks.py
@@ -19,6 +19,7 @@ from app.agents.templates.mail_templates import (
     process_list_drafts_response,
     process_list_messages_response,
 )
+from app.constants.log_tags import LogTag
 from app.utils.markdown_utils import normalize_email_body_to_html
 from shared.py.wide_events import log
 
@@ -222,7 +223,7 @@ def gmail_compose_before_hook(
             if "to" in arguments and "recipient_email" not in arguments:
                 arguments["recipient_email"] = arguments["to"]
                 params["arguments"] = arguments
-                log.info(f"Mapped 'to' argument to 'recipient_email' for {tool}")
+                log.info(f"{LogTag.COMPOSIO} Mapped 'to' argument to 'recipient_email' for {tool}")
 
             # Check if at least one recipient type is provided
             recipient = arguments.get("recipient_email") or arguments.get("to")
@@ -240,7 +241,7 @@ def gmail_compose_before_hook(
             # If validation fails, return params immediately to skip streaming
             if not has_recipient or not has_content:
                 log.warning(
-                    f"Skipping streaming for {tool}: Missing required fields. "
+                    f"{LogTag.COMPOSIO} Skipping streaming for {tool}: Missing required fields. "
                     f"Has recipient: {has_recipient}, Has content: {has_content}"
                 )
                 return params
@@ -294,7 +295,7 @@ def gmail_compose_before_hook(
         return params
 
     except Exception as e:
-        log.error(f"Error in gmail_compose_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_compose_before_hook: {e}")
         return params
 
 
@@ -337,7 +338,7 @@ def gmail_fetch_after_hook(tool: str, toolkit: str, response: ToolExecutionRespo
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_fetch_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_fetch_after_hook: {e}")
         return response["data"]
 
 
@@ -355,7 +356,7 @@ def gmail_message_detail_after_hook(
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_message_detail_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_message_detail_after_hook: {e}")
         return response["data"]
 
 
@@ -401,7 +402,7 @@ def gmail_thread_after_hook(tool: str, toolkit: str, response: ToolExecutionResp
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_thread_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_thread_after_hook: {e}")
         return response["data"]
 
 
@@ -417,7 +418,7 @@ def gmail_drafts_after_hook(tool: str, toolkit: str, response: ToolExecutionResp
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_drafts_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_drafts_after_hook: {e}")
         return response["data"]
 
 
@@ -433,7 +434,7 @@ def gmail_draft_detail_after_hook(tool: str, toolkit: str, response: ToolExecuti
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_draft_detail_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_draft_detail_after_hook: {e}")
         return response["data"]
 
 
@@ -459,7 +460,7 @@ def gmail_attachment_after_hook(tool: str, toolkit: str, response: ToolExecution
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_attachment_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_attachment_after_hook: {e}")
         return response["data"]
 
 
@@ -478,7 +479,7 @@ def gmail_send_draft_before_hook(tool: str, toolkit: str, params: Any) -> Any:
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_send_draft_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_send_draft_before_hook: {e}")
 
     return params
 
@@ -497,7 +498,7 @@ def gmail_trash_before_hook(tool: str, toolkit: str, params: Any) -> Any:
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_trash_before_hook for {tool}: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_trash_before_hook for {tool}: {e}")
 
     return params
 
@@ -525,7 +526,7 @@ def gmail_label_before_hook(tool: str, toolkit: str, params: Any) -> Any:
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_label_before_hook for {tool}: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_label_before_hook for {tool}: {e}")
 
     return params
 
@@ -553,7 +554,7 @@ def gmail_modify_labels_before_hook(tool: str, toolkit: str, params: Any) -> Any
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_modify_labels_before_hook for {tool}: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_modify_labels_before_hook for {tool}: {e}")
 
     return params
 
@@ -571,7 +572,7 @@ def gmail_draft_management_before_hook(tool: str, toolkit: str, params: Any) -> 
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_draft_management_before_hook for {tool}: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_draft_management_before_hook for {tool}: {e}")
 
     return params
 
@@ -591,7 +592,7 @@ def gmail_list_drafts_before_hook(tool: str, toolkit: str, params: Any) -> Any:
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_list_drafts_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_list_drafts_before_hook: {e}")
 
     return params
 
@@ -608,7 +609,7 @@ def gmail_get_draft_before_hook(tool: str, toolkit: str, params: Any) -> Any:
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_get_draft_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_get_draft_before_hook: {e}")
 
     return params
 
@@ -631,7 +632,7 @@ def gmail_get_contacts_before_hook(tool: str, toolkit: str, params: Any) -> Any:
             writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_get_contacts_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_get_contacts_before_hook: {e}")
 
     return params
 
@@ -648,7 +649,7 @@ def gmail_search_people_before_hook(tool: str, toolkit: str, params: Any) -> Any
             writer(payload)
 
     except Exception as e:
-        log.error(f"Error in gmail_search_people_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_search_people_before_hook: {e}")
 
     return params
 
@@ -668,7 +669,7 @@ def gmail_fetch_by_id_after_hook(tool: str, toolkit: str, response: ToolExecutio
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in gmail_fetch_by_id_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_fetch_by_id_after_hook: {e}")
         return response["data"]
 
 
@@ -705,7 +706,7 @@ def gmail_send_draft_after_hook(tool: str, toolkit: str, response: ToolExecution
         return response["data"]
 
     except Exception as e:
-        log.error(f"Error in gmail_send_draft_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_send_draft_after_hook: {e}")
         return response["data"]
 
 
@@ -785,7 +786,7 @@ def gmail_get_contacts_after_hook(tool: str, toolkit: str, response: ToolExecuti
         }
 
     except Exception as e:
-        log.error(f"Error in gmail_get_contacts_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_get_contacts_after_hook: {e}")
         return response["data"]
 
 
@@ -864,5 +865,5 @@ def gmail_search_people_after_hook(tool: str, toolkit: str, response: ToolExecut
         }
 
     except Exception as e:
-        log.error(f"Error in gmail_search_people_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in gmail_search_people_after_hook: {e}")
         return response["data"]

--- a/apps/api/app/utils/composio_hooks/reddit_hooks.py
+++ b/apps/api/app/utils/composio_hooks/reddit_hooks.py
@@ -10,6 +10,7 @@ from typing import Any
 from composio.types import ToolExecuteParams, ToolExecutionResponse
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 from .registry import register_after_hook, register_before_hook
@@ -49,7 +50,7 @@ def process_reddit_post(post_data: dict) -> dict:
             "stickied": data.get("stickied", False),
         }
     except Exception as e:
-        log.error(f"Error processing Reddit post: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error processing Reddit post: {e}")
         return {}
 
 
@@ -83,7 +84,7 @@ def process_reddit_search_results(response_data: dict) -> dict:
             "result_count": len(processed_posts),
         }
     except Exception as e:
-        log.error(f"Error processing Reddit search results: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error processing Reddit search results: {e}")
         return response_data
 
 
@@ -116,7 +117,7 @@ def process_reddit_comment(comment_data: dict) -> dict:
             "edited": data.get("edited", False),
         }
     except Exception as e:
-        log.error(f"Error processing Reddit comment: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error processing Reddit comment: {e}")
         return {}
 
 
@@ -151,7 +152,7 @@ def reddit_content_before_hook(
 
             writer(payload)
     except Exception as e:
-        log.error(f"Error in reddit_content_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_content_before_hook: {e}")
 
     return params
 
@@ -168,7 +169,7 @@ def reddit_delete_before_hook(
             payload = {"progress": f"Deleting {content_type}..."}
             writer(payload)
     except Exception as e:
-        log.error(f"Error in reddit_delete_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_delete_before_hook: {e}")
 
     return params
 
@@ -190,7 +191,7 @@ def reddit_retrieve_before_hook(
 
             writer(payload)
     except Exception as e:
-        log.error(f"Error in reddit_retrieve_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_retrieve_before_hook: {e}")
 
     return params
 
@@ -244,7 +245,7 @@ def reddit_search_after_hook(tool: str, toolkit: str, response: ToolExecutionRes
         return processed_response
 
     except Exception as e:
-        log.error(f"Error in reddit_search_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_search_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -293,7 +294,7 @@ def reddit_post_detail_after_hook(tool: str, toolkit: str, response: ToolExecuti
         return processed_post
 
     except Exception as e:
-        log.error(f"Error in reddit_post_detail_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_post_detail_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -359,7 +360,7 @@ def reddit_comments_after_hook(tool: str, toolkit: str, response: ToolExecutionR
         }
 
     except Exception as e:
-        log.error(f"Error in reddit_comments_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_comments_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -419,5 +420,5 @@ def reddit_content_created_after_hook(
         }
 
     except Exception as e:
-        log.error(f"Error in reddit_content_created_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in reddit_content_created_after_hook: {e}")
         return response.get("data", {})

--- a/apps/api/app/utils/composio_hooks/registry.py
+++ b/apps/api/app/utils/composio_hooks/registry.py
@@ -13,6 +13,7 @@ from typing import Any, Union
 
 from composio.types import Tool, ToolExecuteParams
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -40,12 +41,12 @@ class ComposioHookRegistry:
     ) -> None:
         """Register a before_execute hook function."""
         self._before_hooks.append(hook_func)
-        log.debug(f"Registered before_execute hook: {hook_func.__name__}")
+        log.debug(f"{LogTag.COMPOSIO} Registered before_execute hook: {hook_func.__name__}")
 
     def register_after_hook(self, hook_func: Callable[[str, str, Any], Any]) -> None:
         """Register an after_execute hook function."""
         self._after_hooks.append(hook_func)
-        log.debug(f"Registered after_execute hook: {hook_func.__name__}")
+        log.debug(f"{LogTag.COMPOSIO} Registered after_execute hook: {hook_func.__name__}")
 
     def execute_before_hooks(
         self, tool: str, toolkit: str, params: ToolExecuteParams
@@ -58,7 +59,7 @@ class ComposioHookRegistry:
                 modified_params = hook_func(tool, toolkit, modified_params)
             except Exception as e:
                 log.error(
-                    f"Error executing before_execute hook {hook_func.__name__} for {tool}: {e}"
+                    f"{LogTag.COMPOSIO} Error executing before_execute hook {hook_func.__name__} for {tool}: {e}"
                 )
                 # Continue with other hooks even if one fails
         return modified_params
@@ -71,7 +72,7 @@ class ComposioHookRegistry:
                 modified_response = hook_func(tool, toolkit, modified_response)
             except Exception as e:
                 log.error(
-                    f"Error executing after_execute hook {hook_func.__name__} for {tool}: {e}"
+                    f"{LogTag.COMPOSIO} Error executing after_execute hook {hook_func.__name__} for {tool}: {e}"
                 )
                 # Continue with other hooks even if one fails
         return modified_response
@@ -79,7 +80,7 @@ class ComposioHookRegistry:
     def register_schema_modifier(self, modifier_func: Callable[[str, str, Tool], Tool]) -> None:
         """Register a schema modifier function."""
         self._schema_modifiers.append(modifier_func)
-        log.debug(f"Registered schema_modifier: {modifier_func.__name__}")
+        log.debug(f"{LogTag.COMPOSIO} Registered schema_modifier: {modifier_func.__name__}")
 
     def execute_schema_modifiers(self, tool: str, toolkit: str, schema: Tool) -> Tool:
         """Execute all registered schema modifiers."""
@@ -89,7 +90,7 @@ class ComposioHookRegistry:
                 modified_schema = modifier_func(tool, toolkit, modified_schema)
             except Exception as e:
                 log.error(
-                    f"Error executing schema_modifier {modifier_func.__name__} for {tool}: {e}"
+                    f"{LogTag.COMPOSIO} Error executing schema_modifier {modifier_func.__name__} for {tool}: {e}"
                 )
                 # Continue with other modifiers even if one fails
         return modified_schema

--- a/apps/api/app/utils/composio_hooks/twitter_hooks.py
+++ b/apps/api/app/utils/composio_hooks/twitter_hooks.py
@@ -10,6 +10,7 @@ from typing import Any
 from composio.types import Tool, ToolExecuteParams, ToolExecutionResponse
 from langgraph.config import get_stream_writer
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 from .registry import (
@@ -125,7 +126,7 @@ def twitter_create_post_before_hook(
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in twitter_create_post_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_create_post_before_hook: {e}")
 
     return params
 
@@ -147,7 +148,7 @@ def twitter_search_before_hook(
         writer(payload)
 
     except Exception as e:
-        log.error(f"Error in twitter_search_before_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_search_before_hook: {e}")
 
     return params
 
@@ -229,7 +230,7 @@ def twitter_search_after_hook(tool: str, toolkit: str, response: ToolExecutionRe
         }
 
     except Exception as e:
-        log.error(f"Error in twitter_search_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_search_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -287,7 +288,7 @@ def twitter_user_lookup_after_hook(tool: str, toolkit: str, response: ToolExecut
         }
 
     except Exception as e:
-        log.error(f"Error in twitter_user_lookup_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_user_lookup_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -355,7 +356,7 @@ def twitter_timeline_after_hook(tool: str, toolkit: str, response: ToolExecution
         }
 
     except Exception as e:
-        log.error(f"Error in twitter_timeline_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_timeline_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -409,7 +410,7 @@ def twitter_followers_after_hook(tool: str, toolkit: str, response: ToolExecutio
         }
 
     except Exception as e:
-        log.error(f"Error in twitter_followers_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_followers_after_hook: {e}")
         return response.get("data", {})
 
 
@@ -445,5 +446,5 @@ def twitter_post_created_after_hook(
         }
 
     except Exception as e:
-        log.error(f"Error in twitter_post_created_after_hook: {e}")
+        log.error(f"{LogTag.COMPOSIO} Error in twitter_post_created_after_hook: {e}")
         return response.get("data", {})

--- a/apps/api/app/utils/composio_hooks/user_id_hooks.py
+++ b/apps/api/app/utils/composio_hooks/user_id_hooks.py
@@ -7,6 +7,7 @@ for all Composio tools.
 
 from composio.types import ToolExecuteParams
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 from .registry import register_before_hook
@@ -48,7 +49,7 @@ def extract_user_id_from_params(
     # The Composio API requires entity_id for connected account authentication
     params["user_id"] = user_id
     params["entity_id"] = user_id
-    log.debug(f"Extracted user_id/entity_id '{user_id}' for {toolkit}:{tool}")
+    log.debug(f"{LogTag.COMPOSIO} Extracted user_id/entity_id '{user_id}' for {toolkit}:{tool}")
     return params
 
 

--- a/apps/api/app/utils/context_utils.py
+++ b/apps/api/app/utils/context_utils.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # ── Performance tuning ───────────────────────────────────────────────────────
@@ -63,7 +64,7 @@ def execute_tool(
             validated = output_model.model_validate(data)
             return validated.model_dump()
         except Exception as e:
-            log.warning(f"Schema validation warning for {tool_name}: {e}")
+            log.warning(f"{LogTag.AGENT} Schema validation warning for {tool_name}: {e}")
             return data
 
     return data
@@ -85,7 +86,7 @@ def fetch_all_providers(
             data = execute_tool(tool_slug, {}, user_id)
             return provider, data
         except Exception as e:
-            log.warning(f"Provider {provider} ({tool_slug}) failed: {e}")
+            log.warning(f"{LogTag.AGENT} Provider {provider} ({tool_slug}) failed: {e}")
             return provider, None
 
     results: dict[str, Any] = {}
@@ -100,10 +101,10 @@ def fetch_all_providers(
                 results[provider] = data
         except FuturesTimeout:
             provider = futures[future]
-            log.warning(f"Provider {provider} timed out")
+            log.warning(f"{LogTag.AGENT} Provider {provider} timed out")
         except Exception as e:
             provider = futures[future]
-            log.error(f"Unexpected error for {provider}: {e}")
+            log.error(f"{LogTag.AGENT} Unexpected error for {provider}: {e}")
     return results
 
 
@@ -136,13 +137,15 @@ async def resolve_providers(
     try:
         connected = await get_user_available_tool_namespaces(user_id)
     except Exception as e:
-        log.warning(f"Could not get connected namespaces: {e}")
+        log.warning(f"{LogTag.AGENT} Could not get connected namespaces: {e}")
 
     if connected:
         filtered = [p for p, slug in provider_tools.items() if namespace_fn(slug) in connected]
         if filtered:
-            log.info(f"Auto-selected {len(filtered)} connected providers: {filtered}")
+            log.info(
+                f"{LogTag.AGENT} Auto-selected {len(filtered)} connected providers: {filtered}"
+            )
             return filtered
 
-    log.warning("No connected providers detected — returning empty list")
+    log.warning(f"{LogTag.AGENT} No connected providers detected — returning empty list")
     return []

--- a/apps/api/app/utils/crawl4ai_utils.py
+++ b/apps/api/app/utils/crawl4ai_utils.py
@@ -7,6 +7,7 @@ from urllib.parse import urlsplit, urlunsplit
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.constants.search import CRAWL4AI_CLOSE_TIMEOUT_SECONDS, CRAWL4AI_WAIT_UNTIL
 from shared.py.wide_events import log
 
@@ -43,7 +44,7 @@ async def _close_crawler(crawler: AsyncWebCrawler, context_name: str) -> None:
     try:
         await crawler.close()
     except Exception as e:
-        log.warning(f"{context_name} browser close failed: {e}")
+        log.warning(f"{LogTag.TOOL} {context_name} browser close failed: {e}")
 
 
 def _spawn_shielded_close(crawler: AsyncWebCrawler, context_name: str) -> asyncio.Task[None]:
@@ -88,7 +89,7 @@ async def managed_crawler(
             # close() is wedged; it keeps running detached and the reaper
             # collects the driver if it never finishes.
             log.warning(
-                f"{context_name} browser close still running after "
+                f"{LogTag.TOOL} {context_name} browser close still running after "
                 f"{CRAWL4AI_CLOSE_TIMEOUT_SECONDS:.0f}s; leaving it to finish in background"
             )
 
@@ -271,7 +272,7 @@ async def batch_fetch_with_crawl4ai(
             )
     except TimeoutError:
         log.warning(
-            f"{context_name} batch timed out after {total_timeout_seconds:.0f}s; "
+            f"{LogTag.TOOL} {context_name} batch timed out after {total_timeout_seconds:.0f}s; "
             "retrying URLs individually"
         )
         return await _recover_with_single_url_crawls(
@@ -285,7 +286,7 @@ async def batch_fetch_with_crawl4ai(
         raise
     except Exception as e:
         error = f"{context_name} batch error: {e}"
-        log.warning(error)
+        log.warning(f"{LogTag.TOOL} {error}")
         return {}, dict.fromkeys(urls, error)
 
     requested_by_exact: dict[str, deque[int]] = defaultdict(deque)
@@ -338,12 +339,14 @@ async def batch_fetch_with_crawl4ai(
 
     if len(results) > len(urls):
         log.warning(
-            f"{context_name} returned {len(results)} results for {len(urls)} URLs; ignoring extras"
+            f"{LogTag.TOOL} {context_name} returned {len(results)} results for {len(urls)} URLs; ignoring extras"
         )
 
     unmatched_count = max(len(unmatched_results) - len(matched_results), 0)
     if unmatched_count:
-        log.warning(f"{context_name} could not map {unmatched_count} results to requested URLs")
+        log.warning(
+            f"{LogTag.TOOL} {context_name} could not map {unmatched_count} results to requested URLs"
+        )
 
     for url in urls:
         if url not in contents and url not in errors:

--- a/apps/api/app/utils/email_utils.py
+++ b/apps/api/app/utils/email_utils.py
@@ -9,6 +9,7 @@ import resend
 
 from app.config.settings import settings
 from app.constants.email import MAILTO_PREFIX
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.models.support_models import SupportEmailNotification, SupportRequestType
 from shared.py.wide_events import log
@@ -76,11 +77,11 @@ async def send_support_team_notification(
                         "reply_to": notification_data.user_email,
                     }
                 )
-                log.info(f"Support notification sent to {support_email}")
+                log.info(f"{LogTag.MAIL} Support notification sent to {support_email}")
             except Exception as e:
-                log.error(f"Failed to send support email to {support_email}: {e!s}")
+                log.error(f"{LogTag.MAIL} Failed to send support email to {support_email}: {e!s}")
     except Exception as e:
-        log.error(f"Error sending support team notifications: {e!s}")
+        log.error(f"{LogTag.MAIL} Error sending support team notifications: {e!s}")
         raise
 
 
@@ -100,9 +101,9 @@ async def send_support_to_user_email(
                 "html": html_content,
             }
         )
-        log.info(f"Confirmation email sent to user {notification_data.user_email}")
+        log.info(f"{LogTag.MAIL} Confirmation email sent to user {notification_data.user_email}")
     except Exception as e:
-        log.error(f"Failed to send confirmation email to user: {e!s}")
+        log.error(f"{LogTag.MAIL} Failed to send confirmation email to user: {e!s}")
         raise
 
 
@@ -129,7 +130,7 @@ def generate_support_team_email_html(data: SupportEmailNotification) -> str:
 
         return html_content
     except Exception as e:
-        log.error(f"Error generating support team email HTML: {e!s}")
+        log.error(f"{LogTag.MAIL} Error generating support team email HTML: {e!s}")
         raise
 
 
@@ -155,7 +156,7 @@ def generate_support_to_user_email_html(data: SupportEmailNotification) -> str:
 
         return html_content
     except Exception as e:
-        log.error(f"Error generating support to user email HTML: {e!s}")
+        log.error(f"{LogTag.MAIL} Error generating support to user email HTML: {e!s}")
         raise
 
 
@@ -185,9 +186,9 @@ async def send_pro_subscription_email(
                 "reply_to": CONTACT_EMAIL,
             }
         )
-        log.info(f"Pro subscription welcome email sent to {user_email}")
+        log.info(f"{LogTag.MAIL} Pro subscription welcome email sent to {user_email}")
     except Exception as e:
-        log.error(f"Failed to send pro subscription email to {user_email}: {e!s}")
+        log.error(f"{LogTag.MAIL} Failed to send pro subscription email to {user_email}: {e!s}")
         raise
 
 
@@ -209,9 +210,9 @@ async def send_welcome_email(user_email: str, user_name: str | None = None) -> N
                 "reply_to": CONTACT_EMAIL,
             }
         )
-        log.info(f"Welcome email sent to {user_email}")
+        log.info(f"{LogTag.MAIL} Welcome email sent to {user_email}")
     except Exception as e:
-        log.error(f"Failed to send welcome email to {user_email}: {e!s}")
+        log.error(f"{LogTag.MAIL} Failed to send welcome email to {user_email}: {e!s}")
         raise
 
 
@@ -238,9 +239,9 @@ async def add_contact_to_resend(user_email: str, user_name: str | None = None) -
         }
 
         resend.Contacts.create(params)
-        log.info(f"Contact added to Resend audience: {user_email}")
+        log.info(f"{LogTag.MAIL} Contact added to Resend audience: {user_email}")
     except Exception as e:
-        log.error(f"Failed to add contact to Resend audience for {user_email}: {e!s}")
+        log.error(f"{LogTag.MAIL} Failed to add contact to Resend audience for {user_email}: {e!s}")
         # Don't raise exception - user creation should still succeed even if contact addition fails
 
 
@@ -260,7 +261,7 @@ def generate_welcome_email_html(user_name: str | None = None) -> str | None:
 
         return html_content
     except Exception as e:
-        log.error(f"Error generating welcome email HTML: {e!s}")
+        log.error(f"{LogTag.MAIL} Error generating welcome email HTML: {e!s}")
         raise
 
 
@@ -277,7 +278,7 @@ async def send_inactive_user_email(
         if user_id:
             user = await users_collection.find_one({"_id": ObjectId(user_id)})
             if not user:
-                log.error(f"User {user_id} not found")
+                log.error(f"{LogTag.MAIL} User {user_id} not found")
                 return False
 
             now = datetime.now(UTC)
@@ -323,11 +324,11 @@ async def send_inactive_user_email(
                 {"$set": {"last_inactive_email_sent": datetime.now(UTC)}},
             )
 
-        log.info(f"Inactive user email sent to {user_email}")
+        log.info(f"{LogTag.MAIL} Inactive user email sent to {user_email}")
         return True
 
     except Exception as e:
-        log.error(f"Failed to send inactive user email to {user_email}: {e!s}")
+        log.error(f"{LogTag.MAIL} Failed to send inactive user email to {user_email}: {e!s}")
         raise
 
 
@@ -345,7 +346,7 @@ def generate_pro_subscription_html(
         )
         return html_content
     except Exception as e:
-        log.error(f"Error generating pro subscription email HTML: {e!s}")
+        log.error(f"{LogTag.MAIL} Error generating pro subscription email HTML: {e!s}")
         raise
 
 
@@ -362,5 +363,5 @@ def generate_inactive_user_email_html(user_name: str | None = None) -> str:
 
         return html_content
     except Exception as e:
-        log.error(f"Error generating inactive user email HTML: {e!s}")
+        log.error(f"{LogTag.MAIL} Error generating inactive user email HTML: {e!s}")
         raise

--- a/apps/api/app/utils/embedding_utils.py
+++ b/apps/api/app/utils/embedding_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 from bson import ObjectId
 from langchain_core.documents import Document
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chromadb import ChromaClient
 from app.db.mongodb.collections import files_collection, notes_collection
 from shared.py.wide_events import log
@@ -112,7 +113,7 @@ async def search_by_similarity(
         return result_items
     except Exception as e:
         log.error(
-            f"Error searching in ChromaDB collection '{collection_name}': {e!s}",
+            f"{LogTag.CHROMA} Error searching in ChromaDB collection '{collection_name}': {e!s}",
             exc_info=True,
         )
         return []

--- a/apps/api/app/utils/favicon_utils.py
+++ b/apps/api/app/utils/favicon_utils.py
@@ -20,6 +20,7 @@ import httpx
 import tldextract
 
 from app.constants.cache import FAVICON_CACHE_TTL
+from app.constants.log_tags import LogTag
 from app.db.redis import get_cache, set_cache
 from shared.py.wide_events import log
 
@@ -321,5 +322,5 @@ async def fetch_favicon_from_url(server_url: str) -> str | None:
         return result
 
     except Exception as e:
-        log.warning(f"Failed to fetch favicon for {server_url}: {e}")
+        log.warning(f"{LogTag.TOOL} Failed to fetch favicon for {server_url}: {e}")
         return None

--- a/apps/api/app/utils/file_utils.py
+++ b/apps/api/app/utils/file_utils.py
@@ -14,6 +14,7 @@ from llama_cloud_services.parse.utils import ResultType
 
 from app.agents.llm.client import init_llm
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.models.files_models import DocumentPageModel, DocumentSummaryModel
 from shared.py.wide_events import log
 
@@ -61,7 +62,7 @@ class DocumentProcessor:
             ext = os.path.splitext(filename)[1].lower()
             return f"File of type {ext} (no content extraction available)"
         except Exception as e:
-            log.error(f"Failed to process file {filename}: {e!s}", exc_info=True)
+            log.error(f"{LogTag.TOOL} Failed to process file {filename}: {e!s}", exc_info=True)
             return f"File processing failed for {filename}"
 
     async def process_image(self, image_data: bytes) -> str:
@@ -106,7 +107,7 @@ class DocumentProcessor:
             return description
 
         except Exception as e:
-            log.error(f"Failed to process image: {e!s}", exc_info=True)
+            log.error(f"{LogTag.TOOL} Failed to process image: {e!s}", exc_info=True)
             return "Image description could not be generated."
 
     async def process_doc(
@@ -173,7 +174,7 @@ class DocumentProcessor:
             ]
 
         except Exception as e:
-            log.error(f"Failed to process PDF: {e!s}", exc_info=True)
+            log.error(f"{LogTag.TOOL} Failed to process PDF: {e!s}", exc_info=True)
             return []
 
     async def process_text(self, text_data: bytes) -> DocumentSummaryModel:
@@ -204,7 +205,7 @@ class DocumentProcessor:
             )
 
         except Exception as e:
-            log.error(f"Failed to process text: {e!s}", exc_info=True)
+            log.error(f"{LogTag.TOOL} Failed to process text: {e!s}", exc_info=True)
             raise e
 
     async def _generate_text_summary(self, text: str) -> str:
@@ -226,7 +227,7 @@ class DocumentProcessor:
             return str(response)
 
         except Exception as e:
-            log.error(f"Failed to generate summary: {e!s}", exc_info=True)
+            log.error(f"{LogTag.TOOL} Failed to generate summary: {e!s}", exc_info=True)
             return "Summary could not be generated."
 
 

--- a/apps/api/app/utils/google_sheets_utils.py
+++ b/apps/api/app/utils/google_sheets_utils.py
@@ -9,6 +9,7 @@ This module provides helpers for Google Sheets and Drive API interactions:
 
 import re
 
+from app.constants.log_tags import LogTag
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
 
@@ -69,7 +70,7 @@ def get_sheet_id_by_name(spreadsheet_id: str, sheet_name: str, user_id: str) -> 
                 return sheet["properties"]["sheetId"]
         return None
     except Exception as e:
-        log.error(f"Error getting sheet ID: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error getting sheet ID: {e}")
         return None
 
 
@@ -94,5 +95,5 @@ def get_column_index_by_header(
                 return idx
         return None
     except Exception as e:
-        log.error(f"Error getting column index: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error getting column index: {e}")
         return None

--- a/apps/api/app/utils/integration_checker.py
+++ b/apps/api/app/utils/integration_checker.py
@@ -10,6 +10,7 @@ from langgraph.config import get_config, get_stream_writer
 
 from app.config.oauth_config import get_integration_by_id, get_integration_scopes
 from app.config.token_repository import token_repository
+from app.constants.log_tags import LogTag
 from app.models.chat_models import SourceCategory
 from shared.py.wide_events import log
 
@@ -80,13 +81,13 @@ async def check_user_has_integration(access_token: str, integration_id: str) -> 
         # Get required scopes for this integration from oauth_config
         required_scopes = get_integration_scopes(integration_id)
         if not required_scopes:
-            log.warning(f"No scopes defined for integration: {integration_id}")
+            log.warning(f"{LogTag.INTEGRATION} No scopes defined for integration: {integration_id}")
             return False
 
         token = await token_repository.get_token_by_auth_token(access_token, renew_if_expired=True)
 
         if not token:
-            log.warning(f"No token found for access token: {access_token}")
+            log.warning(f"{LogTag.INTEGRATION} No token found for access token: {access_token}")
             return False
 
         authorized_scopes = str(token.get("scope", "")).split()
@@ -96,7 +97,7 @@ async def check_user_has_integration(access_token: str, integration_id: str) -> 
         return len(missing_scopes) == 0
 
     except Exception as e:
-        log.error(f"Error checking integration permissions: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error checking integration permissions: {e}")
         return False
 
 
@@ -126,7 +127,7 @@ async def stream_integration_connection_prompt(
         # Get integration details
         integration = get_integration_by_id(integration_id)
         if not integration:
-            log.error(f"Integration not found: {integration_id}")
+            log.error(f"{LogTag.INTEGRATION} Integration not found: {integration_id}")
             return
 
         # Prepare the integration connection data
@@ -140,10 +141,12 @@ async def stream_integration_connection_prompt(
 
         # Stream the data to frontend
         writer(connection_data)
-        log.info(f"Streamed integration connection prompt for: {integration_id}")
+        log.info(
+            f"{LogTag.INTEGRATION} Streamed integration connection prompt for: {integration_id}"
+        )
 
     except Exception as e:
-        log.error(f"Error streaming integration connection prompt: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error streaming integration connection prompt: {e}")
 
 
 def get_required_integration_for_tool_category(tool_category: str) -> str | None:

--- a/apps/api/app/utils/internet_utils.py
+++ b/apps/api/app/utils/internet_utils.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 from fastapi import HTTPException, status
 import httpx
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import search_urls_collection
 from app.db.redis import get_cache, set_cache
 from app.db.utils import serialize_document
@@ -81,7 +82,7 @@ async def _resolve_and_validate(hostname: str) -> None:
             )
         if _is_blocked_ip(ip):
             log.warning(
-                "ssrf_blocked",
+                f"{LogTag.TOOL} ssrf_blocked",
                 hostname=hostname,
                 resolved_ip=ip_str,
             )

--- a/apps/api/app/utils/linear_utils.py
+++ b/apps/api/app/utils/linear_utils.py
@@ -8,6 +8,7 @@ This module provides helper functions for Linear GraphQL API interactions:
 from difflib import SequenceMatcher
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
 
@@ -54,7 +55,9 @@ def graphql_request(
 
     if isinstance(result, dict) and "errors" in result:
         error_messages = [e.get("message", str(e)) for e in result["errors"]]
-        log.error(f"GraphQL Errors: {error_messages} Query: {query} Variables: {variables}")
+        log.error(
+            f"{LogTag.INTEGRATION} GraphQL Errors: {error_messages} Query: {query} Variables: {variables}"
+        )
         raise Exception(f"GraphQL errors: {'; '.join(error_messages)}")
 
     return result.get("data", {}) if isinstance(result, dict) else {}

--- a/apps/api/app/utils/linkedin_utils.py
+++ b/apps/api/app/utils/linkedin_utils.py
@@ -10,6 +10,7 @@ upload endpoint with the authenticated headers.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.services.composio.proxy_client import proxy_request_sync
 from shared.py.wide_events import log
 
@@ -63,7 +64,7 @@ def get_author_urn(user_id: str, organization_id: str | None = None) -> str:
         if sub:
             return f"urn:li:person:{sub}"
     except Exception as e:
-        log.error(f"Error getting user info: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error getting user info: {e}")
 
     raise ValueError("Could not determine author URN")
 
@@ -92,7 +93,7 @@ def upload_image_from_url(
         image_urn = (init_result or {}).get("value", {}).get("image")
 
         if not upload_url or not image_urn:
-            log.error("Failed to get upload URL from LinkedIn")
+            log.error(f"{LogTag.INTEGRATION} Failed to get upload URL from LinkedIn")
             return None
 
         _proxy(
@@ -104,7 +105,7 @@ def upload_image_from_url(
         return image_urn
 
     except Exception as e:
-        log.error(f"Error uploading image: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error uploading image: {e}")
         return None
 
 
@@ -132,7 +133,7 @@ def upload_document_from_url(
         document_urn = (init_result or {}).get("value", {}).get("document")
 
         if not upload_url or not document_urn:
-            log.error("Failed to get upload URL from LinkedIn")
+            log.error(f"{LogTag.INTEGRATION} Failed to get upload URL from LinkedIn")
             return None
 
         _proxy(
@@ -144,5 +145,5 @@ def upload_document_from_url(
         return document_urn
 
     except Exception as e:
-        log.error(f"Error uploading document: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error uploading document: {e}")
         return None

--- a/apps/api/app/utils/markdown_utils.py
+++ b/apps/api/app/utils/markdown_utils.py
@@ -4,6 +4,7 @@ import re
 
 import markdown2
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -24,7 +25,7 @@ def convert_markdown_to_html(markdown_text: str) -> str:
         )
         return html
     except Exception as e:
-        log.error(f"Error converting markdown to HTML: {e}")
+        log.error(f"{LogTag.TOOL} Error converting markdown to HTML: {e}")
         return markdown_text
 
 

--- a/apps/api/app/utils/mcp_oauth_utils.py
+++ b/apps/api/app/utils/mcp_oauth_utils.py
@@ -38,6 +38,7 @@ from mcp.types import (
 )
 from pydantic import AnyHttpUrl
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # Sent in the MCP-Protocol-Version header on OAuth discovery/token requests for
@@ -110,7 +111,7 @@ def validate_https_url(url: str, allow_localhost: bool = True) -> None:
         hostname = parsed.hostname or ""
         hostname_lower = hostname.lower()
         if hostname_lower in ("localhost", "127.0.0.1", "::1"):
-            log.debug(f"Allowing HTTP for localhost URL: {url}")
+            log.debug(f"{LogTag.MCP} Allowing HTTP for localhost URL: {url}")
             return
 
     raise OAuthSecurityError(
@@ -234,30 +235,30 @@ async def extract_auth_challenge(server_url: str) -> dict:
                 if error_desc_value:
                     result["error_description"] = error_desc_value
 
-                log.info(f"[TIMING] Probe {server_url}: 401 OAuth required, {elapsed_ms:.0f}ms")
-                log.debug(f"Parsed WWW-Authenticate for {server_url}: {result}")
+                log.info(f"{LogTag.MCP} Probe {server_url}: 401 OAuth required, {elapsed_ms:.0f}ms")
+                log.debug(f"{LogTag.MCP} Parsed WWW-Authenticate for {server_url}: {result}")
                 return result
 
             log.info(
-                f"[TIMING] Probe {server_url}: {response.status_code} (no auth), {elapsed_ms:.0f}ms"
+                f"{LogTag.MCP} Probe {server_url}: {response.status_code} (no auth), {elapsed_ms:.0f}ms"
             )
             return {}
 
     except httpx.ConnectError as e:
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         # Re-raise connection errors so caller can handle them appropriately
-        log.warning(f"[TIMING] Probe {server_url}: ConnectError after {elapsed_ms:.0f}ms - {e}")
+        log.warning(f"{LogTag.MCP} Probe {server_url}: ConnectError after {elapsed_ms:.0f}ms - {e}")
         raise
 
     except httpx.TimeoutException as e:
         elapsed_ms = (time.perf_counter() - start_time) * 1000
-        log.warning(f"[TIMING] Probe {server_url}: Timeout after {elapsed_ms:.0f}ms - {e}")
+        log.warning(f"{LogTag.MCP} Probe {server_url}: Timeout after {elapsed_ms:.0f}ms - {e}")
         return {}
 
     except Exception as e:
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         log.warning(
-            f"[TIMING] Probe {server_url}: Error after {elapsed_ms:.0f}ms - {type(e).__name__}: {e}"
+            f"{LogTag.MCP} Probe {server_url}: Error after {elapsed_ms:.0f}ms - {type(e).__name__}: {e}"
         )
         return {}
 
@@ -287,13 +288,13 @@ async def find_protected_resource_metadata(server_url: str) -> str | None:
                     data = response.json()
                     if "authorization_servers" in data or "resource" in data:
                         elapsed_ms = (time.perf_counter() - start_time) * 1000
-                        log.info(f"[TIMING] Found PRM at {url} in {elapsed_ms:.0f}ms")
+                        log.info(f"{LogTag.MCP} Found PRM at {url} in {elapsed_ms:.0f}ms")
                         return url
             except Exception as e:
-                log.debug(f"PRM not found at {url}: {e}")
+                log.debug(f"{LogTag.MCP} PRM not found at {url}: {e}")
 
     elapsed_ms = (time.perf_counter() - start_time) * 1000
-    log.debug(f"[TIMING] PRM discovery failed for {server_url} after {elapsed_ms:.0f}ms")
+    log.debug(f"{LogTag.MCP} PRM discovery failed for {server_url} after {elapsed_ms:.0f}ms")
     return None
 
 
@@ -311,7 +312,7 @@ async def fetch_protected_resource_metadata(prm_url: str) -> ProtectedResourceMe
         response = await client.get(prm_url, headers=headers, timeout=OAUTH_DISCOVERY_TIMEOUT)
         response.raise_for_status()
         elapsed_ms = (time.perf_counter() - start_time) * 1000
-        log.info(f"[TIMING] Fetched PRM from {prm_url} in {elapsed_ms:.0f}ms")
+        log.info(f"{LogTag.MCP} Fetched PRM from {prm_url} in {elapsed_ms:.0f}ms")
         return ProtectedResourceMetadata.model_validate(response.json())
 
 
@@ -345,10 +346,12 @@ async def fetch_auth_server_metadata(auth_server_url: str) -> OAuthMetadata:
                 response = await client.send(create_oauth_metadata_request(url))
                 if response.status_code == 200:
                     elapsed_ms = (time.perf_counter() - start_time) * 1000
-                    log.info(f"[TIMING] Found auth server metadata at {url} in {elapsed_ms:.0f}ms")
+                    log.info(
+                        f"{LogTag.MCP} Found auth server metadata at {url} in {elapsed_ms:.0f}ms"
+                    )
                     return OAuthMetadata.model_validate(response.json())
             except Exception as e:
-                log.debug(f"Auth metadata not found at {url}: {e}")
+                log.debug(f"{LogTag.MCP} Auth metadata not found at {url}: {e}")
 
     # MCP Spec Fallback: If metadata discovery fails, use default URL pattern
     # Per MCP Authorization spec (2025-03-26): fallback URLs use the
@@ -362,7 +365,7 @@ async def fetch_auth_server_metadata(auth_server_url: str) -> OAuthMetadata:
     # /token is correct for server.smithery.ai/excalidraw).
     elapsed_ms = (time.perf_counter() - start_time) * 1000
     log.info(
-        f"[TIMING] Metadata discovery failed for {auth_server_url} after {elapsed_ms:.0f}ms, "
+        f"{LogTag.MCP} Metadata discovery failed for {auth_server_url} after {elapsed_ms:.0f}ms, "
         "using MCP spec fallback URLs (origin-only, per spec)"
     )
 
@@ -430,18 +433,20 @@ async def revoke_token(
             # - 400: Invalid request (e.g., unsupported token_type_hint)
             # - 503: Service unavailable
             if response.status_code == 200:
-                log.info(f"Token revoked successfully at {revocation_endpoint}")
+                log.info(f"{LogTag.MCP} Token revoked successfully at {revocation_endpoint}")
                 return True
 
             # Log error but don't raise - revocation is best-effort
-            log.warning(f"Token revocation returned {response.status_code}: {response.text}")
+            log.warning(
+                f"{LogTag.MCP} Token revocation returned {response.status_code}: {response.text}"
+            )
             return False
 
     except httpx.TimeoutException:
-        log.warning(f"Token revocation timed out at {revocation_endpoint}")
+        log.warning(f"{LogTag.MCP} Token revocation timed out at {revocation_endpoint}")
         return False
     except Exception as e:
-        log.warning(f"Token revocation failed: {e}")
+        log.warning(f"{LogTag.MCP} Token revocation failed: {e}")
         return False
 
 
@@ -497,17 +502,19 @@ async def introspect_token(
 
             if response.status_code == 200:
                 result = response.json()
-                log.debug(f"Token introspection result: active={result.get('active')}")
+                log.debug(f"{LogTag.MCP} Token introspection result: active={result.get('active')}")
                 return result
 
-            log.warning(f"Token introspection returned {response.status_code}: {response.text}")
+            log.warning(
+                f"{LogTag.MCP} Token introspection returned {response.status_code}: {response.text}"
+            )
             return None
 
     except httpx.TimeoutException:
-        log.warning(f"Token introspection timed out at {introspection_endpoint}")
+        log.warning(f"{LogTag.MCP} Token introspection timed out at {introspection_endpoint}")
         return None
     except Exception as e:
-        log.warning(f"Token introspection failed: {e}")
+        log.warning(f"{LogTag.MCP} Token introspection failed: {e}")
         return None
 
 
@@ -539,7 +546,7 @@ def parse_oauth_error_response(response: Any) -> dict:
                 # Fall back to raw text
                 result["error_description"] = response.text[:500]  # Truncate long errors
     except Exception as e:
-        log.debug(f"Failed to parse OAuth error response: {e}")
+        log.debug(f"{LogTag.MCP} Failed to parse OAuth error response: {e}")
         result["error_description"] = str(e)
 
     return result
@@ -619,7 +626,7 @@ def validate_jwt_issuer(
 
             if normalized_token != normalized_expected:
                 log.warning(
-                    f"JWT issuer mismatch for {integration_id}: "
+                    f"{LogTag.MCP} JWT issuer mismatch for {integration_id}: "
                     f"expected '{expected_issuer}', got '{token_issuer}'"
                 )
                 return False
@@ -627,7 +634,7 @@ def validate_jwt_issuer(
         return True
 
     except Exception as e:
-        log.debug(f"Could not validate JWT issuer for {integration_id}: {e}")
+        log.debug(f"{LogTag.MCP} Could not validate JWT issuer for {integration_id}: {e}")
         # Don't fail on validation errors - token may be opaque
         return True
 
@@ -644,5 +651,7 @@ def select_authorization_server(servers: list[str]) -> str:
     if len(servers) == 1:
         return servers[0]
 
-    log.info(f"Multiple auth servers available ({len(servers)}), using first: {servers[0]}")
+    log.info(
+        f"{LogTag.MCP} Multiple auth servers available ({len(servers)}), using first: {servers[0]}"
+    )
     return servers[0]

--- a/apps/api/app/utils/mcp_utils.py
+++ b/apps/api/app/utils/mcp_utils.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from langchain_core.tools import BaseTool
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -81,13 +82,15 @@ def wrap_tool_with_null_filter(
     async def filtered_arun(**kwargs: Any) -> Any:
         filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
         log.set(operation="mcp_tool_call", tool_name=tool.name)
-        log.debug(f"MCP tool '{tool.name}': original args={kwargs}, filtered={filtered_kwargs}")
+        log.debug(
+            f"{LogTag.MCP} MCP tool '{tool.name}': original args={kwargs}, filtered={filtered_kwargs}"
+        )
         try:
             return await original_arun(**filtered_kwargs)
         except Exception as e:
             error_msg = str(e)
             error_lower = error_msg.lower()
-            log.error(f"MCP tool '{tool.name}' failed: {error_msg}")
+            log.error(f"{LogTag.MCP} MCP tool '{tool.name}' failed: {error_msg}")
 
             # Re-raise auth errors so the orchestrator can handle token refresh.
             if "401" in error_msg or "unauthorized" in error_lower:
@@ -100,18 +103,20 @@ def wrap_tool_with_null_filter(
                     raise TypeError(
                         "on_connection_error must be a synchronous callable, not a coroutine function"
                     )
-                log.warning(f"MCP tool '{tool.name}' hit connection error, evicting session")
+                log.warning(
+                    f"{LogTag.MCP} MCP tool '{tool.name}' hit connection error, evicting session"
+                )
                 on_connection_error()
 
             if is_connection_error and reconnect_and_retry:
                 try:
                     log.warning(
-                        f"MCP tool '{tool.name}' attempting transparent reconnect-and-retry"
+                        f"{LogTag.MCP} MCP tool '{tool.name}' attempting transparent reconnect-and-retry"
                     )
                     return await reconnect_and_retry(tool.name, filtered_kwargs)
                 except Exception as retry_err:
                     log.error(
-                        f"MCP tool '{tool.name}' reconnect-retry failed: "
+                        f"{LogTag.MCP} MCP tool '{tool.name}' reconnect-retry failed: "
                         f"{type(retry_err).__name__}: {retry_err}"
                     )
                     return f"MCP tool error after reconnect: {retry_err}"

--- a/apps/api/app/utils/notes_utils.py
+++ b/apps/api/app/utils/notes_utils.py
@@ -1,5 +1,6 @@
 from langchain_core.documents import Document
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chromadb import ChromaClient
 from app.db.mongodb.collections import notes_collection
 from app.db.redis import delete_cache, set_cache
@@ -13,7 +14,7 @@ async def insert_note(
     auto_created=False,
 ) -> NoteResponse:
     log.set(user_id=user_id, auto_created=auto_created, operation="insert_note")
-    log.info(f"Creating new note for user: {user_id}")
+    log.info(f"{LogTag.API} Creating new note for user: {user_id}")
 
     langchain_chroma_client = await ChromaClient.get_langchain_client(collection_name="notes")
 
@@ -25,7 +26,7 @@ async def insert_note(
 
     note_id = str(result.inserted_id)
 
-    log.info(f"Note created with ID: {note_id}")
+    log.info(f"{LogTag.API} Note created with ID: {note_id}")
 
     # Add note to ChromaDB for vector search
     await langchain_chroma_client.aadd_documents(
@@ -40,7 +41,7 @@ async def insert_note(
         ],
         ids=[note_id],
     )
-    log.info(f"Note with id {note_id} indexed in ChromaDB")
+    log.info(f"{LogTag.API} Note with id {note_id} indexed in ChromaDB")
 
     response_data = {
         "id": note_id,
@@ -55,6 +56,6 @@ async def insert_note(
     await delete_cache(f"notes:{user_id}")
 
     await set_cache(f"note:{user_id}:{note_id}", response_data)
-    log.info(f"Note created with ID: {note_id} and cache updated")
+    log.info(f"{LogTag.API} Note created with ID: {note_id} and cache updated")
 
     return NoteResponse(**response_data)

--- a/apps/api/app/utils/notification/actions.py
+++ b/apps/api/app/utils/notification/actions.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from fastapi import Request
 import httpx
 
+from app.constants.log_tags import LogTag
 from app.models.notification.notification_models import (
     ActionResult,
     ActionType,
@@ -56,17 +57,13 @@ class ApiCallActionHandler(ActionHandler):
         request: Request | None,
     ) -> ActionResult:
         api_config = action.config.api_call
-        log.set(
-            operation="execute_api_call_action",
-            action_id=action.id,
-            notification_id=notification.id,
-            user_id=user_id,
-        )
-        log.info("Resolved API call action config", api_config=api_config)
+        log.set(user={"id": user_id})
+        log.set_ns("notification", operation="dispatch", notification_id=notification.id)
+        log.info(f"{LogTag.NOTIFICATION} Resolved API call action config", api_config=api_config)
 
         if api_config is None:
             log.error(
-                f"API call configuration missing for action {action.id} in notification {notification.id}"
+                f"{LogTag.NOTIFICATION} API call configuration missing for action {action.id} in notification {notification.id}"
             )
             return ActionResult(
                 success=False,
@@ -125,7 +122,7 @@ class ApiCallActionHandler(ActionHandler):
 
         except httpx.HTTPError as e:
             log.error(
-                f"API call failed for action {action.id} in notification {notification.id}: {e!s}"
+                f"{LogTag.NOTIFICATION} API call failed for action {action.id} in notification {notification.id}: {e!s}"
             )
             return ActionResult(
                 success=False,
@@ -134,7 +131,7 @@ class ApiCallActionHandler(ActionHandler):
             )
         except Exception as e:
             log.error(
-                f"Unexpected error during API call for action {action.id} in notification {notification.id}: {e!s}"
+                f"{LogTag.NOTIFICATION} Unexpected error during API call for action {action.id} in notification {notification.id}: {e!s}"
             )
             return ActionResult(
                 success=False,
@@ -164,7 +161,7 @@ class RedirectActionHandler(ActionHandler):
 
         if redirect_config is None:
             log.error(
-                f"Redirect configuration missing for action {action.id} in notification {notification.id}"
+                f"{LogTag.NOTIFICATION} Redirect configuration missing for action {action.id} in notification {notification.id}"
             )
             return ActionResult(
                 success=False,
@@ -206,7 +203,7 @@ class ModalActionHandler(ActionHandler):
 
         if modal_config is None:
             log.error(
-                f"Modal configuration missing for action {action.id} in notification {notification.id}"
+                f"{LogTag.NOTIFICATION} Modal configuration missing for action {action.id} in notification {notification.id}"
             )
             return ActionResult(
                 success=False,

--- a/apps/api/app/utils/notification/channels/inapp.py
+++ b/apps/api/app/utils/notification/channels/inapp.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.constants.notifications import CHANNEL_TYPE_INAPP
 from app.core.websocket_manager import websocket_manager
 from app.models.notification.notification_models import (
@@ -77,8 +78,12 @@ class InAppChannelAdapter(ChannelAdapter):
                     "notification": content,
                 },
             )
-            log.info(f"In-app notification delivered to user {user_id}: {content.get('title')}")
+            log.info(
+                f"{LogTag.NOTIFICATION} In-app notification delivered to user {user_id}: {content.get('title')}"
+            )
             return self._success()
         except Exception as e:
-            log.error(f"Failed to deliver in-app notification to user {user_id}: {e}")
+            log.error(
+                f"{LogTag.NOTIFICATION} Failed to deliver in-app notification to user {user_id}: {e}"
+            )
             return self._error(str(e))

--- a/apps/api/app/utils/notification/orchestrator.py
+++ b/apps/api/app/utils/notification/orchestrator.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from fastapi import Request
 
+from app.constants.log_tags import LogTag
 from app.constants.notifications import (
     ALL_AUTO_INJECTED_CHANNELS,
     CHANNEL_TYPE_INAPP,
@@ -38,7 +39,7 @@ from app.utils.notification.channels import (
 from app.utils.notification.storage import (
     MongoDBNotificationStorage,
 )
-from shared.py.wide_events import log
+from shared.py.wide_events import NotificationContext, log
 
 
 class NotificationOrchestrator:
@@ -71,30 +72,22 @@ class NotificationOrchestrator:
     def register_channel_adapter(self, adapter: ChannelAdapter) -> None:
         """Register a new channel adapter"""
         self.channel_adapters[adapter.channel_type] = adapter
-        log.info(f"Registered channel adapter: {adapter.channel_type}")
+        log.info(f"{LogTag.NOTIFICATION} Registered channel adapter: {adapter.channel_type}")
 
     def register_action_handler(self, handler: ActionHandler) -> None:
         """Register a new action handler"""
         self.action_handlers[handler.action_type] = handler
-        log.info(f"Registered action handler: {handler.action_type}")
+        log.info(f"{LogTag.NOTIFICATION} Registered action handler: {handler.action_type}")
 
     # NOTIFICATION CREATION & MANAGEMENT
     async def create_notification(self, request: NotificationRequest) -> NotificationRecord | None:
         """Create, store, and deliver a new notification."""
-        channels_requested = [ch.channel_type for ch in request.channels]
         log.set(
-            notification={
-                "id": request.id,
-                "user_id": request.user_id,
-                "notification_type": request.type.value if request.type else None,
-                "source": request.source,
-                "title": request.content.title if request.content else None,
-                "body_preview": (request.content.body or "")[:80] if request.content else None,
-                "channels": channels_requested,
-                "operation": "create_notification",
-            }
+            notification=NotificationContext(operation="send", notification_id=request.id)
         )
-        log.info(f"Creating notification {request.id} for user {request.user_id}")
+        log.info(
+            f"{LogTag.NOTIFICATION} Creating notification {request.id} for user {request.user_id}"
+        )
 
         # Create notification record
         notification_record = NotificationRecord(
@@ -116,7 +109,7 @@ class NotificationOrchestrator:
     # NOTIFICATION DELIVERY SYSTEM
     async def _deliver_notification(self, notification: NotificationRecord) -> None:
         """Deliver a notification through all configured channels."""
-        log.info(f"Delivering notification {notification.id}")
+        log.info(f"{LogTag.NOTIFICATION} Delivering notification {notification.id}")
 
         delivery_tasks = []
         explicitly_requested = {ch.channel_type for ch in notification.original_request.channels}
@@ -133,7 +126,7 @@ class NotificationOrchestrator:
             for platform in ALL_AUTO_INJECTED_CHANNELS:
                 if platform != CHANNEL_TYPE_INAPP and not channel_prefs.get(platform, True):
                     log.info(
-                        f"Skipping {platform} delivery for {notification.user_id}: disabled by preference"
+                        f"{LogTag.NOTIFICATION} Skipping {platform} delivery for {notification.user_id}: disabled by preference"
                     )
                     continue
                 adapter = self.channel_adapters.get(platform)
@@ -150,7 +143,7 @@ class NotificationOrchestrator:
                 if isinstance(result, ChannelDeliveryStatus):
                     channel_statuses.append(result)
                 elif isinstance(result, Exception):
-                    log.error(f"Delivery failed: {result}")
+                    log.error(f"{LogTag.NOTIFICATION} Delivery failed: {result}")
 
             # Compute overall status: DELIVERED only if at least one channel
             # actually succeeded (i.e. not failed and not skipped).
@@ -162,15 +155,12 @@ class NotificationOrchestrator:
             overall_status = (
                 NotificationStatus.DELIVERED if delivered_channels else NotificationStatus.FAILED
             )
-            log.set(
-                notification={
-                    "id": notification.id,
-                    "user_id": notification.user_id,
-                    "delivery_status": overall_status.value,
-                    "channels_attempted": [s.channel_type for s in channel_statuses],
-                    "channels_delivered": [s.channel_type for s in delivered_channels],
-                    "operation": "deliver_notification",
-                }
+            log.set_ns(
+                "notification",
+                operation="dispatch",
+                notification_id=notification.id,
+                result_count=len(delivered_channels),
+                success=overall_status == NotificationStatus.DELIVERED,
             )
             now = datetime.now(UTC)
 
@@ -215,7 +205,9 @@ class NotificationOrchestrator:
         try:
             return await fetch_channel_preferences(user_id)
         except Exception as e:
-            log.warning(f"Failed to fetch channel prefs for {user_id}, using defaults: {e}")
+            log.warning(
+                f"{LogTag.NOTIFICATION} Failed to fetch channel prefs for {user_id}, using defaults: {e}"
+            )
             return dict(DEFAULT_CHANNEL_PREFERENCES)
 
     async def _deliver_via_channel(
@@ -226,7 +218,7 @@ class NotificationOrchestrator:
             content = await adapter.transform(notification.original_request)
             return await adapter.deliver(content, notification.user_id)
         except Exception as e:
-            log.error(f"Channel delivery failed: {e}")
+            log.error(f"{LogTag.NOTIFICATION} Channel delivery failed: {e}")
             return ChannelDeliveryStatus(
                 channel_type=adapter.channel_type,
                 status=NotificationStatus.PENDING,
@@ -243,12 +235,15 @@ class NotificationOrchestrator:
     ) -> ActionResult:
         """Execute a notification action."""
         log.set(
-            action_id=action_id,
-            notification_id=notification_id,
-            user_id=user_id,
+            user={"id": user_id},
             operation="execute_action",
+            notification=NotificationContext(
+                operation="dispatch", notification_id=notification_id
+            ),
         )
-        log.info(f"Executing action {action_id} for notification {notification_id}")
+        log.info(
+            f"{LogTag.NOTIFICATION} Executing action {action_id} for notification {notification_id}"
+        )
 
         # Get notification
         notification = await self.storage.get_notification(notification_id, user_id)
@@ -302,7 +297,9 @@ class NotificationOrchestrator:
         # Update notification if needed (additional updates from handler)
         if result.update_notification:
             await self.storage.update_notification(notification_id, result.update_notification)
-            log.info(f"Broadcasting notification {notification.id} to user {notification.user_id}")
+            log.info(
+                f"{LogTag.NOTIFICATION} Broadcasting notification {notification.id} to user {notification.user_id}"
+            )
             # Broadcast update to user via websocket
             await websocket_manager.broadcast_to_user(
                 user_id,
@@ -322,7 +319,9 @@ class NotificationOrchestrator:
         if not notification:
             return None
 
-        log.info(f"Marking notification {notification_id} as read for user {user_id}")
+        log.info(
+            f"{LogTag.NOTIFICATION} Marking notification {notification_id} as read for user {user_id}"
+        )
 
         await self.storage.update_notification(
             notification_id,
@@ -348,7 +347,9 @@ class NotificationOrchestrator:
         if not notification:
             return False
 
-        log.info(f"Archiving notification {notification_id} for user {user_id}")
+        log.info(
+            f"{LogTag.NOTIFICATION} Archiving notification {notification_id} for user {user_id}"
+        )
 
         await self.storage.update_notification(
             notification_id,
@@ -403,7 +404,7 @@ class NotificationOrchestrator:
 
                 results[notification_id] = success
             except Exception as e:
-                log.error(f"Bulk action failed for {notification_id}: {e}")
+                log.error(f"{LogTag.NOTIFICATION} Bulk action failed for {notification_id}: {e}")
                 results[notification_id] = False
 
         return results

--- a/apps/api/app/utils/notification/orchestrator.py
+++ b/apps/api/app/utils/notification/orchestrator.py
@@ -82,9 +82,7 @@ class NotificationOrchestrator:
     # NOTIFICATION CREATION & MANAGEMENT
     async def create_notification(self, request: NotificationRequest) -> NotificationRecord | None:
         """Create, store, and deliver a new notification."""
-        log.set(
-            notification=NotificationContext(operation="send", notification_id=request.id)
-        )
+        log.set(notification=NotificationContext(operation="send", notification_id=request.id))
         log.info(
             f"{LogTag.NOTIFICATION} Creating notification {request.id} for user {request.user_id}"
         )
@@ -237,9 +235,7 @@ class NotificationOrchestrator:
         log.set(
             user={"id": user_id},
             operation="execute_action",
-            notification=NotificationContext(
-                operation="dispatch", notification_id=notification_id
-            ),
+            notification=NotificationContext(operation="dispatch", notification_id=notification_id),
         )
         log.info(
             f"{LogTag.NOTIFICATION} Executing action {action_id} for notification {notification_id}"

--- a/apps/api/app/utils/notification/storage.py
+++ b/apps/api/app/utils/notification/storage.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import (
     notifications_collection,
 )
@@ -76,14 +77,12 @@ class MongoDBNotificationStorage:
     async def update_notification(self, notification_id: str, updates: dict[str, Any]) -> None:
         """Update a notification's fields"""
         updates["updated_at"] = datetime.now(UTC)
-        log.set(
-            notification_id=notification_id,
-            operation="update_notification",
-            update_fields=list(updates.keys()),
-        )
+        log.set_ns("notification", notification_id=notification_id)
 
         # Debug logging
-        log.info(f"Updating notification {notification_id} with updates: {updates}")
+        log.info(
+            f"{LogTag.NOTIFICATION} Updating notification {notification_id} with updates: {updates}"
+        )
 
         result = await notifications_collection.update_one(
             {"id": notification_id}, {"$set": updates}
@@ -91,15 +90,17 @@ class MongoDBNotificationStorage:
 
         # Log the result
         log.info(
-            f"Update result - matched: {result.matched_count}, modified: {result.modified_count}"
+            f"{LogTag.NOTIFICATION} Update result - matched: {result.matched_count}, modified: {result.modified_count}"
         )
 
         if result.matched_count == 0:
-            log.warning(f"No notification found with id: {notification_id}")
+            log.warning(f"{LogTag.NOTIFICATION} No notification found with id: {notification_id}")
         elif result.modified_count == 0:
-            log.warning(f"Notification {notification_id} found but not modified")
+            log.warning(
+                f"{LogTag.NOTIFICATION} Notification {notification_id} found but not modified"
+            )
         else:
-            log.info(f"Successfully updated notification {notification_id}")
+            log.info(f"{LogTag.NOTIFICATION} Successfully updated notification {notification_id}")
 
     async def get_user_notifications(
         self,

--- a/apps/api/app/utils/oauth_utils.py
+++ b/apps/api/app/utils/oauth_utils.py
@@ -9,6 +9,7 @@ import httpx
 
 from app.config.settings import settings
 from app.config.token_repository import token_repository
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 http_async_client = httpx.AsyncClient()
@@ -49,7 +50,7 @@ async def build_google_oauth_url(
             if token:
                 existing_scopes = (token.get("scope") or "").split()
         except Exception as e:
-            log.debug(f"Could not get existing scopes for user {user_id}: {e}")
+            log.debug(f"{LogTag.OAUTH} Could not get existing scopes for user {user_id}: {e}")
 
     # Combine all scopes (base + existing + new), removing duplicates
     all_scopes = list(set(base_scopes + existing_scopes + integration_scopes))
@@ -92,13 +93,13 @@ async def upload_user_picture(image_bytes: bytes, public_id: str) -> str:
         )
         image_url = upload_result.get("secure_url")
         if not image_url:
-            log.error("Missing secure_url in Cloudinary upload response")
+            log.error(f"{LogTag.OAUTH} Missing secure_url in Cloudinary upload response")
             raise HTTPException(status_code=500, detail="Invalid response from image service")
 
-        log.info(f"Image uploaded successfully. URL: {image_url}")
+        log.info(f"{LogTag.OAUTH} Image uploaded successfully. URL: {image_url}")
         return image_url
     except Exception as e:
-        log.error(f"Failed to upload image to Cloudinary: {e!s}", exc_info=True)
+        log.error(f"{LogTag.OAUTH} Failed to upload image to Cloudinary: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail="Image upload failed")
 
 
@@ -119,7 +120,7 @@ async def get_tokens_by_user_id(user_id: str) -> tuple[str, str, bool]:
         token = await token_repository.get_token(user_id, "google")
 
         if not token:
-            log.error(f"No token found in repository for user: {user_id}")
+            log.error(f"{LogTag.OAUTH} No token found in repository for user: {user_id}")
             return "", "", False
 
         # Check if token needs refresh
@@ -127,7 +128,7 @@ async def get_tokens_by_user_id(user_id: str) -> tuple[str, str, bool]:
         refresh_token = cast(str, token.get("refresh_token", ""))
 
         if not refresh_token:
-            log.error(f"Missing refresh token for user: {user_id}")
+            log.error(f"{LogTag.OAUTH} Missing refresh token for user: {user_id}")
             return "", "", False
 
         # Check if token needs to be refreshed
@@ -139,7 +140,7 @@ async def get_tokens_by_user_id(user_id: str) -> tuple[str, str, bool]:
         refreshed_token = await token_repository.refresh_token(user_id, "google")
 
         if not refreshed_token:
-            log.error(f"Failed to refresh token for user: {user_id}")
+            log.error(f"{LogTag.OAUTH} Failed to refresh token for user: {user_id}")
             return "", refresh_token, False
 
         new_access_token = cast(str, refreshed_token.get("access_token", ""))
@@ -148,5 +149,5 @@ async def get_tokens_by_user_id(user_id: str) -> tuple[str, str, bool]:
         return new_access_token, new_refresh_token, True
 
     except Exception as e:
-        log.error(f"Error getting tokens for user {user_id}: {e!s}")
+        log.error(f"{LogTag.OAUTH} Error getting tokens for user {user_id}: {e!s}")
         return "", "", False

--- a/apps/api/app/utils/profile_card.py
+++ b/apps/api/app/utils/profile_card.py
@@ -9,6 +9,7 @@ from langchain_core.messages import HumanMessage
 
 from app.agents.llm.client import init_llm
 from app.agents.prompts.onboarding_prompts import HOLO_CARD_PROMPT
+from app.constants.log_tags import LogTag
 from app.constants.profession_bios import get_random_bio_for_profession
 from app.db.mongodb.collections import users_collection
 from app.models.onboarding_models import HoloCardLLMOutput
@@ -188,11 +189,11 @@ async def generate_holo_card_content(
         result: HoloCardLLMOutput = await structured_llm.ainvoke([HumanMessage(content=prompt)])
         phrase = result.personality_phrase.strip().strip('"').strip("'")
         bio = result.user_bio.strip()
-        log.info(f"Generated holo card content for user {user_id}: phrase='{phrase}'")
+        log.info(f"{LogTag.API} Generated holo card content for user {user_id}: phrase='{phrase}'")
         return phrase, bio, BioStatus.COMPLETED
 
     except Exception as e:
-        log.error(f"Error generating holo card content: {e}", exc_info=True)
+        log.error(f"{LogTag.API} Error generating holo card content: {e}", exc_info=True)
         return (
             _phrase_fallback(profession),
             get_random_bio_for_profession(name, profession or "other"),

--- a/apps/api/app/utils/redis_utils.py
+++ b/apps/api/app/utils/redis_utils.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -32,8 +33,8 @@ class RedisPoolManager:
                     try:
                         redis_settings = RedisSettings.from_dsn(settings.REDIS_URL)
                         cls._pool = await create_pool(redis_settings)
-                        log.info("Redis pool created successfully")
+                        log.info(f"{LogTag.STORAGE} Redis pool created successfully")
                     except Exception as e:
-                        log.error(f"Failed to create Redis pool: {e}")
+                        log.error(f"{LogTag.STORAGE} Failed to create Redis pool: {e}")
                         raise
         return cls._pool

--- a/apps/api/app/utils/request_coalescing.py
+++ b/apps/api/app/utils/request_coalescing.py
@@ -16,6 +16,7 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from typing import Any, TypeVar
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 T = TypeVar("T")
@@ -52,11 +53,11 @@ async def coalesce_request(key: str, factory: Callable[[], Coroutine[Any, Any, T
     async with _lock:
         if key in _pending_requests:
             # Another request is already running, wait for it
-            log.debug(f"Request coalescing: waiting for in-flight '{key}'")
+            log.debug(f"{LogTag.STARTUP} Request coalescing: waiting for in-flight '{key}'")
             task = _pending_requests[key]
         else:
             # We're the first, create the task
-            log.debug(f"Request coalescing: starting new request for '{key}'")
+            log.debug(f"{LogTag.STARTUP} Request coalescing: starting new request for '{key}'")
             coro = factory()
             task = asyncio.create_task(coro)
             _pending_requests[key] = task

--- a/apps/api/app/utils/research_utils.py
+++ b/apps/api/app/utils/research_utils.py
@@ -9,6 +9,7 @@ from langchain_core.messages import HumanMessage
 
 from app.agents.llm.client import get_free_llm_chain, invoke_with_fallback
 from app.constants.cache import SIX_HOUR_TTL
+from app.constants.log_tags import LogTag
 from app.decorators.caching import Cacheable
 from shared.py.wide_events import log
 
@@ -65,7 +66,7 @@ async def decompose_research_queries(
             if valid:
                 return valid
     except Exception as e:
-        log.warning(f"Query decomposition LLM call failed: {e}")
+        log.warning(f"{LogTag.TOOL} Query decomposition LLM call failed: {e}")
 
     # Fallback: heuristic sub-queries matching n_queries contract (depth 1→3, 2→6, 3→9)
     base = [

--- a/apps/api/app/utils/schema_fixes.py
+++ b/apps/api/app/utils/schema_fixes.py
@@ -6,6 +6,7 @@ This module provides utilities to normalize schemas before conversion.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -40,7 +41,7 @@ def normalize_schema_refs(schema: dict[str, Any]) -> dict[str, Any]:
 
         if numeric_keys:
             log.warning(
-                f"Found numeric definition keys: {numeric_keys}. "
+                f"{LogTag.STARTUP} Found numeric definition keys: {numeric_keys}. "
                 f"This can cause $ref resolution issues. Normalizing..."
             )
 
@@ -53,7 +54,9 @@ def normalize_schema_refs(schema: dict[str, Any]) -> dict[str, Any]:
                     new_key = f"Def{old_key}"
                     new_defs[new_key] = value
                     key_mapping[old_key] = new_key
-                    log.debug(f"Renamed definition key: '{old_key}' -> '{new_key}'")
+                    log.debug(
+                        f"{LogTag.STARTUP} Renamed definition key: '{old_key}' -> '{new_key}'"
+                    )
                 else:
                     new_defs[old_key] = value
 
@@ -83,7 +86,7 @@ def _update_refs_recursive(obj: Any, key_mapping: dict[str, str], defs_key: str)
                 if ref_key in key_mapping:
                     new_ref = f"#/{defs_key}/{key_mapping[ref_key]}"
                     obj["$ref"] = new_ref
-                    log.debug(f"Updated $ref: '{ref}' -> '{new_ref}'")
+                    log.debug(f"{LogTag.STARTUP} Updated $ref: '{ref}' -> '{new_ref}'")
 
         # Recurse into dict values
         for value in obj.values():
@@ -112,12 +115,14 @@ def patch_tool_schema(tool: Any) -> Any:
     try:
         normalized = normalize_schema_refs(tool.inputSchema)
         if normalized != tool.inputSchema:
-            log.info(f"Normalized schema for tool: {tool.name}")
+            log.info(f"{LogTag.STARTUP} Normalized schema for tool: {tool.name}")
             # Create a modified copy
             tool_dict = tool.model_dump()
             tool_dict["inputSchema"] = normalized
             return type(tool)(**tool_dict)
     except Exception as e:
-        log.warning(f"Could not normalize schema for tool {tool.name}: {e}. Using original schema.")
+        log.warning(
+            f"{LogTag.STARTUP} Could not normalize schema for tool {tool.name}: {e}. Using original schema."
+        )
 
     return tool

--- a/apps/api/app/utils/search_utils.py
+++ b/apps/api/app/utils/search_utils.py
@@ -11,6 +11,7 @@ from app.constants.cache import (
     WEB_SEARCH_CACHE_TTL,
     WEBPAGE_FETCH_CACHE_TTL,
 )
+from app.constants.log_tags import LogTag
 from app.decorators.caching import Cacheable
 from app.utils.exceptions import FetchError
 from shared.py.wide_events import log
@@ -37,7 +38,7 @@ def get_tavily_client() -> TavilyClient:
         if not settings.TAVILY_API_KEY:
             raise ValueError("TAVILY_API_KEY is not configured")
         _tavily_client = TavilyClient(api_key=settings.TAVILY_API_KEY)
-        log.info("Initialized Tavily client")
+        log.info(f"{LogTag.TOOL} Initialized Tavily client")
     return _tavily_client
 
 
@@ -48,7 +49,7 @@ def get_firecrawl_client() -> FirecrawlApp:
         if not settings.FIRECRAWL_API_KEY:
             raise ValueError("FIRECRAWL_API_KEY is not configured")
         _firecrawl_client = FirecrawlApp(api_key=settings.FIRECRAWL_API_KEY)
-        log.info("Initialized Firecrawl client")
+        log.info(f"{LogTag.TOOL} Initialized Firecrawl client")
     return _firecrawl_client
 
 
@@ -88,11 +89,11 @@ async def fetch_tavily_search(
 
         # Perform the search
         result = tavily.search(**search_params)
-        log.info(f"Fetched Tavily search results for query: {query}")
+        log.info(f"{LogTag.TOOL} Fetched Tavily search results for query: {query}")
 
         return result
     except Exception as e:
-        log.error(f"Error calling Tavily API: {e}")
+        log.error(f"{LogTag.TOOL} Error calling Tavily API: {e}")
         return {}
 
 
@@ -121,7 +122,7 @@ async def perform_search(query: str, count: int) -> dict:
         }
 
     except Exception as e:
-        log.error(f"Search failed: {e}")
+        log.error(f"{LogTag.TOOL} Search failed: {e}")
         return {
             "web": [],
             "news": [],
@@ -227,7 +228,7 @@ async def fetch_with_httpx(url: str) -> str:
         if not markdown:
             raise FetchError("httpx+BS4 returned empty content", url=url)
 
-        log.info(f"httpx fallback successfully fetched: {url[:60]}")
+        log.info(f"{LogTag.TOOL} httpx fallback successfully fetched: {url[:60]}")
         return markdown[:60_000]  # Cap at 60KB
     except FetchError:
         raise
@@ -258,7 +259,7 @@ async def search_with_duckduckgo(query: str, count: int = 5) -> dict:
         # treats as success; without this guard it parses as a silent "0 results".
         if response.status_code == 202 or "bots use duckduckgo" in response.text[:2000].lower():
             log.warning(
-                f"DuckDuckGo served a bot-challenge page "
+                f"{LogTag.TOOL} DuckDuckGo served a bot-challenge page "
                 f"(status {response.status_code}) for query: {query[:60]}"
             )
             return {"results": []}
@@ -285,10 +286,10 @@ async def search_with_duckduckgo(query: str, count: int = 5) -> dict:
                 }
             )
 
-        log.info(f"DuckDuckGo returned {len(results)} results for: {query[:60]}")
+        log.info(f"{LogTag.TOOL} DuckDuckGo returned {len(results)} results for: {query[:60]}")
         return {"results": results}
     except Exception as e:
-        log.error(f"DuckDuckGo search failed: {e}")
+        log.error(f"{LogTag.TOOL} DuckDuckGo search failed: {e}")
         return {"results": []}
 
 
@@ -302,8 +303,10 @@ async def search_for_research(query: str, count: int = 5) -> dict:
         results = tavily_result.get("results") if isinstance(tavily_result, dict) else None
         if results:
             return {"results": results}
-        log.warning(f"Tavily returned no results, falling back to DuckDuckGo for: {query[:60]}")
+        log.warning(
+            f"{LogTag.TOOL} Tavily returned no results, falling back to DuckDuckGo for: {query[:60]}"
+        )
     except Exception as e:
-        log.warning(f"Tavily research search failed, falling back to DuckDuckGo: {e}")
+        log.warning(f"{LogTag.TOOL} Tavily research search failed, falling back to DuckDuckGo: {e}")
 
     return await search_with_duckduckgo(query, count)

--- a/apps/api/app/utils/seeding_utils.py
+++ b/apps/api/app/utils/seeding_utils.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import conversations_collection
 from app.models.chat_models import (
     ConversationModel,
@@ -90,10 +91,10 @@ async def seed_onboarding_todo(user_id: str) -> None:
 
         # Create the todo using the service
         await TodoService.create_todo(todo, user_id)
-        log.info(f"Seeded onboarding todo for user {user_id}")
+        log.info(f"{LogTag.STARTUP} Seeded onboarding todo for user {user_id}")
 
     except Exception as e:
-        log.error(f"Failed to seed onboarding todo for user {user_id}: {e}")
+        log.error(f"{LogTag.STARTUP} Failed to seed onboarding todo for user {user_id}: {e}")
 
 
 async def seed_onboarding_conversation(user_id: str) -> str | None:
@@ -120,9 +121,13 @@ async def seed_onboarding_conversation(user_id: str) -> str | None:
             {"$set": {"is_onboarding_conversation": True}},
         )
 
-        log.info(f"Seeded onboarding conversation {conversation_id} for user {user_id}")
+        log.info(
+            f"{LogTag.STARTUP} Seeded onboarding conversation {conversation_id} for user {user_id}"
+        )
         return conversation_id
 
     except Exception as e:
-        log.error(f"Failed to seed onboarding conversation for user {user_id}: {e}")
+        log.error(
+            f"{LogTag.STARTUP} Failed to seed onboarding conversation for user {user_id}: {e}"
+        )
         return None

--- a/apps/api/app/utils/stream_utils.py
+++ b/apps/api/app/utils/stream_utils.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import json
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
 from app.models.chat_models import ToolDataEntry, tool_fields
 from app.utils.agent_utils import IntegrationMetadata, format_tool_call_entry
@@ -303,7 +304,7 @@ async def recover_stream_state(
         and not tool_data.get("tool_data")
     ):
         tool_data = progress_tool_data
-    log.debug(f"Recovered {len(complete_message)} chars from Redis progress")
+    log.debug(f"{LogTag.CHAT} Recovered {len(complete_message)} chars from Redis progress")
     return complete_message, tool_data
 
 

--- a/apps/api/app/utils/timezone.py
+++ b/apps/api/app/utils/timezone.py
@@ -28,6 +28,7 @@ from zoneinfo import ZoneInfo
 
 from langchain_core.runnables import RunnableConfig
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 # ``±HH:MM`` fixed-offset form (e.g. "+05:30", "-08:00").
@@ -88,7 +89,9 @@ class Timezone:
         if parsed is not None:
             return parsed
         if raw is not None and not isinstance(raw, (Timezone, _tzinfo)):
-            log.warning("Timezone.parse: unrecognized timezone, using UTC", timezone=raw)
+            log.warning(
+                f"{LogTag.STARTUP} Timezone.parse: unrecognized timezone, using UTC", timezone=raw
+            )
         return cls.utc()
 
     @classmethod
@@ -210,7 +213,9 @@ def home_timezone_from_config(config: RunnableConfig) -> Timezone:
         log.set(timezone_source=TimezoneSource.AGENT_CONFIG.value, user_timezone=raw)
         return Timezone.parse(raw)
     log.set(timezone_source=TimezoneSource.FALLBACK_UTC.value, user_timezone="+00:00")
-    log.warning("home_timezone_from_config: no user_timezone in config; using UTC")
+    log.warning(
+        f"{LogTag.STARTUP} home_timezone_from_config: no user_timezone in config; using UTC"
+    )
     return Timezone.utc()
 
 

--- a/apps/api/app/utils/todo_vector_utils.py
+++ b/apps/api/app/utils/todo_vector_utils.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 from bson import ObjectId
 
+from app.constants.log_tags import LogTag
 from app.db.chroma.chromadb import ChromaClient
 from app.db.mongodb.collections import todos_collection
 from app.db.utils import serialize_document
@@ -104,11 +105,11 @@ async def store_todo_embedding(todo_id: str, todo_data: dict, user_id: str) -> b
         # Store in ChromaDB (LangChain Chroma handles embedding generation automatically)
         chroma_collection.add_texts(texts=[content], metadatas=[metadata], ids=[str(todo_id)])
 
-        log.info(f"Stored embedding for todo {todo_id}")
+        log.info(f"{LogTag.CHROMA} Stored embedding for todo {todo_id}")
         return True
 
     except Exception as e:
-        log.error(f"Error storing embedding for todo {todo_id}: {e!s}")
+        log.error(f"{LogTag.CHROMA} Error storing embedding for todo {todo_id}: {e!s}")
         return False
 
 
@@ -122,7 +123,7 @@ async def update_todo_embedding(todo_id: str, todo_data: dict, user_id: str) -> 
         return await store_todo_embedding(todo_id, todo_data, user_id)
 
     except Exception as e:
-        log.error(f"Error updating embedding for todo {todo_id}: {e!s}")
+        log.error(f"{LogTag.CHROMA} Error updating embedding for todo {todo_id}: {e!s}")
         return False
 
 
@@ -137,11 +138,11 @@ async def delete_todo_embedding(todo_id: str) -> bool:
         # Delete the embedding
         chroma_collection.delete(ids=[str(todo_id)])
 
-        log.info(f"Deleted embedding for todo {todo_id}")
+        log.info(f"{LogTag.CHROMA} Deleted embedding for todo {todo_id}")
         return True
 
     except Exception as e:
-        log.error(f"Error deleting embedding for todo {todo_id}: {e!s}")
+        log.error(f"{LogTag.CHROMA} Error deleting embedding for todo {todo_id}: {e!s}")
         return False
 
 
@@ -199,7 +200,7 @@ async def semantic_search_todos(
 
         if not todo_ids:
             # No vector results found
-            log.info(f"No vector results for query '{query}'")
+            log.info(f"{LogTag.CHROMA} No vector results for query '{query}'")
             return []
 
         # Fetch full todo documents from MongoDB in the order of similarity
@@ -209,15 +210,15 @@ async def semantic_search_todos(
             if todo_doc:
                 todos.append(TodoResponse(**serialize_document(todo_doc)))
 
-        log.info(f"Semantic search returned {len(todos)} todos for query '{query}'")
+        log.info(f"{LogTag.CHROMA} Semantic search returned {len(todos)} todos for query '{query}'")
         return todos
 
     except Exception as e:
-        log.error(f"Error in semantic search for todos: {e!s}")
+        log.error(f"{LogTag.CHROMA} Error in semantic search for todos: {e!s}")
 
         # Fallback to traditional search on error
         if include_traditional_search:
-            log.info("Falling back to traditional search due to error")
+            log.info(f"{LogTag.CHROMA} Falling back to traditional search due to error")
             from app.services.todos.todo_service import search_todos
 
             return await search_todos(query, user_id)
@@ -287,10 +288,10 @@ async def hybrid_search_todos(
         # Return top results
         result = [all_todos[todo_id] for todo_id in sorted_todo_ids[:top_k]]
 
-        log.info(f"Hybrid search returned {len(result)} todos for query '{query}'")
+        log.info(f"{LogTag.CHROMA} Hybrid search returned {len(result)} todos for query '{query}'")
         return result
 
     except Exception as e:
-        log.error(f"Error in hybrid search: {e!s}")
+        log.error(f"{LogTag.CHROMA} Error in hybrid search: {e!s}")
         # Fallback to semantic search only
         return await semantic_search_todos(query, user_id, top_k, **filters)

--- a/apps/api/app/utils/twitter_utils.py
+++ b/apps/api/app/utils/twitter_utils.py
@@ -6,6 +6,7 @@ attaches the user's OAuth token server-side; callers only supply `user_id`.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from app.services.composio.proxy_client import proxy_request_sync
 from app.utils.errors import AppError
 from shared.py.wide_events import log
@@ -39,7 +40,7 @@ def get_my_user_id(user_id: str) -> str | None:
         data = _proxy(user_id, endpoint=f"{TWITTER_API_BASE}/users/me", method="GET")
         return (data or {}).get("data", {}).get("id")
     except Exception as e:
-        log.error(f"Error getting user ID: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error getting user ID: {e}")
         return None
 
 
@@ -58,7 +59,7 @@ def lookup_user_by_username(user_id: str, username: str) -> dict[str, Any] | Non
         )
         return (data or {}).get("data")
     except Exception as e:
-        log.error(f"Error looking up user {username}: {e}")
+        log.error(f"{LogTag.INTEGRATION} Error looking up user {username}: {e}")
         return None
 
 

--- a/apps/api/app/utils/user_preferences_utils.py
+++ b/apps/api/app/utils/user_preferences_utils.py
@@ -5,6 +5,7 @@ Provides functions to format user preferences for agent system prompts.
 
 from typing import Any
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log
 
 
@@ -58,7 +59,7 @@ def build_user_context_parts(preferences: dict[str, Any]) -> list[str]:
                 parts.append(f"Special Instructions: {instructions}")
 
     except Exception as e:
-        log.warning(f"Error building user context parts: {e!s}")
+        log.warning(f"{LogTag.AGENT} Error building user context parts: {e!s}")
 
     return parts
 
@@ -135,5 +136,5 @@ def format_user_preferences_for_agent(
         return None
 
     except Exception as e:
-        log.error(f"Error formatting user preferences for agent: {e!s}")
+        log.error(f"{LogTag.AGENT} Error formatting user preferences for agent: {e!s}")
         return None

--- a/apps/api/app/utils/weather_utils.py
+++ b/apps/api/app/utils/weather_utils.py
@@ -7,6 +7,7 @@ import httpx
 
 from app.config.settings import settings
 from app.constants.cache import ONE_HOUR_TTL
+from app.constants.log_tags import LogTag
 from app.db.redis import get_cache, set_cache
 from shared.py.wide_events import log
 
@@ -190,7 +191,7 @@ async def user_weather(location_name: str | None = None):
 
             cached_weather = await get_cache(cache_key)
             if cached_weather:
-                log.debug(f"Using cached weather data for location {cached_weather}")
+                log.debug(f"{LogTag.TOOL} Using cached weather data for location {cached_weather}")
                 return cached_weather
 
             weather = await prepare_weather_data(
@@ -203,11 +204,11 @@ async def user_weather(location_name: str | None = None):
 
         except Exception as e:
             error_msg = f"Could not find location: {location_name}"
-            log.error(f"Error getting location data: {e!s}")
+            log.error(f"{LogTag.TOOL} Error getting location data: {e!s}")
             return error_msg
 
     except Exception as e:
-        log.error(f"Error fetching weather: {e!s}")
+        log.error(f"{LogTag.TOOL} Error fetching weather: {e!s}")
         return f"Failed to fetch weather: {e!s}"
 
 
@@ -334,5 +335,5 @@ async def geocode_location(location_name: str) -> dict[str, Any]:
         }
 
     except Exception as e:
-        log.error(f"Error geocoding location '{location_name}': {e!s}")
+        log.error(f"{LogTag.TOOL} Error geocoding location '{location_name}': {e!s}")
         raise Exception(f"Failed to geocode location: {e!s}")

--- a/apps/api/app/utils/workflow_utils.py
+++ b/apps/api/app/utils/workflow_utils.py
@@ -7,6 +7,7 @@ from typing import Any
 from langchain_core.runnables.config import RunnableConfig
 from langgraph.types import StreamWriter
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import workflows_collection
 from app.db.utils import serialize_document
 from app.models.workflow_models import (
@@ -52,9 +53,11 @@ async def handle_workflow_error(
             {"_id": workflow_id, "user_id": user_id},
             {"$set": update_data},
         )
-        log.error(f"Workflow {workflow_id} error: {error}")
+        log.error(f"{LogTag.WORKFLOW} Workflow {workflow_id} error: {error}")
     except Exception as update_error:
-        log.error(f"Failed to update workflow {workflow_id} error state: {update_error}")
+        log.error(
+            f"{LogTag.WORKFLOW} Failed to update workflow {workflow_id} error state: {update_error}"
+        )
 
 
 def ensure_trigger_config_object(trigger_config: Any) -> TriggerConfig:
@@ -94,7 +97,7 @@ def transform_workflow_document(doc: dict) -> dict:
             "paused",
         ]:
             log.warning(
-                f"Unknown status '{old_status}' in workflow {doc.get('_id')}, defaulting to 'failed'"
+                f"{LogTag.WORKFLOW} Unknown status '{old_status}' in workflow {doc.get('_id')}, defaulting to 'failed'"
             )
             transformed_doc["status"] = "failed"
 
@@ -209,7 +212,7 @@ async def create_workflow_directly(
 
         writer({"workflow_created": workflow_data})
 
-        log.info(f"[create_workflow] Created workflow directly: {workflow.id}")
+        log.info(f"{LogTag.WORKFLOW} Created workflow directly: {workflow.id}")
 
         return success_response(
             {"status": "created", "workflow_id": workflow.id},
@@ -219,7 +222,7 @@ async def create_workflow_directly(
     except asyncio.CancelledError:
         raise
     except Exception as e:
-        log.warning(f"[create_workflow] Direct creation failed: {e}")
+        log.warning(f"{LogTag.WORKFLOW} Direct creation failed: {e}")
         return None
 
 

--- a/apps/api/app/workers/lifecycle/shutdown.py
+++ b/apps/api/app/workers/lifecycle/shutdown.py
@@ -4,6 +4,7 @@ ARQ worker shutdown functionality.
 
 import asyncio
 
+from app.constants.log_tags import LogTag
 from app.core.provider_registration import unified_shutdown
 from app.utils.browser_reaper import stop_browser_reaper
 from shared.py.wide_events import log
@@ -11,7 +12,7 @@ from shared.py.wide_events import log
 
 async def shutdown(ctx: dict):
     """ARQ worker shutdown function with proper cleanup."""
-    log.info("ARQ worker shutting down...")
+    log.info(f"{LogTag.WORKER} ARQ worker shutting down...")
 
     await stop_browser_reaper()
 
@@ -22,4 +23,4 @@ async def shutdown(ctx: dict):
     startup_time = ctx.get("startup_time", 0)
     if startup_time:
         runtime = asyncio.get_event_loop().time() - startup_time
-        log.info(f"ARQ worker ran for {runtime:.2f} seconds")
+        log.info(f"{LogTag.WORKER} ARQ worker ran for {runtime:.2f} seconds")

--- a/apps/api/app/workers/lifecycle/startup.py
+++ b/apps/api/app/workers/lifecycle/startup.py
@@ -17,6 +17,7 @@ from shared.py.logging import configure_file_logging
 if os.getenv("LOG_FORMAT", "console") != "json":
     configure_file_logging("./logs/worker")
 
+from app.constants.log_tags import LogTag  # noqa: E402
 from app.core.provider_registration import (  # noqa: E402
     setup_warnings,
     unified_startup,
@@ -32,7 +33,7 @@ setup_warnings()
 async def startup(ctx: dict):
     """ARQ worker startup function with eager initialization."""
 
-    log.info("ARQ worker starting up...")
+    log.info(f"{LogTag.WORKER} ARQ worker starting up...")
     # Store startup time for monitoring/debugging
     ctx["startup_time"] = asyncio.get_event_loop().time()
 

--- a/apps/api/app/workers/tasks/cleanup_tasks.py
+++ b/apps/api/app/workers/tasks/cleanup_tasks.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.models.user_models import OnboardingPhase
 from app.services.onboarding.intelligence_job import (
@@ -51,7 +52,7 @@ async def cleanup_stuck_personalization(ctx, max_age_minutes: int = 30) -> str:
                 try:
                     if await is_intelligence_job_live(user_id):
                         log.info(
-                            "[cleanup] skipping live pipeline",
+                            f"{LogTag.WORKER} skipping live pipeline",
                             user_id=user_id,
                             last_update=str(updated_at),
                         )
@@ -61,7 +62,7 @@ async def cleanup_stuck_personalization(ctx, max_age_minutes: int = 30) -> str:
                     job_id = await enqueue_intelligence_job(user_id)
                     if job_id:
                         log.info(
-                            "[cleanup] re-queued stuck user",
+                            f"{LogTag.WORKER} re-queued stuck user",
                             user_id=user_id,
                             last_update=str(updated_at),
                             job_id=job_id,
@@ -69,14 +70,14 @@ async def cleanup_stuck_personalization(ctx, max_age_minutes: int = 30) -> str:
                         queued_count += 1
                     else:
                         log.warning(
-                            "[cleanup] enqueue returned no job",
+                            f"{LogTag.WORKER} enqueue returned no job",
                             user_id=user_id,
                         )
                         error_count += 1
 
                 except Exception as e:
                     log.exception(
-                        f"[cleanup] error re-queueing user {user_id}: {e}",
+                        f"{LogTag.WORKER} error re-queueing user {user_id}: {e}",
                     )
                     error_count += 1
 
@@ -93,5 +94,5 @@ async def cleanup_stuck_personalization(ctx, max_age_minutes: int = 30) -> str:
 
         except Exception as e:
             error_msg = f"Error in cleanup_stuck_personalization: {e}"
-            log.exception(error_msg)
+            log.exception(f"{LogTag.WORKER} {error_msg}")
             return error_msg

--- a/apps/api/app/workers/tasks/memory_email_tasks.py
+++ b/apps/api/app/workers/tasks/memory_email_tasks.py
@@ -1,6 +1,7 @@
 """ARQ worker task for Gmail email memory processing."""
 
 from app.agents.memory.email_processor import process_gmail_to_memory
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log, wide_task
 
 
@@ -20,7 +21,7 @@ async def process_gmail_emails_to_memory(ctx, user_id: str) -> str:
 
         if result.get("already_processed", False):
             message = f"Gmail emails already processed for user {user_id}"
-            log.info(message)
+            log.info(f"{LogTag.WORKER} {message}")
             return message
 
         total = result.get("total", 0)
@@ -31,9 +32,9 @@ async def process_gmail_emails_to_memory(ctx, user_id: str) -> str:
 
         if processing_complete:
             message = f"Gmail email processing completed for user {user_id}: {successful}/{total} emails processed successfully"
-            log.info(message)
+            log.info(f"{LogTag.WORKER} {message}")
             return message
         log.warning(
-            f"Gmail email processing incomplete for user {user_id}: {failed} failed",
+            f"{LogTag.WORKER} Gmail email processing incomplete for user {user_id}: {failed} failed",
         )
         return f"Gmail email processing failed for user {user_id}: {successful}/{total} emails processed, {failed} failed - not marking as complete"

--- a/apps/api/app/workers/tasks/onboarding_tasks.py
+++ b/apps/api/app/workers/tasks/onboarding_tasks.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 
 from bson import ObjectId
 
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
 from app.models.user_models import OnboardingPhase
 from app.services.onboarding.intelligence_job import clear_active_intelligence_job
@@ -23,7 +24,7 @@ async def process_onboarding_intelligence_task(ctx: dict, user_id: str) -> str:
             await process_onboarding_intelligence(user_id)
         except Exception as e:
             log.error(
-                f"Onboarding intelligence failed for user {user_id}: {e}",
+                f"{LogTag.WORKER} Onboarding intelligence failed for user {user_id}: {e}",
                 exc_info=True,
             )
             try:
@@ -36,10 +37,12 @@ async def process_onboarding_intelligence_task(ctx: dict, user_id: str) -> str:
                         }
                     },
                 )
-                log.info(f"Set phase to PERSONALIZATION_COMPLETE after failure for user {user_id}")
+                log.info(
+                    f"{LogTag.WORKER} Set phase to PERSONALIZATION_COMPLETE after failure for user {user_id}"
+                )
             except Exception as db_err:
                 log.error(
-                    f"Failed to update onboarding phase after error for user {user_id}: {db_err}",
+                    f"{LogTag.WORKER} Failed to update onboarding phase after error for user {user_id}: {db_err}",
                     exc_info=True,
                 )
             return f"Onboarding intelligence failed for user {user_id}: {e}"
@@ -49,9 +52,9 @@ async def process_onboarding_intelligence_task(ctx: dict, user_id: str) -> str:
                     await clear_active_intelligence_job(user_id, job_id)
                 except Exception as clear_err:
                     log.warning(
-                        f"Failed to clear intelligence job id for user {user_id}: {clear_err}"
+                        f"{LogTag.WORKER} Failed to clear intelligence job id for user {user_id}: {clear_err}"
                     )
 
         message = f"Onboarding intelligence completed for user {user_id}"
-        log.info(message)
+        log.info(f"{LogTag.WORKER} {message}")
         return message

--- a/apps/api/app/workers/tasks/reminder_tasks.py
+++ b/apps/api/app/workers/tasks/reminder_tasks.py
@@ -4,6 +4,7 @@ Reminder-related ARQ tasks.
 
 from datetime import UTC, datetime, timedelta
 
+from app.constants.log_tags import LogTag
 from app.services.reminder_service import reminder_scheduler
 from shared.py.wide_events import log, wide_task
 
@@ -20,10 +21,10 @@ async def process_reminder(ctx: dict, reminder_id: str) -> str:
         Processing result message
     """
     async with wide_task("process_reminder", reminder_id=reminder_id):
-        log.info(f"Processing reminder task: {reminder_id}")
+        log.info(f"{LogTag.WORKER} Processing reminder task: {reminder_id}")
         await reminder_scheduler.process_task_execution(reminder_id)
         result = f"Successfully processed reminder {reminder_id}"
-        log.info(result)
+        log.info(f"{LogTag.WORKER} {result}")
         return result
 
 
@@ -40,7 +41,7 @@ async def cleanup_expired_reminders(ctx: dict) -> str:
     async with wide_task("cleanup_expired_reminders"):
         from app.db.mongodb.collections import reminders_collection
 
-        log.info("Running cleanup of expired reminders")
+        log.info(f"{LogTag.WORKER} Running cleanup of expired reminders")
         cutoff_date = datetime.now(UTC) - timedelta(days=30)
 
         result = await reminders_collection.delete_many(
@@ -51,5 +52,5 @@ async def cleanup_expired_reminders(ctx: dict) -> str:
         )
         log.set(reminders_deleted=result.deleted_count)
         message = f"Cleaned up {result.deleted_count} expired reminders"
-        log.info(message)
+        log.info(f"{LogTag.WORKER} {message}")
         return message

--- a/apps/api/app/workers/tasks/sandbox_tasks.py
+++ b/apps/api/app/workers/tasks/sandbox_tasks.py
@@ -14,9 +14,10 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import e2b_sandboxes_collection
 from app.services.sandbox import mark_sandbox_dead
-from shared.py.wide_events import log, wide_task
+from shared.py.wide_events import SandboxContext, log, wide_task
 
 
 async def sweep_idle_sandboxes(_ctx: dict[str, Any]) -> str:
@@ -39,6 +40,7 @@ async def sweep_idle_sandboxes(_ctx: dict[str, Any]) -> str:
                 await mark_sandbox_dead(user_id)
                 evicted += 1
             except Exception as e:
-                log.warning(f"Failed to mark sandbox dead for {user_id}: {e}")
-        log.set(evicted=evicted)
+                log.warning(f"{LogTag.SANDBOX} failed to mark dead user={user_id}: {e}")
+        log.set(sandbox=SandboxContext(operation="sweep", evicted_count=evicted))
+        log.info(f"{LogTag.SANDBOX} sweep evicted {evicted} idle sandboxes")
         return f"Evicted {evicted} idle sandboxes (cutoff={cutoff.isoformat()})"

--- a/apps/api/app/workers/tasks/session_tasks.py
+++ b/apps/api/app/workers/tasks/session_tasks.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.config.settings import settings
+from app.constants.log_tags import LogTag
 from app.services.storage import (
     delete_session_dir,
     flush_fs_metrics,
@@ -34,7 +35,7 @@ async def prune_inactive_sessions(_ctx: dict[str, Any]) -> str:
                 pruned += 1
             except Exception as e:
                 log.warning(
-                    "[prune] failed",
+                    f"{LogTag.WORKER} prune failed",
                     user_id=user_id,
                     conv=conv_id,
                     error=str(e),

--- a/apps/api/app/workers/tasks/user_tasks.py
+++ b/apps/api/app/workers/tasks/user_tasks.py
@@ -4,6 +4,7 @@ User-related ARQ tasks.
 
 from datetime import UTC, datetime, timedelta
 
+from app.constants.log_tags import LogTag
 from shared.py.wide_events import log, wide_task
 
 
@@ -22,7 +23,7 @@ async def check_inactive_users(ctx: dict) -> str:
         from app.db.mongodb.collections import users_collection
         from app.utils.email_utils import send_inactive_user_email
 
-        log.info("Checking for inactive users")
+        log.info(f"{LogTag.WORKER} Checking for inactive users")
 
         now = datetime.now(UTC)
         seven_days_ago = now - timedelta(days=7)
@@ -56,13 +57,13 @@ async def check_inactive_users(ctx: dict) -> str:
 
                 if sent:
                     email_count += 1
-                    log.info(f"Sent inactive email to {user['email']}")
+                    log.info(f"{LogTag.WORKER} Sent inactive email to {user['email']}")
 
             except Exception as e:
                 email_failures += 1
-                log.error(f"Failed to send email to {user['email']}: {e!s}")
+                log.error(f"{LogTag.WORKER} Failed to send email to {user['email']}: {e!s}")
 
         log.set(emails_sent=email_count, email_failures=email_failures)
         message = f"Processed {len(inactive_users)} inactive users, sent {email_count} emails"
-        log.info(message)
+        log.info(f"{LogTag.WORKER} {message}")
         return message

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -16,6 +16,7 @@ from app.api.v1.middleware.tiered_rate_limiter import (
     RateLimitExceededException,
     tiered_rate_limit,
 )
+from app.constants.log_tags import LogTag
 from app.core.websocket_manager import get_websocket_manager
 from app.db.mongodb.collections import todos_collection
 from app.models.chat_models import MessageModel
@@ -72,7 +73,7 @@ async def process_workflow_generation_task(
         Processing result message
     """
     async with wide_task("process_workflow_generation_task", todo_id=todo_id, user_id=user_id):
-        log.info(f"Processing workflow generation for todo {todo_id}: {title}")
+        log.info(f"{LogTag.WORKER} Processing workflow generation for todo {todo_id}: {title}")
 
         try:
             # Build short card description plus detailed execution prompt
@@ -115,7 +116,7 @@ async def process_workflow_generation_task(
 
                 if result.modified_count > 0:
                     log.info(
-                        f"Successfully generated and linked standalone workflow {workflow.id} for todo {todo_id} with {len(workflow.steps)} steps"
+                        f"{LogTag.WORKER} Successfully generated and linked standalone workflow {workflow.id} for todo {todo_id} with {len(workflow.steps)} steps"
                     )
                     log.set(
                         workflow=WorkflowContext(
@@ -138,10 +139,10 @@ async def process_workflow_generation_task(
                             },
                         )
                         log.set(websocket_broadcast_success=True)
-                        log.info(f"WebSocket event sent for workflow {workflow.id}")
+                        log.info(f"{LogTag.WORKER} WebSocket event sent for workflow {workflow.id}")
                     except Exception as ws_error:
                         log.set(websocket_broadcast_success=False)
-                        log.warning(f"Failed to send WebSocket event: {ws_error}")
+                        log.warning(f"{LogTag.WORKER} Failed to send WebSocket event: {ws_error}")
 
                     # Clear the generating flag
                     from app.services.workflow.queue_service import WorkflowQueueService
@@ -152,7 +153,9 @@ async def process_workflow_generation_task(
                 raise ValueError(f"Todo {todo_id} not found or not updated")
 
             # Mark workflow generation as failed
-            log.error(f"Failed to generate workflow for todo {todo_id}: No workflow created")
+            log.error(
+                f"{LogTag.WORKER} Failed to generate workflow for todo {todo_id}: No workflow created"
+            )
             raise ValueError("Workflow generation failed: No workflow created")
 
         except Exception as e:
@@ -176,10 +179,10 @@ async def process_workflow_generation_task(
                     },
                 )
                 log.set(websocket_broadcast_success=True)
-                log.info(f"WebSocket failure event sent for todo {todo_id}")
+                log.info(f"{LogTag.WORKER} WebSocket failure event sent for todo {todo_id}")
             except Exception as ws_error:
                 log.set(websocket_broadcast_success=False)
-                log.warning(f"Failed to send failure WebSocket event: {ws_error}")
+                log.warning(f"{LogTag.WORKER} Failed to send failure WebSocket event: {ws_error}")
 
             raise
 
@@ -209,7 +212,7 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
     async with wide_task("execute_workflow_by_id", workflow_id=workflow_id):
         actual_fire_utc = datetime.now(UTC)
         log.set(actual_fire_utc=actual_fire_utc.isoformat())
-        log.info(f"Processing workflow execution: {workflow_id}")
+        log.info(f"{LogTag.WORKER} Processing workflow execution: {workflow_id}")
 
         scheduler = WorkflowScheduler()
         workflow = None
@@ -246,7 +249,7 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                 await scheduler.claim_scheduled_for_execution(workflow_id)
             ):
                 log.warning(
-                    f"Workflow {workflow_id} not in scheduled state "
+                    f"{LogTag.WORKER} Workflow {workflow_id} not in scheduled state "
                     f"(already claimed or running); skipping duplicate scheduled fire"
                 )
                 return f"Workflow {workflow_id} already claimed; skipped duplicate scheduled fire"
@@ -262,7 +265,7 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                 )
                 if abs(drift) > 300:
                     log.warning(
-                        f"Workflow {workflow_id} fired {drift}s off schedule "
+                        f"{LogTag.WORKER} Workflow {workflow_id} fired {drift}s off schedule "
                         f"(positive = late, negative = early)",
                     )
 
@@ -300,13 +303,15 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
             try:
                 await _rearm_if_scheduled(scheduler, workflow, context)
             except Exception as rearm_err:
-                log.error("Failed to re-arm workflow %s: %s" % (workflow_id, rearm_err))
+                log.error(
+                    f"{LogTag.WORKER} Failed to re-arm workflow %s: %s" % (workflow_id, rearm_err)
+                )
 
             return f"Workflow {workflow_id} executed successfully"
 
         except Exception as e:
             log.exception(
-                f"Error executing workflow {workflow_id}: {e}",
+                f"{LogTag.WORKER} Error executing workflow {workflow_id}: {e}",
             )
 
             # Complete execution record with failure
@@ -318,7 +323,7 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                         error_message=str(e),
                     )
                 except Exception as e2:
-                    log.debug("Failed to complete execution record: %s" % e2)
+                    log.debug(f"{LogTag.WORKER} Failed to complete execution record: %s" % e2)
 
             # Track failed execution
             if workflow:
@@ -327,7 +332,7 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                         workflow_id, workflow.user_id, is_successful=False
                     )
                 except Exception as e2:
-                    log.debug("Failed to update workflow stats: %s" % e2)
+                    log.debug(f"{LogTag.WORKER} Failed to update workflow stats: %s" % e2)
 
             # Send failure notification so the user knows the workflow failed
             if workflow:
@@ -406,14 +411,18 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                         )
                     )
                 except Exception as notify_err:
-                    log.debug("Failed to send failure notification: %s" % notify_err)
+                    log.debug(
+                        f"{LogTag.WORKER} Failed to send failure notification: %s" % notify_err
+                    )
 
             # Still arm the next occurrence — a transient failure (rate limit, LLM
             # error) must not permanently kill a recurring workflow.
             try:
                 await _rearm_if_scheduled(scheduler, workflow, context)
             except Exception as rearm_err:
-                log.error("Failed to re-arm workflow %s: %s" % (workflow_id, rearm_err))
+                log.error(
+                    f"{LogTag.WORKER} Failed to re-arm workflow %s: %s" % (workflow_id, rearm_err)
+                )
 
             return "Error executing workflow %s: %s" % (workflow_id, str(e))
 
@@ -441,7 +450,9 @@ async def execute_workflow_as_chat(workflow, user: dict, context: dict) -> str:
     user_id = user["user_id"]
 
     try:
-        log.info(f"Executing workflow {workflow.id} as chat session for user {user_id}")
+        log.info(
+            f"{LogTag.WORKER} Executing workflow {workflow.id} as chat session for user {user_id}"
+        )
 
         # Resolve the agent's home zone for this run. There is no request header
         # here (ARQ worker), so prefer the real profile zone; fall back to the
@@ -461,14 +472,14 @@ async def execute_workflow_as_chat(workflow, user: dict, context: dict) -> str:
             )
             if resolved_tz.is_utc:
                 log.warning(
-                    "Workflow agent time falling back to UTC; no real user/schedule timezone",
+                    f"{LogTag.WORKER} Workflow agent time falling back to UTC; no real user/schedule timezone",
                     workflow_id=workflow.id,
                     user_id=user_id,
                 )
             log.set(workflow_agent_timezone=resolved_tz.value)
             user_data["timezone"] = resolved_tz.value
         except Exception as e:
-            log.warning(f"Could not resolve workflow timezone for {user_id}: {e}")
+            log.warning(f"{LogTag.WORKER} Could not resolve workflow timezone for {user_id}: {e}")
             user_data = {"user_id": user_id}
 
         # Get or create the workflow conversation for thread context
@@ -575,7 +586,7 @@ async def regenerate_workflow_steps(
     """
     async with wide_task("regenerate_workflow_steps", workflow_id=workflow_id, user_id=user_id):
         log.info(
-            f"Regenerating workflow steps: {workflow_id} for user {user_id}, reason: {regeneration_reason}"
+            f"{LogTag.WORKER} Regenerating workflow steps: {workflow_id} for user {user_id}, reason: {regeneration_reason}"
         )
 
         # Import here to avoid circular imports
@@ -590,7 +601,7 @@ async def regenerate_workflow_steps(
         )
 
         result = f"Successfully regenerated steps for workflow {workflow_id}"
-        log.info(result)
+        log.info(f"{LogTag.WORKER} {result}")
         return result
 
 
@@ -608,7 +619,7 @@ async def generate_workflow_steps(ctx: dict, workflow_id: str, user_id: str) -> 
         Processing result message
     """
     async with wide_task("generate_workflow_steps", workflow_id=workflow_id, user_id=user_id):
-        log.info(f"Generating workflow steps: {workflow_id} for user {user_id}")
+        log.info(f"{LogTag.WORKER} Generating workflow steps: {workflow_id} for user {user_id}")
 
         # Import here to avoid circular imports
         from app.services.workflow import WorkflowService
@@ -644,11 +655,11 @@ async def generate_workflow_steps(ctx: dict, workflow_id: str, user_id: str) -> 
                     },
                 )
                 log.set(websocket_broadcast_success=True)
-                log.info(f"WebSocket event sent for todo workflow {workflow_id}")
+                log.info(f"{LogTag.WORKER} WebSocket event sent for todo workflow {workflow_id}")
             except Exception as ws_error:
                 log.set(websocket_broadcast_success=False)
-                log.warning(f"Failed to send WebSocket event: {ws_error}")
+                log.warning(f"{LogTag.WORKER} Failed to send WebSocket event: {ws_error}")
 
         result = f"Successfully generated steps for workflow {workflow_id}"
-        log.info(result)
+        log.info(f"{LogTag.WORKER} {result}")
         return result

--- a/apps/bots/discord/src/deploy-commands.ts
+++ b/apps/bots/discord/src/deploy-commands.ts
@@ -9,7 +9,7 @@
  * Run with: `pnpm deploy-commands` or `tsx src/deploy-commands.ts`
  */
 
-import { allCommands, type BotCommand } from "@gaia/shared";
+import { allCommands, type BotCommand, createBotLogger } from "@gaia/shared";
 import {
   ApplicationCommandType,
   ContextMenuCommandBuilder,
@@ -119,6 +119,8 @@ export function buildAllCommands() {
   return [...allCommands.map(buildSlashCommand), ...CONTEXT_MENU_COMMANDS];
 }
 
+const deployLogger = createBotLogger("discord", "deploy-commands");
+
 // Only run deployment when executed directly (not imported)
 const isMain =
   typeof process !== "undefined" &&
@@ -132,7 +134,12 @@ if (isMain) {
   const clientId = process.env.DISCORD_CLIENT_ID;
 
   if (!token || !clientId) {
-    console.error("Missing DISCORD_BOT_TOKEN or DISCORD_CLIENT_ID");
+    deployLogger.error("deploy_commands_missing_env", {
+      missing: [
+        ...(!token ? ["DISCORD_BOT_TOKEN"] : []),
+        ...(!clientId ? ["DISCORD_CLIENT_ID"] : []),
+      ],
+    });
     process.exit(1);
   }
 
@@ -140,11 +147,15 @@ if (isMain) {
 
   (async () => {
     try {
-      console.log("Registering slash and context menu commands...");
+      deployLogger.info("deploy_commands_started", {
+        command_count: commands.length,
+      });
       await rest.put(Routes.applicationCommands(clientId), { body: commands });
-      console.log("Successfully registered all commands");
+      deployLogger.info("deploy_commands_succeeded", {
+        command_count: commands.length,
+      });
     } catch (error) {
-      console.error("Failed to register commands:", error);
+      deployLogger.error("deploy_commands_failed", undefined, error);
       process.exit(1);
     }
   })();

--- a/apps/bots/telegram/src/set-commands.ts
+++ b/apps/bots/telegram/src/set-commands.ts
@@ -8,13 +8,17 @@
  * Run with: `pnpm set-commands` or `tsx src/set-commands.ts`
  */
 
-import { allCommands } from "@gaia/shared";
+import { allCommands, createBotLogger } from "@gaia/shared";
 import { Bot } from "grammy";
+
+const setCommandsLogger = createBotLogger("telegram", "set-commands");
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
 
 if (!token) {
-  console.error("Missing TELEGRAM_BOT_TOKEN");
+  setCommandsLogger.error("set_commands_missing_env", {
+    missing: ["TELEGRAM_BOT_TOKEN"],
+  });
   process.exit(1);
 }
 
@@ -32,14 +36,12 @@ const commands = [
 (async () => {
   try {
     await bot.api.setMyCommands(commands);
-    console.log(
-      `Successfully registered ${commands.length} Telegram bot commands:`,
-    );
-    for (const cmd of commands) {
-      console.log(`  /${cmd.command} — ${cmd.description}`);
-    }
+    setCommandsLogger.info("set_commands_succeeded", {
+      command_count: commands.length,
+      commands: commands.map((cmd) => `/${cmd.command}`),
+    });
   } catch (error) {
-    console.error("Failed to register Telegram bot commands:", error);
+    setCommandsLogger.error("set_commands_failed", undefined, error);
     process.exit(1);
   }
 })();

--- a/apps/desktop/scripts/prepare-next-server.mjs
+++ b/apps/desktop/scripts/prepare-next-server.mjs
@@ -121,28 +121,35 @@ async function deleteByExtension(dir, ext) {
   }
 }
 
+// The onnxruntime-web artifacts the wake-word engine actually fetches at
+// runtime. `libs/wake-word/src/web/runtime.ts` imports `onnxruntime-web/wasm`
+// and runs the plain "wasm" execution provider, which loads the CPU wasm binary
+// plus its Emscripten glue. The JSEP/WebGPU, asyncify, and JSPI flavors are
+// never loaded — and the JSEP binary alone (25 MiB) exceeds Cloudflare Workers'
+// per-asset cap, so it is deliberately kept out of the synced runtime. Keep this
+// in lockstep with RUNTIME_FILES in apps/web/scripts/sync-wake-word-runtime.mjs.
+const ORT_RUNTIME_FILES = new Set([
+  "ort-wasm-simd-threaded.wasm",
+  "ort-wasm-simd-threaded.mjs",
+]);
+const ORT_CANARY_FILE = "ort-wasm-simd-threaded.wasm";
+
 /**
- * Strip onnxruntime-web wasm variants the wake-word engine never requests.
- * The default ESM entry loads the JSEP flavor `ort-wasm-simd-threaded.jsep.*`
- * even for the plain "wasm" provider (JSEP is the unified CPU+WebGPU build).
- * Keep that pair; drop plain/asyncify/jspi. Pruning jsep instead leaves the
- * engine with "no available backend found" and the wake word silently dead in
- * packaged builds — the canary fails the build loudly if that ever happens.
+ * Strip onnxruntime-web wasm variants the wake-word engine never requests,
+ * keeping only the CPU wasm pair the "wasm" provider loads. The canary fails
+ * the build loudly if that load-bearing binary ever goes missing — a packaged
+ * build without it leaves the engine with "no available backend found" and the
+ * wake word silently dead.
  */
 async function pruneOnnxRuntime(ortDir) {
   if (!existsSync(ortDir)) return;
   for (const name of await readdir(ortDir)) {
-    const unused =
-      name.includes(".asyncify.") ||
-      name.includes(".jspi.") ||
-      name === "ort-wasm-simd-threaded.wasm" ||
-      name === "ort-wasm-simd-threaded.mjs";
-    if (unused) await rm(resolve(ortDir, name), { force: true });
+    if (!ORT_RUNTIME_FILES.has(name)) await rm(resolve(ortDir, name), { force: true });
   }
-  const jsepWasm = resolve(ortDir, "ort-wasm-simd-threaded.jsep.wasm");
-  if (!existsSync(jsepWasm)) {
+  const canaryWasm = resolve(ortDir, ORT_CANARY_FILE);
+  if (!existsSync(canaryWasm)) {
     throw new Error(
-      `wake-word runtime '${jsepWasm}' missing after prune. The onnxruntime-web ` +
+      `wake-word runtime '${canaryWasm}' missing after prune. The onnxruntime-web ` +
         "wasm flavor the engine loads may have changed — update pruneOnnxRuntime().",
     );
   }

--- a/apps/voice-agent/src/agent.py
+++ b/apps/voice-agent/src/agent.py
@@ -28,7 +28,7 @@ from livekit.plugins.turn_detector.multilingual import MultilingualModel
 
 from shared.py.logging import configure_file_logging
 from shared.py.secrets import inject_infisical_secrets
-from shared.py.wide_events import log
+from shared.py.wide_events import VoiceContext, log
 from src.config import bootstrap_settings
 from src.constants import (
     BACKEND_REQUEST_TIMEOUT_S,
@@ -36,6 +36,7 @@ from src.constants import (
     PROMETHEUS_METRICS_PORT,
     PROMETHEUS_MULTIPROC_DIR,
     VOICE_SYSTEM_PROMPT,
+    LogTag,
 )
 from src.llm import CustomLLM
 from src.utils import extract_meta_data, ms_since, user_id_from_room
@@ -54,20 +55,20 @@ def prewarm(proc: JobProcess) -> None:
     not affected by model I/O. MultilingualModel is created per-room in entrypoint()
     because its constructor requires a job context.
     """
-    log.info("prewarm start")
+    log.info(f"{LogTag.AGENT} prewarm start")
     t0 = time.monotonic()
 
     settings = bootstrap_settings()
     proc.userdata["settings"] = settings
-    log.info("settings loaded", elapsed_ms=ms_since(t0))
+    log.info(f"{LogTag.AGENT} settings loaded", elapsed_ms=ms_since(t0))
 
     t_vad = time.monotonic()
     proc.userdata["vad"] = silero.VAD.load()
-    log.info("VAD loaded", elapsed_ms=ms_since(t_vad))
+    log.info(f"{LogTag.AGENT} VAD loaded", elapsed_ms=ms_since(t_vad))
 
     # MultilingualModel cannot be instantiated here — its __init__ calls
     # get_job_context().inference_executor which only exists inside entrypoint().
-    log.info("prewarm done", phase="prewarm_done", total_ms=ms_since(t0))
+    log.info(f"{LogTag.AGENT} prewarm done", phase="prewarm_done", total_ms=ms_since(t0))
 
 
 def _register_session_logging(
@@ -85,11 +86,13 @@ def _register_session_logging(
     def _on_user_state_changed(ev: UserStateChangedEvent) -> None:
         if ev.new_state == "speaking":
             _speaking_start["t"] = time.monotonic()
-            log.debug("user speaking start", phase="user_speaking_start", **identity)
+            log.debug(
+                f"{LogTag.AGENT} user speaking start", phase="user_speaking_start", **identity
+            )
         elif ev.old_state == "speaking":
             duration_ms = ms_since(_speaking_start.get("t", time.monotonic()))
             log.debug(
-                "user speaking end",
+                f"{LogTag.AGENT} user speaking end",
                 phase="user_speaking_end",
                 duration_ms=duration_ms,
                 **identity,
@@ -100,7 +103,7 @@ def _register_session_logging(
         stt_latency_ms = ms_since(_speaking_start.get("t", time.monotonic()))
         if ev.is_final:
             log.info(
-                "STT final",
+                f"{LogTag.AGENT} STT final",
                 phase="stt_final",
                 transcript=ev.transcript,
                 language=ev.language,
@@ -109,7 +112,7 @@ def _register_session_logging(
             )
         else:
             log.debug(
-                "STT interim",
+                f"{LogTag.AGENT} STT interim",
                 phase="stt_interim",
                 transcript=ev.transcript,
                 **identity,
@@ -118,17 +121,19 @@ def _register_session_logging(
     @session.on("agent_state_changed")
     def _on_agent_state_changed(ev: AgentStateChangedEvent) -> None:
         if ev.new_state == "thinking":
-            log.debug("agent thinking", phase="agent_thinking", **identity)
+            log.debug(f"{LogTag.AGENT} agent thinking", phase="agent_thinking", **identity)
         elif ev.new_state == "speaking":
-            log.debug("agent speaking start", phase="agent_speaking_start", **identity)
+            log.debug(
+                f"{LogTag.AGENT} agent speaking start", phase="agent_speaking_start", **identity
+            )
         elif ev.old_state == "speaking":
-            log.debug("agent speaking end", phase="agent_speaking_end", **identity)
+            log.debug(f"{LogTag.AGENT} agent speaking end", phase="agent_speaking_end", **identity)
 
     @session.on("agent_false_interruption")
     def _on_agent_false_interruption(ev: AgentFalseInterruptionEvent) -> None:
         # Framework handles automatic resume when ev.resumed is True
         log.info(
-            "false interruption",
+            f"{LogTag.AGENT} false interruption",
             phase="false_interruption",
             resumed=ev.resumed,
             **identity,
@@ -146,7 +151,9 @@ def _register_session_logging(
     async def log_usage() -> None:  # NOSONAR python:S7503
         """Emit the session's aggregated STT/TTS/LLM usage at shutdown."""
         summary = usage_collector.get_summary()
-        log.info("session usage", phase="session_usage", summary=str(summary), **identity)
+        log.info(
+            f"{LogTag.AGENT} session usage", phase="session_usage", summary=str(summary), **identity
+        )
 
     ctx.add_shutdown_callback(log_usage)
 
@@ -167,7 +174,7 @@ async def _apply_participant_credentials(
     if token:
         custom_llm.set_agent_token(token)
         log.debug(
-            "token set",
+            f"{LogTag.AGENT} token set",
             phase="token_set",
             participant=who,
             origin=origin,
@@ -178,7 +185,7 @@ async def _apply_participant_credentials(
         # each session's metadata names the API that minted it.
         custom_llm.set_backend_url(meta.backend_url)
         log.info(
-            "backend url set",
+            f"{LogTag.AGENT} backend url set",
             phase="backend_url_set",
             backend_url=meta.backend_url,
             participant=who,
@@ -191,7 +198,7 @@ async def _apply_participant_credentials(
         applied_voice["id"] = voice_id
         tts.update_options(voice_id=voice_id)
         log.info(
-            "voice set",
+            f"{LogTag.AGENT} voice set",
             phase="voice_set",
             voice_id=voice_id,
             participant=who,
@@ -200,7 +207,7 @@ async def _apply_participant_credentials(
     if conv_id:
         await custom_llm.set_conversation_id(conv_id)
         log.debug(
-            "conversation id set",
+            f"{LogTag.AGENT} conversation id set",
             phase="conv_id_set",
             conversation_id=conv_id,
             participant=who,
@@ -221,7 +228,7 @@ def _spawn_credential_task(
         tasks.discard(t)
         if not t.cancelled() and t.exception():
             log.error(
-                "Background credential task failed",
+                f"{LogTag.AGENT} Background credential task failed",
                 exc_info=t.exception(),
                 **identity,
             )
@@ -246,9 +253,10 @@ async def entrypoint(ctx: JobContext) -> None:
         "job_id": getattr(ctx.job, "id", None),
     }
     log.set(**identity)
+    log.set(voice=VoiceContext(operation="session_start", room=ctx.room.name))
 
     room_start = time.monotonic()
-    log.info("room start", phase="room_start", **identity)
+    log.info(f"{LogTag.AGENT} room start", phase="room_start", **identity)
 
     custom_llm = CustomLLM(
         base_url=settings.GAIA_BACKEND_URL,
@@ -296,7 +304,7 @@ async def entrypoint(ctx: JobContext) -> None:
     @ctx.room.on("participant_connected")
     def _on_participant_connected(p: rtc.RemoteParticipant) -> None:
         log.info(
-            "participant joined",
+            f"{LogTag.AGENT} participant joined",
             phase="participant_joined",
             participant=p.identity,
             **identity,
@@ -336,7 +344,7 @@ async def entrypoint(ctx: JobContext) -> None:
     # STT away, so the token lands long before it is needed.
     for p in ctx.room.remote_participants.values():
         log.info(
-            "existing participant",
+            f"{LogTag.AGENT} existing participant",
             phase="existing_participant",
             participant=p.identity,
             **identity,
@@ -348,7 +356,7 @@ async def entrypoint(ctx: JobContext) -> None:
         )
 
     log.info(
-        "session start",
+        f"{LogTag.AGENT} session start",
         phase="session_start",
         setup_ms=ms_since(room_start),
         **identity,

--- a/apps/voice-agent/src/config.py
+++ b/apps/voice-agent/src/config.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 
 from shared.py.settings import BaseAppSettings
 from shared.py.wide_events import log
+from src.constants import LogTag
 
 # Load API's .env for shared Infisical bootstrap vars
 _api_env_path = Path(__file__).parent.parent.parent / "api" / ".env"
@@ -48,7 +49,7 @@ def bootstrap_settings() -> VoiceAgentSettings:
     its config from the inherited env without re-fetching from Infisical.
     """
     settings = get_settings()
-    log.info("Voice agent settings initialized")
+    log.info(f"{LogTag.VOICE} Voice agent settings initialized")
     return settings
 
 

--- a/apps/voice-agent/src/constants.py
+++ b/apps/voice-agent/src/constants.py
@@ -1,6 +1,22 @@
 """Voice agent constants — SSE protocol tokens, TTS flush thresholds, compiled regexes."""
 
 import re
+from typing import Final
+
+
+class LogTag:
+    """Greppable bracketed prefixes for real-time log lines, one per area.
+
+    Mirrors ``app.constants.log_tags.LogTag`` in the API: prefix every
+    ``log.info`` / ``log.warning`` / ``log.error`` / ``log.debug`` message so a
+    single token filters the area's logs (``grep '\\[VOICE-LLM\\]'`` /
+    ``|= "[VOICE-AGENT]"``). Structured context still goes in ``log.set`` fields.
+    """
+
+    VOICE: Final[str] = "[VOICE]"  # config, utils, general worker
+    LLM: Final[str] = "[VOICE-LLM]"  # llm.py — backend SSE streaming + TTS chunking
+    AGENT: Final[str] = "[VOICE-AGENT]"  # agent.py — session/turn lifecycle
+
 
 SSE_DATA_PREFIX = "data:"
 DONE_SENTINEL = "[DONE]"
@@ -94,6 +110,7 @@ VOICE_SYSTEM_PROMPT = (
 )
 
 __all__ = [
+    "LogTag",
     "SSE_DATA_PREFIX",
     "DONE_SENTINEL",
     "FRONTEND_STREAM_TOPIC",

--- a/apps/voice-agent/src/llm.py
+++ b/apps/voice-agent/src/llm.py
@@ -11,7 +11,7 @@ import aiohttp
 from livekit import rtc  # type: ignore[attr-defined]
 from livekit.agents.llm import LLM, ChatChunk, ChatContext, ChoiceDelta
 
-from shared.py.wide_events import log, wide_task
+from shared.py.wide_events import VoiceContext, log, wide_task
 from src.constants import (
     BACKEND_REQUEST_TIMEOUT_S,
     DONE_SENTINEL,
@@ -28,6 +28,7 @@ from src.constants import (
     TTS_MIN_EMIT_CHARS,
     TTS_MIN_SENTENCE_CHARS,
     VOICE_TTS_KEY,
+    LogTag,
 )
 from src.utils import (
     build_messages_from_ctx,
@@ -100,7 +101,7 @@ class CustomLLM(LLM):
                     conversation_id, topic="conversation-id"
                 )
             except Exception as e:
-                log.error("Failed to send conversation ID", error=str(e))
+                log.error(f"{LogTag.LLM} Failed to send conversation ID", error=str(e))
 
     async def set_conversation_description(self, description: str) -> None:
         """Store and broadcast conversation description to room participants."""
@@ -113,7 +114,7 @@ class CustomLLM(LLM):
                     description, topic="conversation-description"
                 )
             except Exception as e:
-                log.error("Failed to send conversation description", error=str(e))
+                log.error(f"{LogTag.LLM} Failed to send conversation description", error=str(e))
 
     async def forward_stream_event_to_frontend(self, raw_event: str) -> None:
         """Forward a raw backend SSE payload to the frontend via LiveKit data channel."""
@@ -125,14 +126,14 @@ class CustomLLM(LLM):
                 topic=FRONTEND_STREAM_TOPIC,
             )
             log.debug(
-                "forward to frontend",
+                f"{LogTag.LLM} forward to frontend",
                 phase="forward_frontend",
                 payload_len=len(raw_event),
                 payload_preview=raw_event[:300],
             )
         except Exception as e:
             log.warning(
-                "Failed to forward backend stream event to frontend",
+                f"{LogTag.LLM} Failed to forward backend stream event to frontend",
                 topic=FRONTEND_STREAM_TOPIC,
                 error=str(e),
             )
@@ -177,7 +178,7 @@ class CustomLLM(LLM):
                     break
                 await self._handle_drain_event(data)
         except Exception as e:
-            log.warning("Voice stream drain failed", error=str(e))
+            log.warning(f"{LogTag.LLM} Voice stream drain failed", error=str(e))
         finally:
             await resp.release()
 
@@ -206,7 +207,9 @@ class CustomLLM(LLM):
                 # forwarding a null id makes it fall through to the normal response
                 # path and append onto the active comms bubble. Skip the immediate
                 # bubble and let the backend's WebSocket push render it instead.
-                log.warning("Voice TTS frame missing message_id; skipping immediate bubble")
+                log.warning(
+                    f"{LogTag.LLM} Voice TTS frame missing message_id; skipping immediate bubble"
+                )
                 return
             await self.forward_stream_event_to_frontend(
                 json.dumps({RESPONSE_KEY: voice_tts, MESSAGE_ID_KEY: message_id})
@@ -239,7 +242,7 @@ class CustomLLM(LLM):
             if self._http_session and not self._http_session.closed:
                 await self._http_session.close()
         except Exception as e:
-            log.warning("Failed to close backend HTTP session", error=str(e))
+            log.warning(f"{LogTag.LLM} Failed to close backend HTTP session", error=str(e))
         finally:
             await super().aclose()
 
@@ -299,21 +302,26 @@ class _VoiceTurn:
         # identity + turn fields, so Loki can slice by any of them.
         async with wide_task(
             "voice_turn",
-            room=self.llm.room.name if self.llm.room else None,
             user_id=self.llm.user_id,
             conversation_id=self.llm.conversation_id,
-            turn_index=self.turn_index,
         ):
+            log.set(
+                voice=VoiceContext(
+                    operation="turn",
+                    room=self.llm.room.name if self.llm.room else None,
+                    turn_index=self.turn_index,
+                )
+            )
             async for chunk in self._run():
                 yield chunk
 
     async def _run(self) -> AsyncGenerator[ChatChunk, None]:
         if not self.user_message:
-            log.warning("empty user message, skipping LLM turn", phase="turn_skip")
+            log.warning(f"{LogTag.LLM} empty user message, skipping LLM turn", phase="turn_skip")
             return
 
         log.info(
-            "chat turn start",
+            f"{LogTag.LLM} chat turn start",
             phase="chat_turn_start",
             user_msg=self.user_message,
             user_msg_len=len(self.user_message),
@@ -321,7 +329,7 @@ class _VoiceTurn:
 
         payload = self._build_payload()
         log.debug(
-            "backend request",
+            f"{LogTag.LLM} backend request",
             phase="backend_request",
             elapsed_ms=ms_since(self.turn_start),
             conversation_id=self.llm.conversation_id,
@@ -341,7 +349,7 @@ class _VoiceTurn:
             if resp.status >= 400:
                 body = await resp.text()
                 log.error(
-                    "Backend returned error response",
+                    f"{LogTag.LLM} Backend returned error response",
                     status=resp.status,
                     body=body[:500],
                     conversation_id=self.llm.conversation_id,
@@ -361,7 +369,7 @@ class _VoiceTurn:
                 handed_off = True
 
             log.info(
-                "chat turn end",
+                f"{LogTag.LLM} chat turn end",
                 phase="chat_turn_end",
                 elapsed_ms=ms_since(self.turn_start),
             )
@@ -369,7 +377,7 @@ class _VoiceTurn:
             # turn so Loki can answer latency/volume/behaviour questions without
             # stitching DEBUG lines together.
             log.info(
-                "turn complete",
+                f"{LogTag.LLM} turn complete",
                 phase="turn_complete",
                 status="ok",
                 **self._turn_fields(),
@@ -379,7 +387,7 @@ class _VoiceTurn:
             # Same wide event on the failure path (status=error) so error
             # turns are queryable with the identical field set.
             log.error(
-                "turn failed",
+                f"{LogTag.LLM} turn failed",
                 phase="turn_complete",
                 status="error",
                 error=str(e),
@@ -395,7 +403,7 @@ class _VoiceTurn:
     def _emit(self, text: str, source: str) -> ChatChunk:
         """Log + wrap a TTS chunk so we can see exactly WHEN text is handed to TTS."""
         log.info(
-            "yield to TTS",
+            f"{LogTag.LLM} yield to TTS",
             phase="yield_tts",
             source=source,
             char_count=len(text),
@@ -413,7 +421,7 @@ class _VoiceTurn:
             if data == DONE_SENTINEL:
                 self.stream_done = True
                 log.info(
-                    "[DONE] received",
+                    f"{LogTag.LLM} [DONE] received",
                     phase="done_received",
                     elapsed_ms=ms_since(self.turn_start),
                 )
@@ -479,7 +487,7 @@ class _VoiceTurn:
     async def _on_stream_done(self) -> str | None:
         """Log stream end and flush whatever text is still buffered."""
         log.debug(
-            "stream done",
+            f"{LogTag.LLM} stream done",
             phase="stream_done",
             total_tokens=self.total_tokens,
             elapsed_ms=ms_since(self.turn_start),
@@ -506,7 +514,7 @@ class _VoiceTurn:
             await self.llm.forward_stream_event_to_frontend(data)
 
         log.info(
-            "backend event",
+            f"{LogTag.LLM} backend event",
             phase="backend_event",
             event_keys=list(event_keys),
             event_data=data[:300],
@@ -551,7 +559,7 @@ class _VoiceTurn:
         self.first_token_received = True
         self.ttfb_ms = ms_since(self.turn_start)
         log.debug(
-            "first token",
+            f"{LogTag.LLM} first token",
             phase="first_token",
             ttfb_ms=self.ttfb_ms,
         )
@@ -564,7 +572,7 @@ class _VoiceTurn:
         self.tts_enabled = False
         self.comms_complete = True
         log.info(
-            "main response complete, ending audio turn",
+            f"{LogTag.LLM} main response complete, ending audio turn",
             phase="main_response_complete",
             elapsed_ms=ms_since(self.turn_start),
             ack_flushed=bool(tail),
@@ -577,7 +585,7 @@ class _VoiceTurn:
             return None
         self.executor_tts_chars += len(spoken)
         log.info(
-            "executor answer arrived",
+            f"{LogTag.LLM} executor answer arrived",
             phase="tts_executor_answer",
             char_count=len(spoken),
             elapsed_ms=ms_since(self.turn_start),
@@ -600,7 +608,7 @@ class _VoiceTurn:
         self.text_buffer.append(piece)
         self.total_tokens += 1
         log.debug(
-            "token",
+            f"{LogTag.LLM} token",
             phase="token",
             token_index=self.total_tokens,
             token=piece,
@@ -667,7 +675,7 @@ class _VoiceTurn:
                 self.first_tts_flush_ms = ms_since(self.turn_start)
         if label:
             log.debug(
-                label,
+                f"{LogTag.LLM} {label}",
                 phase="tts_flush" if label == "TTS FLUSH" else "tts_final",
                 text_before_sanitize=raw,
                 text_after_sanitize=out,

--- a/apps/voice-agent/src/utils.py
+++ b/apps/voice-agent/src/utils.py
@@ -15,6 +15,7 @@ from src.constants import (
     SENTINEL_RE,
     TAG_RE,
     WHITESPACE_RE,
+    LogTag,
 )
 
 
@@ -73,7 +74,9 @@ def extract_meta_data(md: str | None) -> ParticipantMeta:
             backend_url=_clean_str(obj.get("backendUrl")),
         )
     except (json.JSONDecodeError, AttributeError, TypeError) as e:
-        log.debug("Unparseable participant metadata", error=str(e), metadata=md[:200])
+        log.debug(
+            f"{LogTag.VOICE} Unparseable participant metadata", error=str(e), metadata=md[:200]
+        )
         return ParticipantMeta()
 
 

--- a/libs/shared/py/wide_events.py
+++ b/libs/shared/py/wide_events.py
@@ -308,6 +308,126 @@ class BotContext(TypedDict, total=False):
     operation: str
 
 
+class SandboxContext(TypedDict, total=False):
+    """Per-user E2B sandbox lifecycle context.
+
+    Accumulated across the multi-step acquire path (cache reuse → resume →
+    create → mount → canary), so callers must MERGE into this namespace rather
+    than overwrite it. ``source`` is the headline field: how the live sandbox
+    serving this request was obtained. Per-stage latency lives separately on the
+    ``fs`` field (``fs.sbx_create``, ``fs.sbx_connect_resume`` …).
+    """
+
+    operation: str  # "acquire"|"pause"|"evict"|"mark_dead"|"sweep"
+    sandbox_id: str
+    shard_id: int
+    source: str  # "cache"|"resume"|"create"
+    created: bool
+    template_id: str
+    workspace_version: int
+    refcount: int
+    mount_status: str  # "mounted"|"ephemeral_fallback"
+    resume_status: str  # "ok"|"unhealthy"|"failed"
+    cache_evicted: str  # "unhealthy"|"canary_stale"
+    health_ok: bool
+    watcher_active: bool
+    artifact_mode: str  # artifact watcher detection mode: "watch_dir"|"accesslog"
+    marked_dead: bool
+    rate_limited: bool
+    rate_limit_reset: str
+    rate_limit_plan: str
+    evicted_count: int  # sweep task: number of idle sandboxes evicted
+
+
+class McpContext(TypedDict, total=False):
+    """Model Context Protocol server/tool operation context."""
+
+    operation: str  # "connect"|"disconnect"|"list_tools"|"call_tool"|"discover"|"health"
+    server_id: str
+    server_name: str
+    tool_name: str
+    tool_count: int
+    transport: str  # "stdio"|"sse"|"http"
+    success: bool
+    error_type: str
+    result_count: int
+
+
+class TriggerContext(TypedDict, total=False):
+    """Integration trigger / event-routing operation context."""
+
+    operation: str  # "register"|"evaluate"|"fire"|"list"|"delete"|"dispatch"
+    trigger_id: str
+    trigger_type: str
+    integration_id: str
+    matched_count: int
+    fired: bool
+    result_count: int
+
+
+class MailContext(TypedDict, total=False):
+    """Email sync / send / classification operation context."""
+
+    operation: str  # "sync"|"fetch"|"send"|"classify"|"summarize"|"watch"
+    provider: str  # "gmail"|"outlook"|...
+    account_id: str
+    folder: str
+    message_count: int
+    result_count: int
+    success: bool
+
+
+class OAuthContext(TypedDict, total=False):
+    """OAuth / connection-lifecycle operation context."""
+
+    operation: str  # "authorize"|"callback"|"refresh"|"revoke"|"status"|"connect"
+    provider: str
+    integration_id: str
+    success: bool
+    error_type: str
+
+
+class NotificationContext(TypedDict, total=False):
+    """Notification dispatch operation context."""
+
+    operation: str  # "send"|"schedule"|"dispatch"|"read"|"mark_all_read"|"list"
+    channel: str  # "push"|"email"|"in_app"
+    notification_id: str
+    result_count: int
+    success: bool
+
+
+class SkillContext(TypedDict, total=False):
+    """Agent skill management operation context."""
+
+    operation: str  # "install"|"list"|"run"|"sync"|"delete"|"get"
+    skill_id: str
+    skill_name: str
+    result_count: int
+    success: bool
+
+
+class VectorContext(TypedDict, total=False):
+    """Vector-store (ChromaDB) operation context."""
+
+    operation: str  # "query"|"upsert"|"delete"|"get"|"embed"|"create_collection"
+    collection: str
+    n_results: int
+    result_count: int
+    embedded_count: int
+
+
+class VoiceContext(TypedDict, total=False):
+    """Voice-agent (LiveKit) session/turn operation context."""
+
+    operation: str  # "session_start"|"turn"|"tts"|"stt"|"tool_call"|"session_end"
+    room: str
+    participant: str
+    model: str
+    provider: str
+    turn_index: int
+
+
 class WideEventFields(TypedDict, total=False):
     """Canonical schema for wide event fields set via log.set().
 
@@ -334,6 +454,15 @@ class WideEventFields(TypedDict, total=False):
     integration: IntegrationContext
     image: ImageContext
     bot: BotContext
+    sandbox: SandboxContext
+    mcp: McpContext
+    trigger: TriggerContext
+    mail: MailContext
+    oauth: OAuthContext
+    notification: NotificationContext
+    skill: SkillContext
+    vector: VectorContext
+    voice: VoiceContext
     # Top-level convenience fields used across endpoints
     operation: str
     outcome: str
@@ -370,6 +499,19 @@ class WideEventLogger:
         """Merge structured context into the current request's wide event."""
         current = _wide_event.get() or {}
         _wide_event.set({**current, **kwargs})
+
+    def set_ns(self, namespace: str, **kwargs: Any) -> None:
+        """Merge ``kwargs`` into a nested ``namespace`` dict on the wide event.
+
+        ``set`` shallow-merges at the top level, so re-setting a nested dict
+        (e.g. ``set(sandbox={...})``) clobbers keys from earlier calls. ``set_ns``
+        read-merges into ``event[namespace]`` instead, preserving every field
+        accumulated across a multi-step path (the sandbox acquire path is the
+        canonical case — see ``SandboxContext``).
+        """
+        current = _wide_event.get() or {}
+        ns = {**current.get(namespace, {}), **kwargs}
+        _wide_event.set({**current, namespace: ns})
 
     # --- Loguru-compatible message methods ---
 
@@ -579,5 +721,14 @@ __all__ = [
     "IntegrationContext",
     "ImageContext",
     "BotContext",
+    "SandboxContext",
+    "McpContext",
+    "TriggerContext",
+    "MailContext",
+    "OAuthContext",
+    "NotificationContext",
+    "SkillContext",
+    "VectorContext",
+    "VoiceContext",
     "get_trace_id",
 ]

--- a/libs/shared/ts/src/bots/api/index.ts
+++ b/libs/shared/ts/src/bots/api/index.ts
@@ -16,6 +16,9 @@ import type {
   ChatRequest,
   SettingsResponse,
 } from "../types";
+import { createBotLogger } from "../utils/logger";
+
+const logger = createBotLogger("shared", "gaia-client");
 
 export class GaiaApiError extends Error {
   status?: number;
@@ -207,9 +210,12 @@ export class GaiaClient {
         // Wait before retrying (exponential backoff)
         const delayMs = Math.min(1000 * 2 ** attempt, 5000);
         attemptedRetries++;
-        console.log(
-          `Retrying stream (attempt ${attemptedRetries}/${maxRetries}) after ${delayMs}ms...`,
-        );
+        logger.warn("chat_stream_retrying", {
+          attempt: attemptedRetries,
+          max_retries: maxRetries,
+          delay_ms: delayMs,
+          error_message: lastError.message,
+        });
         await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }

--- a/libs/shared/ts/src/bots/config/index.ts
+++ b/libs/shared/ts/src/bots/config/index.ts
@@ -2,12 +2,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as dotenv from "dotenv";
 import type { BotConfig } from "../types";
+import { createBotLogger } from "../utils/logger";
 import { injectInfisicalSecrets } from "./secrets";
 
 export { injectInfisicalSecrets } from "./secrets";
 
-const log = (msg: string) => console.log(`[config] ${msg}`);
-const warn = (msg: string) => console.warn(`[config] ${msg}`);
+const logger = createBotLogger("shared", "config");
 
 /**
  * Loads and validates the bot configuration from environment variables.
@@ -26,16 +26,16 @@ export async function loadConfig(): Promise<BotConfig> {
   const sharedEnvPath = path.resolve(process.cwd(), "..", ".env");
   if (fs.existsSync(sharedEnvPath)) {
     dotenv.config({ path: sharedEnvPath });
-    log(`Loaded shared env from ${sharedEnvPath}`);
+    logger.info("env_loaded", { source: "shared", path: sharedEnvPath });
   } else {
-    warn(`No shared .env found at ${sharedEnvPath}`);
+    logger.warn("env_not_found", { source: "shared", path: sharedEnvPath });
   }
 
   // 2. Local .env in cwd — Docker / standalone fallback
   const localEnvPath = path.resolve(process.cwd(), ".env");
   if (fs.existsSync(localEnvPath)) {
     dotenv.config({ path: localEnvPath });
-    log(`Loaded local env from ${localEnvPath}`);
+    logger.info("env_loaded", { source: "local", path: localEnvPath });
   }
 
   // 3. Infisical — fills any vars not already set
@@ -76,15 +76,21 @@ export async function loadConfig(): Promise<BotConfig> {
 
   const posthogApiKey = process.env.POSTHOG_API_KEY;
   if (!posthogApiKey) {
-    warn("POSTHOG_API_KEY not set — bot analytics will be disabled");
+    logger.warn("config_optional_missing", {
+      key: "POSTHOG_API_KEY",
+      effect: "bot_analytics_disabled",
+    });
   }
 
   const rabbitmqUrl = process.env.RABBITMQ_URL;
   if (!rabbitmqUrl) {
-    warn("RABBITMQ_URL not set — outbound message consumer will be disabled");
+    logger.warn("config_optional_missing", {
+      key: "RABBITMQ_URL",
+      effect: "outbound_consumer_disabled",
+    });
   }
 
-  log("Configuration loaded successfully");
+  logger.info("config_loaded");
   return {
     gaiaApiUrl: gaiaApiUrl!,
     gaiaApiKey: gaiaApiKey!,

--- a/libs/shared/ts/src/bots/config/secrets.ts
+++ b/libs/shared/ts/src/bots/config/secrets.ts
@@ -11,9 +11,9 @@
  */
 
 import { InfisicalSDK } from "@infisical/sdk";
+import { createBotLogger } from "../utils/logger";
 
-const log = (msg: string) => console.log(`[secrets] ${msg}`);
-const warn = (msg: string) => console.warn(`[secrets] ${msg}`);
+const logger = createBotLogger("shared", "secrets");
 
 class InfisicalConfigError extends Error {
   constructor(message: string) {
@@ -45,7 +45,7 @@ export async function injectInfisicalSecrets(): Promise<void> {
           `Missing: ${INFISICAL_VARS.join(", ")}`,
       );
     }
-    log("No Infisical config found, using local .env only");
+    logger.info("infisical_skipped", { reason: "no_config_vars_set" });
     return;
   }
 
@@ -57,7 +57,10 @@ export async function injectInfisicalSecrets(): Promise<void> {
     if (isProduction) {
       throw new InfisicalConfigError(msg);
     }
-    warn(msg);
+    logger.warn("infisical_config_incomplete", {
+      missing: missing,
+      present: present,
+    });
     return;
   }
 
@@ -68,13 +71,13 @@ export async function injectInfisicalSecrets(): Promise<void> {
 
   try {
     const start = Date.now();
-    log("Connecting to Infisical...");
+    logger.info("infisical_connecting");
 
     const client = new InfisicalSDK({
       siteUrl: "https://app.infisical.com",
     });
     await client.auth().universalAuth.login({ clientId, clientSecret });
-    log(`Authenticated in ${Date.now() - start}ms`);
+    logger.info("infisical_authenticated", { duration_ms: Date.now() - start });
 
     const secretsStart = Date.now();
     const result = await client.secrets().listSecrets({
@@ -96,10 +99,12 @@ export async function injectInfisicalSecrets(): Promise<void> {
       }
     }
 
-    log(
-      `Fetched ${result.secrets.length} secrets in ${Date.now() - secretsStart}ms ` +
-        `(${injected} injected, ${skipped} skipped — local env takes precedence)`,
-    );
+    logger.info("infisical_secrets_loaded", {
+      total: result.secrets.length,
+      injected,
+      skipped,
+      duration_ms: Date.now() - secretsStart,
+    });
   } catch (error) {
     if (error instanceof InfisicalConfigError) throw error;
     throw new InfisicalConfigError(

--- a/libs/shared/ts/src/bots/utils/formatters.ts
+++ b/libs/shared/ts/src/bots/utils/formatters.ts
@@ -16,7 +16,10 @@ import type {
   BotWorkflow,
   PlatformName,
 } from "../types";
+import { createBotLogger } from "./logger";
 import { isTableRow, isTableSeparator } from "./text";
+
+const logger = createBotLogger("shared", "formatters");
 
 /**
  * Formats a workflow for display in a bot message.
@@ -554,6 +557,6 @@ export function formatBotError(error: unknown): string {
     return "⚠️ Response was incomplete. Please try again.";
   }
 
-  console.error("Unhandled bot error:", error);
+  logger.error("unhandled_bot_error", undefined, error);
   return "❌ Something went wrong. Please try again later.";
 }


### PR DESCRIPTION
Makes logs debuggable end-to-end across **api**, **voice-agent**, and **bots** by adding a greppable subsystem prefix to ~1,828 real-time log lines (via a new central `LogTag` registry, normalizing inconsistent legacy prefixes like `[intelligence]`/`[juicefs]`) and, in bots, converting stray `console.*` to the structured `createBotLogger`. It also upgrades wide-event data quality: 8 new `*Context` TypedDicts (Mcp/Trigger/Mail/OAuth/Notification/Skill/Vector/Voice, plus Sandbox) registered in `WideEventFields`, a `log.set_ns()` helper for multi-step accumulation, and 68 flat ad-hoc `log.set()` fields consolidated into those namespaces with 44 derivable gaps filled (sandbox lifecycle now instrumented create→resume→reuse→mount→canary→evict→pause). The change is non-breaking: Grafana/Loki only query the generic request envelope (`http_request`/`path`/`status_code`/`duration_ms`), which is preserved, and no domain business field is referenced by any dashboard or alert. Verified clean: mypy (api 676 files, voice 7), ruff, all four bot type-checks, and biome on changed files.