### PR TITLE
fix(desktop): route to desktop login on logout instead of landing page

### DIFF
--- a/apps/web/src/features/auth/hooks/useLogout.ts
+++ b/apps/web/src/features/auth/hooks/useLogout.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { del } from "idb-keyval";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
+import { useElectron } from "@/hooks/useElectron";
 import { resetUser } from "@/lib/analytics";
 import { db } from "@/lib/db/chatDb";
 import { authApi } from "../api/authApi";
@@ -9,6 +10,7 @@ import { authApi } from "../api/authApi";
 export const useLogout = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const { isElectron } = useElectron();
 
   const clearAllStorage = useCallback(async () => {
     // 1. Close all database connections first
@@ -91,9 +93,12 @@ export const useLogout = () => {
 
     // Redirection will be handled by the authApi.logout method
     // but in case it doesn't (for example, if there's no logout_url),
-    // we redirect to the homepage
-    router.push("/");
-  }, [clearAllStorage, router]);
+    // we redirect to the post-logout landing. In Electron the marketing
+    // homepage lives in the (landing) group, which has no ElectronRouteGuard
+    // to bounce logged-out users — so send desktop users straight to the
+    // desktop login screen instead of the public landing page.
+    router.push(isElectron ? "/desktop-login" : "/");
+  }, [clearAllStorage, router, isElectron]);
 
   return { logout };
 };


### PR DESCRIPTION
## Problem

Logging out in the **desktop (Electron) app** dropped the user on the public **marketing landing page** instead of an app-appropriate login screen.

## Root cause

`useLogout` always ran `router.push("/")` as its post-logout fallback (the redirect only goes elsewhere when the backend returns a `logout_url`, which the desktop flow doesn't).

In Electron, `/` resolves to the marketing homepage in the `(landing)` route group. That group's layout **intentionally excludes `ElectronRouteGuard`** — the guard that bounces logged-out desktop users to `/desktop-login`. So a logged-out desktop user just lands on the public landing page inside the Electron window.

## Fix

Make the fallback Electron-aware:

```ts
router.push(isElectron ? "/desktop-login" : "/");
```

- **Desktop** → `/desktop-login` (matches the existing convention in `ElectronRouteGuard.tsx`, which already sends logged-out Electron users there).
- **Web** → `/` (unchanged).

Surgical change: one import + one ternary + the dep array. The `logout_url` redirect path is untouched.

## Verification

- `nx run web:type-check` — passed
- `nx lint web` — passed (no new warnings in this file)

Not yet exercised in a packaged desktop build (requires full web build + Electron package); logic mirrors the verified root cause and the existing `ElectronRouteGuard` routing.