### PR TITLE
fix(web): expand toasts on hover only

### DIFF
--- a/apps/web/src/components/ui/Toaster.tsx
+++ b/apps/web/src/components/ui/Toaster.tsx
@@ -15,6 +15,10 @@ export function Toaster({ position = "top-right" }: ToasterProps) {
       position={position}
       options={{
         fill: "#262626",
+        // Sileo auto-expands the description panel by default (autopilot).
+        // We want the collapsed pill until the user hovers — hover-expansion
+        // is built into sileo and unaffected by this flag.
+        autopilot: false,
         styles: {
           title: "text-white! truncate max-w-2xl",
           description: "text-white/75!",

--- a/apps/web/src/lib/toast.tsx
+++ b/apps/web/src/lib/toast.tsx
@@ -109,9 +109,9 @@ function translate(message: string, opts?: ToastOptions): SileoOptions {
   const out: SileoOptions = {};
 
   if (message.length > TITLE_MAX_CHARS && opts?.description === undefined) {
-    // Long title, no description: move full message to description so it wraps
+    // Long title, no description: move full message to description so it wraps.
+    // The full text shows on hover (expansion is hover-only, see Toaster.tsx).
     out.description = message;
-    out.autopilot = true;
     // title intentionally omitted — sileo defaults to state name ("error", "success", etc.)
   } else {
     out.title = message;
@@ -135,8 +135,9 @@ type SileoFn = (opts: SileoOptions) => string;
 // Wire up the toast's controls. We deliberately DON'T use sileo's native
 // `button` slot — it renders one full-width button. Instead we render our own
 // compact, auto-width control row in the description, which keeps buttons small
-// and lets an action and a dismiss sit side by side. autopilot makes the panel
-// visible (not hover-only). Returns a binder called with sileo's returned id.
+// and lets an action and a dismiss sit side by side. The panel (and thus the
+// controls) shows on hover only (autopilot is disabled in Toaster.tsx).
+// Returns a binder called with sileo's returned id.
 function attachControls(
   out: SileoOptions,
   state: ToastState,
@@ -158,7 +159,6 @@ function attachControls(
         />
       </>
     );
-    out.autopilot = true;
   }
 
   return (id) => {

--- a/apps/web/src/lib/toast.tsx
+++ b/apps/web/src/lib/toast.tsx
@@ -110,8 +110,11 @@ function translate(message: string, opts?: ToastOptions): SileoOptions {
 
   if (message.length > TITLE_MAX_CHARS && opts?.description === undefined) {
     // Long title, no description: move full message to description so it wraps.
-    // The full text shows on hover (expansion is hover-only, see Toaster.tsx).
+    // The collapsed pill would show only the state name, hiding the entire
+    // message — so this case opts back into auto-expansion (expansion is
+    // otherwise hover-only, see Toaster.tsx).
     out.description = message;
+    out.autopilot = true;
     // title intentionally omitted — sileo defaults to state name ("error", "success", etc.)
   } else {
     out.title = message;


### PR DESCRIPTION
## Summary

Sileo auto-expands the toast description panel by default (`autopilot`), and our wrapper additionally forced `autopilot: true` on every dismissible toast — so toasts popped open on their own instead of staying as collapsed pills.

- Disable autopilot globally in the `Toaster` and drop the per-call overrides: the panel (description + dismiss/action controls) now shows **only while hovered**; leaving collapses it again. Hover-expansion is built into sileo and unaffected by the flag.
- **Exception:** long messages (>50 chars, no explicit description) are promoted into the description, and their collapsed pill would show only the state name — that one case opts back into auto-expansion so the text is readable immediately.

Cherry-picked from `feat/agent-model-fallback` (pushed there after #841 had already merged).

## Verification (live, real browser)

- Real user-triggered toast (pin action in chat) tracked with a MutationObserver across its full lifecycle: `data-expanded=false` from mount to dismissal — no auto-expansion.
- `/dev/toasts` playground: hover expands (description + Dismiss reachable, 40px → 108px), leave collapses; long-message toast auto-expands within 250ms; regular toasts stay collapsed.
- Biome + web type-check green.

## Known adjacent issue (not addressed here)

Our `ToastControls` renders HeroUI `<Button>`s inside sileo's toast root, which is itself a `<button>` — invalid nested-button markup that logs React hydration errors on every toast with controls. Worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)