### PR TITLE
fix(infra): arq worker healthcheck must not require Infisical

### DIFF
--- a/apps/api/scripts/arq_healthcheck.py
+++ b/apps/api/scripts/arq_healthcheck.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Liveness probe for the ARQ worker, invoked by the Docker healthcheck.
+
+The worker refreshes arq's ``arq:health`` key from its poll loop every
+``health_check_interval`` seconds with a TTL of ``interval + 1`` (see arq's
+``Worker.record_health``), so the key disappears within ~31s if the loop wedges
+or the process dies. Checking that key is exactly what ``arq --check`` does
+internally — but ``arq --check`` first imports the whole application, which a
+Docker healthcheck cannot do: it runs outside the entrypoint, so it has no
+``INFISICAL_TOKEN`` and the import dies during settings bootstrap.
+
+This probe imports nothing from ``app`` (so no application change can break it)
+and talks only to Redis — the worker's own job substrate.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import redis
+
+# Stable Swarm overlay alias; a healthcheck cannot read the Infisical-injected
+# REDIS_URL, so it targets the well-known service name directly.
+REDIS_HOST = "redis"
+REDIS_PORT = 6379
+REDIS_TIMEOUT_SECONDS = 5
+
+# Must match WorkerSettings.health_check_key in
+# app/workers/config/worker_settings.py.
+ARQ_HEALTH_KEY = "arq:health"
+
+
+def main() -> int:
+    client = redis.Redis(
+        host=REDIS_HOST,
+        port=REDIS_PORT,
+        socket_connect_timeout=REDIS_TIMEOUT_SECONDS,
+        socket_timeout=REDIS_TIMEOUT_SECONDS,
+    )
+    try:
+        return 0 if client.exists(ARQ_HEALTH_KEY) else 1
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -155,9 +155,13 @@ services:
         aliases:
           - arq_worker
     healthcheck:
-      # arq --check fails when the poll loop stops refreshing its health key (a
-      # wedged worker); the old Redis-socket probe passed even when frozen.
-      test: ["CMD", "arq", "app.worker.WorkerSettings", "--check"]
+      # Reads arq's own liveness key (arq:health — refreshed from the poll loop
+      # with a ~31s TTL, so it's gone within ~31s if the loop wedges). This is
+      # what `arq --check` asserts internally, but without importing the app:
+      # a healthcheck runs outside the entrypoint, so it has no INFISICAL_TOKEN
+      # and a full app import dies in settings bootstrap — which silently rolled
+      # the worker back on every deploy. The probe touches only Redis.
+      test: ["CMD", "python", "scripts/arq_healthcheck.py"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What

Replaces the `arq_worker` Docker healthcheck (`arq app.worker.WorkerSettings --check`) with a standalone probe, `apps/api/scripts/arq_healthcheck.py`, that reads arq's own `arq:health` liveness key directly from Redis.

## Why — root cause of the silent rollbacks

The deploy convergence check kept reporting `arq_worker was rolled back by Swarm (rollback_started)`. Investigation on the prod node showed the worker **never crashed** — every task exited cleanly via SIGTERM, no errors. The actual cause:

- `arq … --check` imports the whole app to read the health key. That import runs `app/config/settings.py`'s module-level `get_settings()` → `inject_infisical_secrets()`, which **requires `INFISICAL_TOKEN`**.
- **Docker healthchecks run outside the `ENTRYPOINT`**, and the entrypoint is the only thing that exports `INFISICAL_TOKEN` from `/run/secrets/`. So the healthcheck subprocess always died with `InfisicalConfigError` (verified by running it live in the prod container).
- Every probe failed → after the 120s `start_period` the worker was marked unhealthy → `failure_action: rollback` reverted it to the previous image **on every deploy**. Backend was unaffected because its `/health` is an in-process HTTP check (no re-import, no secrets), so prod ended up **split-brain**: backend on new code, worker silently on stale code.

This has been latent since the healthcheck switched from a Redis socket probe to `arq --check` (#789); CI only surfaced it once the convergence step started failing on `rollback_started`.

## The fix

A probe that asserts the same signal `arq --check` does — the `arq:health` key — but imports nothing from `app`:

- No app import, no Infisical, no `INFISICAL_TOKEN` needed → works in the healthcheck's stripped environment.
- Depends only on Redis (arq's own job substrate) at the stable overlay alias `redis:6379`.
- Cannot be broken by any application-code change.
- ~50ms, so no `timeout` risk.

## Verification

Run against a **real arq worker** locally (throwaway Redis + `arq.run_worker`):

| State | `arq:health` | probe exit | `arq --check` |
|---|---|---|---|
| Before startup | absent | `1` | — |
| Worker running | present, TTL 31s | `0` | `0` (agrees) |
| Loop wedged (blocking job, process still alive) | expired | `1` | — |
| Worker dead | gone | `1` | — |

Confirmed from arq 0.26.3 source: key is `arq:health` verbatim, written with `interval+1`s TTL, refreshed every poll iteration **including when idle**. The wedge case (process up, event loop blocked → key expires → probe red) was demonstrated explicitly.

## Scope / notes

- Surgical: one new script + one compose healthcheck line. `start_period`/`monitor` unchanged (120s already covers real init time).
- Dev compose has no `arq_worker` healthcheck, so no change needed there.
- **Not bundled** (separate latent bug): `inject_infisical_secrets()` only reads creds from env, so non-entrypoint subprocesses can't bootstrap secrets — a `/run/secrets/` file fallback would harden that, but it's its own change.
- After merge + image rebuild, the next deploy's worker will pass the new healthcheck and converge on current code instead of rolling back, closing the backend/worker split-brain.