### PR TITLE
fix(workflow): cap per-workflow conversation (16MB) + raise Pro trigger limits

### DIFF
--- a/apps/api/app/config/rate_limits.py
+++ b/apps/api/app/config/rate_limits.py
@@ -154,8 +154,10 @@ FEATURE_LIMITS: dict[str, TieredRateLimits] = {
         ),
     ),
     "trigger_workflow_executions": TieredRateLimits(
-        free=RateLimitConfig(day=5, month=20),  # Keep restrictive
-        pro=RateLimitConfig(day=150, month=4500),  # +50% (100→150, 3000→4500)
+        free=RateLimitConfig(day=5, month=20),  # Keep restrictive (trial)
+        # Account-level triggers (e.g. Gmail) fire one execution per event, so Pro
+        # needs real headroom; the cap stays as a cost guard, not a daily blocker.
+        pro=RateLimitConfig(day=1500, month=45000),
         info=FeatureInfo(
             title="Trigger Workflow Executions",
             description="Automated workflow executions triggered by integrations",

--- a/apps/api/app/services/conversation_service.py
+++ b/apps/api/app/services/conversation_service.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 from bson import ObjectId
@@ -221,9 +222,17 @@ async def delete_conversation(conversation_id: str, user: dict) -> dict:
     }
 
 
-async def update_messages(request: UpdateMessagesRequest, user: dict) -> dict:
+async def update_messages(
+    request: UpdateMessagesRequest, user: dict, max_messages: int | None = None
+) -> dict:
     """
     Add messages to an existing conversation, including any file IDs attached to the messages.
+
+    When ``max_messages`` is set, the ``messages`` array is capped to the most recent
+    ``max_messages`` entries (via ``$slice``). System-generated conversations that append
+    on every run — e.g. the single per-workflow thread reused across executions — must
+    bound their history, or the document eventually exceeds MongoDB's 16MB limit and
+    every subsequent write fails with WriteError 17419.
     """
     user_id = user.get("user_id")
     conversation_id = request.conversation_id
@@ -236,10 +245,15 @@ async def update_messages(request: UpdateMessagesRequest, user: dict) -> dict:
         message_dict.setdefault("message_id", str(ObjectId()))
         messages.append(message_dict)
 
+    push_spec: dict[str, Any] = {"$each": messages}
+    if max_messages is not None:
+        # Negative slice keeps only the most recent ``max_messages`` entries.
+        push_spec["$slice"] = -max_messages
+
     update_result = await conversations_collection.update_one(
         {"user_id": user_id, "conversation_id": conversation_id},
         {
-            "$push": {"messages": {"$each": messages}},
+            "$push": {"messages": push_spec},
             "$currentDate": {"updatedAt": True},
         },
     )

--- a/apps/api/app/services/conversation_service.py
+++ b/apps/api/app/services/conversation_service.py
@@ -225,14 +225,10 @@ async def delete_conversation(conversation_id: str, user: dict) -> dict:
 async def update_messages(
     request: UpdateMessagesRequest, user: dict, max_messages: int | None = None
 ) -> dict:
-    """
-    Add messages to an existing conversation, including any file IDs attached to the messages.
+    """Append messages to a conversation.
 
-    When ``max_messages`` is set, the ``messages`` array is capped to the most recent
-    ``max_messages`` entries (via ``$slice``). System-generated conversations that append
-    on every run — e.g. the single per-workflow thread reused across executions — must
-    bound their history, or the document eventually exceeds MongoDB's 16MB limit and
-    every subsequent write fails with WriteError 17419.
+    ``max_messages`` caps stored history to the most recent N (via ``$slice``) so
+    per-workflow threads can't outgrow MongoDB's 16MB document limit.
     """
     user_id = user.get("user_id")
     conversation_id = request.conversation_id

--- a/apps/api/app/services/workflow/conversation_service.py
+++ b/apps/api/app/services/workflow/conversation_service.py
@@ -11,6 +11,12 @@ from app.services.conversation_service import (
 )
 from shared.py.wide_events import log
 
+# A workflow reuses ONE conversation across every execution, appending the trigger
+# message + result each run. Left unbounded that document grows past MongoDB's 16MB
+# limit and every run then fails with WriteError 17419. Cap the thread to its most
+# recent N messages — enough recent context for the agent, far under the size cap.
+WORKFLOW_CONVERSATION_MAX_MESSAGES = 50
+
 
 async def get_or_create_workflow_conversation(
     workflow_id: str, user_id: str, workflow_title: str
@@ -84,9 +90,12 @@ async def add_workflow_execution_messages(
             conversation_id=conversation_id, messages=workflow_execution_messages
         )
 
-        # Use existing update_messages service
+        # Use existing update_messages service, capping the per-workflow thread so it
+        # can't grow past MongoDB's 16MB document limit over many executions.
         user_dict = {"user_id": user_id}
-        await update_messages(messages_request, user_dict)
+        await update_messages(
+            messages_request, user_dict, max_messages=WORKFLOW_CONVERSATION_MAX_MESSAGES
+        )
 
     except Exception as e:
         log.error(

--- a/apps/api/app/services/workflow/conversation_service.py
+++ b/apps/api/app/services/workflow/conversation_service.py
@@ -11,10 +11,8 @@ from app.services.conversation_service import (
 )
 from shared.py.wide_events import log
 
-# A workflow reuses ONE conversation across every execution, appending the trigger
-# message + result each run. Left unbounded that document grows past MongoDB's 16MB
-# limit and every run then fails with WriteError 17419. Cap the thread to its most
-# recent N messages — enough recent context for the agent, far under the size cap.
+# A workflow reuses one conversation across all runs; cap it so the doc can't grow
+# past MongoDB's 16MB limit (and fail every run with WriteError 17419).
 WORKFLOW_CONVERSATION_MAX_MESSAGES = 50
 
 
@@ -90,8 +88,6 @@ async def add_workflow_execution_messages(
             conversation_id=conversation_id, messages=workflow_execution_messages
         )
 
-        # Use existing update_messages service, capping the per-workflow thread so it
-        # can't grow past MongoDB's 16MB document limit over many executions.
         user_dict = {"user_id": user_id}
         await update_messages(
             messages_request, user_dict, max_messages=WORKFLOW_CONVERSATION_MAX_MESSAGES


### PR DESCRIPTION
## Problem

A workflow's executions are persisted into a **single conversation per `workflow_id`** (`get_or_create_workflow_conversation`). Every run appends a trigger message + result via `update_messages`, which does an unbounded `$push`. Over many runs the document grows until it crosses MongoDB's **16MB cap**, after which **every** subsequent run fails at message persistence with `WriteError 17419` and the workflow silently stops producing output.

Measured in prod (read-only) on the offending workflow's conversation:
```
doc = 16.0 MB | messages = 1,703 | avg 9.6 KB/msg | max 1.1 MB/msg
```
Pure accumulation — bounding the count fixes it.

## Fix

- `update_messages(..., max_messages=None)` — when set, the `$push` uses `$slice: -max_messages`, keeping only the most recent N messages atomically.
- The per-workflow conversation path (`add_workflow_execution_messages`) passes `WORKFLOW_CONVERSATION_MAX_MESSAGES = 50` — plenty of recent thread context, ~2 orders of magnitude under 16MB at the observed avg message size.
- **Regular chat conversations pass no cap and are completely unchanged.**

## Verification (local Mongo)

```
push 60 w/ cap=50  -> len=50  (m10..m59)   # oldest pruned
push +20 w/ cap=50 -> len=50  (m30..m79)   # window slides, stays bounded
push +10 NO cap    -> len=60                # chat path still grows (unchanged)
PRUNE_VERIFIED: True
```
`ruff` + `ruff format` clean; `mypy` clean; `pytest tests/unit -k "conversation or workflow"` → **603 passed**.

## Notes
- Count-based `$slice` is atomic and sufficient here (avg msg ~9.6 KB). Pathologically large *single* messages (>16MB) are a separate concern not addressed here.
- Existing already-oversized conversations won't shrink until the next append trims them; a one-off backfill could prune them immediately if desired.
- Part of the workflow-reliability set with #844 (rate limit) and #846 (trigger matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
