### PR TITLE
feat(seo): internal-linking overhaul, crawlable nav, SSR'd marketplace/use-cases hubs

### DIFF
--- a/apps/mobile/src/components/ui/markdown-renderer.tsx
+++ b/apps/mobile/src/components/ui/markdown-renderer.tsx
@@ -471,7 +471,6 @@ function ListBlock({
     <View style={{ marginVertical: 4, paddingLeft: 16 }}>
       {items.map((item, idx) => (
         <View
-          // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
           key={`li-${idx}-${item[0]?.text.slice(0, 12)}`}
           style={{ flexDirection: "row", marginBottom: 8, paddingRight: 8 }}
         >

--- a/apps/mobile/src/config/openui/components/analytics.tsx
+++ b/apps/mobile/src/config/openui/components/analytics.tsx
@@ -477,7 +477,6 @@ export function BarChartView(props: z.infer<typeof barChartSchema>) {
           const raw = String(row[props.xKey]);
           const label = rotateLabels ? truncate(raw, 6) : truncate(raw, 9);
           return (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
             <G key={`group-${String(row[props.xKey])}-${i}`}>
               {keys.map((key, ki) => {
                 const val = toNumber(row[key]);
@@ -562,7 +561,6 @@ export function BarChartView(props: z.infer<typeof barChartSchema>) {
             padTop + i * groupHeight + (groupHeight - usableGroupH) / 2;
           const groupCenter = padTop + i * groupHeight + groupHeight / 2;
           return (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
             <G key={`group-${String(row[props.xKey])}-${i}`}>
               {keys.map((key, ki) => {
                 const val = toNumber(row[key]);

--- a/apps/mobile/src/config/openui/components/content.tsx
+++ b/apps/mobile/src/config/openui/components/content.tsx
@@ -352,7 +352,6 @@ export function ImageGalleryView(props: z.infer<typeof imageGallerySchema>) {
         style={{ flexDirection: "row", flexWrap: "wrap", marginHorizontal: -4 }}
       >
         {images.map((img, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
           <View key={`${img.src}-${i}`} style={{ width: "50%", padding: 4 }}>
             <GalleryThumb img={img} onPress={() => setSelected(i)} />
           </View>
@@ -981,7 +980,6 @@ export function CarouselView(props: z.infer<typeof carouselSchema>) {
         >
           {props.items.map((item, i) => (
             <View
-              // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
               key={`${item.title}-${i}`}
               style={{
                 width: 6,

--- a/apps/mobile/src/config/openui/components/layout.tsx
+++ b/apps/mobile/src/config/openui/components/layout.tsx
@@ -308,7 +308,6 @@ export function DataCardView(props: z.infer<typeof dataCardSchema>) {
       <View className="gap-2">
         {props.fields.map((field, index) => (
           <View
-            // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
             key={`${field.label}-${index}`}
             className="rounded-2xl bg-zinc-900 p-3 flex-row items-center justify-between gap-4"
           >

--- a/apps/mobile/src/features/chat/components/chat/chat-message.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-message.tsx
@@ -258,7 +258,6 @@ export function ChatMessage({
                 if (emojiSize) {
                   return (
                     <Text
-                      // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
                       key={`${message.id}-${index}`}
                       style={{
                         fontSize: emojiSize,
@@ -272,7 +271,6 @@ export function ChatMessage({
               }
               return (
                 <MessageBubble
-                  // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
                   key={`${message.id}-${index}`}
                   message={part}
                   variant="sent"

--- a/apps/mobile/src/features/chat/components/chat/tool-calls-section.tsx
+++ b/apps/mobile/src/features/chat/components/chat/tool-calls-section.tsx
@@ -218,7 +218,6 @@ function StackedToolIcons({ calls }: { calls: ToolCallEntry[] }) {
       {displayIcons.map((call, index) => (
         // Web wrapper: relative flex min-w-8 items-center justify-center (32px col)
         <View
-          // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
           key={`${call.tool_name || "tool"}-${index}`}
           style={{
             minWidth: 32,

--- a/apps/mobile/src/features/chat/tool-data/cards/artifact-card.tsx
+++ b/apps/mobile/src/features/chat/tool-data/cards/artifact-card.tsx
@@ -158,7 +158,6 @@ export function ArtifactCard({ data }: { data: ArtifactData[] }) {
   return (
     <View className="mx-4 my-1 gap-2">
       {artifacts.map((artifact, index) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
         <ArtifactRow key={`${artifact.path}-${index}`} artifact={artifact} />
       ))}
     </View>

--- a/apps/mobile/src/features/chat/tool-data/cards/calendar-fetch-card.tsx
+++ b/apps/mobile/src/features/chat/tool-data/cards/calendar-fetch-card.tsx
@@ -250,7 +250,6 @@ export function CalendarFetchCard({ data }: CalendarFetchCardProps) {
                   <View className="gap-2">
                     {dayEvents.map((event, index) => (
                       <EventRow
-                        // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
                         key={`${dateString}-${event.summary}-${index}`}
                         event={event}
                       />

--- a/apps/mobile/src/features/chat/tool-data/cards/chart-card.tsx
+++ b/apps/mobile/src/features/chat/tool-data/cards/chart-card.tsx
@@ -149,7 +149,6 @@ function BarChartView({ data }: { data: ChartData }) {
         const color = BAR_COLORS[i % BAR_COLORS.length];
 
         return (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
           <G key={`bar-${el.label}-${i}`}>
             <Rect
               x={x}
@@ -453,7 +452,6 @@ function DataTable({ data }: { data: ChartData }) {
       </View>
       {elements.map((el, i) => (
         <View
-          // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
           key={`row-${el.label}-${i}`}
           className="flex-row px-3 py-2"
           style={{

--- a/apps/mobile/src/features/chat/tool-data/cards/deep-research-card.tsx
+++ b/apps/mobile/src/features/chat/tool-data/cards/deep-research-card.tsx
@@ -115,7 +115,6 @@ function DeepResearchRunningCard({ data }: { data: DeepResearchResults }) {
         <View className="mb-3 gap-1">
           {subSteps.slice(0, -1).map((step, index) => (
             <View
-              // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
               key={`step-${index}-${step.slice(0, 10)}`}
               className="flex-row items-center gap-1.5"
             >

--- a/apps/mobile/src/features/chat/tool-data/cards/streaming-meta-cards.tsx
+++ b/apps/mobile/src/features/chat/tool-data/cards/streaming-meta-cards.tsx
@@ -810,7 +810,6 @@ export function ArtifactCard({ data }: { data: unknown }) {
 
           return (
             <View
-              // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
               key={`${artifact.path || artifact.filename || "artifact"}-${artifact.size_bytes || 0}-${index}`}
               className={`rounded-xl bg-white/5 border border-white/8 px-3 py-3 ${index > 0 ? "mt-2" : ""}`}
             >

--- a/apps/web/src/app/[locale]/(landing)/automate/[combo]/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/automate/[combo]/page.tsx
@@ -92,7 +92,7 @@ export default async function AutomateComboPage({ params }: PageProps) {
 
   const breadcrumbItems = [
     { name: "Home", url: siteConfig.url },
-    { name: "Marketplace", url: `${siteConfig.url}/marketplace` },
+    { name: "Automate", url: `${siteConfig.url}/automate` },
     {
       name: `${data.toolA} + ${data.toolB}`,
       url: pageUrl,
@@ -129,8 +129,8 @@ export default async function AutomateComboPage({ params }: PageProps) {
             {t("common.home")}
           </Link>
           <span className="mx-2">/</span>
-          <Link href="/marketplace" className="hover:text-zinc-300">
-            {t("marketplace.breadcrumb")}
+          <Link href="/automate" className="hover:text-zinc-300">
+            {t("automate.breadcrumb")}
           </Link>
           <span className="mx-2">/</span>
           <span className="text-zinc-300">
@@ -305,8 +305,8 @@ export default async function AutomateComboPage({ params }: PageProps) {
             <p className="mb-6 leading-relaxed text-zinc-400">
               {t("automate.gaia_supports_combos")}
             </p>
-            <Button as="a" href="/marketplace" color="primary" radius="full">
-              {t("common.browse_marketplace")}
+            <Button as="a" href="/automate" color="primary" radius="full">
+              {t("automate.browse_all_combos")}
             </Button>
           </div>
         </section>

--- a/apps/web/src/app/[locale]/(landing)/for/[persona]/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/for/[persona]/page.tsx
@@ -47,8 +47,10 @@ interface PersonaConfig {
 
 const SPECIAL_PERSONA_CONFIGS: Record<string, PersonaConfig> = {
   "startup-founders": {
+    // "AI chief of staff" deliberately absent — that head term belongs to the
+    // dedicated /ai-chief-of-staff page; this page targets founder queries.
     metaTitle:
-      "GAIA for Startup Founders — AI Chief of Staff & Proactive Automation",
+      "GAIA for Startup Founders — Proactive AI That Runs Your Startup Ops",
     metaDescription:
       "GAIA connects to your email, Slack, calendar, CRM, GitHub, and 30+ tools — then handles the operational work so you can focus on building. Save 8-12 hours every week.",
     schemaDescription:
@@ -56,7 +58,6 @@ const SPECIAL_PERSONA_CONFIGS: Record<string, PersonaConfig> = {
     keywords: [
       "AI for founders",
       "startup AI assistant",
-      "AI chief of staff",
       "founder productivity",
       "investor update automation",
       "workflow automation for startups",

--- a/apps/web/src/app/[locale]/(landing)/founders/FoundersClient.tsx
+++ b/apps/web/src/app/[locale]/(landing)/founders/FoundersClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import FAQAccordion from "@/components/seo/FAQAccordion";
 import ChatDemo from "@/features/landing/components/demo/founders-demo/ChatDemo";
 import {
@@ -161,6 +162,19 @@ export default function FoundersClient() {
           Everything you need to know about GAIA for founders.
         </p>
         <FAQAccordion faqs={FOUNDERS_FAQS} />
+      </section>
+
+      {/* Cross-link: the "AI chief of staff" head term belongs to its dedicated page */}
+      <section className="mx-auto w-full max-w-3xl px-6 pb-20 text-center">
+        <p className="text-sm text-zinc-500">
+          Want the full picture of GAIA as a proactive executive assistant?{" "}
+          <Link
+            href="/ai-chief-of-staff"
+            className="text-zinc-300 underline underline-offset-2 hover:text-white"
+          >
+            See GAIA as your AI chief of staff
+          </Link>
+        </p>
       </section>
 
       <FinalSection />

--- a/apps/web/src/app/[locale]/(landing)/marketplace/client.tsx
+++ b/apps/web/src/app/[locale]/(landing)/marketplace/client.tsx
@@ -2,7 +2,6 @@
 
 import { Pagination } from "@heroui/pagination";
 import Image from "next/image";
-import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { integrationsApi } from "@/features/integrations/api/integrationsApi";
 import { IntegrationsFilters } from "@/features/integrations/components/IntegrationsFilters";
@@ -11,35 +10,66 @@ import {
   PublicIntegrationCardSkeletonGrid,
 } from "@/features/integrations/components/PublicIntegrationCard";
 import type { CommunityIntegration } from "@/features/integrations/types";
+import { MARKETPLACE_ITEMS_PER_PAGE } from "@/features/integrations/utils/normalizeNativeIntegrations";
 import FinalSection from "@/features/landing/components/sections/FinalSection";
 
-const ITEMS_PER_PAGE = 18;
+const ITEMS_PER_PAGE = MARKETPLACE_ITEMS_PER_PAGE;
 
-export function IntegrationsPageClient() {
-  const searchParams = useSearchParams();
-  const [integrations, setIntegrations] = useState<CommunityIntegration[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+export interface MarketplaceInitialData {
+  integrations: CommunityIntegration[];
+  total: number;
+  native: CommunityIntegration[];
+}
+
+interface IntegrationsPageClientProps {
+  /** Server-fetched first page so cards render in the SSR HTML. */
+  initialData?: MarketplaceInitialData | null;
+}
+
+export function IntegrationsPageClient({
+  initialData,
+}: IntegrationsPageClientProps) {
+  const hasServerData = Boolean(initialData);
+  const [integrations, setIntegrations] = useState<CommunityIntegration[]>(
+    initialData ? initialData.integrations : [],
+  );
+  const [isLoading, setIsLoading] = useState(!hasServerData);
   const [isFiltering, setIsFiltering] = useState(false);
-  const [total, setTotal] = useState(0);
+  const [total, setTotal] = useState(initialData ? initialData.total : 0);
   const [currentPage, setCurrentPage] = useState(1);
+  // Filters start at defaults matching the server-rendered page 1. URL
+  // filters (?search=, ?category=) are applied after hydration — reading
+  // them via useSearchParams at render time forces this whole tree into
+  // client-only rendering, which would drop the SSR'd cards from the HTML.
   const [filters, setFilters] = useState<{
     search: string;
     category: string;
     sort: "popular" | "recent" | "name";
   }>({
-    search: searchParams.get("search") || "",
-    category: searchParams.get("category") || "all",
+    search: "",
+    category: "all",
     sort: "popular",
   });
   const isInitialMount = useRef(true);
   const hasRefreshed = useRef(false);
 
-  // Native integrations state (fetched once, filtered client-side)
+  // Native integrations state (server-provided, or fetched once and
+  // filtered client-side)
   const [nativeIntegrations, setNativeIntegrations] = useState<
     CommunityIntegration[]
-  >([]);
+  >(hasServerData && initialData ? initialData.native : []);
   const [, setNativeLoading] = useState(false);
-  const nativeFetched = useRef(false);
+  const nativeFetched = useRef((initialData?.native.length ?? 0) > 0);
+
+  // Apply URL filters after hydration (see comment on the filters state).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const search = params.get("search") || "";
+    const category = params.get("category") || "all";
+    if (search || category !== "all") {
+      setFilters((prev) => ({ ...prev, search, category }));
+    }
+  }, []);
 
   const totalPages = useMemo(() => Math.ceil(total / ITEMS_PER_PAGE), [total]);
 
@@ -119,7 +149,8 @@ export function IntegrationsPageClient() {
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
-      loadIntegrations(1, false);
+      // Page 1 already rendered from server data — skip the duplicate fetch.
+      if (!hasServerData) loadIntegrations(1, false);
     } else {
       setCurrentPage(1);
       loadIntegrations(1, true);

--- a/apps/web/src/app/[locale]/(landing)/marketplace/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/marketplace/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 
 import JsonLd from "@/components/seo/JsonLd";
+import type { IntegrationConfigResponse } from "@/features/integrations/api/integrationsApi";
+import type { CommunityIntegrationsResponse } from "@/features/integrations/types";
+import {
+  MARKETPLACE_ITEMS_PER_PAGE,
+  normalizeNativeIntegrations,
+} from "@/features/integrations/utils/normalizeNativeIntegrations";
 import { marketplaceFAQs } from "@/lib/page-faqs";
 import {
   generateBreadcrumbSchema,
@@ -11,8 +16,48 @@ import {
   generateWebPageSchema,
   siteConfig,
 } from "@/lib/seo";
+import { getServerApiBaseUrl } from "@/lib/serverApiBaseUrl";
 
-import { IntegrationsPageClient } from "./client";
+import { IntegrationsPageClient, type MarketplaceInitialData } from "./client";
+
+/**
+ * Server-fetch the first page of the marketplace so the integration cards —
+ * and the /marketplace/[slug] links they carry — are in the crawlable HTML.
+ * Without this the hub ships skeletons and Google sees no internal links to
+ * the integration detail pages.
+ */
+async function getInitialMarketplaceData(): Promise<MarketplaceInitialData | null> {
+  const baseUrl = getServerApiBaseUrl();
+  if (!baseUrl) return null;
+
+  try {
+    const [communityRes, configRes] = await Promise.all([
+      fetch(
+        `${baseUrl}/integrations/community?sort=popular&limit=${MARKETPLACE_ITEMS_PER_PAGE}&offset=0`,
+        { next: { revalidate: 3600 } },
+      ),
+      fetch(`${baseUrl}/integrations/config`, {
+        next: { revalidate: 3600 },
+      }),
+    ]);
+
+    if (!communityRes.ok) return null;
+    const community =
+      (await communityRes.json()) as CommunityIntegrationsResponse;
+    const config = configRes.ok
+      ? ((await configRes.json()) as IntegrationConfigResponse)
+      : null;
+
+    return {
+      integrations: community.integrations ?? [],
+      total: community.total ?? 0,
+      native: config ? normalizeNativeIntegrations(config.integrations) : [],
+    };
+  } catch (error) {
+    console.error("[marketplace] Failed to fetch initial listing:", error);
+    return null;
+  }
+}
 
 export const metadata: Metadata = generatePageMetadata({
   title: "AI Integration Marketplace - Connect Your Tools to GAIA",
@@ -39,7 +84,8 @@ export const metadata: Metadata = generatePageMetadata({
 
 export const revalidate = 3600;
 
-export default function MarketplacePage() {
+export default async function MarketplacePage() {
+  const initialData = await getInitialMarketplaceData();
   const webPageSchema = generateWebPageSchema(
     "AI Integration Marketplace - Connect Your Tools to AI",
     "Browse 50+ AI integrations for productivity, communication, and developer tools. Automate Gmail, Slack, Notion, GitHub and more with GAIA's AI-powered MCP integration marketplace.",
@@ -96,9 +142,7 @@ export default function MarketplacePage() {
       <JsonLd
         data={[webPageSchema, breadcrumbSchema, itemListSchema, faqSchema]}
       />
-      <Suspense>
-        <IntegrationsPageClient />
-      </Suspense>
+      <IntegrationsPageClient initialData={initialData} />
     </>
   );
 }

--- a/apps/web/src/app/[locale]/(landing)/use-cases/client.tsx
+++ b/apps/web/src/app/[locale]/(landing)/use-cases/client.tsx
@@ -7,13 +7,17 @@ import PublishWorkflowCTA from "@/features/use-cases/components/PublishWorkflowC
 import UseCaseSection from "@/features/use-cases/components/UseCaseSection";
 import type { CommunityWorkflow } from "@/features/workflows/api/workflowApi";
 import UnifiedWorkflowCard from "@/features/workflows/components/shared/UnifiedWorkflowCard";
+import type { UseCase } from "@/types/features/workflowTypes";
 
 interface UseCasesPageClientProps {
   communityWorkflows: CommunityWorkflow[];
+  /** Server-fetched explore workflows so the cards render in the SSR HTML. */
+  exploreUseCases?: UseCase[];
 }
 
 export default function UseCasesPageClient({
   communityWorkflows,
+  exploreUseCases,
 }: UseCasesPageClientProps) {
   const contentRef = useRef(null);
 
@@ -28,7 +32,11 @@ export default function UseCasesPageClient({
             Practical use cases showing how GAIA works for you
           </p>
         </div>
-        <UseCaseSection dummySectionRef={contentRef} useBlurEffect={true} />
+        <UseCaseSection
+          dummySectionRef={contentRef}
+          useBlurEffect={true}
+          exploreWorkflows={exploreUseCases}
+        />
         <div id="community-section" className="mt-22 space-y-6">
           <div className="mb-14 text-center">
             <h1 className="mb-1 font-serif text-3xl sm:text-5xl md:text-6xl font-normal">

--- a/apps/web/src/app/[locale]/(landing)/use-cases/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/use-cases/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import UseCasesPageClient from "@/app/[locale]/(landing)/use-cases/client";
 import JsonLd from "@/components/seo/JsonLd";
 import { wallpapers } from "@/config/wallpapers";
+import { convertWorkflowToUseCase } from "@/features/use-cases/utils/convertWorkflowToUseCase";
 import {
   type CommunityWorkflow,
   workflowApi,
@@ -16,6 +17,7 @@ import {
   generateWebPageSchema,
   siteConfig,
 } from "@/lib/seo";
+import type { UseCase } from "@/types/features/workflowTypes";
 
 export const metadata: Metadata = generatePageMetadata({
   title: "Use Cases & Workflows",
@@ -38,12 +40,23 @@ export const revalidate = 3600; // Revalidate every hour
 
 export default async function UseCasesPage() {
   let communityWorkflows: CommunityWorkflow[] = [];
+  let exploreUseCases: UseCase[] = [];
 
   try {
     const response = await workflowApi.getCommunityWorkflows(8, 0);
     communityWorkflows = response.workflows;
   } catch (error) {
     console.error("Error loading community workflows:", error);
+  }
+
+  // Server-fetch the explore/curated workflows so their cards — and the
+  // /use-cases/[slug] links they carry — are in the crawlable HTML instead
+  // of appearing only after a client-side fetch.
+  try {
+    const response = await workflowApi.getExploreWorkflows(25, 0);
+    exploreUseCases = response.workflows.map(convertWorkflowToUseCase);
+  } catch (error) {
+    console.error("Error loading explore workflows:", error);
   }
 
   const webPageSchema = generateWebPageSchema(
@@ -89,7 +102,10 @@ export default async function UseCasesPage() {
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[40vh] bg-linear-to-t from-background to-transparent" />
       </div>
 
-      <UseCasesPageClient communityWorkflows={communityWorkflows} />
+      <UseCasesPageClient
+        communityWorkflows={communityWorkflows}
+        exploreUseCases={exploreUseCases}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/navigation/Navbar.tsx
+++ b/apps/web/src/components/navigation/Navbar.tsx
@@ -124,6 +124,21 @@ export default function Navbar() {
     <div
       className={`fixed top-0 left-0 z-50 w-full px-4 pt-4 transition-all duration-300`}
     >
+      {/* Crawlable copy of the mega-menu links: the interactive NavbarMenu is
+          ssr:false and mounts on hover only, so its links never reach the
+          server HTML. sr-only keeps them indexable and screen-reader
+          accessible without any visual or hydration cost. */}
+      <nav aria-label="Site sections" className="sr-only">
+        <ul>
+          {[...appConfig.links.product, ...appConfig.links.resources]
+            .filter((link) => !link.external && !link.hideNavbar)
+            .map((link) => (
+              <li key={link.href}>
+                <Link href={link.href}>{link.footerLabel ?? link.label}</Link>
+              </li>
+            ))}
+        </ul>
+      </nav>
       <div
         className={`relative mx-auto transition-all duration-300 w-full ${isScrolled ? "sm:w-6xl" : "sm:w-full"}`}
         onMouseLeave={handleNavbarMouseLeave}

--- a/apps/web/src/components/seo/JsonLd.tsx
+++ b/apps/web/src/components/seo/JsonLd.tsx
@@ -41,7 +41,6 @@ export default function JsonLd({ data }: JsonLdProps) {
             // biome-ignore lint/suspicious/noArrayIndexKey: mapping json ld is fine
             key={`jsonld-${baseId}-${index}`}
             type="application/ld+json"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD structured data must be inlined as a script tag; content is JSON.stringify output
             dangerouslySetInnerHTML={{ __html: json }}
           />
         );

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -80,7 +80,6 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 
   return (
     <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: static CSS generated from the chart theme config — no user input
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(

--- a/apps/web/src/components/ui/map.tsx
+++ b/apps/web/src/components/ui/map.tsx
@@ -2167,7 +2167,6 @@ function MapClusterLayer<
   return null;
 }
 
-
 export type { MapArcDatum, MapArcEvent, MapGeoJSONEvent, MapRef, MapViewport };
 export {
   MapArc,

--- a/apps/web/src/config/appConfig.tsx
+++ b/apps/web/src/config/appConfig.tsx
@@ -174,6 +174,24 @@ export const appConfig = {
         icon: <GlobalIcon width={20} height={20} color={"currentColor"} />,
         description: "Side-by-side with ChatGPT, Claude, and Poke",
       },
+      {
+        href: "/ai-chief-of-staff",
+        label: "AI Chief of Staff",
+        description: "Your proactive AI that runs your day",
+        hideNavbar: true,
+      },
+      {
+        href: "/inbox-zero-ai",
+        label: "Inbox Zero AI",
+        description: "Automated email triage, replies, and tasks",
+        hideNavbar: true,
+      },
+      {
+        href: "/open-source-ai-assistant",
+        label: "Open Source AI Assistant",
+        description: "Self-host your personal AI — your data, your servers",
+        hideNavbar: true,
+      },
     ] as AppLink[],
 
     resources: [
@@ -263,6 +281,12 @@ export const appConfig = {
         description: "Open source tools that power GAIA",
       },
       {
+        href: "/faq",
+        label: "FAQ",
+        icon: <BookOpen02Icon width={20} height={20} color={"currentColor"} />,
+        description: "Common questions about GAIA, answered",
+      },
+      {
         href: "/contact",
         label: "Contact",
         icon: <HeartHandIcon width={20} height={20} color={"currentColor"} />,
@@ -333,7 +357,7 @@ export const appConfig = {
       {
         href: "/for/startup-founders",
         label: "Startup Founders",
-        description: "AI chief of staff for founders",
+        description: "Run your company without drowning in ops",
         hideNavbar: true,
       },
       {

--- a/apps/web/src/features/chat/components/bubbles/bot/MemoryCard.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/MemoryCard.tsx
@@ -322,7 +322,6 @@ export default function MemoryCard({ items: rawItems }: MemoryCardProps) {
     <div className="flex w-full max-w-md flex-col gap-0 overflow-hidden rounded-2xl bg-zinc-800">
       <div className="flex flex-col gap-3 p-4">
         {items.map((item, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
           <div key={`${item.action}-${i}`}>
             {i > 0 && <Divider className="mb-3 bg-zinc-700/50" />}
             {item.action === "add" && <AddSection item={item} />}

--- a/apps/web/src/features/chat/components/bubbles/bot/UnifiedToolThread.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/UnifiedToolThread.tsx
@@ -132,7 +132,6 @@ export default function UnifiedToolThread({
           }
           return (
             <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
               key={`${d.category}-${i}`}
               className="relative flex min-w-8 items-center justify-center"
               style={{

--- a/apps/web/src/features/integrations/api/integrationsApi.ts
+++ b/apps/web/src/features/integrations/api/integrationsApi.ts
@@ -1,7 +1,6 @@
 import { apiService } from "@/lib/api/service";
 import { sanitizeRedirectUrl } from "@/lib/url-safety";
 import type { CommunityWorkflowsResponse } from "@/types/features/workflowTypes";
-
 import type {
   CommunityIntegration,
   CommunityIntegrationsResponse,
@@ -13,6 +12,7 @@ import type {
   MyIntegrationsResponse,
   PublicIntegrationResponse,
 } from "../types";
+import { normalizeNativeIntegrations } from "../utils/normalizeNativeIntegrations";
 
 export interface IntegrationConfigResponse {
   integrations: Integration[];
@@ -353,26 +353,7 @@ export const integrationsApi = {
    */
   getNativeIntegrations: async (): Promise<CommunityIntegration[]> => {
     const response = await integrationsApi.getIntegrationConfig();
-    return response.integrations
-      .filter((i) => i.source === "platform" && i.available !== false)
-      .sort((a, b) => (b.displayPriority ?? 0) - (a.displayPriority ?? 0))
-      .map((i) => ({
-        integrationId: i.id,
-        slug: i.slug,
-        name: i.name,
-        description: i.description,
-        category: i.category,
-        iconUrl: i.iconUrl ?? null,
-        cloneCount: 0,
-        toolCount: i.tools?.length ?? 0,
-        tools: (i.tools ?? []).map((t) => ({
-          name: t.name,
-          description: t.description ?? null,
-        })),
-        publishedAt: null,
-        creator: null,
-        source: "platform" as const,
-      }));
+    return normalizeNativeIntegrations(response.integrations);
   },
 
   /**

--- a/apps/web/src/features/integrations/utils/normalizeNativeIntegrations.ts
+++ b/apps/web/src/features/integrations/utils/normalizeNativeIntegrations.ts
@@ -1,0 +1,34 @@
+import type { CommunityIntegration, Integration } from "../types";
+
+/**
+ * Normalize platform integrations from /integrations/config to the
+ * CommunityIntegration shape used by marketplace cards. Shared between the
+ * client API layer and the server-rendered /marketplace hub.
+ */
+export function normalizeNativeIntegrations(
+  integrations: Integration[],
+): CommunityIntegration[] {
+  return integrations
+    .filter((i) => i.source === "platform" && i.available !== false)
+    .sort((a, b) => (b.displayPriority ?? 0) - (a.displayPriority ?? 0))
+    .map((i) => ({
+      integrationId: i.id,
+      slug: i.slug,
+      name: i.name,
+      description: i.description,
+      category: i.category,
+      iconUrl: i.iconUrl ?? null,
+      cloneCount: 0,
+      toolCount: i.tools?.length ?? 0,
+      tools: (i.tools ?? []).map((t) => ({
+        name: t.name,
+        description: t.description ?? null,
+      })),
+      publishedAt: null,
+      creator: null,
+      source: "platform" as const,
+    }));
+}
+
+/** Page size for the marketplace community listing (server + client). */
+export const MARKETPLACE_ITEMS_PER_PAGE = 18;

--- a/apps/web/src/features/landing/components/demo/DemoToolCalls.tsx
+++ b/apps/web/src/features/landing/components/demo/DemoToolCalls.tsx
@@ -36,7 +36,6 @@ export default function DemoToolCalls({
         <div className="flex items-center -space-x-2">
           {tools.map((t, i) => (
             <div
-              // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
               key={`${t.name}-${i}`}
               className="relative flex h-7 w-7 items-center justify-center"
               style={{ rotate: i % 2 === 0 ? "8deg" : "-8deg", zIndex: i }}
@@ -73,7 +72,6 @@ export default function DemoToolCalls({
             <div className="py-1">
               {tools.map((t, i) => (
                 <div
-                  // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
                   key={`${t.name}-${i}-detail`}
                   className="flex items-stretch gap-2"
                 >

--- a/apps/web/src/features/landing/components/demo/todo-demo/DemoTodoRun.tsx
+++ b/apps/web/src/features/landing/components/demo/todo-demo/DemoTodoRun.tsx
@@ -57,7 +57,6 @@ export default function DemoTodoRun({ phase }: DemoTodoRunProps) {
         <AnimatePresence>
           {calls.map((call, index) => (
             <m.div
-              // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
               key={`${call.category}-${index}`}
               initial={{ opacity: 0, x: -10 }}
               animate={{ opacity: 1, x: 0 }}

--- a/apps/web/src/features/landing/components/sections/FinalSection.tsx
+++ b/apps/web/src/features/landing/components/sections/FinalSection.tsx
@@ -285,7 +285,6 @@ export default function FinalSection({
                   <Tooltip
                     content={label}
                     placement="bottom"
-                    // biome-ignore lint/suspicious/noArrayIndexKey: static list rendered in a fixed order — the index-composited key is stable
                     key={index + href}
                   >
                     <Link

--- a/apps/web/src/features/use-cases/components/UseCaseSection.tsx
+++ b/apps/web/src/features/use-cases/components/UseCaseSection.tsx
@@ -6,6 +6,7 @@ import * as m from "motion/react-m";
 import Link from "next/link";
 import { useCallback, useRef, useState } from "react";
 import { ChevronUp } from "@/components/shared/icons";
+import { convertWorkflowToUseCase } from "@/features/use-cases/utils/convertWorkflowToUseCase";
 import type { Workflow } from "@/features/workflows/api/workflowApi";
 import UnifiedWorkflowCard from "@/features/workflows/components/shared/UnifiedWorkflowCard";
 import { useExploreWorkflows } from "@/features/workflows/hooks/useExploreWorkflows";
@@ -60,21 +61,7 @@ export default function UseCaseSection({
 
   // Convert store workflows to UseCase format
   const convertedExploreWorkflows: UseCase[] = storeExploreWorkflows.map(
-    (w) => ({
-      title: w.title,
-      description: w.description,
-      action_type: "workflow" as const,
-      integrations:
-        w.steps
-          ?.map((s) => s.category)
-          .filter((v, i, a) => a.indexOf(v) === i) || [],
-      categories: w.categories || ["featured"],
-      published_id: w.id,
-      slug: w.slug ?? undefined,
-      steps: w.steps,
-      creator: w.creator,
-      total_executions: w.total_executions || 0,
-    }),
+    convertWorkflowToUseCase,
   );
 
   // Use provided explore workflows or converted store workflows

--- a/apps/web/src/features/use-cases/utils/convertWorkflowToUseCase.ts
+++ b/apps/web/src/features/use-cases/utils/convertWorkflowToUseCase.ts
@@ -1,0 +1,27 @@
+import type {
+  CommunityWorkflow,
+  UseCase,
+} from "@/types/features/workflowTypes";
+
+/**
+ * Convert a community/explore workflow into the UseCase card shape.
+ * Shared between the server-rendered /use-cases hub (SSR'd links for
+ * crawlers) and the client-side explore store consumers.
+ */
+export function convertWorkflowToUseCase(workflow: CommunityWorkflow): UseCase {
+  return {
+    title: workflow.title,
+    description: workflow.description,
+    action_type: "workflow" as const,
+    integrations:
+      workflow.steps
+        ?.map((s) => s.category)
+        .filter((v, i, a) => a.indexOf(v) === i) || [],
+    categories: workflow.categories || ["featured"],
+    published_id: workflow.id,
+    slug: workflow.slug ?? undefined,
+    steps: workflow.steps,
+    creator: workflow.creator,
+    total_executions: workflow.total_executions || 0,
+  };
+}

--- a/apps/web/src/features/whats-new/components/WhatsNewContent.tsx
+++ b/apps/web/src/features/whats-new/components/WhatsNewContent.tsx
@@ -108,7 +108,6 @@ export function WhatsNewContent({ html }: WhatsNewContentProps) {
   }, [html]);
 
   return (
-    // biome-ignore lint/security/noDangerouslySetInnerHtml: content is sanitized with DOMPurify above
     <div className="text-sm" dangerouslySetInnerHTML={{ __html: processed }} />
   );
 }

--- a/apps/web/src/messages/de.json
+++ b/apps/web/src/messages/de.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "Entdecken Sie 240+ Automatisierungskombos. Verbinden Sie Gmail + Slack, Notion + Todoist, GitHub + Linear und mehr — GAIA verwaltet die Workflows zwischen Ihren Tools automatisch.",
     "combos_count": "{count} Automatisierungskombos",
     "dont_see_your_combo": "Ihre Kombination nicht gefunden?",
-    "dont_see_your_combo_desc": "Durchsuchen Sie den vollständigen Integrationsmarktplatz oder verbinden Sie jedes Tool über MCP."
+    "dont_see_your_combo_desc": "Durchsuchen Sie den vollständigen Integrationsmarktplatz oder verbinden Sie jedes Tool über MCP.",
+    "browse_all_combos": "Alle Kombos durchsuchen"
   },
   "glossary": {
     "breadcrumb": "Glossar",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "Browse 240+ automation combos. Connect Gmail + Slack, Notion + Todoist, GitHub + Linear, and more — GAIA handles the workflows between your tools automatically.",
     "combos_count": "{count} automation combos",
     "dont_see_your_combo": "Don't see your combo?",
-    "dont_see_your_combo_desc": "Browse the full integration marketplace or connect any tool via MCP."
+    "dont_see_your_combo_desc": "Browse the full integration marketplace or connect any tool via MCP.",
+    "browse_all_combos": "Browse all combos"
   },
   "glossary": {
     "breadcrumb": "Glossary",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "Explora más de 240 combos de automatización. Conecta Gmail + Slack, Notion + Todoist, GitHub + Linear, y más — GAIA gestiona los flujos de trabajo entre tus herramientas automáticamente.",
     "combos_count": "{count} combos de automatización",
     "dont_see_your_combo": "¿No ves tu combo?",
-    "dont_see_your_combo_desc": "Explora el mercado de integraciones completo o conecta cualquier herramienta vía MCP."
+    "dont_see_your_combo_desc": "Explora el mercado de integraciones completo o conecta cualquier herramienta vía MCP.",
+    "browse_all_combos": "Ver todos los combos"
   },
   "glossary": {
     "breadcrumb": "Glosario",

--- a/apps/web/src/messages/fr.json
+++ b/apps/web/src/messages/fr.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "Parcourez plus de 240 combos d'automatisation. Connectez Gmail + Slack, Notion + Todoist, GitHub + Linear, et plus — GAIA gère les workflows entre vos outils automatiquement.",
     "combos_count": "{count} combos d'automatisation",
     "dont_see_your_combo": "Vous ne voyez pas votre combo ?",
-    "dont_see_your_combo_desc": "Parcourez le marketplace d'intégrations complet ou connectez n'importe quel outil via MCP."
+    "dont_see_your_combo_desc": "Parcourez le marketplace d'intégrations complet ou connectez n'importe quel outil via MCP.",
+    "browse_all_combos": "Voir tous les combos"
   },
   "glossary": {
     "breadcrumb": "Glossaire",

--- a/apps/web/src/messages/ja.json
+++ b/apps/web/src/messages/ja.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "240以上の自動化コンボを検索しましょう。Gmail + Slack、Notion + Todoist、GitHub + Linearなどを接続 — GAIAがツール間のワークフローを自動的に処理します。",
     "combos_count": "{count}件の自動化コンボ",
     "dont_see_your_combo": "コンボが見つかりませんか？",
-    "dont_see_your_combo_desc": "完全なインテグレーションマーケットプレイスを閲覧するか、MCPを通じて任意のツールを接続してください。"
+    "dont_see_your_combo_desc": "完全なインテグレーションマーケットプレイスを閲覧するか、MCPを通じて任意のツールを接続してください。",
+    "browse_all_combos": "すべてのコンボを見る"
   },
   "glossary": {
     "breadcrumb": "用語集",

--- a/apps/web/src/messages/ko.json
+++ b/apps/web/src/messages/ko.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "240개 이상의 자동화 콤보를 탐색하세요. Gmail + Slack, Notion + Todoist, GitHub + Linear 등 연결 — GAIA가 도구 간 워크플로우를 자동으로 처리합니다.",
     "combos_count": "{count}개의 자동화 콤보",
     "dont_see_your_combo": "원하는 콤보가 없나요?",
-    "dont_see_your_combo_desc": "전체 통합 마켓플레이스를 탐색하거나 MCP를 통해 모든 도구를 연결하세요."
+    "dont_see_your_combo_desc": "전체 통합 마켓플레이스를 탐색하거나 MCP를 통해 모든 도구를 연결하세요.",
+    "browse_all_combos": "모든 콤보 보기"
   },
   "glossary": {
     "breadcrumb": "용어집",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -55,7 +55,8 @@
     "hub_meta_description": "Explore mais de 240 combos de automação. Conecte Gmail + Slack, Notion + Todoist, GitHub + Linear e mais — o GAIA cuida dos fluxos de trabalho entre suas ferramentas automaticamente.",
     "combos_count": "{count} combos de automação",
     "dont_see_your_combo": "Não encontrou seu combo?",
-    "dont_see_your_combo_desc": "Explore o marketplace de integrações completo ou conecte qualquer ferramenta via MCP."
+    "dont_see_your_combo_desc": "Explore o marketplace de integrações completo ou conecte qualquer ferramenta via MCP.",
+    "browse_all_combos": "Ver todos os combos"
   },
   "glossary": {
     "breadcrumb": "Glossário",

--- a/apps/web/src/types/features/workflowTypes.ts
+++ b/apps/web/src/types/features/workflowTypes.ts
@@ -60,7 +60,13 @@ export interface PublicWorkflowStep {
 
 // Re-export trigger types for convenience
 // Re-export shared types that are identical between web and mobile
-export type { ExecutionConfig, TriggerConfig, TriggerFieldSchema, TriggerSchema, WorkflowMetadata };
+export type {
+  ExecutionConfig,
+  TriggerConfig,
+  TriggerFieldSchema,
+  TriggerSchema,
+  WorkflowMetadata,
+};
 
 // ============================================================================
 // COMMUNITY & EXPLORE WORKFLOW TYPES


### PR DESCRIPTION
> **Stacked on #865** (which stacks on #864). Merge in order; retarget as each lands.

## Why

The SEO audit found the site's link equity flowing to the wrong places:
- The three highest-intent keyword pages — `/ai-chief-of-staff`, `/inbox-zero-ai`, `/open-source-ai-assistant` — and `/faq` had **zero internal links** (XML-sitemap-only discovery). Orphaned pages don't break out of page 2.
- The mega-menu is `dynamic(ssr:false)` + hover-gated, so none of its links exist in crawlable HTML.
- The `/marketplace` and `/use-cases` hubs fetched their listings client-side — Google saw skeletons, and the detail pages received no internal-link equity from their own hubs.
- `/for/startup-founders` (footer-linked) targeted "AI chief of staff", starving the dedicated (orphaned) `/ai-chief-of-staff` page for its own head term.
- `/automate/[combo]` pages breadcrumbed to `/marketplace` instead of their own `/automate` hub.

## What

- **Footer links** for the three keyword pages (Product) + `/faq` (Company) via `appConfig` — `hideNavbar` so the visible nav is untouched.
- **sr-only crawlable nav** in the SSR'd Navbar mirroring the mega-menu links; the interactive menu stays lazy so hydration cost is unchanged.
- **Breadcrumb fix** on all 208 combo pages (visible + BreadcrumbList schema) → `/automate`; explore-more CTA follows (new `automate.browse_all_combos` key, translated in all 7 locales).
- **Cannibalization fix:** `/for/startup-founders` retitled to founder-intent ("Proactive AI That Runs Your Startup Ops"), "AI chief of staff" keyword removed, and a contextual cross-link added to `/ai-chief-of-staff`.
- **`/marketplace` SSR:** page 1 (community + native) fetched server-side and passed as props. Root cause of the skeleton HTML was `useSearchParams` at render time forcing client-only rendering — replaced with post-hydration URL parsing (the filters component already self-syncs from the URL). Native-integration normalization extracted to a shared util (used by both the client API and the server fetch).
- **`/use-cases` SSR:** explore/curated workflows now server-fetched and passed down (`UseCaseSection` already supported the prop); the CommunityWorkflow→UseCase converter extracted to a shared util.

## Verification
- `biome check` clean on changed files (2 pre-existing complexity warnings in `UseCaseSection` remain, untouched); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)