### PR TITLE
feat(observability): alert on service-down + route critical alerts to email

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -19,6 +19,8 @@ secrets:
     external: true
   gaia_grafana_slack_webhook:
     external: true
+  gaia_grafana_smtp_password:
+    external: true
   gaia_postgres_password:
     external: true
     name: gaia_postgres_password_v2
@@ -806,9 +808,22 @@ services:
       # links in Slack, share links, dashboard URLs). Without this the default
       # resolves to localhost:4000 and Slack alerts link nowhere.
       GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-https://logs.heygaia.io}
+      # SMTP for email alerts (critical/down events). Gmail / Google Workspace:
+      # GRAFANA_SMTP_USER is the sending account, the app password is the
+      # gaia_grafana_smtp_password secret (Grafana reads the __FILE variant), and
+      # GRAFANA_ALERT_EMAIL is the destination the email contact point sends to
+      # (see provisioning/alerting/contact-points.yaml → $__env{GRAFANA_ALERT_EMAIL}).
+      GF_SMTP_ENABLED: "true"
+      GF_SMTP_HOST: ${GRAFANA_SMTP_HOST:-smtp.gmail.com:587}
+      GF_SMTP_USER: ${GRAFANA_SMTP_USER}
+      GF_SMTP_PASSWORD__FILE: /run/secrets/gaia_grafana_smtp_password
+      GF_SMTP_FROM_ADDRESS: ${GRAFANA_SMTP_FROM_ADDRESS:-${GRAFANA_SMTP_USER}}
+      GF_SMTP_FROM_NAME: "GAIA Alerts"
+      GRAFANA_ALERT_EMAIL: ${GRAFANA_ALERT_EMAIL:-aryan@heygaia.io}
     secrets:
       - gaia_grafana_admin_password
       - gaia_grafana_slack_webhook
+      - gaia_grafana_smtp_password
     networks:
       - gaia-prod-shared
     healthcheck:

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -813,6 +813,13 @@ services:
       # gaia_grafana_smtp_password secret (Grafana reads the __FILE variant), and
       # GRAFANA_ALERT_EMAIL is the destination the email contact point sends to
       # (see provisioning/alerting/contact-points.yaml → $__env{GRAFANA_ALERT_EMAIL}).
+      #
+      # REQUIRED (no default): GRAFANA_SMTP_USER must be set in the deploy env before
+      # `docker stack deploy` — it's the full Gmail/Workspace sending address (e.g.
+      # alerts@heygaia.io) that owns the app password. If unset, GF_SMTP_USER is empty
+      # and Gmail rejects auth with `535 Username and Password not accepted`, so email
+      # alerts silently never send (Slack still works). The app password must belong to
+      # this same account. See internal-docs → Production → Grafana → Alerting.
       GF_SMTP_ENABLED: "true"
       GF_SMTP_HOST: ${GRAFANA_SMTP_HOST:-smtp.gmail.com:587}
       GF_SMTP_USER: ${GRAFANA_SMTP_USER}

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -555,6 +555,11 @@ services:
       # Slack webhook consumed by contact-points.yaml (leave empty to disable alerts)
       SLACK_ALERT_WEBHOOK_URL: ${SLACK_ALERT_WEBHOOK_URL:-}
       SLACK_ALERT_CHANNEL: ${SLACK_ALERT_CHANNEL:-#alerts}
+      # Destination for the email contact point ($__env{GRAFANA_ALERT_EMAIL} in
+      # contact-points.yaml). SMTP is disabled in dev, so email won't actually
+      # send — this default just keeps the contact point's address non-empty so
+      # alerting provisioning loads cleanly.
+      GRAFANA_ALERT_EMAIL: ${GRAFANA_ALERT_EMAIL:-alerts@example.com}
     restart: unless-stopped
     depends_on:
       loki:

--- a/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
@@ -341,3 +341,206 @@ groups:
         labels:
           severity: critical
           service: api
+
+  # Availability: a Prometheus scrape target being down means the container or
+  # its metrics endpoint is unreachable. This is the class of failure that went
+  # unnoticed when the arq_worker crash-looped to 0/1 replicas — `up` goes to 0
+  # for a static target whose container is gone, so this rule now catches it.
+  - orgId: 1
+    name: gaia-availability
+    folder: GAIA
+    interval: 1m
+    rules:
+      # 10. Any core service target down for 2m (multi-dimensional: one alert
+      # instance per failing job). voice_agent is intentionally excluded — it is
+      # scaled to 0 by default, so its target is legitimately down.
+      - uid: gaia-target-down
+        title: Service target down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: up{job=~"gaia-api|arq_worker|postgres|redis|rabbitmq"}
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: "Target {{ $labels.job }} ({{ $labels.instance }}) is DOWN — container or metrics endpoint unreachable"
+        labels:
+          severity: critical
+          service: availability
+
+      # 11. ARQ worker has no running replica: the worker exports its own metrics
+      # on :9100, so `absent()` / up==0 on that job is a direct "background jobs
+      # are not processing" signal. Kept separate from rule 10 so it carries a
+      # worker-specific summary even if the regex above is ever narrowed.
+      - uid: gaia-arq-worker-down
+        title: ARQ worker down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: up{job="arq_worker"}
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: ARQ worker is not reporting metrics — background tasks (reminders, workflows, memory) are not processing
+        labels:
+          severity: critical
+          service: arq_worker
+
+      # 12. A container in the stack is restarting repeatedly (crash loop). cadvisor
+      # exports container_start_time_seconds; `changes()` over 15m counts how many
+      # times a container's start time moved = its restart count. >3 in 15m flags a
+      # flapping service before it settles (or while it crash-loops like arq did).
+      - uid: gaia-container-restarts
+        title: Container restart loop
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: changes(container_start_time_seconds{name=~"gaia-prod_.*"}[15m])
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [3] }
+        noDataState: OK
+        execErrState: OK
+        for: 0m
+        annotations:
+          summary: "Container {{ $labels.name }} appears to be restarting repeatedly"
+        labels:
+          severity: warning
+          service: availability
+
+      # 13. A bot or the embedding sidecar is down. These export no native metrics,
+      # so prometheus.yml blackbox-probes their /health endpoints (job
+      # blackbox_internal); probe_success==0 means the container is down or its
+      # HTTP health endpoint is unreachable. Multi-dimensional: one instance per
+      # failing target, with the URL in $labels.instance.
+      - uid: gaia-internal-service-down
+        title: Bot or sidecar down
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 120, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: probe_success{job="blackbox_internal"}
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+        noDataState: Alerting
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: "{{ $labels.instance }} is DOWN — container or /health endpoint unreachable"
+        labels:
+          severity: critical
+          service: availability
+
+      # 14. API severely slow: p95 > 3s for 5m. The warning-tier latency rule
+      # (gaia-api-p95-latency, >1s) goes to Slack only; this critical tier also
+      # pages email so a real latency incident isn't missed.
+      - uid: gaia-api-p95-latency-critical
+        title: API p95 latency critical
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job="gaia-api", handler!~"/metrics|/health.*|/favicon.ico"}[5m])))
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [3] }
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: API p95 latency is {{ $values.B }}s (critical threshold 3s)
+        labels:
+          severity: critical
+          service: api

--- a/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
@@ -544,3 +544,171 @@ groups:
         labels:
           severity: critical
           service: api
+
+  # Extended coverage: failure modes that historically went unmonitored
+  # (cert expiry, OOM kills, Redis memory pressure, stuck queues). All metrics
+  # verified present in prod Prometheus before adding.
+  - orgId: 1
+    name: gaia-extended
+    folder: GAIA
+    interval: 1m
+    rules:
+      # 15. TLS cert for api.heygaia.io expires in < 14 days
+      - uid: gaia-ssl-cert-expiry
+        title: TLS certificate expiring soon
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: min(probe_ssl_earliest_cert_expiry{job="blackbox_api"}) - time()
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model: { refId: B, type: reduce, expression: A, reducer: last }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: lt, params: [1209600] }
+        noDataState: OK
+        execErrState: Error
+        for: 10m
+        annotations:
+          summary: "api.heygaia.io TLS cert expires in < 14 days ({{ $values.B }}s left)"
+        labels:
+          severity: critical
+          service: api
+
+      # 16. A container was OOM-killed in the last 15m
+      - uid: gaia-container-oom
+        title: Container OOM killed
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 900, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: sum(increase(container_oom_events_total[15m]))
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model: { refId: B, type: reduce, expression: A, reducer: last }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+        noDataState: OK
+        execErrState: OK
+        for: 0m
+        annotations:
+          summary: "{{ $values.B }} container OOM-kill event(s) in the last 15m"
+        labels:
+          severity: critical
+          service: host
+
+      # 17. Redis memory > 85% of maxmemory (eviction risk for SSE/cache/rate-limit)
+      - uid: gaia-redis-memory
+        title: Redis memory pressure
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: redis_memory_used_bytes / clamp_min(redis_memory_max_bytes, 1)
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model: { refId: B, type: reduce, expression: A, reducer: last }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [0.85] }
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        annotations:
+          summary: Redis is using {{ $values.B | humanizePercentage }} of maxmemory
+        labels:
+          severity: warning
+          service: redis
+
+      # 18. Redis evicting keys (memory full — data being dropped)
+      - uid: gaia-redis-evictions
+        title: Redis evicting keys
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: increase(redis_evicted_keys_total[10m])
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model: { refId: B, type: reduce, expression: A, reducer: last }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        annotations:
+          summary: "Redis evicted {{ $values.B }} keys in 10m — memory full"
+        labels:
+          severity: warning
+          service: redis
+
+      # 19. RabbitMQ backlog with NO consumers (a consumer died; work stuck)
+      - uid: gaia-rabbitmq-no-consumers
+        title: RabbitMQ backlog with no consumers
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              refId: A
+              expr: (sum(rabbitmq_queue_messages_ready) > 100) and (sum(rabbitmq_queue_consumers) == 0)
+              instant: true
+          - refId: B
+            datasourceUid: __expr__
+            model: { refId: B, type: reduce, expression: A, reducer: last }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        annotations:
+          summary: "RabbitMQ has {{ $values.B }} ready messages but zero consumers"
+        labels:
+          severity: critical
+          service: rabbitmq

--- a/infra/docker/observability/grafana/provisioning/alerting/contact-points.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/contact-points.yaml
@@ -1,11 +1,20 @@
 apiVersion: 1
 
-# Slack contact point. The webhook URL is NOT committed — Grafana reads it at
-# provision time from the `gaia_grafana_slack_webhook` swarm secret via the
-# $__file{} reference. The secret is mounted into the grafana service
-# (see docker-compose.prod.yml); create it once with:
-#   printf '%s' "$WEBHOOK" | docker secret create gaia_grafana_slack_webhook -
+# Contact points for GAIA alerting.
+#
+# Every alert routes to Slack (see notification-policies.yaml). Critical alerts
+# additionally go to email via the `critical-slack-email` contact point below,
+# which bundles BOTH a Slack and an email receiver under one name — Grafana fires
+# every receiver in a contact point, so a single critical alert lands in Slack
+# AND inbox without needing `continue` route trickery.
+#
+# Secrets are NOT committed. Grafana reads them at provision time from swarm
+# secrets via $__file{}; the destination email comes from an env var via
+# $__env{}. Both are wired into the grafana service in docker-compose.prod.yml.
+#   printf '%s' "$WEBHOOK"      | docker secret create gaia_grafana_slack_webhook -
+#   printf '%s' "$APP_PASSWORD" | docker secret create gaia_grafana_smtp_password -
 contactPoints:
+  # All alerts (Slack only). Root notification policy points here.
   - orgId: 1
     name: slack-alerts
     receivers:
@@ -15,4 +24,22 @@ contactPoints:
           url: $__file{/run/secrets/gaia_grafana_slack_webhook}
           title: "{{ template \"slack.default.title\" . }}"
           text: "{{ template \"slack.default.text\" . }}"
+        disableResolveMessage: false
+
+  # Critical alerts: Slack + email. The severity=critical route targets this.
+  - orgId: 1
+    name: critical-slack-email
+    receivers:
+      - uid: critical-slack
+        type: slack
+        settings:
+          url: $__file{/run/secrets/gaia_grafana_slack_webhook}
+          title: "{{ template \"slack.default.title\" . }}"
+          text: "{{ template \"slack.default.text\" . }}"
+        disableResolveMessage: false
+      - uid: critical-email
+        type: email
+        settings:
+          addresses: $__env{GRAFANA_ALERT_EMAIL}
+          singleEmail: true
         disableResolveMessage: false

--- a/infra/docker/observability/grafana/provisioning/alerting/notification-policies.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/notification-policies.yaml
@@ -1,5 +1,9 @@
 apiVersion: 1
 
+# Root policy: every alert goes to Slack. Critical alerts match the nested route
+# and instead go to `critical-slack-email` (Slack + email), so they reach inbox
+# without dropping off Slack. Non-critical alerts fall through to the root
+# receiver. Critical repeats more often (1h) than the warning default (4h).
 policies:
   - orgId: 1
     receiver: slack-alerts
@@ -7,3 +11,11 @@ policies:
     group_wait: 30s
     group_interval: 5m
     repeat_interval: 4h
+    routes:
+      - receiver: critical-slack-email
+        matchers:
+          - severity = critical
+        group_by: ["grafana_folder", "alertname"]
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 1h

--- a/infra/docker/observability/prometheus.yml
+++ b/infra/docker/observability/prometheus.yml
@@ -92,3 +92,26 @@ scrape_configs:
         target_label: instance
       - target_label: __address__
         replacement: blackbox_exporter:9115
+
+  # Blackbox /health probes for the remaining stack containers that expose no
+  # native Prometheus metrics (the bots + embedding sidecar). Gives each a
+  # probe_success series so the "container down" alert (alert-rules.yaml rule 13)
+  # covers them too — without this, a dead bot is invisible to alerting.
+  - job_name: blackbox_internal
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - http://embedding-sidecar:8200/health
+          - http://discord-bot:3200/health
+          - http://slack-bot:3201/health
+          - http://telegram-bot:3202/health
+          - http://whatsapp-bot:3203/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox_exporter:9115

--- a/scripts/swarm/lab-rehearsal.sh
+++ b/scripts/swarm/lab-rehearsal.sh
@@ -239,6 +239,9 @@ else
   create_secret gaia_infisical_machine_identity_client_secret "$INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"
   create_secret gaia_infisical_project_id                     "$INFISICAL_PROJECT_ID"
   create_secret gaia_metrics_token                            "$METRICS_TOKEN"
+  # Grafana email alerting (Gmail app password). Real value in prod; placeholder
+  # for the lab so the grafana service can start with GF_SMTP_PASSWORD__FILE set.
+  create_secret gaia_grafana_smtp_password                    "${GRAFANA_SMTP_PASSWORD:-lab-placeholder-smtp-password}"
 
   ok "Secrets created"
   docker --context "$CONTEXT_NAME" secret ls


### PR DESCRIPTION
## Why

When the ARQ worker crash-looped to 0/1 replicas in prod, **no alert fired** — there was no rule watching for a service being down, and critical alerts only went to Slack (no email). This adds that coverage.

## Alert rules added (Grafana-managed)

| Rule | Signal | Severity |
|---|---|---|
| `gaia-target-down` | `up==0` for gaia-api/arq_worker/postgres/redis/rabbitmq | critical |
| `gaia-arq-worker-down` | worker not reporting metrics | critical |
| `gaia-container-restarts` | cadvisor restart-loop (`changes(container_start_time_seconds)`) | warning |
| `gaia-internal-service-down` | blackbox `/health` probe down (4 bots + embedding sidecar) | critical |
| `gaia-api-p95-latency-critical` | p95 > 3s | critical |

(These join the existing 9 rules: 5xx, latency, queue backlog, DB connections, ChromaDB, host disk/mem, external probe.)

## Routing

- **All alerts → Slack** (unchanged root policy)
- **Critical → Slack *and* email** via a combined `critical-slack-email` contact point (one contact point holding both a Slack and an email receiver, so critical alerts reach inbox without dropping off Slack)

## Wiring

- `prometheus.yml`: new `blackbox_internal` scrape job probing the bots + embedding-sidecar `/health` endpoints (they expose no native metrics, so without this a dead bot is invisible)
- `docker-compose.prod.yml`: Grafana SMTP env (Gmail) + new `gaia_grafana_smtp_password` secret
- `docker-compose.yml`: `GRAFANA_ALERT_EMAIL` default so dev alerting provisioning loads cleanly
- `scripts/swarm/lab-rehearsal.sh`: create the new SMTP secret

## Deploy notes

Requires creating the secret on the prod manager before the Grafana service picks it up:
```
printf '%s' "<gmail-app-password>" | docker secret create gaia_grafana_smtp_password -
```
and setting `GRAFANA_SMTP_USER` (sending Gmail account) in the deploy env. Grafana provisioning is baked into the `gaia-grafana` image, so the new rules go live on the next image build + stack redeploy.

## Verification

- PromQL of every new rule validated against live prod Prometheus (`up{job="arq_worker"}=0` confirmed — would have fired on this incident).
- Slack delivery path tested live (Grafana test-receivers API → `status: ok`).
- Email delivery + full rule firing validated in a local Grafana+Prometheus stack (see PR discussion).