### PR TITLE
fix(triggers): match workflows by Composio trigger nano-id, not UUID

### DIFF
--- a/apps/api/app/api/v1/endpoints/webhook_composio.py
+++ b/apps/api/app/api/v1/endpoints/webhook_composio.py
@@ -36,7 +36,12 @@ async def _process_webhook_event(handler: Any, event_data: ComposioWebhookEvent)
         await asyncio.wait_for(
             handler.process_event(
                 event_type=event_data.type,
-                trigger_id=event_data.trigger_id,
+                # Handlers match against trigger_config.composio_trigger_ids, which
+                # stores the trigger NANO id (ti_...) returned by triggers.create().
+                # Composio's webhook puts that nano id in `trigger_nano_id` and the
+                # trigger's internal UUID in `trigger_id` — matching against the UUID
+                # never hits, so forward the nano id (falling back to the UUID).
+                trigger_id=event_data.trigger_nano_id or event_data.trigger_id,
                 user_id=event_data.user_id,
                 data=event_data.data,
             ),

--- a/apps/api/app/services/triggers/handlers/gmail.py
+++ b/apps/api/app/services/triggers/handlers/gmail.py
@@ -77,32 +77,43 @@ class GmailTriggerHandler(TriggerHandler):
                 log.debug(f"{LogTag.TRIGGER} Gmail payload validation failed: {e}")
 
             user_id = data.get("user_id")
-            if not user_id:
-                log.error(f"{LogTag.TRIGGER} No user_id in Gmail webhook data")
+            workflows: list[Workflow] = []
+            queries: list[dict[str, Any]] = []
+
+            # Strategy 1: gmail_new_message workflows are account-level (no trigger
+            # IDs), so they can only be matched by user_id. Poll webhooks may omit
+            # user_id, so only run this strategy when we actually have one.
+            if user_id:
+                queries.append(
+                    {
+                        "user_id": user_id,
+                        "activated": True,
+                        "trigger_config.type": TriggerType.INTEGRATION,
+                        "trigger_config.trigger_name": {"$in": self.SUPPORTED_TRIGGERS},
+                        "trigger_config.enabled": True,
+                    }
+                )
+
+            # Strategy 2: gmail_poll_inbox workflows are matched by their registered
+            # trigger id. The id uniquely identifies the workflow (and its owner), so
+            # we do NOT gate on user_id here — Composio's poll webhooks frequently
+            # arrive with an empty user_id, and gating on it dropped every event.
+            if trigger_id:
+                queries.append(
+                    {
+                        "activated": True,
+                        "trigger_config.type": TriggerType.INTEGRATION,
+                        "trigger_config.trigger_name": "gmail_poll_inbox",
+                        "trigger_config.enabled": True,
+                        "trigger_config.composio_trigger_ids": trigger_id,
+                    }
+                )
+
+            if not queries:
+                log.error(f"{LogTag.TRIGGER} Gmail webhook has neither user_id nor trigger_id")
                 return []
 
-            workflows: list[Workflow] = []
-
-            # Strategy 1: match gmail_new_message workflows by user_id
-            user_query = {
-                "user_id": user_id,
-                "activated": True,
-                "trigger_config.type": TriggerType.INTEGRATION,
-                "trigger_config.trigger_name": {"$in": self.SUPPORTED_TRIGGERS},
-                "trigger_config.enabled": True,
-            }
-
-            # Strategy 2: match gmail_poll_inbox workflows by trigger_id
-            poll_query = {
-                "user_id": user_id,
-                "activated": True,
-                "trigger_config.type": TriggerType.INTEGRATION,
-                "trigger_config.trigger_name": "gmail_poll_inbox",
-                "trigger_config.enabled": True,
-                "trigger_config.composio_trigger_ids": trigger_id,
-            }
-
-            for query in (user_query, poll_query):
+            for query in queries:
                 async for workflow_doc in workflows_collection.find(query):
                     try:
                         workflow_doc["id"] = workflow_doc.get("_id")


### PR DESCRIPTION
## Problem

Composio **integration-trigger** workflows (e.g. Gmail "Smart Inbox Triage", "Meeting Briefing") never run. Confirmed by read-only prod triage of a real account: every `gmail_poll_inbox` and `calendar_event_starting_soon` workflow has **`total_executions = 0`, ever** — across all users that's **360 + 203 workflows**. `gmail_new_message` workflows *do* run (then hit the rate limit, see #844).

## Root cause (verified end-to-end in prod)

A Composio trigger has two identifiers:
- `id` / nano-id — e.g. `ti_XDp_It8URXsp` — **this is what `triggers.create()` returns and what we store** in `trigger_config.composio_trigger_ids`.
- `uuid` — e.g. `e8dbdb58-5acc-4104-a75a-8b6e38dcfd86`.

Every handler matches `{"trigger_config.composio_trigger_ids": trigger_id}`, but the webhook endpoint forwarded **`event_data.trigger_id` = the UUID**. A UUID can never equal a stored `ti_…` nano-id → **no match → workflow never queued.**

Confirmed with the user's real webhook events (101 in 14d):
```
trigger_no_matching_workflows | user_id=(EMPTY) | trigger_id=e8dbdb58-…(UUID) | GMAIL_NEW_GMAIL_MESSAGE
```
The Composio SDK confirms the payload carries the nano-id in `trigger_nano_id` (`composio/core/models/triggers.py`), and that poll webhooks can ship an **empty `user_id`** (sourced from `metadata.connection.clientUniqueUserId`). The Gmail handler bailed on `if not user_id: return []` before even attempting the trigger match — a second, compounding failure.

`gmail_new_message` is unaffected because it matches by `user_id` (which those webhooks carry).

## Fix

- **`webhook_composio.py`**: forward `event_data.trigger_nano_id` (the `ti_…` value we store), falling back to `trigger_id`. One change repairs trigger matching for **all** handlers (calendar, github, notion, slack, linear, todoist, asana, google_docs/sheets, gmail_poll).
- **`gmail.py`**: run the `gmail_poll_inbox` strategy keyed solely by the trigger id (which uniquely identifies the workflow and owner) — no longer require `user_id`, so empty-`user_id` poll webhooks are no longer dropped. `gmail_new_message` (Strategy 1) still matches by `user_id`.

## Verification

- Local reproduction against Mongo (`FIX_VERIFIED: True`): a `gmail_poll_inbox` workflow now matches on its nano-id with an **empty** webhook `user_id`; the UUID correctly does **not** match.
- `ruff check` + `ruff format --check` clean; `mypy` clean on both files.
- `pytest tests/unit -k "gmail or trigger or webhook"` → **535 passed**.

## Notes
- Companion to #844 (rate-limit). Together: triggered workflows now both *match* (this PR) and aren't immediately throttled (#844).
- Stored `composio_trigger_ids` are already all nano-ids, so no data migration is needed; matching simply uses the correct field now.


Todo:

- [ ] Review Files
- [ ] Test webhook
- [ ] Seed Script for old workflow triggers