### PR TITLE
fix(api): make ensure_system_subtree resilient to JuiceFS I/O faults

### DIFF
--- a/apps/api/app/services/storage/system_workspace.py
+++ b/apps/api/app/services/storage/system_workspace.py
@@ -103,12 +103,22 @@ async def ensure_system_subtree() -> bool:
         files = system_files()
         signature = _library_signature(files)
         marker = root / _SYSTEM_HASH_MARKER
-        if marker.is_file() and marker.read_text(encoding="utf-8").strip() == signature:
-            return True
-        root.mkdir(parents=True, exist_ok=True)
-        _write_system_files(root, files)
-        _prune_orphan_system_files(root, files)
-        marker.write_text(signature, encoding="utf-8")
+        try:
+            if marker.is_file() and marker.read_text(encoding="utf-8").strip() == signature:
+                return True
+            root.mkdir(parents=True, exist_ok=True)
+            _write_system_files(root, files)
+            _prune_orphan_system_files(root, files)
+            marker.write_text(signature, encoding="utf-8")
+        except OSError as exc:
+            # JuiceFS is mounted but has I/O errors (e.g. R2 storage unreachable).
+            # Log loudly and degrade gracefully — the worker must not crash because
+            # of a storage fault; per-user copies will be used instead.
+            log.error(
+                f"{LogTag.STORAGE} system_subtree I/O error — JuiceFS fault, "
+                f"per-user copies will be used instead: {exc}"
+            )
+            return False
         return True
 
     return await asyncio.to_thread(_write)


### PR DESCRIPTION
## What

Wrap the `_system` subtree write in `ensure_system_subtree()` with `try/except OSError`, logging loudly and returning `False` (degraded) instead of letting the exception propagate.

## Why

The production ARQ worker crash-looped to 0/1 replicas. Root cause: the host JuiceFS mount at `/mnt/jfs` returned `OSError(5, EIO)` on reads (Cloudflare R2 backend fault — the R2 data-plane token had lost its Object-Read permission). On startup, `ensure_system_subtree()` reads `/mnt/jfs/_system/.gaia_system.v`; that read hit the EIO. The function only caught `JuiceFSUnavailable` (the "not mounted" case), not `OSError` (the "mounted but faulting" case), so the exception propagated and `_process_results()` treated the failed startup service as fatal → `RuntimeError("arq_worker startup failed")` → exit 1 → crash loop.

A storage-backend fault on an optional, best-effort dedup subtree must **degrade**, not take down the whole worker. This matches the function's documented contract ("returns False if the mount is unavailable; per-user copies are used instead") and the existing `JuiceFSUnavailable` handling. Swarm auto-rollback could not help because *both* image versions crash on the same external fault.

## Scope

One file, `apps/api/app/services/storage/system_workspace.py`. Passes `ruff check` and `mypy`.

> Note: the R2 read-permission issue is being fixed separately at the infra layer; this change ensures a storage fault can never again crash the worker.