### PR TITLE
refactor(startup): required vs best-effort startup services

### DIFF
--- a/apps/api/app/core/provider_registration.py
+++ b/apps/api/app/core/provider_registration.py
@@ -52,6 +52,7 @@ from app.db.postgresql import init_postgresql_engine
 from app.db.rabbitmq import declare_outbound_topology_on_startup, init_rabbitmq_publisher
 from app.db.redis import redis_cache
 from app.helpers.lifespan_helpers import (
+    StartupService,
     _process_results,
     close_checkpointer_manager,
     close_mcp_client_pool,
@@ -116,7 +117,7 @@ def _spawn_background_task(
 
 
 def _spawn_background_services(
-    services: list[tuple[Callable[[], Awaitable[object]], str]],
+    services: list[StartupService],
     *,
     name: str = "startup_warmup",
     after: Callable[[], Awaitable[object]] | None = None,
@@ -131,8 +132,8 @@ def _spawn_background_services(
     """
 
     async def _run_all() -> None:
-        startup_tasks = [service_func() for service_func, _ in services]
-        service_names = [service_name for _, service_name in services]
+        startup_tasks = [service.func() for service in services]
+        service_names = [service.name for service in services]
 
         results = await asyncio.gather(*startup_tasks, return_exceptions=True)
 
@@ -224,41 +225,48 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
     # In development and in the ARQ worker we initialize these during startup.
     # In production FastAPI we schedule them to initialize in the background.
     eager_services = [
-        (init_mongodb_async, "mongodb"),
-        (redis_cache.verify_connection, "redis"),
-        (init_reminder_service, "reminder_service"),
-        (init_workflow_service, "workflow_service"),
-        # JuiceFS mount must be live before any tool call touches /mnt/jfs.
-        # The provider is a no-op when R2/JFS settings are unconfigured, so
-        # this is safe to include unconditionally.
-        (lambda: providers.aget("juicefs_mount"), "juicefs_mount"),
-        # Global shared system subtree (INDEX/GUIDE/builtin skills) — once,
-        # Awaits the mount internally.
-        (init_system_subtree, "system_subtree"),
+        StartupService(init_mongodb_async, "mongodb", required=True),
+        StartupService(redis_cache.verify_connection, "redis", required=True),
+        StartupService(init_reminder_service, "reminder_service", required=True),
+        StartupService(init_workflow_service, "workflow_service", required=True),
+        # JuiceFS mount — best-effort: the provider is a no-op when R2/JFS settings
+        # are unconfigured, and a storage-backend fault (R2 read errors) must degrade
+        # file features, not crash the worker.
+        StartupService(lambda: providers.aget("juicefs_mount"), "juicefs_mount", required=False),
+        # Shared system subtree (INDEX/GUIDE/builtin skills) — best-effort optimization;
+        # falls back to per-user copies. Awaits the mount internally.
+        StartupService(init_system_subtree, "system_subtree", required=False),
     ]
 
     # Outbound bot-message queues must exist before any executor reply or
     # reminder is published — declared in both the API and the ARQ worker.
-    eager_services.append((declare_outbound_topology_on_startup, "outbound_topology"))
+    eager_services.append(
+        StartupService(declare_outbound_topology_on_startup, "outbound_topology", required=True)
+    )
 
     # Context-specific services: WebSocket only needed for web interface
     if context == "main_app":
-        eager_services.append((init_websocket_consumer, "websocket_consumer"))
+        eager_services.append(
+            StartupService(init_websocket_consumer, "websocket_consumer", required=True)
+        )
         # Re-sync active users whose skill catalog is stale (deploy shipped new
         # skills). Detached so it never blocks boot; runs only in the web app.
         _spawn_background_task("workspace_stale_resync", resync_stale_user_workspaces)
 
-    startup_services: list[tuple[Callable[[], Awaitable[object]], str]] = list(eager_services)
+    startup_services: list[StartupService] = list(eager_services)
     startup_services.append(
-        (
+        StartupService(
             lambda: providers.initialize_auto_providers(
                 concurrency=AUTO_PROVIDER_CONCURRENCY,
                 strict=False,
             ),
             "lazy_providers_auto_initializer",
+            required=False,
         )
     )
-    startup_services.append((warmup_tools_cache, "tools_cache_warmup"))
+    startup_services.append(
+        StartupService(warmup_tools_cache, "tools_cache_warmup", required=False)
+    )
 
     # FastAPI with hot reloading disabled: start serving quickly,
     # warm up in background.
@@ -278,13 +286,14 @@ async def unified_startup(context: Literal["main_app", "arq_worker"]) -> None:
         return
 
     # Build parallel execution tasks (faster startup via concurrency)
-    startup_tasks = [service_func() for service_func, _ in startup_services]
-    service_names = [service_name for _, service_name in startup_services]
+    startup_tasks = [service.func() for service in startup_services]
 
     try:
         # Execute all tasks in parallel (return_exceptions prevents cascade failures)
         results = await asyncio.gather(*startup_tasks, return_exceptions=True)
-        _process_results(results, service_names)  # Validate results and handle failures
+        _process_results(
+            results, startup_services
+        )  # raise on required failures; degrade best-effort
 
         log.info(f"All {context} services initialized successfully")
         log.info(f"{context.title().replace('_', ' ')} startup complete")

--- a/apps/api/app/helpers/lifespan_helpers.py
+++ b/apps/api/app/helpers/lifespan_helpers.py
@@ -1,3 +1,6 @@
+from collections.abc import Awaitable, Callable
+from typing import NamedTuple
+
 from app.core.lazy_loader import providers
 from app.core.websocket_consumer import (
     start_websocket_consumer,
@@ -138,14 +141,43 @@ async def close_mcp_client_pool():
         log.error(f"Error closing MCP client pool: {e}")
 
 
-def _process_results(results, service_names):
-    failed_services = []
-    for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            failed_services.append(service_names[i])
-            log.error(f"Failed to initialize {service_names[i]}: {result}")
+class StartupService(NamedTuple):
+    """A startup coroutine plus whether its failure is fatal.
 
-        if failed_services:
-            error_msg = f"Failed to initialize services: {failed_services}"
-            log.error(error_msg)
-            raise RuntimeError(error_msg)
+    ``required=True``  → failure aborts startup (Mongo, Redis, schedulers, outbound
+    topology): the process is useless without it, so crashing is the honest signal.
+    ``required=False`` → best-effort: optional infrastructure / optimizations the app
+    degrades gracefully without (the JuiceFS mount, the shared system subtree, cache
+    warmups). A storage-backend fault hitting one of these used to take down the whole
+    ARQ worker; now it logs and the process keeps running. Criticality lives on the
+    descriptor at its definition site so it can't drift from a separate lookup table.
+    """
+
+    func: Callable[[], Awaitable[object]]
+    name: str
+    required: bool = True
+
+
+def _process_results(results: list[object], services: list[StartupService]) -> None:
+    """Raise if any REQUIRED startup service failed; degrade (log) for best-effort ones.
+
+    A best-effort service failing for ANY reason (not just I/O) is non-fatal. Required
+    services still hard-fail so a genuine misconfiguration surfaces loudly instead of a
+    half-initialized process.
+    """
+    required_failures = []
+    for result, service in zip(results, services):
+        if not isinstance(result, Exception):
+            continue
+        if service.required:
+            required_failures.append(service.name)
+            log.error(f"Failed to initialize {service.name}: {result}")
+        else:
+            log.warning(
+                f"Best-effort startup service '{service.name}' failed; continuing degraded: {result}"
+            )
+
+    if required_failures:
+        error_msg = f"Failed to initialize required services: {required_failures}"
+        log.error(error_msg)
+        raise RuntimeError(error_msg)


### PR DESCRIPTION
## Why

Follow-up to #820 (merged). That PR fixed the *symptom* — it caught `OSError` in `ensure_system_subtree` so a JuiceFS/R2 read fault wouldn't crash the worker. But the *architectural* flaw was in the orchestrator: `_process_results` treated **every** startup service as fatal, so any optional step (a dedup optimization, a cache warmup) had the same kill-power as MongoDB. Any failure — not just the one I/O path patched — would still take down the whole worker.

## What

`_process_results` now only hard-fails for **required** services; **best-effort** ones log and continue degraded on **any** error type:

| Required (fail loud) | Best-effort (degrade) |
|---|---|
| mongodb, redis, reminder_service, workflow_service, outbound_topology, websocket_consumer | juicefs_mount, system_subtree, tools_cache_warmup, lazy_providers_auto_initializer |

Criticality is carried on a `StartupService(func, name, required)` **descriptor at the definition site** — not a separate name→bool lookup table — so it can't silently drift, and a new service must state its criticality (defaults to `required=True`, the safe/loud default).

## Notes

- The other startup path (`_spawn_background_services`, main_app warmup) already degraded gracefully; only the synchronous `_process_results` path (used by the ARQ worker) hard-crashed, so the fix is localized there.
- The #820 `system_workspace` `OSError` catch stays — it's coherent with that function's existing `JuiceFSUnavailable` handling and honors its documented "degrade to per-user copies" contract. This PR is the general safety net beneath it.
- Passes `ruff` + `mypy`.

Companion to the June 2026 worker-down incident (#820 worker resilience, #821 alerting).