### PR TITLE
fix(composio): restore trigger-option dropdowns broken by user_id guard

### DIFF
--- a/apps/api/app/services/composio/langchain_composio_service.py
+++ b/apps/api/app/services/composio/langchain_composio_service.py
@@ -69,7 +69,10 @@ def _reinstate_reserved_python_keywords(request: dict, keywords: dict) -> dict:
 
 
 class StructuredTool(BaseStructuredTool):
+    """StructuredTool that returns a structured failure instead of raising on invalid args."""
+
     def run(self, *args, **kwargs):
+        """Run the tool, converting argument validation errors into a failure result."""
         try:
             return super().run(*args, **kwargs)
         except pydantic.ValidationError as e:
@@ -187,6 +190,7 @@ class LangchainProvider(
         return action_func
 
     def wrap_tool(self, tool: Tool, execute_tool: AgenticProviderExecuteFn) -> StructuredTool:
+        """Wrap a single Composio tool as a LangChain StructuredTool."""
         # Replace reserved python keywords
         schema_params, keywords = _substitute_reserved_python_keywords(schema=tool.input_parameters)
 

--- a/apps/api/app/services/composio/langchain_composio_service.py
+++ b/apps/api/app/services/composio/langchain_composio_service.py
@@ -16,7 +16,6 @@ from langchain_core.tools import StructuredTool as BaseStructuredTool
 import pydantic
 
 from app.constants.log_tags import LogTag
-from app.utils.errors import AppError
 from shared.py.wide_events import log
 
 _python_reserved = {"for", "async", "from", "import", "as", "pass", "continue"}
@@ -105,23 +104,13 @@ class LangchainProvider(
             metadata = (
                 runnable_config.get("metadata", {}) if isinstance(runnable_config, dict) else {}
             )
+            # user_id is read only for the observability log below. It is present
+            # for agent-flow calls (which pass it in config metadata) and None for
+            # trigger-option calls (which bind the user at get_tool(user_id=...)
+            # time — invisible here but still used for auth at execution). Identity
+            # is resolved at execution, not here, so a None is harmless; Composio
+            # errors loudly if no user_id reaches it either way.
             user_id = metadata.get("user_id") if isinstance(metadata, dict) else None
-            if not user_id:
-                # Composio defaults a missing user_id to its "default" account,
-                # which would silently route this call to the wrong (or no)
-                # connected account. Fail loudly instead of hitting "default".
-                log.warning(
-                    f"{LogTag.COMPOSIO} composio tool {tool} (toolkit={toolkit}) invoked without a "
-                    "user_id in runnable metadata; refusing to fall back to the "
-                    "Composio 'default' account."
-                )
-                raise AppError(
-                    message=f"Missing user_id in runnable metadata for composio tool {tool}",
-                    why="Composio tool invoked without a user_id in runnable metadata.",
-                    fix="Ensure the runnable config includes metadata.user_id before invoking the tool.",
-                    status_code=400,
-                    meta={"tool": tool, "toolkit": toolkit},
-                )
 
             kwargs = _reinstate_reserved_python_keywords(
                 request=kwargs,

--- a/apps/api/app/utils/composio_hooks/user_id_hooks.py
+++ b/apps/api/app/utils/composio_hooks/user_id_hooks.py
@@ -20,13 +20,14 @@ def extract_user_id_from_params(
     """
     Extract user_id from RunnableConfig metadata and add it to tool execution params.
 
-    This function is used as a before_execute modifier for Composio tools to ensure
-    user context is properly passed through during tool execution.
+    Used as a before_execute modifier so the agent flow (tools fetched with
+    user_id="") can supply the user per-invocation via runnable metadata. When
+    no metadata is present, params["user_id"] keeps whatever the SDK bound at
+    `tools.get(user_id=...)` time (the trigger-option-handler flow) — this hook
+    only overrides it when runnable metadata carries a user_id.
 
     Sets both 'user_id' (new SDK) and 'entity_id' (legacy) for compatibility
     with Composio's connected account authentication.
-
-    Migrated from the old standalone function to use the new hook system.
     """
     log.set(composio_tool=tool, composio_toolkit=toolkit)
     arguments = params.get("arguments", {})


### PR DESCRIPTION
## Problem

Workflow **trigger-option dropdowns** (GitHub / Notion / Slack / Linear / Google Sheets) stopped loading, failing with:

> Missing user_id in runnable metadata for composio tool GITHUB_LIST_REPOSITORIES_FOR_THE_AUTHENTICATED_USER

This started with the Composio 1.0 migration (#736), which added a guard in the LangChain provider wrapper that raised whenever a tool was invoked without `user_id` in the `RunnableConfig` metadata.

## Root cause

The guard only recognized **one** way `user_id` reaches a tool — runnable metadata. But there are two legitimate sources:

- **Agent flow** — tools fetched with `user_id=""`; the user is supplied per-invocation via `RunnableConfig.metadata` (set in `build_agent_config`).
- **Trigger-option handlers** — fetch tools via `get_tool(user_id=...)`, which the Composio SDK binds onto the execute partial (`tools.get(user_id=X)` → `functools.partial(self.execute, user_id=X, ...)`) and carries through to execution. These invoke with **no config**.

So trigger handlers *do* supply the user — the call authenticates correctly via the bound user — but the metadata-only guard rejected it before execution. Verified against the Composio `0.13.1` SDK source (`tools.py` `execute()` resolves `user_id` from the bound value when metadata is absent).

## Fix

Remove the guard. Identity is resolved at execution from whichever source applies, and Composio errors loudly if neither yields a `user_id`. The before-hook docstring now documents the bound-user reliance so the guard isn't reintroduced. The wrapper still reads `user_id` from metadata for the observability log line (present for agent-flow calls, `None` for trigger lookups — cosmetic).

## Verification

Exercised the real wrapper path through `StructuredTool.invoke`:

- Trigger flow (bound user, no config) → executes with the bound user ✓ (bug fixed)
- Agent flow (config metadata) → wrapper reads the real user ✓
- Neither source → Composio's own loud error path ✓

`ruff` and `mypy` pass on both changed files.