### PR TITLE
feat(api): development-only auth bypass for agent-driven testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,16 @@ Each app has its own `.env` file:
 
 Refer to `.env.example` files in each directory for required variables.
 
+## Agent-Driven E2E Testing
+
+To verify a change in the real running app (not just lint/type-check), drive the browser yourself and suggest this setup to the user when end-to-end testing comes up:
+
+- **Auth**: set `DEV_AUTH_BYPASS_EMAIL=<email>` in `apps/api/.env` (see `apps/api/CLAUDE.md` → Dev auth bypass). Every API request authenticates as that user — no login flow, no cookies. Development only; production refuses to boot with it set.
+- **Browser**: the two recommended tools, in order:
+  1. **agent-browser** (`npm i -g agent-browser && agent-browser install`) — Rust CDP daemon with an MCP server, accessibility-tree snapshots with stable element refs (`@e1`), annotated screenshots, and persistent encrypted profiles so a login survives across sessions.
+  2. **chrome-devtools MCP** — works against a running Chrome, good for console/network/performance introspection. Chrome ≥136 refuses `--remote-debugging-port` on the default profile: launch Chrome with a dedicated `--user-data-dir` and remote debugging enabled.
+- Run `nx dev web` (+ `nx dev api` with local infra for full-stack flows), open `localhost:3000`, and verify with snapshots/screenshots before claiming a UI change works.
+
 ## Docker
 
 Dockerfiles are located in each app directory. Docker Compose configuration is in `infra/docker/`:

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,6 +33,10 @@ RABBITMQ_URL=amqp://guest:guest@localhost:5672/  # pragma: allowlist secret
 WORKOS_API_KEY=
 WORKOS_CLIENT_ID=
 WORKOS_COOKIE_PASSWORD=
+# Development-only: authenticate EVERY request as this user (must already
+# exist in Mongo — log in once normally first). Lets agents/tools drive the
+# app end to end without a session. Production refuses to boot if set.
+# DEV_AUTH_BYPASS_EMAIL=you@example.com
 
 # =============================
 # Bot Integration

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -265,6 +265,14 @@ Secrets in production are injected from **Infisical** before Pydantic validates 
 
 See `apps/api/.env.example` or the `ProductionSettings` class in `app/config/settings.py` for the full list of required keys. For local dev, `DevelopmentSettings` makes most keys optional — set at minimum `ENV=development`, MongoDB URL, Redis URL, and WorkOS credentials.
 
+### Dev auth bypass (`DEV_AUTH_BYPASS_EMAIL`)
+
+Set `DEV_AUTH_BYPASS_EMAIL=<email>` in `apps/api/.env` and every request is authenticated as that Mongo user with no WorkOS session — `WorkOSAuthMiddleware` short-circuits before any cookie handling. This is how agents (and you) drive the full app end to end locally without logging in: point `apps/web/.env.local` at `http://localhost:8000/api/v1/` and the web app just works.
+
+- The user must already exist (log in once normally to create it); a missing user logs an error on every request.
+- Development only: `get_settings()` raises at startup if the var is set with `ENV=production` — never weaken that check.
+- The bypass user context carries `dev_bypass=True` for anything that needs to tell.
+
 ## Pre-commit Hooks & Security Scanners
 
 The API pre-commit config (`.pre-commit-config.yaml`) runs: **ruff**, **ruff-format**, **bandit**, **pip-audit**, and **mypy**.

--- a/apps/api/app/api/v1/dependencies/oauth_dependencies.py
+++ b/apps/api/app/api/v1/dependencies/oauth_dependencies.py
@@ -5,9 +5,11 @@ from typing import Any
 from bson import ObjectId
 from fastapi import Depends, Header, HTTPException, Request, WebSocket, status
 
+from app.config.settings import settings
 from app.constants.error_codes import NOT_AUTHENTICATED
 from app.constants.log_tags import LogTag
 from app.db.mongodb.collections import users_collection
+from app.utils.auth_utils import authenticate_workos_session, build_user_context
 from app.utils.timezone import Timezone, TimezoneSource, resolve_home_timezone
 from shared.py.wide_events import log
 
@@ -103,7 +105,19 @@ async def get_current_user_ws(websocket: WebSocket):
     Raises:
         WebSocketException: Connection will be closed on auth failure
     """
-    from app.utils.auth_utils import authenticate_workos_session
+    # Dev auth bypass — WebSockets never pass through WorkOSAuthMiddleware
+    # (BaseHTTPMiddleware only handles HTTP), so the bypass is mirrored here.
+    # get_settings() hard-fails if this is set in production.
+    if settings.ENV == "development" and settings.DEV_AUTH_BYPASS_EMAIL:
+        user_data = await users_collection.find_one({"email": settings.DEV_AUTH_BYPASS_EMAIL})
+        if user_data:
+            return build_user_context(user_data, auth_provider="workos", dev_bypass=True)
+        log.error(
+            f"{LogTag.OAUTH} DEV_AUTH_BYPASS_EMAIL is set to "
+            f"{settings.DEV_AUTH_BYPASS_EMAIL!r} but no such user exists in Mongo"
+        )
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return {}
 
     # Extract the session cookie from WebSocket
     wos_session = websocket.cookies.get("wos_session")

--- a/apps/api/app/api/v1/middleware/auth.py
+++ b/apps/api/app/api/v1/middleware/auth.py
@@ -77,6 +77,14 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
         self.agent_only_paths = ["/api/v1/chat-stream"]
         self.agent_only_path_prefixes: tuple[str, ...] = ()
         self.user_cache_expiry = 3600
+        self.dev_bypass_email = (
+            settings.DEV_AUTH_BYPASS_EMAIL if settings.ENV == "development" else None
+        )
+        if self.dev_bypass_email:
+            log.warning(
+                f"{LogTag.API} DEV AUTH BYPASS ACTIVE — every request is "
+                f"authenticated as {self.dev_bypass_email} (development only)"
+            )
 
     async def dispatch(
         self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
@@ -84,6 +92,9 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
         """Authenticate, then invoke the next handler. Refresh cookies on the way out."""
         if any(request.url.path.startswith(path) for path in self.exclude_paths):
             return await call_next(request)
+
+        if self.dev_bypass_email:
+            return await self._dispatch_dev_bypass(request, call_next)
 
         wos_session = request.cookies.get("wos_session")
         if not wos_session:
@@ -168,6 +179,34 @@ class WorkOSAuthMiddleware(BaseHTTPMiddleware):
             )
 
         return response
+
+    async def _dispatch_dev_bypass(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        """Authenticate the request as the configured dev user, skipping WorkOS.
+
+        Only reachable when ``DEV_AUTH_BYPASS_EMAIL`` is set in development
+        (production refuses to boot with it — see ``get_settings``). A bypass
+        email that doesn't resolve to a Mongo user is a config error and is
+        logged on every request rather than silently degrading to 401s.
+        """
+        request.state.user = None
+        request.state.authenticated = False
+        request.state.new_session = None
+
+        user_data = await users_collection.find_one({"email": self.dev_bypass_email})
+        if user_data:
+            request.state.user = build_user_context(
+                user_data, auth_provider="workos", dev_bypass=True
+            )
+            request.state.authenticated = True
+        else:
+            log.error(
+                f"{LogTag.API} DEV_AUTH_BYPASS_EMAIL is set to "
+                f"{self.dev_bypass_email!r} but no such user exists in Mongo — "
+                "create the user (log in once normally) or fix the email."
+            )
+        return await call_next(request)
 
     async def _authenticate_session(
         self, wos_session: str

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -552,6 +552,12 @@ class DevelopmentSettings(CommonSettings):
     # ----------------------------------------------
     DEBUG_EMAIL_PROCESSING: bool = False
 
+    # Development-only auth bypass: every request is authenticated as this
+    # user (must exist in Mongo) with no WorkOS session, so agents and tools
+    # can drive the app end to end. get_settings() refuses to start in
+    # production when this is set.
+    DEV_AUTH_BYPASS_EMAIL: str | None = None
+
     # Default to show warnings in development environment
     SHOW_MISSING_KEY_WARNINGS: bool = True
 
@@ -633,6 +639,15 @@ def get_settings():
         if env == "development":
             settings_obj = DevelopmentSettings.from_env()
         else:
+            # Hard block, not a warning: the dev auth bypass authenticates
+            # every request as a fixed user, so production must refuse to
+            # boot rather than run with it. Checked via os.getenv because
+            # from_env() downgrades pydantic validation errors to warnings.
+            if os.getenv("DEV_AUTH_BYPASS_EMAIL"):
+                raise RuntimeError(
+                    "DEV_AUTH_BYPASS_EMAIL is set but ENV=production — "
+                    "the dev auth bypass must never be enabled in production."
+                )
             settings_obj = ProductionSettings.from_env()
             log.info(f"{LogTag.STARTUP} Production settings initialized")
 


### PR DESCRIPTION
## What

`DEV_AUTH_BYPASS_EMAIL=<email>` in `apps/api/.env` makes `WorkOSAuthMiddleware` authenticate **every request** as that Mongo user — no WorkOS session, no cookies, no login flow. Point `apps/web/.env.local` at the local API and the whole app is drivable by an agent (or a human) with zero auth friction.

## Safety — four layers

1. **Production refuses to boot**: `get_settings()` raises `RuntimeError` when the var is set with `ENV=production`. Checked via `os.getenv` deliberately — `from_env()` downgrades pydantic validation errors to warnings, so a model validator would not actually block startup.
2. The field is declared only on `DevelopmentSettings`.
3. The middleware independently re-checks `settings.ENV == "development"` before honoring it.
4. Activation logs a loud `DEV AUTH BYPASS ACTIVE` warning at startup; a bypass email with no matching Mongo user logs an error on every request (fail loud, no silent 401s).

The bypass user context is built through the canonical `build_user_context` (same as all other auth paths) and carries `dev_bypass=True`.

## Docs

- `apps/api/CLAUDE.md`: new *Dev auth bypass* section under Environment.
- Root `CLAUDE.md`: new *Agent-Driven E2E Testing* section — documents the bypass plus **agent-browser** and **chrome-devtools MCP** as the two recommended browser drivers for end-to-end verification.
- `.env.example`: commented entry.

## Testing

- Verified by script: with `ENV=production` + `DEV_AUTH_BYPASS_EMAIL` set, settings initialization raises (`PASS: production boot raised`); with `ENV=development` it loads and exposes the field.
- `nx run api:lint` ✅; `api:type-check` shows only the 2 pre-existing mypy errors in `app/services/storage/` (present on develop).
- Middleware path not exercised against a live Mongo (local Docker infra still pending WSL2 reboot) — it mirrors the existing agent-token fallback structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)