### PR TITLE
fix(workflow): drop monthly cap on triggered workflow executions

### DIFF
--- a/apps/api/app/config/rate_limits.py
+++ b/apps/api/app/config/rate_limits.py
@@ -154,8 +154,14 @@ FEATURE_LIMITS: dict[str, TieredRateLimits] = {
         ),
     ),
     "trigger_workflow_executions": TieredRateLimits(
-        free=RateLimitConfig(day=5, month=20),  # Keep restrictive
-        pro=RateLimitConfig(day=150, month=4500),  # +50% (100→150, 3000→4500)
+        # Integration triggers fire one execution per event (Gmail's account-level
+        # trigger fires on EVERY new email). A monthly cap meant a single busy day
+        # exhausted the budget, after which every triggered workflow — across ALL
+        # integrations — failed with 429 for the rest of the month. The daily limit
+        # is the cost guard; month=0 (no monthly cap) keeps automations alive
+        # day-to-day instead of locking the user out for weeks.
+        free=RateLimitConfig(day=15, month=0),
+        pro=RateLimitConfig(day=150, month=0),
         info=FeatureInfo(
             title="Trigger Workflow Executions",
             description="Automated workflow executions triggered by integrations",

--- a/apps/api/tests/unit/config/test_rate_limits.py
+++ b/apps/api/tests/unit/config/test_rate_limits.py
@@ -206,14 +206,16 @@ class TestFeatureLimits:
             )
 
     def test_monthly_limits_gte_daily_limits(self) -> None:
-        """Monthly limits should be >= daily limits for both tiers."""
+        """Monthly limits should be >= daily limits, unless 0 (0 = no monthly cap)."""
         for key, limits in FEATURE_LIMITS.items():
-            assert limits.free.month >= limits.free.day, (
-                f"{key}: free month ({limits.free.month}) < free day ({limits.free.day})"
-            )
-            assert limits.pro.month >= limits.pro.day, (
-                f"{key}: pro month ({limits.pro.month}) < pro day ({limits.pro.day})"
-            )
+            if limits.free.month:
+                assert limits.free.month >= limits.free.day, (
+                    f"{key}: free month ({limits.free.month}) < free day ({limits.free.day})"
+                )
+            if limits.pro.month:
+                assert limits.pro.month >= limits.pro.day, (
+                    f"{key}: pro month ({limits.pro.month}) < pro day ({limits.pro.day})"
+                )
 
     def test_all_features_have_nonempty_info(self) -> None:
         for key, limits in FEATURE_LIMITS.items():
@@ -224,15 +226,22 @@ class TestFeatureLimits:
     PAID_ONLY_FEATURES = {"voice_mode"}
 
     def test_free_limits_are_positive(self) -> None:
-        """Non-paid-only features should have at least some free tier allowance."""
+        """Non-paid-only features should grant some free allowance.
+
+        A 0 in a single period means "no limit" for that period (see
+        RateLimitConfig), so a feature is valid as long as it grants free access
+        through at least one window — e.g. trigger executions are capped daily
+        but uncapped monthly (month=0).
+        """
         for key, limits in FEATURE_LIMITS.items():
             if key in self.PAID_ONLY_FEATURES:
                 # Paid-only features deliberately have free.day == free.month == 0
                 assert limits.free.day == 0, f"{key}: expected free day == 0 (paid-only)"
                 assert limits.free.month == 0, f"{key}: expected free month == 0 (paid-only)"
             else:
-                assert limits.free.day > 0, f"{key}: free day is 0"
-                assert limits.free.month > 0, f"{key}: free month is 0"
+                assert limits.free.day > 0 or limits.free.month > 0, (
+                    f"{key}: free tier has no allowance (day and month both 0)"
+                )
 
     def test_specific_chat_messages_limits(self) -> None:
         chat = FEATURE_LIMITS["chat_messages"]


### PR DESCRIPTION
## Problem

Composio/integration triggers (e.g. Gmail "on every new email, do X") and other automated workflows were silently failing for many users. Root-caused via production logs (Grafana/Loki, 7 days) + a local reproduction against the real limiter.

The pipeline up to execution is healthy:

| Boundary | 7-day evidence | Verdict |
|---|---|---|
| Composio → webhook | 34,874 `POST /api/v1/webhook/composio`, all 200 | ✅ |
| Webhook → match/queue | 22,252 Gmail workflows queued, 0 unhandled, 0 queue failures | ✅ |
| Queue → worker start | 25,587 executions started | ✅ |
| **Worker → execution** | **46,672 blocked with `429 rate_limit_exceeded` across 110 users** | ❌ |

The 429s are GAIA's **own** `@tiered_rate_limit("trigger_workflow_executions")`, with `reset_time` at the next UTC month boundary — a **monthly** quota.

## Root cause

`trigger_workflow_executions` limits were `free 5/day, 20/month` and `pro 150/day, 4500/month`. Every triggered execution consumes one unit of this **per-user, shared-across-all-integrations** quota. Gmail uses an **account-level** trigger that fires one full execution **per inbound email** (no coalescing), so a normal inbox exhausts the tiny **monthly** cap almost immediately — after which **every** triggered/scheduled workflow for that user returns 429 **for the rest of the month**. That's both "Gmail does nothing" and "all workflows are broken."

### Reproduction (real limiter + real Redis)
- **Before:** FREE user — emails 1–5 run, **#6 onward blocked 429**; 5/12 ran, 7 "did nothing." Emitted the exact prod 429 detail (`feature: trigger_workflow_executions`).
- **After:** FREE user runs **12/12**; monthly cap removed.

## Fix

`apps/api/app/config/rate_limits.py`:
- **Drop the monthly cap** (`month=0` = no monthly limit, per `RateLimitConfig`) so a busy day never locks a user out for weeks.
- Keep the **daily** limit as the cost guard; raise free daily `5 → 15` so light usage actually works.
- Pro daily stays `150` (same ~4500/mo effective ceiling) — cost-neutral, but a burst day no longer kills the rest of the month.

Updated two rate-limit invariant tests to recognize the documented `0 = no limit` sentinel (a feature may be capped daily but uncapped monthly).

> Numbers are easy to tune — if busier inboxes need more daily headroom, bump `day`.

## Verification
- `pytest tests/unit/config/test_rate_limits.py` → **54 passed**
- `ruff check` + `ruff format --check` clean; `mypy app/config/rate_limits.py` clean
- Reproduction confirms FREE now runs 12/12 (was 5/12)

## Known follow-ups (out of scope here)
- **Per-email firing has no debounce/coalescing** — even with headroom, account-level Gmail triggers fire one full agent run per email. Worth coalescing for cost.
- **Result-delivery gap** — in 3 days, 5,154 workflow runs "executed successfully" but only 319 emitted a completion notification (0 "silent skips"). Most successful runs don't reach result delivery — separate investigation (the `feat/workflow-platform-message-delivery` branch already touches this area).
- **Unbounded workflow conversation doc** — one workflow's conversation exceeded MongoDB's 16MB cap (`WriteError 17419`) and now fails every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
