### PR TITLE
docs(api): dev-bypass local-run gotchas (dummy WorkOS creds, IPv4 Redis on Windows)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -272,6 +272,8 @@ Set `DEV_AUTH_BYPASS_EMAIL=<email>` in `apps/api/.env` and every request is auth
 - The user must already exist (log in once normally to create it); a missing user logs an error on every request.
 - Development only: `get_settings()` raises at startup if the var is set with `ENV=production` — never weaken that check.
 - The bypass user context carries `dev_bypass=True` for anything that needs to tell.
+- WorkOS is never called under the bypass, but `DevelopmentSettings` still requires the `WORKOS_*` keys — dummy values are fine locally.
+- On Windows with a native Redis (Memurai), use `REDIS_URL=redis://127.0.0.1:6379` — Memurai binds IPv4 only and `localhost` resolves to `::1` first, which makes the ARQ/lifespan services time out and startup fail.
 
 ## Pre-commit Hooks & Security Scanners
 


### PR DESCRIPTION
Two gotchas discovered while live-testing the merged dev auth bypass (#861) on a native Windows stack:

- `DevelopmentSettings` still requires the `WORKOS_*` keys even though the bypass never calls WorkOS — dummy values are fine locally.
- Native Redis on Windows (Memurai) binds IPv4 only; `REDIS_URL` must use `127.0.0.1`, not `localhost` (which resolves to `::1` and makes the ARQ lifespan services time out, failing startup).

Verified end to end: API boots on Mongo + Memurai + RabbitMQ (OTP 28), and `GET /user/me` with zero cookies returns the bypass user with `dev_bypass: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)