### PR TITLE
fix(grafana): prevent SMTP from_address crash-loop on unset deploy env

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -825,17 +825,21 @@ services:
       # GRAFANA_ALERT_EMAIL is the destination the email contact point sends to
       # (see provisioning/alerting/contact-points.yaml → $__env{GRAFANA_ALERT_EMAIL}).
       #
-      # REQUIRED (no default): GRAFANA_SMTP_USER must be set in the deploy env before
-      # `docker stack deploy` — it's the full Gmail/Workspace sending address (e.g.
-      # alerts@heygaia.io) that owns the app password. If unset, GF_SMTP_USER is empty
-      # and Gmail rejects auth with `535 Username and Password not accepted`, so email
-      # alerts silently never send (Slack still works). The app password must belong to
-      # this same account. See internal-docs → Production → Grafana → Alerting.
+      # GRAFANA_SMTP_USER is the full Gmail/Workspace sending address that owns the
+      # app password; it defaults to aryan@heygaia.io. The from-address must match the
+      # authenticated account (Gmail rewrites mismatched senders), so it carries the
+      # same default. Both use a single-level `:-` default — never a nested one:
+      # `docker stack deploy` does not recurse into a default's value, so an unset
+      # GRAFANA_SMTP_USER would leak the literal "${GRAFANA_SMTP_USER}" as the from
+      # address, which Grafana rejects as an invalid email and refuses to boot. To send
+      # from a different account, override GRAFANA_SMTP_USER and GRAFANA_SMTP_FROM_ADDRESS
+      # together, and make sure the app-password secret belongs to it.
+      # See internal-docs → Production → Grafana → Alerting.
       GF_SMTP_ENABLED: "true"
       GF_SMTP_HOST: ${GRAFANA_SMTP_HOST:-smtp.gmail.com:587}
-      GF_SMTP_USER: ${GRAFANA_SMTP_USER}
+      GF_SMTP_USER: ${GRAFANA_SMTP_USER:-aryan@heygaia.io}
       GF_SMTP_PASSWORD__FILE: /run/secrets/gaia_grafana_smtp_password
-      GF_SMTP_FROM_ADDRESS: ${GRAFANA_SMTP_FROM_ADDRESS:-${GRAFANA_SMTP_USER}}
+      GF_SMTP_FROM_ADDRESS: ${GRAFANA_SMTP_FROM_ADDRESS:-aryan@heygaia.io}
       GF_SMTP_FROM_NAME: "GAIA Alerts"
       GRAFANA_ALERT_EMAIL: ${GRAFANA_ALERT_EMAIL:-aryan@heygaia.io}
     secrets:


### PR DESCRIPTION
## What

Fixes the production Grafana (`logs.heygaia.io`) crash-loop caused by a broken nested default in the prod compose SMTP config.

## Root cause

Grafana was exiting on every boot with:

```
Error: ✗ invalid email address for SMTP from_address config
```

`GF_SMTP_FROM_ADDRESS` used a **nested default**:

```yaml
GF_SMTP_FROM_ADDRESS: ${GRAFANA_SMTP_FROM_ADDRESS:-${GRAFANA_SMTP_USER}}
```

`docker stack deploy` interpolation does **not** recurse into a default's value. With `GRAFANA_SMTP_USER` unset in the deploy env (it had no default and was never provisioned), the literal string `${GRAFANA_SMTP_USER}` was passed to Grafana as the from-address. With `GF_SMTP_ENABLED=true`, Grafana validates the address at startup, rejects the non-email, and exits 1 — crash loop.

## Fix

Replace both SMTP identity vars with **single-level `:-` defaults** of `aryan@heygaia.io` (consistent with the existing `GRAFANA_ALERT_EMAIL` default in the same block):

```yaml
GF_SMTP_USER: ${GRAFANA_SMTP_USER:-aryan@heygaia.io}
GF_SMTP_FROM_ADDRESS: ${GRAFANA_SMTP_FROM_ADDRESS:-aryan@heygaia.io}
```

Now an unset deploy env can never produce an invalid from-address, so Grafana cannot crash on this again. The comment is updated to document why nested defaults must not be used here.

## Verification

- `docker compose -f docker-compose.prod.yml config` with `GRAFANA_SMTP_*` unset now renders valid emails (`aryan@heygaia.io`) instead of the literal `${GRAFANA_SMTP_USER}`.
- Prod was restored out-of-band via `docker service update` (running container `Restarts=0`, `HTTP Server Listen`, `logs.heygaia.io → 200`); this change makes the fix durable across the next deploy.

## Note

To send alert email from a different account, override **both** `GRAFANA_SMTP_USER` and `GRAFANA_SMTP_FROM_ADDRESS` in the deploy env, and ensure the `gaia_grafana_smtp_password` secret is an app password for that account.