### PR TITLE
feat(briefing,todos): retention-loop fixes — pushes, honest signals, channel priority, day-zero hello

### DIFF
--- a/apps/api/app/agents/prompts/briefing_prompts.py
+++ b/apps/api/app/agents/prompts/briefing_prompts.py
@@ -296,7 +296,7 @@ only. Produce ONE structured payload.
 {week_summary_block}
 
 Estimated time saved this week: about {hours_saved} hours.
-Current streak: {streak_days} day(s) of at least one completed todo.
+Current streak: {streak_days} day(s) you completed at least one todo yourself.
 {awards_block}
 {_ITEM_QUALITY}
 
@@ -431,3 +431,51 @@ No user-facing message and no payload: the user is asleep and the morning
 briefing does the talking. End with one terse line listing the todos you
 created (consumed by logs only).
 """  # nosec B608 - natural-language prompt; bandit's SQL heuristic matches the words "update ... set" in prose, there is no SQL here
+
+
+def build_day_zero_hello_prompt(*, first_name: str, goal_block: str, has_goal: bool) -> str:
+    """The first text GAIA sends a user right after they link a chat platform."""
+
+    if has_goal:
+        task = f"""Say hi to {first_name} by name, warm and quick. Then, from what you know
+about their goal below, name that goal in plain words and offer ONE specific
+thing you'll have ready by their first brief tomorrow morning. Make the offer
+concrete and grounded in their actual goal ("I'll pull together a shortlist of
+seed funds that back API startups so you can start reaching out"), never a vague
+"I'll help you get started". One clear offer, not a menu."""
+    else:
+        task = f"""Say hi to {first_name} by name, warm and quick. You don't know their goal
+yet, so ask ONE specific question that gets you there, grounded in anything you
+do know from the context below. Not "what are your goals?" but a real, pointed
+question a sharp friend would ask. One question, not three."""
+
+    return f"""You are GAIA, texting {first_name} for the first time. They just connected a
+chat platform to you, so this message lands in that chat like a text from a
+friend, not an onboarding email.
+
+## WHAT YOU KNOW ABOUT THEM
+{goal_block}
+
+## YOUR MESSAGE
+{task}
+
+Close by letting them know their first brief lands tomorrow morning around 8.
+Keep it light, one short line for that, not a sales pitch.
+
+## VOICE
+Text like a real person who is genuinely glad they showed up. Contractions
+always. Vary your sentence length. Open on the actual point, no "Welcome to
+GAIA!" throat-clearing. Warm, specific, a little bit of personality, never
+corporate and never a bulleted list. Do not use em dashes or en dashes anywhere;
+use commas, periods, or parentheses. Do not overdo it into fake slang or forced
+quirkiness. No emoji unless it truly fits, and at most one.
+
+## OUTPUT
+Your ENTIRE final message is a JSON array of 1 to 2 short strings inside one
+```json code fence, each string one chat bubble in the order they should send.
+No prose before or after the fence. Example shape (not the content):
+
+```json
+["first bubble here", "second bubble here"]
+```
+"""

--- a/apps/api/app/agents/prompts/todo_prompts.py
+++ b/apps/api/app/agents/prompts/todo_prompts.py
@@ -1,69 +1,34 @@
 """Prompts and tool descriptions for the agent task management tools."""
 
 # System prompt appended to model context
-TODO_SYSTEM_PROMPT = """You have TWO separate task systems — do not confuse them.
+TODO_SYSTEM_PROMPT = """You have TWO separate task systems. Do not confuse them.
 
-— EXECUTION PLANS (plan_tasks / update_tasks) —
-Ephemeral step tracking for YOUR current work. Use for 2+ step tasks.
-These disappear after execution. Not saved anywhere.
+PLAN_TASKS (plan_tasks / update_tasks): ephemeral step tracking for YOUR current work.
+Use for any 2+ step task. These vanish after the run and are saved nowhere.
 
-— GAIA TRACKED TODOS (create_tracked_todo / update_tracked_todo) —
-GAIA-managed todos that show on the user's todos page but carry a canvas of GAIA's working
-notes. They are distinct from the user's own day-to-day action items (those live in providers
-like Todoist, Google Tasks, Apple Reminders, etc.).
-Create only when GAIA itself performs or schedules a real action on an external system that it
-needs to remember, follow up on, or repeat (sent an email, created an issue, posted to Slack,
-scheduled recurring work). Reads never qualify: fetching, listing, searching, or summarizing
-data never creates a tracked todo, no matter how complex it is or how often it runs, and saving
-a summary as a todo is not tracking. One todo per initiative.
-Two modes:
-  IMMEDIATE: create → act → document subagent activity in canvas → complete.
-  LONG-RUNNING: create → act → update canvas → leave open for future follow-up.
-Only the executor creates these — subagents NEVER create tracked todos.
-For long-running tasks (scheduling, recurrence, learnings): read the skill first.
+TRACKED TODOS (create_tracked_todo and the tools around it): GAIA-managed todos that
+persist on the user's todos page with a canvas of GAIA's working notes. Create one only
+when GAIA itself performs or schedules a real action on an external system it must
+remember, follow up on, or repeat. The create_tracked_todo tool description is the full
+rulebook (when to create, what reads never qualify, the required `serves`, budgets); read
+the "tracked-todo-working-memory" skill for the create/search workflow, canvas structure,
+and goal lanes. Only the executor creates these, never a subagent.
 
 THE APPROVAL RULE (outward visibility):
-Work only the user and GAIA can see — research, drafts, triage, prep — executes without
-permission (requires_approval=False → 'queued'). Anything the outside world can see —
-sending email/DMs, posting, inviting others, spending money — needs the user's Approve
-tap first (requires_approval=True → 'proposed'). Never take an outward-facing action
-from a todo that did not enter via Approve; if an approved plan grows a NEW outward
-action mid-run, stop and call block_todo with the question instead of acting.
-block_todo is also how you pause on any decision only the user can make (which
-recipient, which figure, spend or not): ask one clear question, never guess. The
-run resumes automatically once the user answers.
-A missing integration never blocks work: produce the deliverable as content and finish
-with a connect-or-take-content handoff.
-Lifecycle tools: approve_todo only on the user's explicit go-ahead in this conversation
-(their words are the approval). When the go-ahead carries a qualification ("send only
-the Sequoia one", "drop the deck link"), pass their VERBATIM words as `instruction` so
-the release run obeys them. dismiss_todo only on their explicit decline; it records
-the rejection so that kind stops being proposed. answer_todo only when they answer a
-blocked todo's question; it records the answer and resumes the run.
+Work only the user and GAIA can see (research, drafts, triage, prep) runs without
+permission: requires_approval=False, enters 'queued'. Anything the outside world can see
+(sending email or DMs, posting, inviting others, spending money) needs the user's Approve
+tap first: requires_approval=True, enters 'proposed'. Never take an outward action from a
+todo that did not enter through Approve. If an approved run grows a NEW outward action, or
+hits any choice only the user can make (which recipient, which figure, spend or not), call
+block_todo with one clear question and wait; never guess. A missing integration is not a
+blocker: produce the deliverable as content and finish with a connect-or-take-content
+handoff.
 
-TRACEABILITY + BUDGETS:
-Every tracked todo requires `serves` — the goal, memory item, or explicit user request
-it advances. Budgets are enforced server-side (max 5 in flight, max 3 pending
-proposals): when creation is rejected, curate — complete, dismiss, or let items expire —
-instead of retrying. If context lists proposal kinds "Do NOT propose again", never
-re-propose those kinds unless the user explicitly asks.
-
-GOAL LANES:
-When the user reveals a durable multi-week objective (raising a round, launching a
-product, a job search), propose making it a goal in that same reply with ONE specific
-question ("Want me to track the raise as a goal? I'd start tonight with a target-investor
-list."). On their yes, create it (kind='goal') with initial_notes carrying the strategy you
-heard: the objective, deadline, constraints, and the next 3 concrete steps. Set goal_id on
-every task that advances a goal. Never create a goal the user has not confirmed, and never
-more than 3 active.
-When chat reveals goal-relevant direction (a channel to drop, a preference, a deadline
-shift, "warm intros not cold emails"), write it into that goal's notes facet in the same
-turn (update_tracked_todo_canvas, facet='notes', mode='section', section='Current State'):
-the night shift and the morning brief plan from that text, not from chat history.
-
-QUICK DECISION:
-- "I need to organize my current steps" → plan_tasks
-- "GAIA is doing something the user might ask about later" → create_tracked_todo"""
+Lifecycle tools act ONLY on the user's explicit word in this conversation: approve_todo on
+their go-ahead (pass any qualification, like "only the Sequoia one", as verbatim
+`instruction` so the release run obeys it), dismiss_todo on their decline, answer_todo when
+they answer a blocked todo's question."""
 
 # Tool description for plan_tasks
 PLAN_TASKS_DESCRIPTION = """Create an execution plan for your current multi-step work.

--- a/apps/api/app/agents/skills/builtin/gaia-task-tracking/SKILL.md
+++ b/apps/api/app/agents/skills/builtin/gaia-task-tracking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tracked-todo-working-memory
-description: Complete guide for GAIA tracked todos — philosophy, two modes (immediate/long-running), canvas activity logging, scheduling/recurrence, and institutional memory.
+description: Workflow guide for GAIA tracked todos: the search-first create flow, two modes (immediate/long-running), the canvas facets, goal lanes, and institutional memory. The create_tracked_todo tool description is the authoritative rulebook.
 target: executor
 ---
 
@@ -8,314 +8,124 @@ target: executor
 
 ## Philosophy
 
-Tracked todos are **GAIA-managed todos**: they show on the user's todos page like a normal todo, but GAIA owns them and keeps a canvas of working notes (and an optional schedule) so it can act on them over time. They are distinct from the user's own hand-created action items. They record what GAIA did, when, how, and why, so future conversations can find and build on past work.
+Tracked todos are **GAIA-managed todos**: they show on the user's todos page like a normal todo, but GAIA owns them and keeps a canvas of working notes (and an optional schedule) so it can act on them over time. They record what GAIA did, when, how, and why, so future conversations can find and build on past work. When the user says "email Rahul about the contract" and months later asks "what happened with Rahul's contract?", the tracked todo and its canvas surface the answer.
 
-When the user says "email Rahul about the contract" and months later asks "what happened with Rahul's contract?", the tracked todo and its canvas surface the answer.
+**One todo per initiative.** "Email Rahul, create a Linear issue, follow up Friday" is ONE tracked todo ("Contract negotiation with Rahul") whose canvas holds the email thread ID, Linear issue URL, and follow-up schedule.
 
-**One todo per initiative.** "Email Rahul, create a Linear issue, follow up Friday" = ONE tracked todo ("Contract negotiation with Rahul") with a canvas holding the email thread ID, Linear issue URL, and follow-up schedule.
+The `create_tracked_todo` tool description is the authority on when to create, what never qualifies, the required `serves`, budgets, and every create field. This skill covers the workflow around it.
 
 ## Tools
 
-Always available to the executor — no `retrieve_tools` needed:
+Always available to the executor, no `retrieve_tools` needed:
 
-- `create_tracked_todo` — create todo with its facet workspace (notes / deliverable / log)
-- `update_tracked_todo` — update labels, due_date, priority, scheduled_at, recurrence, expires_at, references
-- `update_tracked_todo_canvas` — write a facet (notes / deliverable / log); modes: append (default), section, replace
-- `complete_tracked_todo` — mark done, archive, requires completion summary
-- `search_todo_context` — semantic search across all canvas embeddings (ChromaDB); includes completed
-- `list_tracked_todos` — list all active tracked todos (up to 50) with full metadata
-- `approve_todo` — release a proposed todo for execution, ONLY on the user's explicit go-ahead; when their go-ahead carries a qualification ("only the Sequoia one"), pass their verbatim words as `instruction`
-- `dismiss_todo` — decline a proposed todo on the user's explicit say-so; records the rejection signal
-- `block_todo` — pause a run on a decision only the user can make; asks one clear question
-- `answer_todo` — resume a blocked (needs_you) todo with the user's answer
+- `create_tracked_todo`: create the todo and its facet workspace
+- `update_tracked_todo`: update labels, due_date, priority, scheduling, references
+- `update_tracked_todo_canvas`: write a facet (notes / deliverable / log)
+- `complete_tracked_todo`: mark done and archive (requires a completion summary)
+- `search_todo_context`: semantic search across all canvases (includes completed)
+- `list_tracked_todos`: list active tracked todos with full metadata
+- `approve_todo` / `dismiss_todo` / `block_todo` / `answer_todo`: lifecycle transitions
 
 ## Search First, Create Last
 
-Creating a new todo is the **last step**, not the first. Always search before creating.
+Creating is the **last step**, not the first. Always `search_todo_context(query="...")` before creating.
 
-```
-search_todo_context(query="relevant keywords")
-```
-
-- Active match → update its canvas; do NOT create. "Related action" = same initiative, person, system, or goal. Always update, even for follow-on steps.
-- Completed match, same initiative resuming → create new ONLY if the user explicitly asked GAIA to DO something for this initiative again. Never create just because search returned a historical match during an unrelated request.
-- No match → create — only if GAIA performed or scheduled a real write/action this turn.
-
-**Create when** GAIA performs or schedules an action on an external system (email, calendar, Slack, Linear, Notion, etc.) that it needs to remember, follow up on, or repeat — and nothing relevant already exists in memory.
-
-**Do NOT create for:**
-
-- Pure reads with no side effects ("what's the weather?", "summarize my emails") — no matter how complex or how often they run; a recurring daily summary is still a read, and saving the summary as a todo is not tracking
-- Steps in your current orchestration (use `plan_tasks`)
-- Casual conversation or one-off questions
-- Anything clearly continuing an existing tracked todo — update that one instead
+- Active match: update its canvas, do NOT create. "Related" means the same initiative, person, system, or goal. Update even for follow-on steps.
+- Completed match, same initiative resuming: create new ONLY if the user explicitly asked GAIA to DO something for it again. Never create just because search returned a historical match during an unrelated request.
+- No match: create.
 
 Overusing tracked todos degrades search quality and clutters GAIA's memory.
 
 ## Two Modes
 
-Once you've confirmed no existing todo covers this (see Search First above):
-
 ### Immediate
 
-Completes in this conversation. Create → delegate → document → complete.
+Completes in this conversation. Create, delegate, document, complete.
 
 ```
-search_todo_context → (nothing relevant found) → create_tracked_todo
-→ handoff to subagent → collect activity report
-→ update_tracked_todo_canvas (append activity log)
-→ complete_tracked_todo
+search_todo_context (nothing found) -> create_tracked_todo
+-> handoff to subagent -> collect activity report
+-> update_tracked_todo_canvas (append to log facet)
+-> complete_tracked_todo
 ```
 
 ### Long-Running
 
-Spans conversations or needs follow-up. Create → act → update → leave open.
+Spans conversations or needs follow-up. Create, act, update, leave open.
 
 ```
-search_todo_context → (nothing relevant found) → create_tracked_todo(scheduled_at=..., ...)
-→ act → update_tracked_todo_canvas → leave open
-→ (future conversation) find via active todos or search → read canvas → act → update
-→ eventually: complete_tracked_todo with learnings
+search_todo_context (nothing found) -> create_tracked_todo(scheduled_at=..., ...)
+-> act -> update canvas -> leave open
+-> (future conversation) find via active todos or search -> read canvas -> act -> update
+-> eventually: complete_tracked_todo with learnings
 ```
 
-- "Send Rahul the report" — search first; if nothing found: immediate todo.
-- "Email Rahul about the meeting" — search first; if nothing found: long-running todo.
-- "He replied, send thanks" — search finds existing todo → update canvas, no new todo.
-- "What's the weather?" / "Summarize my emails" — no todo.
+- "Send Rahul the report": search first; if nothing found, immediate.
+- "Email Rahul about the meeting": search first; if nothing found, long-running.
+- "He replied, send thanks": search finds the existing todo, so update its canvas, no new todo.
 
 ## Canvas
 
-### Writing to the Canvas
-
-`update_tracked_todo_canvas` has three modes — **pick the right one**, never default to `replace` out of habit:
-
-- `append` (default) — pass only the new content. Use for activity log entries, timeline events, notes.
-- `section` — pass only the new body of that section (no heading). Use for updating one named section (e.g. `Current State`).
-- `replace` — pass the entire canvas markdown. Only for full restructure or initial setup.
-
-`append` and `section` do **not require reading the file first** — the tool handles it internally.
-
-```python
-# Log what a subagent did — no read needed
-update_tracked_todo_canvas(todo_id="...", mode="append", content="\n### 2026-03-26\n- **Gmail agent**: Sent email...")
-
-# Update a single section — no read needed
-update_tracked_todo_canvas(todo_id="...", mode="section", section="Current State", content="Waiting for Rahul's reply.")
-
-# Full rewrite — only when restructuring
-update_tracked_todo_canvas(todo_id="...", mode="replace", content="# Title\n\n## Key Details\n...")
-```
-
-### Structure
-
 A tracked todo's workspace has three facets (pass `facet` to `update_tracked_todo_canvas`):
 
-- **notes** — GAIA's private working memory: plan, key details, current state. Seeded from `initial_notes`, or this default template:
+- **notes**: GAIA's private working memory (plan, key details, current state, learnings). Seeded from `initial_notes`, or the default template below.
+- **deliverable**: the polished, send-ready output the user sees. For a proposal it is the EXACT content Approve releases.
+- **log**: the chronological activity and timeline audit trail. Activity entries live HERE, not in notes.
+
+Write modes: `append` (default, for log entries and new notes), `section` (replace one named `## Section`, e.g. Current State), `replace` (full rewrite, only when restructuring). `append` and `section` do not require reading the facet first.
+
+### Notes template
 
 ```markdown
 # {title}
 
 ## Key Details
-
-<!-- email addresses, thread IDs, calendar IDs, issue IDs — everything needed to take action -->
+<!-- email addresses, thread IDs, calendar IDs, issue IDs: everything needed to act -->
 
 ## Current State
-
-<!-- what's true RIGHT NOW — updated after every action -->
+<!-- what's true RIGHT NOW, updated after every action -->
 
 ## Context
-
-<!-- accumulated context from signals, related information, decisions made -->
+<!-- accumulated context, related information, decisions made -->
 
 ## Learnings
-
-<!-- written on completion: what worked, what didn't, key decisions, timing insights. DO NOT write activity log entries here -->
+<!-- written on completion: what worked, what didn't, key decisions. Not activity log entries -->
 ```
 
-- **deliverable** — the polished, send-ready output the user sees. For a proposal (`requires_approval=True`) this is the EXACT content Approve releases, seeded from the required `initial_deliverable`. Internal todos start from a light template.
-- **log** — the activity/timeline audit trail. Chronological activity (Activity Log, Timeline) lives HERE, not in notes.
+### Activity log
 
-### Activity Log
-
-After subagents return, record their structured reports in the **log** facet:
+After subagents return, append their structured reports to the **log** facet:
 
 ```python
-update_tracked_todo_canvas(todo_id="...", facet="log", mode="append", content="### 2026-03-26\n- **Gmail agent**: Sent email...")
+update_tracked_todo_canvas(todo_id="...", facet="log", mode="append",
+  content="### 2026-03-26\n- **Gmail agent**: Sent email to rahul@example.com re: Q2 contract.\n  Tools: GMAIL_SEND_DRAFT. Thread ID: 18f3a2b.")
 ```
 
-```markdown
-### 2026-03-26
+The log also receives system-written entries (creation, canvas updates, completion) automatically. Append yours; never rewrite or delete the system ones.
 
-- **Gmail agent**: Sent email to rahul@example.com re: Q2 contract renewal.
-  Tools: GMAIL_CREATE_DRAFT → GMAIL_SEND_DRAFT. Thread ID: 18f3a2b.
-  Subject: "Q2 Contract Renewal — Next Steps". Draft approved and sent.
-- **Linear agent**: Created issue LIN-423 "Track Q2 contract renewal".
-  Tools: LINEAR_CREATE_ISSUE. URL: https://linear.app/team/LIN-423.
+## Goal Lanes
+
+A goal is a long-lived lane (`kind="goal"`) whose canvas is the living strategy the nightly pass advances. When the user reveals a durable multi-week objective (raising a round, launching a product, a job search), propose making it a goal in that same reply with ONE specific question ("Want me to track the raise as a goal? I'd start tonight with a target-investor list."). On their yes, create it with `initial_notes` carrying the strategy you heard: the objective, deadline, constraints, and the next 3 concrete steps. Set `goal_id` on every task that advances the goal.
+
+When later chat reveals goal-relevant direction (a channel to drop, a deadline shift, "warm intros not cold emails"), write it into that goal's notes facet in the same turn:
+
+```python
+update_tracked_todo_canvas(todo_id="<goal>", facet="notes", mode="section",
+  section="Current State", content="Warm intros only, no cold email.")
 ```
 
-### System Log
-
-The log facet also receives system-written entries automatically (creation, canvas updates, completion). Append your activity entries; never rewrite or delete the system ones.
-
-## Create Fields
-
-- `title` (required) — short descriptive title
-- `serves` (required) — the goal, memory item, or explicit user request this todo advances; creation is rejected when empty
-- `requires_approval` (required) — the approval rule. `True` for outward-visible work (sending email/DMs, posting, inviting others, spending money): enters `proposed` and waits for the user's Approve tap, and MUST carry its finished `initial_deliverable`. `False` for work only the user and GAIA can see (research, drafts, triage, prep): enters `queued` and runs immediately
-- `description` — what needs to happen and expected outcome
-- `initial_deliverable` — deliverable facet: the polished, send-ready output. REQUIRED for proposals (it is what Approve releases); optional otherwise
-- `initial_notes` — notes facet: initial working memory; default template if omitted
-- `labels` — list of strings
-- `priority` — `high` | `medium` | `low` | `none` (default `none`)
-- `scheduled_at` — ISO datetime when GAIA should auto-execute (must be future). Omit for cron recurrence — first fire is computed from the cron.
-- `recurrence` — repeat pattern. Cron-style works alone (no `scheduled_at` needed); shortcut values still need `scheduled_at` as anchor.
-- `expires_at` — ISO datetime when todo becomes irrelevant (skipped if expired)
-
-`due_date` is only settable via `update_tracked_todo`, not at creation time.
-
-## Scheduling & Recurrence
-
-### `scheduled_at`
-
-ISO datetime, must be in the future. GAIA auto-executes via background worker at that time.
-
-### `recurrence`
-
-ALWAYS evaluated in the user's stored timezone — pass cron in user-local wall-clock terms, the backend converts to UTC. Do NOT bake offsets into the cron string. After successful execution, `scheduled_at` auto-advances and a new job is enqueued.
-
-- `daily` — +1 day (shortcut, needs `scheduled_at` as anchor)
-- `weekly` — +7 days (shortcut, needs `scheduled_at`)
-- `every_4h` — +4 hours (shortcut, needs `scheduled_at`)
-- `every_1h` — +1 hour (shortcut, needs `scheduled_at`)
-- Cron — `0 9 * * 1-5` = weekdays 9am user-local; `0 9,20 * * *` = 9am and 8pm daily. ONE recurrence, not two todos. No `scheduled_at` needed — first fire is computed from the cron.
-
-### `due_date` vs `expires_at`
-
-- **`due_date`** = deadline. Overdue tasks still need doing. Set via `update_tracked_todo`.
-- **`expires_at`** = relevance window. Expired tasks are skipped entirely.
-- Both can be set together (e.g., "file taxes": due April 15, expires April 15).
-- Don't set `expires_at` on open-ended tasks with no natural expiry.
-
-### Validation
-
-- `scheduled_at` must be future
-- Shortcut `recurrence` (`daily`, `weekly`, `every_4h`, `every_1h`) requires `scheduled_at` as anchor. Cron does not.
-- Cannot clear `scheduled_at` while a shortcut `recurrence` is set
-- Cron expressions validated via croniter
-- If both `scheduled_at` and a cron `recurrence` are passed, `scheduled_at` is ignored (first fire comes from the cron)
-
-### Execution & Retry
-
-- Background worker (ARQ) runs at `scheduled_at`
-- Redis lock prevents concurrent execution of same todo
-- Failure: retries up to 3× with backoff (1 hour, then 4 hours)
-- After 3 failures: `failed` label added, user notified
-- Success with recurrence: `scheduled_at` advances, new job enqueued
+The night shift and the morning brief plan from that text, not from chat history.
 
 ## Institutional Memory
 
-### References
-
-Manually link related past todos:
-
-```
-update_tracked_todo(todo_id="abc", references=["old_todo_id_1"])
-```
-
-References are appended (not replaced). Use `search_todo_context` to find past todos worth referencing — its snippets surface the past approaches.
-
-### Writing Learnings Before Completion
-
-Before calling `complete_tracked_todo`, update the canvas with a thorough `## Learnings` section. Future similar tasks will reference these.
-
-**Good:** "Sarah responds in 2-3 days", "approval takes 1 week", "batch the Linear + Notion updates in one handoff"
-**Bad:** "went well", restating the timeline, obvious observations
-
-## Lifecycle
-
-### Before Acting
-
-1. Check the `ACTIVE TRACKED TODOS:` block in your context — does the request relate to an existing todo?
-2. If yes: pull its context (key details from the context block or `search_todo_context`), then act, then update its facets
-3. If unclear: `search_todo_context(query="...")` to check for duplicates
-
-### After Acting
-
-- Update canvas with activity log from subagent reports
-- Update properties if needed (`update_tracked_todo`)
-
-### Completing
-
-1. Write `## Learnings` in canvas
-2. `complete_tracked_todo(todo_id="...", summary="...")` — archives VFS, marks completed in DB + ChromaDB
-
-## Examples
-
-### Immediate: send an email
-
-```python
-create_tracked_todo(
-  title="Sent Q2 report to Sarah",
-  serves="User asked to send Sarah the Q2 report",
-  requires_approval=False,
-  initial_notes="# Sent Q2 report to Sarah\n\n## Key Details\n- Recipient: sarah@example.com\n\n## Current State\nReport sent in this conversation.\n\n## Learnings\n"
-)
-# handoff to Gmail → collect report → update canvas → complete
-```
-
-### Long-running: follow-up with expiry
-
-```python
-create_tracked_todo(
-  title="Follow up with Rahul re: contract",
-  serves="User asked GAIA to chase the Q2 vendor contract with Rahul",
-  requires_approval=True,
-  description="Sent initial email. Follow up if no reply.",
-  scheduled_at="2026-04-01T09:00:00Z",
-  expires_at="2026-04-08T00:00:00Z",
-  initial_deliverable="# Follow-up email to Rahul\n\nHi Rahul, just checking in on the Q2 vendor agreement I sent last week. Any questions I can answer?",
-  initial_notes="# Rahul Contract Follow-up\n\n## Key Details\n- Email: rahul@example.com\n- Thread ID: 18f3a2b\n- Contract: Q2 vendor agreement\n\n## Current State\nInitial email sent. Waiting for reply.\n\n## Learnings\n"
-)
-```
-
-### Recurring: daily check
-
-```python
-create_tracked_todo(
-  title="Daily HN top posts summary",
-  serves="User asked for a daily HN top posts summary",
-  requires_approval=False,
-  scheduled_at="2026-03-26T08:00:00Z",
-  recurrence="daily"
-)
-```
-
-### Recurring: weekday cron
-
-```python
-create_tracked_todo(
-  title="Weekday standup prep",
-  serves="User asked GAIA to prep their standup every weekday",
-  requires_approval=False,
-  scheduled_at="2026-03-26T09:00:00Z",
-  recurrence="0 9 * * 1-5"
-)
-```
-
-### Update after creation
-
-```python
-update_tracked_todo(todo_id="abc123", due_date="2026-04-15")
-update_tracked_todo(todo_id="abc123", scheduled_at="2026-03-30T10:00:00Z")
-update_tracked_todo(todo_id="abc123", scheduled_at="", recurrence="")  # Clear scheduling
-update_tracked_todo(todo_id="abc123", labels=["waiting-for-reply"])
-```
+- **References**: `update_tracked_todo(todo_id="abc", references=["old_id"])` links related past todos (appended, not replaced). Use `search_todo_context` to find them.
+- **Learnings before completion**: before `complete_tracked_todo`, write a thorough `## Learnings` section in notes. Good: "Sarah responds in 2-3 days", "batch the Linear and Notion updates in one handoff". Bad: "went well", restating the timeline.
 
 ## Anti-Patterns
 
-- **Not creating** a tracked todo when GAIA touched external systems (even "just" sending an email)
-- **Multiple todos** for one initiative (one email todo + one Linear todo + one Notion todo → should be one)
-- **Vague canvas** ("made progress") instead of specific details with IDs and tool names
-- **Not collecting** activity reports from subagents before writing the canvas
-- **Not searching** before creating — duplicates make future lookups confusing
-- **Not writing learnings** before completing — wastes institutional memory
+- Not creating a tracked todo when GAIA touched external systems (even "just" sending an email).
+- Multiple todos for one initiative (one email, one Linear, one Notion, when it should be one).
+- Vague canvas ("made progress") instead of specific details with IDs and tool names.
+- Not collecting subagent activity reports before writing the canvas.
+- Not searching before creating.
+- Not writing learnings before completing.

--- a/apps/api/app/agents/tools/tracked_todo_tools.py
+++ b/apps/api/app/agents/tools/tracked_todo_tools.py
@@ -17,7 +17,6 @@ from langchain_core.tools import tool
 from app.constants.todos import (
     FACET_FIELDS,
     FACET_NOTES,
-    GAIA_TRACKED_LABEL,
     gaia_assigned_filter,
 )
 from app.db.mongodb.collections import todos_collection
@@ -362,7 +361,7 @@ def _format_tracked_todo_full(doc: dict, now: datetime) -> str:
     """Format one tracked-todo doc as the multi-line block used by list_tracked_todos."""
     todo_id = str(doc["_id"])
     title = doc.get("title", "Untitled")
-    labels = [lbl for lbl in doc.get("labels", []) if lbl != GAIA_TRACKED_LABEL]
+    labels = doc.get("labels", [])
     labels_str = f" [{', '.join(labels)}]" if labels else ""
     priority = doc.get("priority", "none")
     age_days = (now - doc.get("created_at", now)).days
@@ -539,9 +538,9 @@ async def create_tracked_todo(
     tracked todo. Search existing tracked todos first (search_todo_context) and
     update a match instead of creating a duplicate.
 
-    IMPORTANT: Before creating a tracked todo with scheduling (scheduled_at, recurrence),
-    read the "tracked-todo-working-memory" skill first for scheduling best practices,
-    canvas template guidelines, and lifecycle rules.
+    IMPORTANT: Read the "tracked-todo-working-memory" skill for the search-first workflow,
+    canvas structure, and goal lanes before creating. Scheduling specifics live in the
+    scheduled_at / recurrence / expires_at args below.
 
     scheduled_at: ISO datetime with the user's timezone offset (e.g., "2026-03-20T09:00:00+05:30").
                   For a one-time run, or as the first-fire anchor for a delta recurrence
@@ -680,18 +679,13 @@ async def update_tracked_todo_canvas(
         "user-facing output to 'deliverable'.",
     ] = FACET_NOTES,
 ) -> str:
-    """Update a facet of an EXISTING tracked todo's workspace.
+    """Update a facet (notes / deliverable / log) of an EXISTING tracked todo.
 
-    PRECONDITION: only call this when you already have a tracked todo for THIS initiative —
-    one you created this turn (you hold its todo_id) or the run's "🎯 ACTIVE TODO". If no
-    tracked todo exists for the task (a one-off fetch / deploy / build / lookup / edit), do
-    NOT call this. Facets live on the todo, not the filesystem — never use read/write/edit.
-
-    Facets: notes (working memory), deliverable (send-ready output), log (activity).
-    Modes (once you have a todo_id):
-    append  → activity log entries, new context. No read needed.
-    section → update a single named section (e.g. Current State). No read needed.
-    replace → full rewrite. Only when restructuring the entire facet.
+    PRECONDITION: call this only when you already hold a tracked todo for THIS initiative,
+    one you created this turn or the run's "🎯 ACTIVE TODO". For a one-off fetch, deploy,
+    build, lookup, or edit with no tracked todo, do not call it. Facets live on the todo,
+    not the filesystem, so never reach for read/write/edit. See the `facet` and `mode` args
+    for which facet holds what and how each write mode behaves.
     """
     user_id = config.get("metadata", {}).get("user_id")
     if not user_id:

--- a/apps/api/app/agents/workspace/operational_docs.py
+++ b/apps/api/app/agents/workspace/operational_docs.py
@@ -225,8 +225,8 @@ The user's own action items (the ones they see in their UI) project to:
         <slug>-<shortid>/meta.json    title, due, priority, labels, project,
                                       subtasks, completion
 
-`ls todos/` shows the user's plate at a glance. "Active" = NOT a
-`gaia-tracked` doc AND open or completed within the last 7 days.
+`ls todos/` shows the user's plate at a glance. "Active" = a todo NOT
+assigned to GAIA AND open or completed within the last 7 days.
 
 - `ls todos/` — what's on the user's plate now.
 - `cat todos/index.md` — one-line summary per todo.

--- a/apps/api/app/api/v1/endpoints/briefings.py
+++ b/apps/api/app/api/v1/endpoints/briefings.py
@@ -11,8 +11,13 @@ from fastapi import APIRouter, Depends, Query
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.constants.briefing import BRIEFING_KIND_DAILY
-from app.models.briefing_models import BriefingListResponse, BriefingModel
-from app.services.briefing import repository
+from app.models.briefing_models import (
+    BriefingListResponse,
+    BriefingModel,
+    ChannelPriorityResponse,
+    ChannelPriorityUpdate,
+)
+from app.services.briefing import delivery_channels, repository
 from app.utils.analytics import track
 from shared.py.wide_events import log
 
@@ -40,6 +45,31 @@ async def get_latest_briefing(
             latest = opened
 
     return latest
+
+
+@router.get("/preferences")
+async def get_briefing_preferences(
+    user: Annotated[dict, Depends(get_current_user)],
+) -> ChannelPriorityResponse:
+    """The user's ordered chat-channel priority for briefing delivery."""
+    user_id = user["user_id"]
+    log.set(user={"id": user_id}, briefing={"operation": "get_preferences"})
+    priority = await delivery_channels.get_channel_priority(user_id)
+    return ChannelPriorityResponse(chat_channel_priority=priority)
+
+
+@router.patch("/preferences")
+async def update_briefing_preferences(
+    payload: ChannelPriorityUpdate,
+    user: Annotated[dict, Depends(get_current_user)],
+) -> ChannelPriorityResponse:
+    """Persist the user's chat-channel priority; the brief lands on the first
+    linked and enabled platform in this order."""
+    user_id = user["user_id"]
+    log.set(user={"id": user_id}, briefing={"operation": "update_preferences"})
+    await delivery_channels.set_channel_priority(user_id, payload.chat_channel_priority)
+    log.set(briefing={"channel_priority": payload.chat_channel_priority})
+    return ChannelPriorityResponse(chat_channel_priority=payload.chat_channel_priority)
 
 
 @router.get("")

--- a/apps/api/app/api/v1/endpoints/first_steps.py
+++ b/apps/api/app/api/v1/endpoints/first_steps.py
@@ -22,3 +22,12 @@ async def mark_first_step(
 ) -> dict[str, Any]:
     await first_steps_service.mark_step(user["user_id"], step)
     return await first_steps_service.get_steps(user["user_id"])
+
+
+@router.patch("/hide")
+async def hide_first_step(
+    user: Annotated[dict, Depends(get_current_user)],
+    step: str = Body(embed=True),
+) -> dict[str, Any]:
+    await first_steps_service.hide_step(user["user_id"], step)
+    return await first_steps_service.get_steps(user["user_id"])

--- a/apps/api/app/api/v1/endpoints/todos.py
+++ b/apps/api/app/api/v1/endpoints/todos.py
@@ -1071,3 +1071,40 @@ async def handoff_todo_to_gaia(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     await delete_cache(f"counts:{user_id}")
     return {"success": True, "todo_id": todo_id, "execution_status": "queued"}
+
+
+@router.post("/todos/{todo_id}/retry", status_code=status.HTTP_200_OK)
+async def retry_gaia_todo(
+    todo_id: str,
+    user: Annotated[dict, Depends(get_current_user)],
+    channel: str = Body(default="web", embed=True),
+):
+    """Re-run a failed GAIA todo: clear the failure state and re-queue execution."""
+    user_id = user["user_id"]
+    log.set(user={"id": user_id}, todo={"operation": "retry", "id": todo_id})
+    try:
+        await lifecycle.retry(todo_id, user_id, channel=channel)
+    except InvalidTransitionError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    await delete_cache(f"counts:{user_id}")
+    log.set(todo={"execution_status": "queued"})
+    return {"success": True, "todo_id": todo_id, "execution_status": "queued"}
+
+
+@router.post("/todos/{todo_id}/dismiss_offer", status_code=status.HTTP_200_OK)
+async def dismiss_gaia_offer(
+    todo_id: str,
+    user: Annotated[dict, Depends(get_current_user)],
+):
+    """Dismiss the GAIA-takeover offer on a user todo, suppressing it everywhere."""
+    user_id = user["user_id"]
+    log.set(user={"id": user_id}, todo={"operation": "dismiss_offer", "id": todo_id})
+    updated = await todos_collection.find_one_and_update(
+        {"_id": ObjectId(todo_id), "user_id": user_id},
+        {"$set": {"gaia_offer_dismissed": True, "updated_at": datetime.now(UTC)}},
+        return_document=ReturnDocument.AFTER,
+    )
+    if not updated:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Todo not found")
+    await TodoService._invalidate_cache(user_id, updated.get("project_id"), todo_id, "update_minor")
+    return {"success": True, "todo_id": todo_id, "gaia_offer_dismissed": True}

--- a/apps/api/app/constants/notifications.py
+++ b/apps/api/app/constants/notifications.py
@@ -48,10 +48,24 @@ DEFAULT_CHANNEL_PREFERENCES: dict[str, bool] = {
     CHANNEL_TYPE_EMAIL: True,
 }
 
+# Default order in which a briefing picks its ONE chat platform. The daily brief
+# lands on the first platform in this list that the user has linked and enabled,
+# not on every linked platform (users.briefing_channel_priority overrides it).
+DEFAULT_CHAT_CHANNEL_PRIORITY: tuple[str, ...] = (
+    CHANNEL_TYPE_TELEGRAM,
+    CHANNEL_TYPE_WHATSAPP,
+    CHANNEL_TYPE_SLACK,
+    CHANNEL_TYPE_DISCORD,
+)
+
 # Notification metadata "kind" values that select an email template. Anything
 # else (including unset) falls back to the plain-notification template.
 NOTIFICATION_KIND_BRIEFING_DAILY = "briefing_daily"
 NOTIFICATION_KIND_BRIEFING_WEEKLY = "briefing_weekly"
+
+# Todo-lifecycle notification kinds (plain template; used for filtering/analytics).
+NOTIFICATION_KIND_TODO_NEEDS_YOU = "todo_needs_you"
+NOTIFICATION_KIND_TODO_DONE = "todo_done"
 
 # Workflow-completion notification copy. GAIA texts like a friend (first person,
 # casual), not a status bar. Each entry is (title, body); {title} is the workflow

--- a/apps/api/app/constants/todos.py
+++ b/apps/api/app/constants/todos.py
@@ -8,12 +8,21 @@ from typing import Any, Final
 
 ONBOARDING_TODO_LIMIT = 3
 
-# DEPRECATED: legacy discriminator for GAIA-owned todos, superseded by the
-# ``assignee`` field on the todo model. Retained only for the one-release
-# dual-read migration window (see ``gaia_assigned_filter``); removed once the
-# backfill (scripts/migrate_todo_assignee.py) has run everywhere. New code MUST
-# key off ``assignee`` / ``ASSIGNEE_GAIA``, never this label.
+# DEPRECATED: legacy discriminator for GAIA-owned todos, fully superseded by the
+# ``assignee`` field. The runtime no longer reads it — only the one-time backfill
+# (scripts/migrate_todo_assignee.py) still references this constant to find and
+# strip the label. Delete both once the backfill has run everywhere.
 GAIA_TRACKED_LABEL: Final[str] = "gaia-tracked"
+
+# Bookkeeping label the executor stamps on a todo that has exhausted its retry
+# attempts; the execution loop reads it to skip permanently-failed todos, and the
+# retry transition clears it to let the re-run proceed.
+FAILED_LABEL: Final[str] = "failed"
+
+# Cap on user-initiated retries of a failed GAIA todo. Distinct from the
+# executor's internal per-run backoff counter (``gaia_retry_count``): this bounds
+# how many times a human may re-run a todo that keeps failing.
+MAX_GAIA_USER_RETRIES: Final[int] = 3
 
 # Todo assignee values. ``assignee`` replaces GAIA_TRACKED_LABEL as the
 # discriminator for who owns a todo. Kept as constants (not a magic string)
@@ -53,22 +62,22 @@ GAIA_TODO_EXECUTIONS_FEATURE: Final[str] = "gaia_todo_executions"
 
 
 def gaia_assigned_filter() -> dict[str, Any]:
-    """Mongo fragment selecting GAIA-assigned todos.
+    """Mongo fragment selecting GAIA-assigned todos (``assignee == "gaia"``).
 
-    Dual-read for the migration window: a todo is GAIA-owned if
-    ``assignee == "gaia"`` OR it still carries the legacy ``gaia-tracked``
-    label. Retired to ``{"assignee": ASSIGNEE_GAIA}`` once the backfill lands.
+    Assumes the assignee backfill (scripts/migrate_todo_assignee.py) has run, so
+    every GAIA-owned todo carries ``assignee``; the legacy ``gaia-tracked`` label
+    is no longer consulted.
     """
-    return {"$or": [{"assignee": ASSIGNEE_GAIA}, {"labels": GAIA_TRACKED_LABEL}]}
+    return {"assignee": ASSIGNEE_GAIA}
 
 
 def user_assigned_filter() -> dict[str, Any]:
-    """Mongo fragment excluding GAIA-assigned todos (inverse of dual-read).
+    """Mongo fragment excluding GAIA-assigned todos (matches user todos).
 
-    Matches user todos: ``assignee != "gaia"`` (covers unmigrated docs with no
-    ``assignee`` field) AND no legacy ``gaia-tracked`` label.
+    ``assignee != "gaia"`` also matches unmigrated docs with no ``assignee``
+    field, which are user todos by default.
     """
-    return {"assignee": {"$ne": ASSIGNEE_GAIA}, "labels": {"$nin": [GAIA_TRACKED_LABEL]}}
+    return {"assignee": {"$ne": ASSIGNEE_GAIA}}
 
 
 # --- Facets --------------------------------------------------------------

--- a/apps/api/app/db/mongodb/indexes.py
+++ b/apps/api/app/db/mongodb/indexes.py
@@ -249,10 +249,22 @@ async def create_todo_indexes():
                 [("user_id", 1), ("project_id", 1), ("due_date", 1)],
                 name="user_project_due",
             ),
-            # For tracked-todo cron sweeps (safety-net + maintenance). Both
-            # scan by gaia-tracked label + completion, then range on
-            # scheduled_at / gaia_retry_count. ESR ordering: equality fields
-            # first (labels, completed), then range fields.
+            # For tracked-todo cron sweeps (safety-net + maintenance). Both now
+            # scan by assignee + completion, then range on scheduled_at /
+            # gaia_retry_count. ESR ordering: equality fields first (assignee,
+            # completed), then range fields.
+            todos_collection.create_index(
+                [
+                    ("assignee", 1),
+                    ("completed", 1),
+                    ("scheduled_at", 1),
+                    ("gaia_retry_count", 1),
+                ],
+                name="tracked_sweep_assignee",
+            ),
+            # Legacy label-based sweep index. Superseded by tracked_sweep_assignee
+            # once the assignee backfill (scripts/migrate_todo_assignee.py) has run
+            # everywhere — safe to drop then.
             todos_collection.create_index(
                 [
                     ("labels", 1),

--- a/apps/api/app/models/briefing_models.py
+++ b/apps/api/app/models/briefing_models.py
@@ -10,9 +10,10 @@ from datetime import UTC, datetime
 from typing import Literal
 import uuid
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.constants.briefing import BRIEFING_KIND_DAILY, HUE_MAX
+from app.constants.notifications import DEFAULT_CHAT_CHANNEL_PRIORITY
 
 BriefingKind = Literal["daily", "weekly"]
 
@@ -103,3 +104,25 @@ class BriefingListResponse(BaseModel):
     """Archive response shape (frontend is coded against this)."""
 
     briefings: list[BriefingModel]
+
+
+class ChannelPriorityResponse(BaseModel):
+    """The user's briefing chat-channel priority order (settings UI reads this)."""
+
+    chat_channel_priority: list[str]
+
+
+class ChannelPriorityUpdate(BaseModel):
+    """A non-empty, duplicate-free ordered subset of the four chat platforms."""
+
+    chat_channel_priority: list[str] = Field(min_length=1)
+
+    @field_validator("chat_channel_priority")
+    @classmethod
+    def _validate_platforms(cls, value: list[str]) -> list[str]:
+        if len(set(value)) != len(value):
+            raise ValueError("chat_channel_priority must not contain duplicates")
+        unknown = [p for p in value if p not in DEFAULT_CHAT_CHANNEL_PRIORITY]
+        if unknown:
+            raise ValueError(f"unknown chat platform(s): {', '.join(unknown)}")
+        return value

--- a/apps/api/app/models/todo_models.py
+++ b/apps/api/app/models/todo_models.py
@@ -139,6 +139,10 @@ class TodoBase(BaseModel):
         default=0,
         description="Number of failed execution attempts (managed by system)",
     )
+    gaia_user_retry_count: int = Field(
+        default=0,
+        description="Number of times the user has manually retried this todo after failure (capped by MAX_GAIA_USER_RETRIES)",
+    )
     expires_at: datetime | None = Field(
         default=None,
         description="When this todo becomes irrelevant regardless of completion (LLM-set relevance window)",
@@ -193,6 +197,10 @@ class TodoBase(BaseModel):
     gaia_offer: str | None = Field(
         default=None,
         description="Silent-classification offer to hand a user todo to GAIA (non-blocking affordance, no notification).",
+    )
+    gaia_offer_dismissed: bool = Field(
+        default=False,
+        description="Set when the user dismisses the gaia_offer affordance; suppresses it on every surface.",
     )
     pitch_expires_at: datetime | None = Field(
         default=None,

--- a/apps/api/app/services/briefing/chat_sync.py
+++ b/apps/api/app/services/briefing/chat_sync.py
@@ -33,39 +33,46 @@ MAX_REPLY_LINES = 10
 MAX_REPLY_CHARS = 200
 
 
+async def persist_bot_message(user_id: str, user: dict, platform: str, parts: list[str]) -> None:
+    """Append one assistant turn (``parts``, joined) to a platform's bot conversation.
+
+    The bot never sees GAIA's outbound in its own history (platform delivery is
+    fire-and-forget), so this writes it in so the user's next reply lands with
+    context. Best-effort: the message is already delivered, so a history-sync
+    failure must not fail (and re-send) the caller's flow — log it.
+    """
+    if not parts:
+        return
+    linked = await PlatformLinkService.get_linked_platforms(user_id)
+    platform_user_id = (linked.get(platform) or {}).get("platformUserId")
+    if not platform_user_id:
+        return
+    date_iso = datetime.now(UTC).isoformat()
+    try:
+        # Resolve through bot_sessions (never cache): /new re-mints the id.
+        conversation_id = await BotService.get_or_create_session(
+            platform, str(platform_user_id), None, user
+        )
+        await update_messages(
+            UpdateMessagesRequest(
+                conversation_id=conversation_id,
+                messages=[MessageModel(type="bot", response="\n\n".join(parts), date=date_iso)],
+            ),
+            {"user_id": user_id},
+        )
+    except Exception as e:
+        log.warning("briefing.chat_sync_failed", user_id=user_id, platform=platform, error=str(e))
+
+
 async def persist_delivered_brief(
     user_id: str, user: dict, parts: list[str], channels: list[str]
 ) -> None:
-    """Append the delivered brief to each bot platform's conversation history.
-
-    Best-effort by design: the brief is already persisted and delivered, so a
-    history-sync failure must not fail (and re-send) the whole run — log it.
-    """
+    """Append the delivered brief to each bot platform's conversation history."""
     platforms = [c for c in channels if ConversationSource.coerce(c) in BOT_CONVERSATION_SOURCES]
     if not platforms or not parts:
         return
-    linked = await PlatformLinkService.get_linked_platforms(user_id)
-    date_iso = datetime.now(UTC).isoformat()
     for platform in platforms:
-        platform_user_id = (linked.get(platform) or {}).get("platformUserId")
-        if not platform_user_id:
-            continue
-        try:
-            # Resolve through bot_sessions (never cache): /new re-mints the id.
-            conversation_id = await BotService.get_or_create_session(
-                platform, str(platform_user_id), None, user
-            )
-            await update_messages(
-                UpdateMessagesRequest(
-                    conversation_id=conversation_id,
-                    messages=[MessageModel(type="bot", response="\n\n".join(parts), date=date_iso)],
-                ),
-                {"user_id": user_id},
-            )
-        except Exception as e:
-            log.warning(
-                "briefing.chat_sync_failed", user_id=user_id, platform=platform, error=str(e)
-            )
+        await persist_bot_message(user_id, user, platform, parts)
 
 
 async def format_replies_block(user_id: str, since: datetime) -> str:

--- a/apps/api/app/services/briefing/context.py
+++ b/apps/api/app/services/briefing/context.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 
 from app.constants.briefing import BRIEFING_KIND_DAILY, WINBACK_THRESHOLD
 from app.constants.todos import (
+    ASSIGNEE_GAIA,
     FACET_NOTES,
     facet_from_doc,
     gaia_assigned_filter,
@@ -26,6 +27,7 @@ from app.memory.engine import memory_engine
 from app.memory.mappers import entry_to_note
 from app.models.briefing_models import BriefingMood
 from app.models.todo_models import ExecutionStatus
+from app.services.briefing import dormancy
 from shared.py.wide_events import log
 
 # GAIA todos that are live work (shown in the plan block).
@@ -98,11 +100,20 @@ async def get_yesterday_payload(
     return doc.get("payload") if doc else None
 
 
+# Users type junk into onboarding ("nothing", "n/a"); junk is not a goal.
+_JUNK_FOCUS_VALUES = {"nothing", "none", "n/a", "na", "-", "idk", "no"}
+
+
+def has_meaningful_focus(focus: str | None) -> bool:
+    """Whether the onboarding focus is a real stated goal (not blank or junk)."""
+    cleaned = (focus or "").strip()
+    return bool(cleaned) and cleaned.lower() not in _JUNK_FOCUS_VALUES
+
+
 async def format_goal_block(user_id: str, user: dict) -> tuple[str, bool]:
     """Return (formatted goal block, has_goal). ``has_goal`` gates cold-start."""
     focus = ((user.get("onboarding") or {}).get("focus") or "").strip()
-    # Users type junk into onboarding ("nothing", "n/a"); junk is not a goal.
-    if focus.lower() in {"nothing", "none", "n/a", "na", "-", "idk", "no"}:
+    if not has_meaningful_focus(focus):
         focus = ""
     lines: list[str] = []
     if focus:
@@ -222,6 +233,7 @@ async def gather_goal_lanes(user_id: str, since: datetime) -> list[GoalLane]:
                 "notes_content": 1,
                 "canvas_content": 1,
                 "completed_at": 1,
+                "created_at": 1,
                 "error_message": 1,
             },
         ):
@@ -298,7 +310,7 @@ async def gather_completed_since(
         {"user_id": user_id, "completed_at": {"$gte": since}}, projection
     )
     async for doc in cursor:
-        is_gaia = doc.get("assignee") == "gaia" or "gaia-tracked" in doc.get("labels", [])
+        is_gaia = doc.get("assignee") == ASSIGNEE_GAIA
         (work.gaia if is_gaia else work.user).append(doc)
     return work
 
@@ -383,8 +395,14 @@ async def format_lookback_block(
 async def compute_winback_state(user_id: str, recent: int = 10) -> WinbackState:
     """Count consecutive most-recent daily briefings the user never acknowledged.
 
-    Acknowledgement is honest and channel-agnostic: the briefing was opened, OR a
-    real todo completed after it went out (the user acted on the loop).
+    Acknowledgement is honest and channel-agnostic: the briefing was opened, OR the
+    user was active since it went out (a reactivation signal — goal created, session
+    active, or any message). A todo completing is deliberately NOT an ack: GAIA's
+    night shift completes its own todos autonomously, so counting completions would
+    let GAIA acknowledge its own briefings and winback would never fire.
+
+    The loop breaks at the first acknowledged briefing, so the reactivation-signal
+    lookup runs only for the unacknowledged tail (at most one extra call past it).
     """
     briefings = (
         await briefings_collection.find(
@@ -398,17 +416,13 @@ async def compute_winback_state(user_id: str, recent: int = 10) -> WinbackState:
     if not briefings:
         return WinbackState(unacknowledged=0, last_was_winback=False)
 
-    latest_completion = await todos_collection.find_one(
-        {"user_id": user_id, "completed_at": {"$ne": None}},
-        {"completed_at": 1},
-        sort=[("completed_at", -1)],
-    )
-    last_completed_at = latest_completion.get("completed_at") if latest_completion else None
-
     unacknowledged = 0
     for doc in briefings:
-        acknowledged = doc.get("opened_at") is not None or (
-            last_completed_at is not None and last_completed_at > doc["created_at"]
+        created_at = doc["created_at"]
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+        acknowledged = doc.get("opened_at") is not None or await dormancy.reactivation_signal_since(
+            user_id, created_at
         )
         if acknowledged:
             break

--- a/apps/api/app/services/briefing/delivery_channels.py
+++ b/apps/api/app/services/briefing/delivery_channels.py
@@ -1,0 +1,74 @@
+"""Briefing delivery-channel resolution.
+
+A briefing goes to a SINGLE chat platform, not every linked one: in-app always,
+plus the first chat platform in the user's priority order that is both linked and
+enabled, plus email when enabled and the user has an address. Passing this as the
+explicit channel list turns off the orchestrator's all-platforms auto-inject (the
+triple-delivery bug); generic notifications keep the auto-inject fan-out.
+"""
+
+from bson import ObjectId
+
+from app.constants.notifications import (
+    CHANNEL_TYPE_EMAIL,
+    CHANNEL_TYPE_INAPP,
+    DEFAULT_CHAT_CHANNEL_PRIORITY,
+)
+from app.db.mongodb.collections import users_collection
+from app.services.platform_link_service import PlatformLinkService
+from app.utils.notification.channel_preferences import fetch_channel_preferences
+
+# The four chat platforms a priority list may contain — the same set the priority
+# endpoint validates against, so a stale doc can never route a brief elsewhere.
+VALID_CHAT_PLATFORMS: frozenset[str] = frozenset(DEFAULT_CHAT_CHANNEL_PRIORITY)
+
+
+def resolve_channel_priority(user: dict) -> list[str]:
+    """The user's stored briefing chat-channel priority, or the default order.
+
+    Drops any stored entry that is not one of the four chat platforms so a
+    hand-edited or legacy document can never route a brief to an unknown channel.
+    """
+    stored = user.get("briefing_channel_priority")
+    if isinstance(stored, list):
+        cleaned = [p for p in stored if p in VALID_CHAT_PLATFORMS]
+        if cleaned:
+            return cleaned
+    return list(DEFAULT_CHAT_CHANNEL_PRIORITY)
+
+
+async def resolve_briefing_channels(user_id: str, user: dict) -> list[str]:
+    """The explicit channels one briefing delivers to.
+
+    Always in-app; plus the first chat platform in the user's priority order that
+    is both linked and preference-enabled; plus email when enabled and the user
+    has an address on file.
+    """
+    channels = [CHANNEL_TYPE_INAPP]
+
+    prefs = await fetch_channel_preferences(user_id)
+    linked = await PlatformLinkService.get_linked_platforms(user_id)
+    for platform in resolve_channel_priority(user):
+        if platform in linked and prefs.get(platform, True):
+            channels.append(platform)
+            break
+
+    if prefs.get(CHANNEL_TYPE_EMAIL, True) and (user.get("email") or "").strip():
+        channels.append(CHANNEL_TYPE_EMAIL)
+
+    return channels
+
+
+async def get_channel_priority(user_id: str) -> list[str]:
+    """The stored (or default) briefing chat-channel priority for a user."""
+    user = await users_collection.find_one(
+        {"_id": ObjectId(user_id)}, {"briefing_channel_priority": 1}
+    )
+    return resolve_channel_priority(user or {})
+
+
+async def set_channel_priority(user_id: str, priority: list[str]) -> None:
+    """Persist a user's briefing chat-channel priority order."""
+    await users_collection.update_one(
+        {"_id": ObjectId(user_id)}, {"$set": {"briefing_channel_priority": priority}}
+    )

--- a/apps/api/app/services/briefing/dormancy.py
+++ b/apps/api/app/services/briefing/dormancy.py
@@ -64,7 +64,14 @@ def wind_down_stage(idle_days: int) -> str | None:
 
 
 async def reactivation_signal_since(user_id: str, since: datetime) -> bool:
-    """True when the user did anything since ``since`` that should wake the loop."""
+    """True when the user did anything since ``since`` that should wake the loop.
+
+    This is the canonical "the user was active since T" predicate: a goal created,
+    authenticated activity (``last_active_at``), or any user message in any
+    conversation. Shared by the dormancy ladder (wake a paused loop) and winback
+    acknowledgement (``context.compute_winback_state``) so the two never diverge on
+    what counts as the user showing up. ``since`` must be timezone-aware.
+    """
     goal = await todos_collection.find_one(
         {"user_id": user_id, "kind": "goal", "created_at": {"$gte": since}}, {"_id": 1}
     )

--- a/apps/api/app/services/briefing/rollout.py
+++ b/apps/api/app/services/briefing/rollout.py
@@ -1,10 +1,10 @@
 """Existing-user rollout — no cold starts.
 
-For each existing user: provision the briefing workflows, then announce on all
-connected channels. Users we can derive a goal for get a normal "briefings are
-here" announcement and a real first briefing next morning; users we can't get a
-short bootstrap interview and their briefings are held (``briefing_bootstrap``
-marker) until a goal memory arrives or the grace window elapses.
+For each existing user: provision the briefing workflows. Users we can derive a
+goal for get a real first briefing next morning; sparse users with no derivable
+goal have their briefings held (``briefing_bootstrap`` marker) until a goal
+memory arrives or the grace window elapses. The user-facing announcement is a
+manual email, not an in-app notification, so this only provisions and gates.
 """
 
 from datetime import UTC, datetime
@@ -17,40 +17,16 @@ from app.db.mongodb.collections import (
     user_integrations_collection,
     users_collection,
 )
-from app.models.notification.notification_models import (
-    NotificationContent,
-    NotificationRequest,
-    NotificationSourceEnum,
-    NotificationType,
-)
 from app.services.briefing import context
 from app.services.briefing.service import BOOTSTRAP_FIELD
-from app.services.notification_service import notification_service
 from app.services.system_workflows.provisioner import provision_briefing_workflows
 from app.services.user_service import get_user_by_id
 from app.utils.analytics import track
 from shared.py.wide_events import log
 
-# When we can't derive a goal AND the account is this sparse, interview instead
-# of guessing.
+# When we can't derive a goal AND the account is this sparse, hold for bootstrap
+# instead of guessing a goal.
 _SPARSE_INTEGRATION_MAX = 1
-
-_ANNOUNCE_TITLE = "Your daily briefing starts tomorrow"
-_ANNOUNCE_BODY = (
-    "Every morning I'll curate your list, look back at what shipped, and plan the "
-    "day in one short brief — with work a single reply releases. First one lands "
-    "tomorrow morning. Change the time or turn it off anytime in your workflows."
-)
-
-_BOOTSTRAP_TITLE = "Let's set up your daily briefing"
-_BOOTSTRAP_BODY = (
-    "I'm about to start sending you a morning brief. Three quick things so it's "
-    "actually useful:\n"
-    "1. What are you working on right now?\n"
-    "2. What should I take off your plate?\n"
-    "3. What hour do you want your briefing?\n"
-    "Reply here and your first brief lands the next morning."
-)
 
 
 async def _is_sparse_account(user_id: str) -> bool:
@@ -63,26 +39,14 @@ async def _is_sparse_account(user_id: str) -> bool:
     return gaia_todos == 0
 
 
-async def _announce(user_id: str, title: str, body: str) -> None:
-    await notification_service.create_notification(
-        NotificationRequest(
-            user_id=user_id,
-            source=NotificationSourceEnum.BACKGROUND_JOB,
-            type=NotificationType.INFO,
-            priority=2,
-            content=NotificationContent(title=title, body=body),
-            metadata={"briefing_announcement": True},
-        )
-    )
-
-
-async def announce_and_provision(user_id: str) -> str:
+async def provision_existing_user(user_id: str) -> str:
     """Roll out briefings to one existing user. Returns the path taken.
 
-    ``"normal"`` — goal derivable, standard announcement, briefings begin next day.
-    ``"bootstrap"`` — sparse + no goal, interview announcement, briefings held.
+    ``"normal"`` — goal derivable, briefings begin next day.
+    ``"bootstrap"`` — sparse + no goal, briefings held until a goal arrives or the
+    grace window elapses.
     """
-    log.set(service="briefing_rollout", operation="announce_and_provision", user_id=user_id)
+    log.set(service="briefing_rollout", operation="provision_existing_user", user_id=user_id)
     user = await get_user_by_id(user_id)
     if not user:
         log.warning("briefing_rollout.unknown_user", user_id=user_id)
@@ -97,10 +61,8 @@ async def announce_and_provision(user_id: str) -> str:
             {"_id": ObjectId(user_id)},
             {"$set": {BOOTSTRAP_FIELD: {"pending": True, "since": datetime.now(UTC)}}},
         )
-        await _announce(user_id, _BOOTSTRAP_TITLE, _BOOTSTRAP_BODY)
-        track(user_id, "briefing_announced", {"path": "bootstrap"})
+        track(user_id, "briefing_provisioned", {"path": "bootstrap"})
         return "bootstrap"
 
-    await _announce(user_id, _ANNOUNCE_TITLE, _ANNOUNCE_BODY)
-    track(user_id, "briefing_announced", {"path": "normal"})
+    track(user_id, "briefing_provisioned", {"path": "normal"})
     return "normal"

--- a/apps/api/app/services/briefing/service.py
+++ b/apps/api/app/services/briefing/service.py
@@ -31,7 +31,7 @@ from app.constants.notifications import (
     NOTIFICATION_KIND_BRIEFING_DAILY,
     NOTIFICATION_KIND_BRIEFING_WEEKLY,
 )
-from app.constants.todos import FACET_DELIVERABLE, facet_from_doc
+from app.constants.todos import FACET_DELIVERABLE, PROPOSAL_TTL_HOURS, facet_from_doc
 from app.db.mongodb.collections import users_collection
 from app.models.briefing_models import BriefingKind, BriefingModel, BriefingPayload
 from app.models.message_models import MessageDict, MessageRequestWithHistory
@@ -39,6 +39,7 @@ from app.models.notification.notification_models import (
     ActionConfig,
     ActionStyle,
     ActionType,
+    ChannelConfig,
     NotificationAction,
     NotificationContent,
     NotificationRequest,
@@ -47,7 +48,7 @@ from app.models.notification.notification_models import (
     RedirectConfig,
 )
 from app.models.todo_models import ExecutionStatus
-from app.services.briefing import chat_sync, context, dormancy, repository
+from app.services.briefing import chat_sync, context, delivery_channels, dormancy, repository
 from app.services.briefing.badges import check_and_award_badges
 from app.services.briefing.context import UserClock
 from app.services.notification_service import notification_service
@@ -303,22 +304,30 @@ def _platform_parts(payload: BriefingPayload) -> list[str]:
 
 
 async def _deliver(
-    user_id: str, briefing: BriefingModel, payload: BriefingPayload, notification_kind: str
+    user_id: str,
+    user: dict,
+    briefing: BriefingModel,
+    payload: BriefingPayload,
+    notification_kind: str,
 ) -> list[str]:
     """Fan out the briefing via the notification orchestrator (in-app + platforms).
 
-    ``metadata.kind`` selects the email template and ``content.rich_content``
-    carries the full payload the email adapter renders — both are the delivery
-    contract the channels layer keys off (without them email falls back to the
-    plain template).
+    Channels are resolved to a single chat platform (per the user's priority) plus
+    in-app and email, then passed explicitly — which suppresses the orchestrator's
+    all-platforms auto-inject so one brief never triple-delivers. ``metadata.kind``
+    selects the email template and ``content.rich_content`` carries the full
+    payload the email adapter renders — both are the delivery contract the channels
+    layer keys off (without them email falls back to the plain template).
     """
     platform_parts = _platform_parts(payload)
+    resolved = await delivery_channels.resolve_briefing_channels(user_id, user)
     record = await notification_service.create_notification(
         NotificationRequest(
             user_id=user_id,
             source=NotificationSourceEnum.BACKGROUND_JOB,
             type=NotificationType.INFO,
             priority=2,
+            channels=[ChannelConfig(channel_type=channel) for channel in resolved],
             content=NotificationContent(
                 title=payload.headline,
                 body=_delivery_body(payload),
@@ -350,8 +359,18 @@ async def _deliver(
     return channels or ["inapp"]
 
 
+def _expires_within_a_day(created_at: datetime | None, now: datetime) -> bool:
+    """True when a staged proposal's PROPOSAL_TTL expiry falls within 24h of now."""
+    if created_at is None:
+        return False
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+    return created_at + timedelta(hours=PROPOSAL_TTL_HOURS) - now <= timedelta(hours=24)
+
+
 def _lane_items(lane: context.GoalLane) -> list[dict]:
     """Code-built items for one goal lane. Truth by construction."""
+    now = datetime.now(UTC)
     items: list[dict] = []
     for d in lane.completed:
         items.append(
@@ -362,9 +381,12 @@ def _lane_items(lane: context.GoalLane) -> list[dict]:
             }
         )
     for d in lane.staged:
+        expiry = (
+            " (expires within a day)" if _expires_within_a_day(d.get("created_at"), now) else ""
+        )
         items.append(
             {
-                "text": f"Staged and ready: {d.get('title')} — a reply releases it.",
+                "text": f"Staged and ready: {d.get('title')}{expiry} — a reply releases it.",
                 "todo_id": str(d["_id"]),
                 "kind": "proposal",
             }
@@ -645,7 +667,7 @@ async def run_daily_briefing(user_id: str) -> None:
     briefing = await repository.upsert_briefing(
         user_id, clock.date_str, BRIEFING_KIND_DAILY, payload
     )
-    channels = await _deliver(user_id, briefing, payload, NOTIFICATION_KIND_BRIEFING_DAILY)
+    channels = await _deliver(user_id, user, briefing, payload, NOTIFICATION_KIND_BRIEFING_DAILY)
     await repository.set_delivered_channels(user_id, clock.date_str, BRIEFING_KIND_DAILY, channels)
     # The bot's conversation must contain the brief it "sent", so replies like
     # "yeah send them" land with real context instead of a cold thread.
@@ -702,7 +724,7 @@ async def run_weekly_digest(user_id: str) -> None:
     briefing = await repository.upsert_briefing(
         user_id, clock.date_str, BRIEFING_KIND_WEEKLY, payload
     )
-    channels = await _deliver(user_id, briefing, payload, NOTIFICATION_KIND_BRIEFING_WEEKLY)
+    channels = await _deliver(user_id, user, briefing, payload, NOTIFICATION_KIND_BRIEFING_WEEKLY)
     await repository.set_delivered_channels(user_id, clock.date_str, BRIEFING_KIND_WEEKLY, channels)
     await chat_sync.persist_delivered_brief(user_id, user, _platform_parts(payload), channels)
 

--- a/apps/api/app/services/dashboard_service.py
+++ b/apps/api/app/services/dashboard_service.py
@@ -94,6 +94,7 @@ async def _suggested(user_id: str, start: datetime, end: datetime) -> list[dict[
         "user_id": user_id,
         "completed": False,
         "gaia_offer": {"$nin": [None, ""]},
+        "gaia_offer_dismissed": {"$ne": True},
         "$nor": [
             {"due_date": {"$gte": start, "$lt": end}},
             {"scheduled_at": {"$gte": start, "$lt": end}},
@@ -118,7 +119,8 @@ async def _your_tasks(user_id: str, start: datetime, end: datetime) -> list[dict
         {
             **_base_item(doc),
             "due_at": _iso(doc.get("due_date") or doc.get("scheduled_at")),
-            "gaia_offer": doc.get("gaia_offer"),
+            # A dismissed offer keeps the task but drops its handoff tag.
+            "gaia_offer": None if doc.get("gaia_offer_dismissed") else doc.get("gaia_offer"),
         }
         async for doc in cursor
     ]

--- a/apps/api/app/services/first_steps_service.py
+++ b/apps/api/app/services/first_steps_service.py
@@ -1,6 +1,6 @@
 """Activation checklist (first-steps widget) progress.
 
-Progress derives from real signals — route visits, integration connects,
+Progress derives from real signals — a stated goal, integration connects,
 platform links, the first Approve — never self-report. Steps satisfied before
 the widget ever rendered are pre-checked on first read so long-time users
 aren't asked to redo history.
@@ -12,24 +12,39 @@ from typing import Any
 from bson import ObjectId
 
 from app.constants.integrations import INTEGRATION_STATUS_CONNECTED
-from app.db.mongodb.collections import user_integrations_collection, users_collection
+from app.constants.todos import ASSIGNEE_GAIA
+from app.db.mongodb.collections import (
+    todos_collection,
+    user_integrations_collection,
+    users_collection,
+)
+from app.models.todo_models import ExecutionStatus
+from app.services.briefing.context import has_meaningful_focus
 from app.utils.analytics import track
 
-STEP_EXPLORE_WORKFLOWS = "explore_workflows"
+STEP_TELL_GAIA_GOAL = "tell_gaia_goal"
 STEP_CONNECT_INTEGRATION = "connect_integration"
-STEP_LINK_TELEGRAM = "link_telegram"
+STEP_LINK_PLATFORM = "link_platform"
 STEP_VISIT_DASHBOARD = "visit_dashboard"
 STEP_FIRST_APPROVE = "first_approve"
 STEP_DISMISSED_ALL = "dismissed_all"
 
 ALL_STEPS: tuple[str, ...] = (
-    STEP_EXPLORE_WORKFLOWS,
+    STEP_TELL_GAIA_GOAL,
     STEP_CONNECT_INTEGRATION,
-    STEP_LINK_TELEGRAM,
+    STEP_LINK_PLATFORM,
     STEP_VISIT_DASHBOARD,
     STEP_FIRST_APPROVE,
 )
 _VALID_STEPS: frozenset[str] = frozenset((*ALL_STEPS, STEP_DISMISSED_ALL))
+
+# A proposal is any GAIA todo that entered the approval lifecycle. queued/running
+# work never needs a tap, so it doesn't imply the user has anything to approve.
+_PROPOSAL_HISTORY_STATUSES = (
+    ExecutionStatus.PROPOSED.value,
+    ExecutionStatus.DISMISSED.value,
+    ExecutionStatus.EXPIRED.value,
+)
 
 
 async def mark_step(user_id: str, step: str) -> None:
@@ -44,20 +59,45 @@ async def mark_step(user_id: str, step: str) -> None:
         track(user_id, "first_steps_step_done", {"step": step})
 
 
+async def hide_step(user_id: str, step: str) -> None:
+    """Hide a single checklist row server-side (persists across browsers)."""
+    if step not in ALL_STEPS:
+        return
+    await users_collection.update_one(
+        {"_id": ObjectId(user_id)},
+        {"$addToSet": {"first_steps.hidden_steps": step}},
+    )
+
+
 async def get_steps(user_id: str) -> dict[str, Any]:
     """Current progress, pre-checking steps already satisfied by existing state."""
-    user = await users_collection.find_one({"_id": ObjectId(user_id)}, {"first_steps": 1}) or {}
-    steps: dict[str, Any] = user.get("first_steps", {})
-
-    if STEP_LINK_TELEGRAM not in steps:
-        # Read the link field directly (importing PlatformLinkService here would
-        # create a cycle — it marks steps on link_account).
-        doc = await users_collection.find_one(
-            {"_id": ObjectId(user_id)}, {"platform_links.telegram": 1}
+    user = (
+        await users_collection.find_one(
+            {"_id": ObjectId(user_id)},
+            {"first_steps": 1, "onboarding": 1, "platform_links": 1},
         )
-        if (doc or {}).get("platform_links", {}).get("telegram", {}).get("id"):
-            await mark_step(user_id, STEP_LINK_TELEGRAM)
-            steps[STEP_LINK_TELEGRAM] = datetime.now(UTC)
+        or {}
+    )
+    steps: dict[str, Any] = dict(user.get("first_steps") or {})
+    now = datetime.now(UTC)
+
+    if STEP_TELL_GAIA_GOAL not in steps:
+        # A real onboarding goal, or any goal-kind todo, counts as "told GAIA".
+        focus = (user.get("onboarding") or {}).get("focus")
+        has_goal_todo = await todos_collection.find_one(
+            {"user_id": user_id, "kind": "goal"}, {"_id": 1}
+        )
+        if has_meaningful_focus(focus) or has_goal_todo:
+            await mark_step(user_id, STEP_TELL_GAIA_GOAL)
+            steps[STEP_TELL_GAIA_GOAL] = now
+
+    if STEP_LINK_PLATFORM not in steps:
+        # Any linked chat platform satisfies the step retroactively.
+        links = user.get("platform_links") or {}
+        if any(isinstance(v, dict) and v.get("id") for v in links.values()):
+            await mark_step(user_id, STEP_LINK_PLATFORM)
+            steps[STEP_LINK_PLATFORM] = now
+
     if STEP_CONNECT_INTEGRATION not in steps:
         # Any connected non-Gmail integration satisfies the step retroactively.
         connected = await user_integrations_collection.find_one(
@@ -69,9 +109,27 @@ async def get_steps(user_id: str) -> dict[str, Any]:
         )
         if connected:
             await mark_step(user_id, STEP_CONNECT_INTEGRATION)
-            steps[STEP_CONNECT_INTEGRATION] = datetime.now(UTC)
+            steps[STEP_CONNECT_INTEGRATION] = now
+
+    # The first_approve row is uncompletable until a proposal has ever existed,
+    # so the frontend hides it until this is true.
+    has_had_proposal = bool(steps.get(STEP_FIRST_APPROVE)) or (
+        await todos_collection.find_one(
+            {
+                "user_id": user_id,
+                "assignee": ASSIGNEE_GAIA,
+                "execution_status": {"$in": list(_PROPOSAL_HISTORY_STATUSES)},
+            },
+            {"_id": 1},
+        )
+        is not None
+    )
+
+    hidden_steps = [s for s in (steps.get("hidden_steps") or []) if s in ALL_STEPS]
 
     return {
         "steps": {step: steps[step].isoformat() if steps.get(step) else None for step in ALL_STEPS},
+        "hidden_steps": hidden_steps,
+        "has_had_proposal": has_had_proposal,
         "dismissed": STEP_DISMISSED_ALL in steps,
     }

--- a/apps/api/app/services/gaia_tasks_fs.py
+++ b/apps/api/app/services/gaia_tasks_fs.py
@@ -1,6 +1,6 @@
 """Mongo → VFS glue for ``/workspace/gaia-tasks/``.
 
-The Mongo side: ``todos`` collection, ``gaia-tracked`` label, 30-day
+The Mongo side: ``todos`` collection, ``assignee == "gaia"``, 30-day
 completion window.
 
 The VFS side: :mod:`app.services.storage.gaia_tasks_vfs`.
@@ -62,8 +62,8 @@ schedule_gaia_tasks_sync = make_scheduler(sync_user_gaia_tasks, log_name="gaia_t
 async def _fetch_active_projections(user_id: str) -> list[GaiaTaskProjection]:
     """Pull the user's active gaia-tasks from Mongo.
 
-    Filter: carries the ``gaia-tracked`` label AND (open OR completed
-    within the last 30 days).
+    Filter: ``assignee == "gaia"`` AND (open OR completed within the last
+    30 days).
     """
     cutoff = datetime.now(UTC) - timedelta(days=ACTIVE_WINDOW_DAYS)
     cursor = todos_collection.find(

--- a/apps/api/app/services/platform_link_service.py
+++ b/apps/api/app/services/platform_link_service.py
@@ -15,6 +15,24 @@ from bson import ObjectId
 
 from app.db.mongodb.collections import users_collection
 from app.services import first_steps_service
+from app.utils.redis_utils import RedisPoolManager
+from shared.py.wide_events import log
+
+
+async def _enqueue_day_zero_hello(user_id: str, platform: str) -> None:
+    """Best-effort: enqueue GAIA's first-hello job for a freshly linked chat
+    platform. The task guards itself to fire once per user, so a duplicate enqueue
+    is harmless; a Redis hiccup must not fail the link."""
+    try:
+        pool = await RedisPoolManager.get_pool()
+        await pool.enqueue_job("send_day_zero_hello", user_id, platform)
+    except Exception as e:
+        log.warning(
+            "platform_link.day_zero_enqueue_failed",
+            user_id=user_id,
+            platform=platform,
+            error=str(e),
+        )
 
 
 class Platform(str, Enum):
@@ -132,8 +150,15 @@ class PlatformLinkService:
             and user["platform_links"][platform].get("id") == platform_user_id
         )
 
-        if platform == Platform.TELEGRAM.value or platform == "telegram":
-            await first_steps_service.mark_step(user_id, first_steps_service.STEP_LINK_TELEGRAM)
+        # Any chat platform link satisfies the "link a platform" activation step.
+        await first_steps_service.mark_step(user_id, first_steps_service.STEP_LINK_PLATFORM)
+
+        # A brand-new chat link is the day-zero moment: greet the user once. The
+        # task guards itself (once ever, young account, still linked), so a
+        # same-id relink never re-greets.
+        if not previously_linked_same:
+            await _enqueue_day_zero_hello(user_id, platform)
+
         return {
             "status": "linked",
             "platform": platform,

--- a/apps/api/app/services/todos/activity.py
+++ b/apps/api/app/services/todos/activity.py
@@ -1,17 +1,20 @@
-"""Completed-work aggregation — the single source for streak + heatmap.
+"""Completed-work aggregation — the single source for the streak.
 
-Everything here derives from ``completed_at`` only: a day is green iff at least
-one todo (either assignee) completed that day in the user's timezone. Heartbeat
-activity (sweeps, syncs) never has a ``completed_at`` and so never counts — gray
-days stay honest, and there is no mechanism to pad or repair a streak. Both the
-dashboard heatmap endpoint and the briefing engine consume these helpers so the
-two surfaces can never disagree.
+Everything here derives from ``completed_at`` only. The streak counts a day iff
+the *user* completed at least one todo that day in their timezone: GAIA's night
+shift completes its own todos autonomously, so counting those would let GAIA pad
+the user's streak. ``DayCounts`` still carries ``gaia_count`` for display copy
+(the weekly digest narrates GAIA's work), but only ``user_count`` advances the
+streak. Heartbeat activity (sweeps, syncs) never has a ``completed_at`` and so
+never counts — gray days stay honest, and there is no mechanism to pad or repair a
+streak. The briefing engine and badges consume these helpers so no two surfaces
+can disagree.
 """
 
 from datetime import UTC, date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
-from app.constants.todos import ASSIGNEE_GAIA, GAIA_TRACKED_LABEL
+from app.constants.todos import ASSIGNEE_GAIA
 from app.db.mongodb.collections import todos_collection
 
 # date-iso -> {"user_count": n, "gaia_count": n}
@@ -22,8 +25,7 @@ DEFAULT_STREAK_LOOKBACK_DAYS = 366
 
 
 def _is_gaia(doc: dict) -> bool:
-    # Dual-read during the migration window (assignee field OR legacy label).
-    return doc.get("assignee") == ASSIGNEE_GAIA or GAIA_TRACKED_LABEL in doc.get("labels", [])
+    return doc.get("assignee") == ASSIGNEE_GAIA
 
 
 def window_start_utc(tz: ZoneInfo, days: int) -> datetime:
@@ -47,15 +49,16 @@ async def completed_day_counts(user_id: str, tz: ZoneInfo, since: datetime) -> D
 
 
 def streak_from_counts(counts: DayCounts, today: date, max_days: int) -> int:
-    """Consecutive days (ending today) with >=1 completion. Empty today is grace.
+    """Consecutive days (ending today) with >=1 user completion. Empty today is grace.
 
-    An empty *today* does not break the streak (the day isn't over); any earlier
-    empty day does. Mirrors the heatmap's honest-streak rule exactly.
+    Only the user's own completions count — GAIA's autonomous night-shift work
+    never advances the streak. An empty *today* does not break the streak (the day
+    isn't over); any earlier empty day does.
     """
     streak = 0
     for offset in range(max_days):
         bucket = counts.get((today - timedelta(days=offset)).isoformat())
-        if bucket and (bucket["user_count"] + bucket["gaia_count"]) > 0:
+        if bucket and bucket["user_count"] > 0:
             streak += 1
         elif offset == 0:
             continue

--- a/apps/api/app/services/todos/gaia_todo_lifecycle.py
+++ b/apps/api/app/services/todos/gaia_todo_lifecycle.py
@@ -23,15 +23,17 @@ from app.api.v1.middleware.tiered_rate_limiter import (
     tiered_limiter,
 )
 from app.constants.memory import MemorySourceType
+from app.constants.notifications import NOTIFICATION_KIND_TODO_NEEDS_YOU
 from app.constants.todos import (
     ASSIGNEE_GAIA,
     DELIVERABLE_TEMPLATE,
     FACET_LOG,
     FACET_NOTES,
+    FAILED_LABEL,
     GAIA_TODO_EXECUTIONS_FEATURE,
-    GAIA_TRACKED_LABEL,
     MAX_ACTIVE_GOALS,
     MAX_GAIA_TODOS_IN_FLIGHT,
+    MAX_GAIA_USER_RETRIES,
     MAX_PENDING_PROPOSALS,
     NOTES_TEMPLATE,
     PITCH_TTL_DAYS,
@@ -43,10 +45,22 @@ from app.constants.todos import (
 from app.core.websocket_manager import WebSocketManager
 from app.db.mongodb.collections import todos_collection
 from app.memory.engine import memory_engine
+from app.models.notification.notification_models import (
+    ActionConfig,
+    ActionStyle,
+    ActionType,
+    NotificationAction,
+    NotificationContent,
+    NotificationRequest,
+    NotificationSourceEnum,
+    NotificationType,
+    RedirectConfig,
+)
 from app.models.payment_models import PlanType
 from app.models.todo_models import ExecutionStatus
 from app.services import first_steps_service
 from app.services.gaia_tasks_fs import schedule_gaia_tasks_sync
+from app.services.notification_service import notification_service
 from app.services.todo_canvas_storage import append_facet, build_vfs_label
 from app.utils.analytics import track
 from app.utils.redis_utils import RedisPoolManager
@@ -59,7 +73,7 @@ IN_FLIGHT_STATUSES: tuple[str, ...] = (
     ExecutionStatus.NEEDS_YOU.value,
 )
 # Labels that are system bookkeeping, never a proposal "kind".
-_RESERVED_KIND_LABELS: frozenset[str] = frozenset({GAIA_TRACKED_LABEL, "failed"})
+_RESERVED_KIND_LABELS: frozenset[str] = frozenset({FAILED_LABEL})
 
 
 class GaiaTodoError(Exception):
@@ -122,8 +136,7 @@ def _build_upgrade_pitch(doc: dict) -> str:
 
 
 def _is_gaia_assigned(doc: dict) -> bool:
-    # Dual-read during the migration window (legacy label OR assignee field).
-    return doc.get("assignee") == ASSIGNEE_GAIA or GAIA_TRACKED_LABEL in doc.get("labels", [])
+    return doc.get("assignee") == ASSIGNEE_GAIA
 
 
 async def _get_gaia_todo(todo_id: str, user_id: str) -> dict:
@@ -493,8 +506,54 @@ async def mark_execution_status(
     )
     if status == ExecutionStatus.DONE:
         track(user_id, "gaia_todo_completed", {"todo_id": todo_id})
+    if status == ExecutionStatus.NEEDS_YOU:
+        # Fires for both entry points into needs_you — the agent's ``block`` and
+        # the release honesty gate both route here, so a paused run always pings.
+        await _notify_needs_you(todo_id, user_id, blocker_question)
     await _broadcast_status(user_id, todo_id, status.value)
     schedule_gaia_tasks_sync(user_id)
+
+
+async def _notify_needs_you(todo_id: str, user_id: str, blocker_question: str | None) -> None:
+    """Push a notification when a run pauses on the user (default channel fan-out).
+
+    Best-effort: the transition is already persisted and broadcast over the
+    websocket, so a delivery failure only delays the ping — log it, never raise.
+    """
+    doc = await todos_collection.find_one(
+        {"_id": ObjectId(todo_id), "user_id": user_id}, {"title": 1}
+    )
+    title = (doc or {}).get("title", "your todo")
+    body = (blocker_question or "").strip() or "GAIA needs a decision from you to continue."
+    try:
+        await notification_service.create_notification(
+            NotificationRequest(
+                user_id=user_id,
+                source=NotificationSourceEnum.AI_AGENT,
+                type=NotificationType.WARNING,
+                content=NotificationContent(
+                    title=f"GAIA needs you: {title}",
+                    body=body,
+                    actions=[
+                        NotificationAction(
+                            type=ActionType.REDIRECT,
+                            label="Open todo",
+                            style=ActionStyle.PRIMARY,
+                            config=ActionConfig(
+                                redirect=RedirectConfig(
+                                    url=f"/todos?todoId={todo_id}",
+                                    open_in_new_tab=False,
+                                    close_notification=True,
+                                )
+                            ),
+                        )
+                    ],
+                ),
+                metadata={"kind": NOTIFICATION_KIND_TODO_NEEDS_YOU, "todo_id": todo_id},
+            )
+        )
+    except Exception as e:
+        log.warning("gaia_todo.needs_you_notification_failed", todo_id=todo_id, error=str(e))
 
 
 async def block(todo_id: str, user_id: str, question: str) -> None:
@@ -553,6 +612,46 @@ async def answer(todo_id: str, user_id: str, answer_text: str, channel: str = "w
         todo_id, user_id, "answered", f"User answered via {channel}: {answer_text[:200]}"
     )
     track(user_id, "todo_answered", {"todo_id": todo_id, "channel": channel})
+    await _broadcast_status(user_id, todo_id, ExecutionStatus.QUEUED.value)
+    schedule_gaia_tasks_sync(user_id)
+
+
+async def retry(todo_id: str, user_id: str, channel: str = "web") -> None:
+    """Re-run a failed todo: the only ``failed → queued`` path.
+
+    Clears the failure state the execution loop reads (the ``failed`` label and
+    ``error_message``) and resets ``gaia_retry_count`` so the re-run is a fresh
+    execution episode, not a one-shot that fails immediately. ``gaia_user_retry_count``
+    bounds how many times a human may retry a todo that keeps failing.
+    """
+    doc = await _require_status(todo_id, user_id, ExecutionStatus.FAILED, "retried")
+    user_retries = doc.get("gaia_user_retry_count", 0)
+    if user_retries >= MAX_GAIA_USER_RETRIES:
+        raise InvalidTransitionError(
+            f"This todo has already been retried {MAX_GAIA_USER_RETRIES} times and keeps "
+            "failing. Edit it or hand it off before retrying again."
+        )
+    now = datetime.now(UTC)
+    await todos_collection.update_one(
+        {"_id": ObjectId(todo_id), "user_id": user_id},
+        {
+            "$set": {
+                "execution_status": ExecutionStatus.QUEUED.value,
+                "scheduled_at": now,
+                "error_message": None,
+                "gaia_retry_count": 0,
+                "gaia_user_retry_count": user_retries + 1,
+            },
+            "$pull": {"labels": FAILED_LABEL},
+        },
+    )
+    await schedule_execution(todo_id, now)
+    await system_log(todo_id, user_id, "retry", f"User retried after failure via {channel}")
+    track(
+        user_id,
+        "todo_retried",
+        {"todo_id": todo_id, "channel": channel, "attempt": user_retries + 1},
+    )
     await _broadcast_status(user_id, todo_id, ExecutionStatus.QUEUED.value)
     schedule_gaia_tasks_sync(user_id)
 

--- a/apps/api/app/services/tracked_todo_service.py
+++ b/apps/api/app/services/tracked_todo_service.py
@@ -23,7 +23,6 @@ from app.constants.todos import (
     FACET_DELIVERABLE,
     FACET_LOG,
     FACET_NOTES,
-    GAIA_TRACKED_LABEL,
     NOTES_TEMPLATE,
     facet_from_doc,
     gaia_assigned_filter,
@@ -94,7 +93,7 @@ async def _extract_canvas_key_details(doc: dict, user_id: str) -> str:
 
 def _format_signal_entry(doc: dict, key_details: str) -> str:
     """Render one tracked todo as a signal-matching context bullet (+ indented key details)."""
-    labels = [lbl for lbl in doc.get("labels", []) if lbl != GAIA_TRACKED_LABEL]
+    labels = doc.get("labels", [])
     labels_str = f" [{', '.join(labels)}]" if labels else ""
     entry = (
         f'- "{doc.get("title", "")}"{labels_str} '
@@ -115,7 +114,7 @@ def _format_tracked_todo_line(doc: dict, now: datetime, active_todo_id: str | No
     """
     age_days = (now - doc.get("created_at", now)).days
     last_update = (now - doc.get("updated_at", now)).days
-    labels = [lbl for lbl in doc.get("labels", []) if lbl != GAIA_TRACKED_LABEL]
+    labels = doc.get("labels", [])
     labels_str = f" [{', '.join(labels)}]" if labels else ""
     todo_id = str(doc["_id"])
     prefix = "⭐ ACTIVE " if todo_id == active_todo_id else ""

--- a/apps/api/app/services/user_todos_fs.py
+++ b/apps/api/app/services/user_todos_fs.py
@@ -1,6 +1,6 @@
 """Mongo → VFS glue for ``/workspace/todos/`` (the USER's todo list).
 
-The Mongo side: ``todos`` collection, NOT carrying ``gaia-tracked``,
+The Mongo side: ``todos`` collection, ``assignee != "gaia"``,
 7-day completion window.
 
 The VFS side: :mod:`app.services.storage.user_todos_vfs`.
@@ -53,10 +53,10 @@ schedule_user_todos_sync = make_scheduler(sync_user_todos, log_name="user_todos_
 
 
 async def _fetch_active_projections(user_id: str) -> list[UserTodoProjection]:
-    """Pull the user's active non-gaia-tracked todos from Mongo.
+    """Pull the user's active non-GAIA todos from Mongo.
 
-    Filter: ``labels`` does NOT contain ``gaia-tracked`` AND (open OR
-    completed within the last 7 days).
+    Filter: ``assignee != "gaia"`` AND (open OR completed within the last
+    7 days).
     """
     cutoff = datetime.now(UTC) - timedelta(days=ACTIVE_WINDOW_DAYS)
     cursor = todos_collection.find(

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -25,6 +25,7 @@ from app.workers.tasks import (
     regenerate_workflow_steps,
     sweep_idle_sandboxes,
 )
+from app.workers.tasks.day_zero_hello_tasks import send_day_zero_hello
 from app.workers.tasks.maintenance_sweep_tasks import maintenance_sweep_tracked_todos
 from app.workers.tasks.scheduler_recovery_tasks import rescan_pending_scheduled_tasks
 from app.workers.tasks.tracked_todo_tasks import (
@@ -54,6 +55,7 @@ _execute_tracked_todo = instrument_task(execute_tracked_todo)
 _safety_net_check_orphaned_todos = instrument_task(safety_net_check_orphaned_todos)
 _maintenance_sweep_tracked_todos = instrument_task(maintenance_sweep_tracked_todos)
 _rescan_pending_scheduled_tasks = instrument_task(rescan_pending_scheduled_tasks)
+_send_day_zero_hello = instrument_task(send_day_zero_hello)
 WorkerSettings.functions = [
     _process_reminder,
     _cleanup_expired_reminders,
@@ -71,6 +73,7 @@ WorkerSettings.functions = [
     _execute_tracked_todo,
     _backfill_active_users,
     _backfill_user_memories,
+    _send_day_zero_hello,
 ]
 
 WorkerSettings.cron_jobs = [

--- a/apps/api/app/workers/tasks/day_zero_hello_tasks.py
+++ b/apps/api/app/workers/tasks/day_zero_hello_tasks.py
@@ -1,0 +1,158 @@
+"""Day-zero hello: GAIA's first text after a user links a chat platform.
+
+Enqueued from ``PlatformLinkService.link_account`` on a brand-new chat link. One
+silent agent turn writes a short, goal-grounded greeting; it is delivered to that
+one platform and mirrored into its bot conversation so the user's reply lands
+with context. Guarded to fire once per user, ever.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+import re
+from uuid import uuid4
+
+from bson import ObjectId
+
+from app.agents.prompts.briefing_prompts import build_day_zero_hello_prompt
+from app.db.mongodb.collections import users_collection
+from app.models.chat_models import ConversationSource
+from app.models.message_models import MessageDict, MessageRequestWithHistory
+from app.services.briefing import chat_sync, context
+from app.services.outbound_delivery import OutboundResult, publish_outbound_message
+from app.services.platform_link_service import PlatformLinkService
+from app.services.user_service import get_user_by_id
+from app.utils.analytics import track
+from shared.py.wide_events import UserContext, log, wide_task
+
+# Only greet accounts young enough that a first hello still makes sense; an old
+# account linking a platform for the first time is not a day-zero moment.
+DAY_ZERO_MAX_ACCOUNT_AGE_DAYS = 14
+
+# Extracts a ```json fenced block (or a bare array) from the agent's final text.
+_JSON_FENCE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.DOTALL)
+
+
+class DayZeroHelloError(Exception):
+    """The agent did not produce a valid bubble array — the run failed."""
+
+
+def _parse_bubbles(raw: str) -> list[str]:
+    """Extract the JSON array of chat bubbles from the agent output (fail loud)."""
+    candidates = _JSON_FENCE.findall(raw) or [raw]
+    for block in candidates:
+        block = block.strip()
+        if not block:
+            continue
+        try:
+            data = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, list) and all(isinstance(b, str) for b in data):
+            bubbles = [b.strip() for b in data if b.strip()]
+            if bubbles:
+                return bubbles
+    raise DayZeroHelloError(
+        f"No valid bubble array in agent output (first 300 chars): {raw[:300]!r}"
+    )
+
+
+async def _run_silent(user: dict, prompt: str) -> str:
+    """One silent agent turn on a fresh thread; returns the final text.
+
+    Mirrors the briefing service's silent-run plumbing, including the inline
+    import that breaks the agent<->workflow import cycle.
+    """
+    from app.agents.core.agent import call_agent_silent
+
+    request = MessageRequestWithHistory(
+        message=prompt,
+        messages=[MessageDict(role="user", content=prompt)],
+        fileIds=[],
+        fileData=[],
+        selectedTool=None,
+        selectedWorkflow=None,
+    )
+    user_data = {
+        "user_id": user["user_id"],
+        "name": user.get("name"),
+        "email": user.get("email"),
+        "timezone": user.get("timezone"),
+    }
+    conversation_id = f"dayzero-{user['user_id']}-{uuid4().hex[:6]}"
+    message, _ = await call_agent_silent(
+        request=request,
+        conversation_id=conversation_id,
+        user=user_data,
+        trigger_context={"execution_mode": "background"},
+        source="day_zero_hello",
+    )
+    return message
+
+
+def _first_name(user: dict) -> str:
+    name = (user.get("name") or "").strip()
+    return name.split()[0] if name else "there"
+
+
+async def send_day_zero_hello(ctx: dict, user_id: str, platform: str) -> str:
+    """Send GAIA's first hello to a freshly-linked chat platform, once per user.
+
+    Guards (all must hold): no prior ``day_zero_hello`` flag, account created
+    within ``DAY_ZERO_MAX_ACCOUNT_AGE_DAYS``, and the platform is still linked.
+    A guard failing is a normal skip; only a real broker failure raises.
+    """
+    async with wide_task("send_day_zero_hello", user=UserContext(id=user_id)):
+        log.set(platform=platform)
+        source = ConversationSource.coerce(platform)
+        if source is None:
+            log.set(skipped="unsupported_platform")
+            return f"skip {user_id}: unsupported platform {platform}"
+
+        user = await get_user_by_id(user_id)
+        if not user:
+            log.set(skipped="unknown_user")
+            return f"skip {user_id}: unknown user"
+        user["user_id"] = user_id
+
+        if user.get("day_zero_hello"):
+            log.set(skipped="already_sent")
+            return f"skip {user_id}: day-zero hello already sent"
+
+        # An ObjectId encodes its creation instant, so it is the account age.
+        created_at = ObjectId(user_id).generation_time
+        if datetime.now(UTC) - created_at > timedelta(days=DAY_ZERO_MAX_ACCOUNT_AGE_DAYS):
+            log.set(skipped="account_too_old")
+            return f"skip {user_id}: account older than {DAY_ZERO_MAX_ACCOUNT_AGE_DAYS} days"
+
+        linked = await PlatformLinkService.get_linked_platforms(user_id)
+        if platform not in linked:
+            log.set(skipped="not_linked")
+            return f"skip {user_id}: {platform} not linked"
+
+        goal_block, has_goal = await context.format_goal_block(user_id, user)
+        prompt = build_day_zero_hello_prompt(
+            first_name=_first_name(user), goal_block=goal_block, has_goal=has_goal
+        )
+        bubbles = _parse_bubbles(await _run_silent(user, prompt))
+
+        result = await publish_outbound_message(source, user_id, bubbles)
+        if result is not OutboundResult.PUBLISHED:
+            # Nothing landed, so leave the once-ever flag unset: a later relink can
+            # still greet them. A broker failure is a real error worth retrying.
+            if result is OutboundResult.FAILED:
+                raise DayZeroHelloError(
+                    f"day-zero hello publish failed for {user_id} on {platform}"
+                )
+            log.set(skipped="publish_skipped")
+            return f"skip {user_id}: publish skipped ({platform})"
+
+        await chat_sync.persist_bot_message(user_id, user, platform, bubbles)
+        await users_collection.update_one(
+            {"_id": ObjectId(user_id)},
+            {"$set": {"day_zero_hello": {"sent_at": datetime.now(UTC), "platform": platform}}},
+        )
+        track(user_id, "day_zero_hello_sent", {"platform": platform, "has_goal": has_goal})
+        log.set(bubbles=len(bubbles), has_goal=has_goal)
+        return f"sent day-zero hello to {user_id} on {platform}"

--- a/apps/api/app/workers/tasks/maintenance_sweep_tasks.py
+++ b/apps/api/app/workers/tasks/maintenance_sweep_tasks.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from bson import ObjectId
 
 from app.agents.core.agent import call_agent_silent
+from app.constants.todos import gaia_assigned_filter
 from app.db.mongodb.collections import todos_collection
 from app.models.message_models import MessageDict, MessageRequestWithHistory
 from app.models.notification.notification_models import (
@@ -110,7 +111,7 @@ async def _classify_tracked_todos(
     Todos still inside their notification backoff are skipped. Each tier is capped
     at 20 entries per sweep.
     """
-    cursor = todos_collection.find({"completed": False, "labels": "gaia-tracked"}).limit(200)
+    cursor = todos_collection.find({"completed": False, **gaia_assigned_filter()}).limit(200)
 
     expired: list[dict] = []
     overdue: list[dict] = []

--- a/apps/api/app/workers/tasks/tracked_todo_tasks.py
+++ b/apps/api/app/workers/tasks/tracked_todo_tasks.py
@@ -17,14 +17,27 @@ from uuid import uuid4
 from bson import ObjectId
 
 from app.agents.core.agent import call_agent_silent
-from app.constants.todos import FACET_DELIVERABLE, FACET_LOG, FACET_NOTES
+from app.constants.notifications import CHANNEL_TYPE_INAPP, NOTIFICATION_KIND_TODO_DONE
+from app.constants.todos import (
+    FACET_DELIVERABLE,
+    FACET_LOG,
+    FACET_NOTES,
+    FAILED_LABEL,
+    gaia_assigned_filter,
+)
 from app.db.mongodb.collections import todos_collection
 from app.models.message_models import MessageDict, MessageRequestWithHistory
 from app.models.notification.notification_models import (
+    ActionConfig,
+    ActionStyle,
+    ActionType,
+    ChannelConfig,
+    NotificationAction,
     NotificationContent,
     NotificationRequest,
     NotificationSourceEnum,
     NotificationType,
+    RedirectConfig,
 )
 from app.models.todo_models import ExecutionStatus
 from app.services.model_service import get_default_model
@@ -109,8 +122,9 @@ async def _execute_todo_with_retry(todo_id: str, pool: Any) -> str:
         )
         return f"expired:{todo_id}"
 
-    # Skip failed todos — user must manually reset before re-execution
-    if "failed" in doc.get("labels", []):
+    # Skip failed todos — the user must retry (POST /todos/{id}/retry clears this
+    # label) before re-execution.
+    if FAILED_LABEL in doc.get("labels", []):
         log.info("tracked_todo.execute_marked_failed", todo_id=todo_id)
         return f"skipped:{todo_id} (marked failed)"
 
@@ -129,7 +143,7 @@ async def _execute_todo_with_retry(todo_id: str, pool: Any) -> str:
 
     try:
         await lifecycle.mark_execution_status(todo_id, user_id, ExecutionStatus.RUNNING)
-        await _run_execution(doc, user_id, user_data=user_data)
+        run_summary = await _run_execution(doc, user_id, user_data=user_data)
 
         # Resolve the post-run state. The agent may have completed the todo
         # mid-run (DONE), or turned it into a proposal awaiting approval, or hit
@@ -156,6 +170,10 @@ async def _execute_todo_with_retry(todo_id: str, pool: Any) -> str:
                 await tracked_todo_service.complete_tracked_todo(
                     todo_id, user_id, summary="Completed overnight by GAIA."
                 )
+
+        # Ping the user when a run actually finished (DONE), scoped so goal-lane
+        # prep stays silent — the morning brief narrates those instead.
+        await _notify_done_if_scoped(todo_id, user_id, doc, run_summary)
 
         # Reset retry counter on success
         await todos_collection.update_one(
@@ -228,11 +246,11 @@ async def _execute_todo_with_retry(todo_id: str, pool: Any) -> str:
         return f"retry:{todo_id} (attempt {new_retry_count})"
 
 
-async def _run_execution(doc: dict, user_id: str, *, user_data: dict) -> None:
+async def _run_execution(doc: dict, user_id: str, *, user_data: dict) -> str | None:
     """
     Dispatch execution to the correct path:
-    - If the todo has a workflow_id, queue the workflow.
-    - Otherwise, run the agent directly.
+    - If the todo has a workflow_id, queue the workflow (no summary to return).
+    - Otherwise, run the agent directly and return its completion summary.
     """
     workflow_id: str | None = doc.get("workflow_id")
 
@@ -252,8 +270,8 @@ async def _run_execution(doc: dict, user_id: str, *, user_data: dict) -> None:
             workflow_id=workflow_id,
             todo_id=str(doc["_id"]),
         )
-    else:
-        await _execute_via_agent(doc, user_id, user_data=user_data)
+        return None
+    return await _execute_via_agent(doc, user_id, user_data=user_data)
 
 
 def _extract_learnings(ref_canvas: str) -> str | None:
@@ -295,10 +313,10 @@ async def _collect_reference_context(ref_ids: list[str], user_id: str) -> str:
 # complete, kept apart from GAIA's scratch. This directive is what stops the
 # canvas from becoming a mixed blob of research + logs + half-drafts.
 _FACET_AUTHORING_DIRECTIVE = (
-    "This is a background prep run. Do the REAL work — research the web, draft, "
-    "compile — and never invent facts (no fabricated names, numbers, or quotes; "
+    "This is a background prep run. Do the REAL work (research the web, draft, "
+    "compile) and never invent facts (no fabricated names, numbers, or quotes; "
     "if you can't verify it, leave it out).\n\n"
-    "CRITICAL — this todo has SEPARATE facets, not one canvas with sections. "
+    "CRITICAL: this todo has SEPARATE facets, not one canvas with sections. "
     "Where results go decides whether the user ever sees them:\n"
     "- Your process (research, findings, drafts-in-progress, the plan) goes in "
     "NOTES: update_tracked_todo_canvas(todo_id, facet='notes', ...).\n"
@@ -306,38 +324,37 @@ _FACET_AUTHORING_DIRECTIVE = (
     "output to the DELIVERABLE facet as the final step:\n"
     "    update_tracked_todo_canvas(todo_id, facet='deliverable', mode='replace', "
     "content=<the whole finished result>)\n"
-    "  The deliverable is the actual thing the user uses or sends — the real code, "
-    "the real vetted list, the real drafts — complete, with NO placeholders like "
+    "  The deliverable is the actual thing the user uses or sends (the real code, "
+    "the real vetted list, the real drafts), complete, with NO placeholders like "
     "[Name] and NO research/log/'Work Order' sections mixed in. This is exactly "
     "what the user reads and what Approve releases.\n"
     "- Do NOT put a '## Deliverable' or '## Output' section inside notes. The "
     "finished output lives ONLY in the deliverable facet; notes must never hold it.\n"
     "- log: one short line of what you did this run.\n"
     '- Before finishing, end NOTES with a "## Learnings" section: 2-4 bullets a '
-    "FUTURE run on a similar task must know, written for a stranger — what worked, "
+    "FUTURE run on a similar task must know, written for a stranger: what worked, "
     'what to avoid, key contacts/links/IDs with dates (e.g. "Replies came only '
     'from subject lines naming their portfolio company", "foo@fund.com bounced '
-    '2026-07-09 — use their partner form"). Not a diary of this run; only reusable '
+    '2026-07-09, use their partner form"). Not a diary of this run; only reusable '
     "knowledge.\n\n"
     "Before you finish, check: is the complete finished result in the DELIVERABLE "
     "facet (not just notes)? If not, write it there now. If a real value doesn't "
-    "exist yet, do the work to get it — never ship a placeholder.\n\n"
+    "exist yet, do the work to get it; never ship a placeholder.\n\n"
     "THE BAR: the user must be able to tap Approve without editing a single word. "
-    "For each draft, match the target channel's real format — an email gets a "
+    "For each draft, match the target channel's real format: an email gets a "
     "specific subject line and a first line only its recipient could receive (a "
     "researched fact about them: their fund's recent investment, their post, their "
     "product); a LinkedIn post gets a hook line and short paragraphs; a tweet fits "
     "the length and reads native. Before writing the deliverable, do the "
     "recipient/audience research the draft depends on. Final check: read the "
-    "deliverable as the user would — if they would change anything before sending, "
+    "deliverable as the user would; if they would change anything before sending, "
     "fix it now, in this run.\n\n"
-    "Anything in the deliverable that a human will read (emails, posts, messages, "
-    "docs) must read like the USER wrote it, not an LLM: vary sentence length, "
-    "open on the point (no 'I hope this finds you well', no throat-clearing), "
-    "plain words over inflated ones, no 'delve'/'seamless'/'leverage'/'excited to "
-    "connect', and never an em dash. Take a position; don't hedge everything. "
-    "Don't overcorrect into forced quirkiness either — natural and specific, not "
-    "performative."
+    "Anything a human will read in the deliverable (emails, posts, messages, docs) "
+    "must sound like the USER wrote it, not an LLM: vary sentence length, open on "
+    "the point (no 'I hope this finds you well'), use plain words, take a position "
+    "instead of hedging, and never use an em dash or filler like 'delve', "
+    "'seamless', 'leverage', or 'excited to connect'. Keep it natural and specific, "
+    "not forced or quirky."
 )
 
 
@@ -345,24 +362,24 @@ _FACET_AUTHORING_DIRECTIVE = (
 # the (already-final) deliverable, not re-draft it. Without this an approved run
 # hits the prep directive above and just rewrites the draft, so nothing is sent.
 _RELEASE_DIRECTIVE = (
-    "The user has APPROVED this — your job now is to PERFORM the action, not to "
+    "The user has APPROVED this; your job now is to PERFORM the action, not to "
     "draft, plan, or propose it. Actually send the emails, post the content, or "
     "create the records described above, using the EXACT approved content in the "
     "deliverable and the appropriate connected integration (Gmail, LinkedIn, X, "
-    "etc.). Do NOT reword, re-draft, re-plan, or ask again — the content is final "
+    "etc.). Do NOT reword, re-draft, re-plan, or ask again: the content is final "
     "and approved. Send to EXACTLY the recipients/destinations named in the "
     "deliverable and no others.\n"
     "Sends are per-recipient. The send record above lists any recipient already "
-    "marked sent — those are DONE; never send to them again, even on a retry. As "
+    "marked sent; those are DONE, so never send to them again, even on a retry. As "
     "each send completes or fails, immediately append one line to the log facet "
     "(update_tracked_todo_canvas, facet='log'): recipient, outcome, confirmation "
-    "ID. One failure does not stop the rest — complete every remaining recipient, "
+    "ID. One failure does not stop the rest: complete every remaining recipient, "
     "then report the exact split ('sent 3 of 5: A, B, C; failed for D (bounce), E "
     "(rate limit)'). A partial send is reported as partial: never round it up to "
     "done, and never re-send a success to make the count clean. If the integration "
-    "is not connected at all, STOP and say so plainly — never claim anything was "
+    "is not connected at all, STOP and say so plainly; never claim anything was "
     "sent when it was not.\n"
-    "The log facet is the permanent record of this release — the briefing and "
+    "The log facet is the permanent record of this release: the briefing and "
     "every future follow-up run read it, so it must contain the full recipient "
     "list, timestamps, and confirmation IDs even when everything succeeded."
 )
@@ -630,6 +647,68 @@ async def _execute_via_agent(doc: dict, user_id: str, *, user_data: dict) -> str
     return complete_message[:200] if complete_message else ""
 
 
+async def _notify_done_if_scoped(
+    todo_id: str, user_id: str, doc: dict, run_summary: str | None
+) -> None:
+    """In-app ping when a run finished (DONE), scoped to work the user asked for.
+
+    Fires only for a release run (approved outward action) or a standalone todo
+    (no ``goal_id``). Goal-lane prep completions stay silent — the morning brief
+    narrates them. Explicit ``inapp`` channel so this never double-delivers over
+    chat (standalone chat delivery already happens in the run). Best-effort: the
+    completion is already persisted, so a delivery failure only drops the ping.
+
+    Workflow-backed todos are excluded: they carry their own completion
+    notification (WORKFLOW_DONE_COPY), so a second ping here would double up.
+    """
+    if doc.get("workflow_id"):
+        return
+    final = await todos_collection.find_one(
+        {"_id": ObjectId(todo_id)}, {"execution_status": 1, "title": 1}
+    )
+    if not final or final.get("execution_status") != ExecutionStatus.DONE.value:
+        return
+    if doc.get("execution_intent") != "release" and doc.get("goal_id"):
+        return
+
+    title: str = final.get("title") or "your todo"
+    body = (run_summary or "").strip()[:200] or "GAIA finished this and it's ready for you."
+    try:
+        await notification_service.create_notification(
+            NotificationRequest(
+                user_id=user_id,
+                source=NotificationSourceEnum.BACKGROUND_JOB,
+                type=NotificationType.SUCCESS,
+                channels=[ChannelConfig(channel_type=CHANNEL_TYPE_INAPP)],
+                content=NotificationContent(
+                    title=f"Shipped: {title}",
+                    body=body,
+                    actions=[
+                        NotificationAction(
+                            type=ActionType.REDIRECT,
+                            label="Open todo",
+                            style=ActionStyle.PRIMARY,
+                            config=ActionConfig(
+                                redirect=RedirectConfig(
+                                    url=f"/todos?todoId={todo_id}",
+                                    open_in_new_tab=False,
+                                    close_notification=True,
+                                )
+                            ),
+                        )
+                    ],
+                ),
+                metadata={"kind": NOTIFICATION_KIND_TODO_DONE, "todo_id": todo_id},
+            )
+        )
+    except Exception as notify_exc:
+        log.warning(
+            "tracked_todo.done_notification_failed",
+            todo_id=todo_id,
+            error=str(notify_exc),
+        )
+
+
 async def _mark_todo_failed(todo_id: str, user_id: str, doc: dict) -> None:
     """
     Mark the todo as permanently failed by adding a 'failed' label,
@@ -638,7 +717,7 @@ async def _mark_todo_failed(todo_id: str, user_id: str, doc: dict) -> None:
     await todos_collection.update_one(
         {"_id": ObjectId(todo_id)},
         {
-            "$addToSet": {"labels": "failed"},
+            "$addToSet": {"labels": FAILED_LABEL},
             "$set": {"updated_at": datetime.now(UTC)},
         },
     )
@@ -755,7 +834,7 @@ async def safety_net_check_orphaned_todos(_ctx: dict) -> str:
     Queries todos where:
     - scheduled_at <= now
     - completed = False
-    - labels includes "gaia-tracked"
+    - assignee == "gaia"
     - gaia_retry_count < MAX_RETRY_ATTEMPTS
 
     For each, checks whether the execution lock already exists; if not,
@@ -769,7 +848,7 @@ async def safety_net_check_orphaned_todos(_ctx: dict) -> str:
             {
                 "scheduled_at": {"$lte": now},
                 "completed": False,
-                "labels": "gaia-tracked",
+                **gaia_assigned_filter(),
                 "gaia_retry_count": {"$lt": MAX_RETRY_ATTEMPTS},
             }
         ).limit(100)

--- a/apps/api/scripts/provision_daily_briefings.py
+++ b/apps/api/scripts/provision_daily_briefings.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """One-time, idempotent existing-user briefing rollout.
 
-For every user: provision the daily-briefing + weekly-digest system workflows and
-send a one-time all-channel announcement. Users we can derive a goal for get the
-standard announcement (real first briefing next morning); sparse users with no
-derivable goal get a short bootstrap interview and their briefings are held until
-they answer or the grace window elapses. Safe to re-run — provisioning is
-idempotent by ``system_workflow_key`` and the announcement path is logged.
+For every user: provision the daily-briefing + weekly-digest system workflows.
+Users we can derive a goal for get a real first briefing next morning; sparse
+users with no derivable goal have their briefings held (bootstrap marker) until a
+goal arrives or the grace window elapses. The user-facing announcement is sent
+manually by email, not from here. Safe to re-run — provisioning is idempotent by
+``system_workflow_key`` and the path taken is logged.
 
 Run: uv run python scripts/provision_daily_briefings.py [--dry-run]
 """
@@ -18,7 +18,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app.db.mongodb.collections import users_collection  # noqa: E402
-from app.services.briefing.rollout import announce_and_provision  # noqa: E402
+from app.services.briefing.rollout import provision_existing_user  # noqa: E402
 
 
 async def rollout(dry_run: bool) -> None:
@@ -33,7 +33,7 @@ async def rollout(dry_run: bool) -> None:
     async for doc in cursor:
         user_id = str(doc["_id"])
         try:
-            path = await announce_and_provision(user_id)
+            path = await provision_existing_user(user_id)
         except Exception as e:  # one bad user must not abort the whole rollout
             print(f"  user {user_id}: FAILED ({e})")
             paths["failed"] = paths.get("failed", 0) + 1

--- a/apps/web/src/components/layout/sidebar/right-variants/TodoSidebar.tsx
+++ b/apps/web/src/components/layout/sidebar/right-variants/TodoSidebar.tsx
@@ -179,6 +179,7 @@ export const TodoSidebar: React.FC<TodoSidebarProps> = ({
                       ? todo.error_message
                       : null
                   }
+                  todoId={todo.id}
                 />
               )}
             </div>
@@ -186,7 +187,7 @@ export const TodoSidebar: React.FC<TodoSidebarProps> = ({
 
           {/* Full-width, out of the checkbox column — same rule as the
               decision cards: offers act at page width, not title width. */}
-          {!isGaiaTodo && todo.gaia_offer && (
+          {!isGaiaTodo && todo.gaia_offer && !todo.gaia_offer_dismissed && (
             <GaiaOfferBanner todoId={todo.id} offer={todo.gaia_offer} />
           )}
 

--- a/apps/web/src/features/briefing/api/briefingApi.ts
+++ b/apps/web/src/features/briefing/api/briefingApi.ts
@@ -1,5 +1,10 @@
+import type { NotificationPlatform } from "@/features/notification/constants";
 import { apiService } from "@/lib/api/service";
 import type { Briefing } from "@/types/features/briefingTypes";
+
+export interface BriefingPreferences {
+  chat_channel_priority: NotificationPlatform[];
+}
 
 export const briefingApi = {
   // Fetch the most recent briefing. 404 means the user has none yet — that's
@@ -26,5 +31,23 @@ export const briefingApi = {
       { silent: true },
     );
     return response.briefings;
+  },
+
+  // The ordered chat-channel priority: the brief lands on the first connected,
+  // enabled platform in this order.
+  fetchChannelPriority: async (): Promise<BriefingPreferences> => {
+    return apiService.get<BriefingPreferences>("/briefings/preferences", {
+      silent: true,
+    });
+  },
+
+  updateChannelPriority: async (
+    order: NotificationPlatform[],
+  ): Promise<BriefingPreferences> => {
+    return apiService.patch<BriefingPreferences>(
+      "/briefings/preferences",
+      { chat_channel_priority: order },
+      { silent: true },
+    );
   },
 };

--- a/apps/web/src/features/briefing/components/ChannelPriorityList.tsx
+++ b/apps/web/src/features/briefing/components/ChannelPriorityList.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Skeleton } from "@heroui/skeleton";
+import { DragDropVerticalIcon } from "@icons";
+import { Reorder, useDragControls } from "motion/react";
+import Image from "next/image";
+import type React from "react";
+import { useChannelPriority } from "@/features/briefing/hooks/useChannelPriority";
+import {
+  NOTIFICATION_PLATFORM_ICONS,
+  NOTIFICATION_PLATFORM_LABELS,
+  type NotificationPlatform,
+} from "@/features/notification/constants";
+
+interface ChannelPriorityListProps {
+  /** Which platforms have a connected account (drives draggable vs. dimmed). */
+  linkedMap: Record<NotificationPlatform, boolean>;
+}
+
+const dragSpring = { type: "spring", stiffness: 600, damping: 40 } as const;
+
+function PlatformIcon({ platform }: { platform: NotificationPlatform }) {
+  return (
+    <Image
+      src={NOTIFICATION_PLATFORM_ICONS[platform]}
+      alt={NOTIFICATION_PLATFORM_LABELS[platform]}
+      width={28}
+      height={28}
+      className="rounded-lg"
+    />
+  );
+}
+
+/** A draggable, connected channel row. The grab handle initiates the drag. */
+function DraggableChannelRow({
+  platform,
+  onDrop,
+}: {
+  platform: NotificationPlatform;
+  onDrop: () => void;
+}) {
+  const controls = useDragControls();
+  const label = NOTIFICATION_PLATFORM_LABELS[platform];
+
+  return (
+    <Reorder.Item
+      value={platform}
+      dragListener={false}
+      dragControls={controls}
+      onDragEnd={onDrop}
+      transition={dragSpring}
+      whileDrag={{
+        scale: 1.02,
+        boxShadow: "0 12px 32px rgba(0,0,0,0.4)",
+      }}
+      className="flex select-none items-center gap-2 rounded-xl bg-zinc-800/60 px-2.5 py-2.5"
+    >
+      <Button
+        isIconOnly
+        size="sm"
+        variant="light"
+        radius="lg"
+        aria-label={`Reorder ${label}`}
+        onPointerDown={(event) => controls.start(event)}
+        className="size-7 min-w-0 cursor-grab touch-none text-zinc-500 hover:text-zinc-300 active:cursor-grabbing"
+      >
+        <DragDropVerticalIcon className="size-4" />
+      </Button>
+      <PlatformIcon platform={platform} />
+      <span className="flex-1 truncate text-sm text-zinc-200">{label}</span>
+    </Reorder.Item>
+  );
+}
+
+/** An unlinked channel: dimmed, non-draggable, nudged toward Linked Accounts. */
+function UnlinkedChannelRow({ platform }: { platform: NotificationPlatform }) {
+  const label = NOTIFICATION_PLATFORM_LABELS[platform];
+
+  return (
+    <div className="flex items-center gap-2 rounded-xl bg-zinc-800/30 px-2.5 py-2.5 opacity-50">
+      <span className="flex size-7 items-center justify-center text-zinc-600">
+        <DragDropVerticalIcon className="size-4" />
+      </span>
+      <PlatformIcon platform={platform} />
+      <span className="flex-1 truncate text-sm text-zinc-400">{label}</span>
+      <span className="shrink-0 text-xs text-zinc-500">
+        Connect in Linked Accounts
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Ordered list of briefing chat channels. Connected platforms are draggable
+ * (drop persists optimistically); unlinked platforms pin to the bottom, dimmed.
+ */
+export const ChannelPriorityList: React.FC<ChannelPriorityListProps> = ({
+  linkedMap,
+}) => {
+  const { isLoading, linkedOrder, unlinkedOrder, reorderLinked, persist } =
+    useChannelPriority(linkedMap);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-[46px] w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Reorder.Group
+        axis="y"
+        values={linkedOrder}
+        onReorder={reorderLinked}
+        className="space-y-2"
+      >
+        {linkedOrder.map((platform) => (
+          <DraggableChannelRow
+            key={platform}
+            platform={platform}
+            onDrop={persist}
+          />
+        ))}
+      </Reorder.Group>
+      {unlinkedOrder.length > 0 && (
+        <div className="space-y-2">
+          {unlinkedOrder.map((platform) => (
+            <UnlinkedChannelRow key={platform} platform={platform} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/features/briefing/hooks/useChannelPriority.ts
+++ b/apps/web/src/features/briefing/hooks/useChannelPriority.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import {
+  type BriefingPreferences,
+  briefingApi,
+} from "@/features/briefing/api/briefingApi";
+import {
+  NOTIFICATION_PLATFORMS,
+  type NotificationPlatform,
+} from "@/features/notification/constants";
+import { toast } from "@/lib/toast";
+
+export const BRIEFING_PREFERENCES_QUERY_KEY = ["briefing-preferences"];
+
+/**
+ * Coerce a server-provided order into a full, de-duplicated permutation of the
+ * four known platforms — the UI always renders every platform, so drift or a
+ * partial list can't drop one.
+ */
+function normalizeOrder(raw?: NotificationPlatform[]): NotificationPlatform[] {
+  const known = new Set<NotificationPlatform>(NOTIFICATION_PLATFORMS);
+  const seen = new Set<NotificationPlatform>();
+  const result: NotificationPlatform[] = [];
+  for (const platform of raw ?? []) {
+    if (known.has(platform) && !seen.has(platform)) {
+      result.push(platform);
+      seen.add(platform);
+    }
+  }
+  for (const platform of NOTIFICATION_PLATFORMS) {
+    if (!seen.has(platform)) result.push(platform);
+  }
+  return result;
+}
+
+interface UseChannelPriorityResult {
+  isLoading: boolean;
+  /** Linked platforms, in priority order — the draggable rows. */
+  linkedOrder: NotificationPlatform[];
+  /** Unlinked platforms, pinned below and non-draggable. */
+  unlinkedOrder: NotificationPlatform[];
+  /** Apply a reordered linked list (fired continuously during a drag). */
+  reorderLinked: (next: NotificationPlatform[]) => void;
+  /** Persist the current order (fired on drop); reverts + toasts on failure. */
+  persist: () => void;
+}
+
+/**
+ * Owns the briefing channel-priority order: fetches it, tracks the live
+ * (optimistic) order during a drag, and persists on drop with revert-on-error.
+ * `linkedMap` marks which platforms have a connected account.
+ */
+export function useChannelPriority(
+  linkedMap: Record<NotificationPlatform, boolean>,
+): UseChannelPriorityResult {
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: BRIEFING_PREFERENCES_QUERY_KEY,
+    queryFn: briefingApi.fetchChannelPriority,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const serverOrder = useMemo(
+    () => normalizeOrder(data?.chat_channel_priority),
+    [data],
+  );
+
+  const [order, setOrder] = useState<NotificationPlatform[]>(serverOrder);
+  useEffect(() => {
+    setOrder(serverOrder);
+  }, [serverOrder]);
+
+  const linkedOrder = order.filter((platform) => linkedMap[platform]);
+  const unlinkedOrder = order.filter((platform) => !linkedMap[platform]);
+
+  const save = useMutation({
+    mutationFn: (next: NotificationPlatform[]) =>
+      briefingApi.updateChannelPriority(next),
+    onSuccess: (_data, next) => {
+      queryClient.setQueryData<BriefingPreferences>(
+        BRIEFING_PREFERENCES_QUERY_KEY,
+        { chat_channel_priority: next },
+      );
+    },
+    onError: () => {
+      setOrder(serverOrder);
+      toast.error("Couldn't save your briefing channel order.");
+    },
+  });
+
+  // Reordering only moves the linked rows among themselves; unlinked platforms
+  // keep their relative order at the tail so the stored list stays a full
+  // permutation.
+  const reorderLinked = (next: NotificationPlatform[]) => {
+    setOrder([...next, ...unlinkedOrder]);
+  };
+
+  const persist = () => {
+    save.mutate([...linkedOrder, ...unlinkedOrder]);
+  };
+
+  return { isLoading, linkedOrder, unlinkedOrder, reorderLinked, persist };
+}

--- a/apps/web/src/features/dashboard/components/NeedsYouRow.tsx
+++ b/apps/web/src/features/dashboard/components/NeedsYouRow.tsx
@@ -2,11 +2,13 @@
 
 import { Button } from "@heroui/button";
 import { Input } from "@heroui/input";
+import { useDisclosure } from "@heroui/modal";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import type React from "react";
 import { useState } from "react";
 import { StatusGlyph } from "@/components/shared/StatusGlyph";
+import { ApproveConfirmModal } from "@/features/todo/components/shared/ApproveConfirmModal";
 import { useAnswerTodo } from "@/features/todo/hooks/useAnswerTodo";
 import { useApproveTodo } from "@/features/todo/hooks/useApproveTodo";
 import { useDismissTodo } from "@/features/todo/hooks/useDismissTodo";
@@ -29,9 +31,18 @@ export const NeedsYouRow: React.FC<NeedsYouRowProps> = ({ item }) => {
   const answerTodo = useAnswerTodo();
   const [answerOpen, setAnswerOpen] = useState(false);
   const [answer, setAnswer] = useState("");
+  const approveModal = useDisclosure();
 
   const refresh = () =>
     queryClient.invalidateQueries({ queryKey: TODAY_QUERY_KEY });
+
+  const confirmApprove = () =>
+    approveTodo.mutate(item.todo_id, {
+      onSuccess: () => {
+        refresh();
+        approveModal.onClose();
+      },
+    });
 
   const submitAnswer = () => {
     const trimmed = answer.trim();
@@ -91,12 +102,17 @@ export const NeedsYouRow: React.FC<NeedsYouRowProps> = ({ item }) => {
               color="primary"
               radius="lg"
               isLoading={approveTodo.isPending}
-              onPress={() =>
-                approveTodo.mutate(item.todo_id, { onSuccess: refresh })
-              }
+              onPress={approveModal.onOpen}
             >
               Approve & send
             </Button>
+            <ApproveConfirmModal
+              isOpen={approveModal.isOpen}
+              onOpenChange={approveModal.onOpenChange}
+              todoId={item.todo_id}
+              onConfirm={confirmApprove}
+              isConfirming={approveTodo.isPending}
+            />
           </div>
         )}
         {isBlocked && !answerOpen && (

--- a/apps/web/src/features/dashboard/components/TodayHeader.tsx
+++ b/apps/web/src/features/dashboard/components/TodayHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import type React from "react";
+import { Fragment } from "react";
 import type { TodayRuns, TodaySubline } from "@/types/features/dashboardTypes";
 
 import { formatClockTime } from "../utils/time";
@@ -41,6 +41,41 @@ export const TodayHeader: React.FC<TodayHeaderProps> = ({
     ? formatClockTime(subline.next_event.time)
     : "";
 
+  // Dot-separated segments: dots sit between present items only, so the last
+  // segment never trails a dangling separator.
+  const segments: { id: string; node: React.ReactNode }[] = [];
+  if (subline.needs_you > 0) {
+    segments.push({
+      id: "needs-you",
+      node: (
+        <span className="font-medium text-amber-400/90">
+          {subline.needs_you} need{subline.needs_you === 1 ? "s" : ""} you
+        </span>
+      ),
+    });
+  }
+  if (subline.next_event) {
+    segments.push({
+      id: "next-event",
+      node: (
+        <span className="truncate">
+          {nextEventTime ? `${nextEventTime} ` : ""}
+          {subline.next_event.title}
+        </span>
+      ),
+    });
+  }
+  if (runs) {
+    segments.push({
+      id: "runs",
+      node: (
+        <span>
+          {Math.max(0, runs.limit - runs.used)}/{runs.limit} runs left
+        </span>
+      ),
+    });
+  }
+
   return (
     <header className="px-3">
       <p className="text-[13px] font-medium text-zinc-500">
@@ -49,39 +84,16 @@ export const TodayHeader: React.FC<TodayHeaderProps> = ({
       <h1 className="mt-2 text-[26px] leading-tight font-semibold tracking-tight text-balance text-zinc-100">
         {headline}
       </h1>
-      <div className="mt-2.5 flex flex-wrap items-center gap-2.5 text-[13px] text-zinc-500 tabular-nums">
-        {subline.needs_you > 0 && (
-          <>
-            <span className="font-medium text-amber-400/90">
-              {subline.needs_you} need{subline.needs_you === 1 ? "s" : ""} you
-            </span>
-            <Dot />
-          </>
-        )}
-        {subline.next_event && (
-          <>
-            <span className="truncate">
-              {nextEventTime ? `${nextEventTime} ` : ""}
-              {subline.next_event.title}
-            </span>
-            <Dot />
-          </>
-        )}
-        {runs && (
-          <>
-            <span>
-              {Math.max(0, runs.limit - runs.used)}/{runs.limit} runs left
-            </span>
-            <Dot />
-          </>
-        )}
-        <Link
-          href="/briefings"
-          className="text-zinc-500 underline decoration-zinc-700 underline-offset-4 transition-colors hover:text-zinc-300"
-        >
-          Full briefing
-        </Link>
-      </div>
+      {segments.length > 0 && (
+        <div className="mt-2.5 flex flex-wrap items-center gap-2.5 text-[13px] text-zinc-500 tabular-nums">
+          {segments.map((segment, index) => (
+            <Fragment key={segment.id}>
+              {index > 0 && <Dot />}
+              {segment.node}
+            </Fragment>
+          ))}
+        </div>
+      )}
     </header>
   );
 };

--- a/apps/web/src/features/first-steps/api/firstStepsApi.ts
+++ b/apps/web/src/features/first-steps/api/firstStepsApi.ts
@@ -14,4 +14,13 @@ export const firstStepsApi = {
   markFirstStep: async (step: string): Promise<void> => {
     await apiService.patch("/users/me/first-steps", { step }, { silent: true });
   },
+
+  // Hides a single checklist row server-side (persists across browsers).
+  hideFirstStep: async (step: string): Promise<void> => {
+    await apiService.patch(
+      "/users/me/first-steps/hide",
+      { step },
+      { silent: true },
+    );
+  },
 };

--- a/apps/web/src/features/first-steps/constants.ts
+++ b/apps/web/src/features/first-steps/constants.ts
@@ -4,18 +4,19 @@ export interface FirstStepDefinition {
   href: string;
 }
 
-// Ordered activation checklist shown in the FirstStepsWidget. Order matches
-// the product spec (openspec/changes/daily-briefing-self-executing-todos).
+// Ordered activation checklist shown in the FirstStepsWidget. Each step maps to
+// a real signal the backend tracks (a stated goal, an integration, a linked
+// chat platform, the Today view, the first Approve).
 export const FIRST_STEPS: FirstStepDefinition[] = [
-  { key: "explore_workflows", label: "Explore workflows", href: "/workflows" },
+  { key: "tell_gaia_goal", label: "Tell GAIA your goal", href: "/c" },
   {
     key: "connect_integration",
     label: "Connect an integration",
     href: "/integrations",
   },
   {
-    key: "link_telegram",
-    label: "Link Telegram",
+    key: "link_platform",
+    label: "Link Telegram or WhatsApp",
     href: "/settings/linked-accounts",
   },
   {

--- a/apps/web/src/features/first-steps/hooks/useFirstStepsWidget.ts
+++ b/apps/web/src/features/first-steps/hooks/useFirstStepsWidget.ts
@@ -2,24 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "@/lib/toast";
 import { FIRST_STEPS, type FirstStepDefinition } from "../constants";
 import { useFirstStepsQuery } from "./useFirstStepsQuery";
-
-// Client-only: the backend contract only exposes per-step *completion*, not a
-// per-step dismissal endpoint. Hiding a single row without marking it complete
-// is therefore tracked locally per browser.
-const HIDDEN_STEPS_STORAGE_KEY = "gaia:first-steps:hidden-steps";
+import { useHideFirstStepMutation } from "./useHideFirstStepMutation";
 
 // Closing the widget minimizes it to the pill; that choice survives reloads.
 const COLLAPSED_STORAGE_KEY = "gaia:first-steps:collapsed";
-
-function readHiddenSteps(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(HIDDEN_STEPS_STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
-  }
-}
 
 // The "all set up" celebration is a one-time event. The backend keeps reporting
 // every step complete forever, so without a persisted flag the in-memory guard
@@ -49,12 +35,11 @@ interface UseFirstStepsWidgetResult {
 
 export const useFirstStepsWidget = (): UseFirstStepsWidgetResult => {
   const { data, isLoading } = useFirstStepsQuery();
+  const hideStepMutation = useHideFirstStepMutation();
   const [expanded, setExpandedState] = useState(true);
-  const [hiddenSteps, setHiddenSteps] = useState<string[]>([]);
   const hasCelebrated = useRef(false);
 
   useEffect(() => {
-    setHiddenSteps(readHiddenSteps());
     setExpandedState(
       window.localStorage.getItem(COLLAPSED_STORAGE_KEY) !== "true",
     );
@@ -69,14 +54,22 @@ export const useFirstStepsWidget = (): UseFirstStepsWidgetResult => {
   };
 
   const completedAt = data?.steps ?? {};
-  const visibleSteps = FIRST_STEPS.filter(
+  const hiddenSteps = data?.hidden_steps ?? [];
+  const hasHadProposal = data?.has_had_proposal ?? false;
+
+  // The first_approve row is uncompletable until GAIA has ever proposed work,
+  // so it isn't part of the checklist until then.
+  const applicableSteps = FIRST_STEPS.filter(
+    (step) => step.key !== "first_approve" || hasHadProposal,
+  );
+  const visibleSteps = applicableSteps.filter(
     (step) => !hiddenSteps.includes(step.key),
   );
-  const completedCount = FIRST_STEPS.filter(
+  const completedCount = applicableSteps.filter(
     (step) => completedAt[step.key],
   ).length;
-  const allComplete =
-    FIRST_STEPS.length > 0 && completedCount === FIRST_STEPS.length;
+  const totalCount = applicableSteps.length;
+  const allComplete = totalCount > 0 && completedCount === totalCount;
 
   useEffect(() => {
     if (allComplete && !hasCelebrated.current) {
@@ -87,9 +80,7 @@ export const useFirstStepsWidget = (): UseFirstStepsWidgetResult => {
   }, [allComplete]);
 
   const hideStep = (stepKey: string) => {
-    const next = [...hiddenSteps, stepKey];
-    setHiddenSteps(next);
-    window.localStorage.setItem(HIDDEN_STEPS_STORAGE_KEY, JSON.stringify(next));
+    hideStepMutation.mutate(stepKey);
   };
 
   const isReady = !isLoading && Boolean(data);
@@ -105,7 +96,7 @@ export const useFirstStepsWidget = (): UseFirstStepsWidgetResult => {
     visibleSteps,
     completedAt,
     completedCount,
-    totalCount: FIRST_STEPS.length,
+    totalCount,
     hideStep,
   };
 };

--- a/apps/web/src/features/first-steps/hooks/useHideFirstStepMutation.ts
+++ b/apps/web/src/features/first-steps/hooks/useHideFirstStepMutation.ts
@@ -5,16 +5,15 @@ import { firstStepsApi } from "../api/firstStepsApi";
 import { FIRST_STEPS_QUERY_KEY } from "./useFirstStepsQuery";
 
 /**
- * Marks a first-steps checklist item complete, optimistically stamping the
- * cache immediately so the widget updates without waiting on the round trip.
- * Mirrors the optimistic-update + invalidate-on-settle pattern used in
- * useEmailActions.
+ * Hides a single checklist row server-side, optimistically adding it to
+ * `hidden_steps` so the widget drops it immediately. Mirrors the optimistic
+ * update + invalidate-on-settle pattern in useMarkFirstStepMutation.
  */
-export const useMarkFirstStepMutation = () => {
+export const useHideFirstStepMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (step: string) => firstStepsApi.markFirstStep(step),
+    mutationFn: (step: string) => firstStepsApi.hideFirstStep(step),
     onMutate: async (step: string) => {
       await queryClient.cancelQueries({ queryKey: FIRST_STEPS_QUERY_KEY });
 
@@ -28,7 +27,9 @@ export const useMarkFirstStepMutation = () => {
           old
             ? {
                 ...old,
-                steps: { ...old.steps, [step]: new Date().toISOString() },
+                hidden_steps: old.hidden_steps.includes(step)
+                  ? old.hidden_steps
+                  : [...old.hidden_steps, step],
               }
             : old,
       );

--- a/apps/web/src/features/first-steps/hooks/useTrackRouteVisit.ts
+++ b/apps/web/src/features/first-steps/hooks/useTrackRouteVisit.ts
@@ -5,7 +5,7 @@ import { useMarkFirstStepMutation } from "./useMarkFirstStepMutation";
 /**
  * Marks a first-steps checklist item complete the moment its page mounts.
  * Call once from the top-level client component of the page that represents
- * that step (e.g. the workflows page for "explore_workflows"). Guards against
+ * that step (e.g. the dashboard page for "visit_dashboard"). Guards against
  * redundant PATCH calls by checking the already-loaded first-steps query data.
  */
 export const useTrackRouteVisit = (step: string): void => {

--- a/apps/web/src/features/settings/components/NotificationSettings.tsx
+++ b/apps/web/src/features/settings/components/NotificationSettings.tsx
@@ -3,12 +3,14 @@
 import { Switch } from "@heroui/switch";
 import { MailIcon } from "@icons";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { ChannelPriorityList } from "@/features/briefing/components/ChannelPriorityList";
 import {
   NOTIFICATION_PLATFORM_ICONS,
   NOTIFICATION_PLATFORM_LABELS,
   NOTIFICATION_PLATFORMS,
   type NotificationChannelPreference,
+  type NotificationPlatform,
 } from "@/features/notification/constants";
 import { SettingsPage } from "@/features/settings/components/ui/SettingsPage";
 import { SettingsRow } from "@/features/settings/components/ui/SettingsRow";
@@ -34,6 +36,17 @@ export default function NotificationSettings() {
   });
   const [loading, setLoading] = useState(true);
   const [togglingPlatform, setTogglingPlatform] = useState<string | null>(null);
+
+  const linkedMap = useMemo(
+    () =>
+      Object.fromEntries(
+        NOTIFICATION_PLATFORMS.map((platform) => [
+          platform,
+          !!platformLinks[platform]?.platformUserId,
+        ]),
+      ) as Record<NotificationPlatform, boolean>,
+    [platformLinks],
+  );
 
   useEffect(() => {
     const fetchAll = async () => {
@@ -131,6 +144,16 @@ export default function NotificationSettings() {
           />
         </SettingsRow>
       </SettingsSection>
+
+      <div>
+        <p className="mb-2 text-sm font-medium text-zinc-300">
+          Where your briefing lands
+        </p>
+        <p className="mb-3 text-sm text-zinc-500">
+          Your daily brief goes to the first connected channel in this order.
+        </p>
+        <ChannelPriorityList linkedMap={linkedMap} />
+      </div>
     </SettingsPage>
   );
 }

--- a/apps/web/src/features/todo/api/todoActionsApi.ts
+++ b/apps/web/src/features/todo/api/todoActionsApi.ts
@@ -32,6 +32,18 @@ export interface AnswerTodoResponse {
   execution_status: "queued";
 }
 
+export interface RetryTodoResponse {
+  success: boolean;
+  todo_id: string;
+  execution_status: "queued";
+}
+
+export interface DismissOfferResponse {
+  success: boolean;
+  todo_id: string;
+  gaia_offer_dismissed: true;
+}
+
 /** Shape of the 402 body returned when the user is out of GAIA execution quota. */
 export interface GaiaExecutionQuotaError {
   error: "gaia_execution_quota";
@@ -75,6 +87,22 @@ export function answerTodo(
   return apiService.post<AnswerTodoResponse>(
     `/todos/${todoId}/answer`,
     { answer, channel: "web" satisfies TodoActionChannel },
+    { silent: true },
+  );
+}
+
+export function retryTodo(todoId: string): Promise<RetryTodoResponse> {
+  return apiService.post<RetryTodoResponse>(
+    `/todos/${todoId}/retry`,
+    { channel: "web" satisfies TodoActionChannel },
+    { silent: true },
+  );
+}
+
+export function dismissOffer(todoId: string): Promise<DismissOfferResponse> {
+  return apiService.post<DismissOfferResponse>(
+    `/todos/${todoId}/dismiss_offer`,
+    {},
     { silent: true },
   );
 }

--- a/apps/web/src/features/todo/components/shared/ApproveConfirmModal.tsx
+++ b/apps/web/src/features/todo/components/shared/ApproveConfirmModal.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { CheckmarkCircle02Icon } from "@icons";
+import type React from "react";
+import { StagedDeliverablePreview } from "@/features/todo/components/shared/StagedDeliverablePreview";
+
+interface ApproveConfirmModalProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  todoId: string;
+  fallbackPreview?: string | null;
+  onConfirm: () => void;
+  isConfirming: boolean;
+}
+
+/**
+ * Confirmation gate before GAIA releases a staged deliverable: the exact
+ * content it will send, and an explicit "Approve & send". Used from surfaces
+ * (like the dashboard) where approving needs a look at the content first.
+ */
+export const ApproveConfirmModal: React.FC<ApproveConfirmModalProps> = ({
+  isOpen,
+  onOpenChange,
+  todoId,
+  fallbackPreview,
+  onConfirm,
+  isConfirming,
+}) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      size="lg"
+      placement="center"
+    >
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader className="text-amber-400">
+              GAIA wants to send this
+            </ModalHeader>
+            <ModalBody>
+              <StagedDeliverablePreview
+                todoId={todoId}
+                fallbackPreview={fallbackPreview}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="flat" radius="lg" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button
+                color="primary"
+                radius="lg"
+                startContent={<CheckmarkCircle02Icon className="size-4" />}
+                isLoading={isConfirming}
+                onPress={onConfirm}
+              >
+                Approve & send
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/apps/web/src/features/todo/components/shared/GaiaOfferBanner.tsx
+++ b/apps/web/src/features/todo/components/shared/GaiaOfferBanner.tsx
@@ -3,34 +3,9 @@
 import { Button } from "@heroui/button";
 import { Cancel01Icon, SparklesIcon } from "@icons";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useDismissOffer } from "@/features/todo/hooks/useDismissOffer";
 import { useHandoffTodo } from "@/features/todo/hooks/useHandoffTodo";
-
-const DISMISSED_OFFERS_KEY = "gaia-todo-offers-dismissed";
-
-function readDismissedOffers(): Set<string> {
-  if (typeof window === "undefined") return new Set();
-  try {
-    const raw = localStorage.getItem(DISMISSED_OFFERS_KEY);
-    return raw ? new Set(JSON.parse(raw) as string[]) : new Set();
-  } catch {
-    return new Set();
-  }
-}
-
-function persistDismissedOffer(todoId: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    const dismissed = readDismissedOffers();
-    dismissed.add(todoId);
-    localStorage.setItem(
-      DISMISSED_OFFERS_KEY,
-      JSON.stringify(Array.from(dismissed)),
-    );
-  } catch {
-    // Local dismiss is a nice-to-have — silently no-op if storage is unavailable.
-  }
-}
 
 interface GaiaOfferBannerProps {
   todoId: string;
@@ -38,10 +13,9 @@ interface GaiaOfferBannerProps {
 }
 
 /**
- * Quiet, dismissible "GAIA can do this" affordance for a user-owned todo
- * with a `gaia_offer`. There's no per-offer-dismiss endpoint, so dismissal
- * is tracked client-side (localStorage), same as other locally-dismissed
- * one-off UI affordances in this codebase.
+ * Quiet, dismissible "GAIA can do this" affordance for a user-owned todo with a
+ * `gaia_offer`. Dismissal is persisted server-side (`gaia_offer_dismissed`) so
+ * the offer stays gone across every surface and reload.
  */
 export const GaiaOfferBanner: React.FC<GaiaOfferBannerProps> = ({
   todoId,
@@ -49,10 +23,7 @@ export const GaiaOfferBanner: React.FC<GaiaOfferBannerProps> = ({
 }) => {
   const [dismissed, setDismissed] = useState(false);
   const handoffTodo = useHandoffTodo();
-
-  useEffect(() => {
-    setDismissed(readDismissedOffers().has(todoId));
-  }, [todoId]);
+  const dismissOffer = useDismissOffer();
 
   if (dismissed) return null;
 
@@ -83,8 +54,10 @@ export const GaiaOfferBanner: React.FC<GaiaOfferBannerProps> = ({
           aria-label="Dismiss offer"
           className="size-7 min-w-0 text-zinc-500"
           onPress={() => {
-            persistDismissedOffer(todoId);
             setDismissed(true);
+            dismissOffer.mutate(todoId, {
+              onError: () => setDismissed(false),
+            });
           }}
         >
           <Cancel01Icon className="size-3.5" />

--- a/apps/web/src/features/todo/components/shared/GaiaTodoMeta.tsx
+++ b/apps/web/src/features/todo/components/shared/GaiaTodoMeta.tsx
@@ -2,12 +2,15 @@
 
 import { AlertCircleIcon } from "@icons";
 import type React from "react";
+import { RetryTodoButton } from "@/features/todo/components/shared/RetryTodoButton";
 
 interface GaiaTodoMetaProps {
   /** Why GAIA proposed/is executing this todo, e.g. "you asked about this last week". */
   serves?: string | null;
   /** Populated when execution failed — rendered loudly, not muted. */
   errorMessage?: string | null;
+  /** When set alongside `errorMessage`, renders a Retry action for the failed run. */
+  todoId?: string;
 }
 
 /**
@@ -34,6 +37,7 @@ function cleanServes(serves: string): string {
 export const GaiaTodoMeta: React.FC<GaiaTodoMetaProps> = ({
   serves,
   errorMessage,
+  todoId,
 }) => {
   if (!serves && !errorMessage) return null;
 
@@ -49,6 +53,11 @@ export const GaiaTodoMeta: React.FC<GaiaTodoMetaProps> = ({
           <AlertCircleIcon className="mt-0.5 size-3.5 shrink-0" />
           <span>{errorMessage}</span>
         </p>
+      )}
+      {errorMessage && todoId && (
+        <div className="pt-1">
+          <RetryTodoButton todoId={todoId} />
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/features/todo/components/shared/RetryTodoButton.tsx
+++ b/apps/web/src/features/todo/components/shared/RetryTodoButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { RefreshIcon } from "@icons";
+import type React from "react";
+import { useRetryTodo } from "@/features/todo/hooks/useRetryTodo";
+
+interface RetryTodoButtonProps {
+  todoId: string;
+}
+
+/** Re-runs a failed GAIA todo. Rendered next to the failure reason. */
+export const RetryTodoButton: React.FC<RetryTodoButtonProps> = ({ todoId }) => {
+  const retryTodo = useRetryTodo();
+
+  return (
+    <Button
+      size="sm"
+      variant="flat"
+      color="danger"
+      radius="lg"
+      startContent={<RefreshIcon className="size-3.5" />}
+      isLoading={retryTodo.isPending}
+      onPress={() => retryTodo.mutate(todoId)}
+    >
+      Retry
+    </Button>
+  );
+};

--- a/apps/web/src/features/todo/components/shared/StagedDeliverablePreview.tsx
+++ b/apps/web/src/features/todo/components/shared/StagedDeliverablePreview.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Spinner } from "@heroui/spinner";
+import type React from "react";
+import MarkdownRenderer from "@/features/chat/components/interface/MarkdownRenderer";
+import { useTodoCanvas } from "@/features/todo/hooks/useTodoCanvas";
+import { cn } from "@/lib/utils";
+
+interface StagedDeliverablePreviewProps {
+  todoId: string;
+  /** Fallback preview text (e.g. the todo's description) shown while canvas.md loads or if it's empty. */
+  fallbackPreview?: string | null;
+  className?: string;
+}
+
+/**
+ * Drops the deliverable template's scaffolding (`# <title>` and `## Output`
+ * headings) — agent bookkeeping, not content the user is approving.
+ */
+function stripDeliverableScaffolding(markdown: string): string {
+  return markdown
+    .replace(/^\s*# .*\n+/, "")
+    .replace(/^\s*## Output\s*\n+/m, "")
+    .trim();
+}
+
+/**
+ * The scrollable "well" showing the exact staged deliverable a GAIA proposal
+ * will release. Loads the deliverable facet directly so the sidebar card and
+ * the approve modal render one identical preview.
+ */
+export const StagedDeliverablePreview: React.FC<
+  StagedDeliverablePreviewProps
+> = ({ todoId, fallbackPreview, className }) => {
+  // The deliverable facet IS what Approve releases — never preview notes.
+  const { content, isLoading } = useTodoCanvas(todoId, {
+    auto: true,
+    facet: "deliverable",
+  });
+
+  const previewText = content
+    ? stripDeliverableScaffolding(content)
+    : fallbackPreview;
+
+  return (
+    <div className={cn("rounded-xl bg-zinc-900 p-3", className)}>
+      {isLoading && !previewText ? (
+        <div className="flex justify-center py-4">
+          <Spinner size="sm" color="default" />
+        </div>
+      ) : previewText ? (
+        // Headings inside a staged draft render at card scale, not the global
+        // page scale — this is a preview well, not a document.
+        <div className="max-h-72 overflow-y-auto text-xs leading-relaxed text-zinc-300 [&_h1]:mt-2 [&_h1]:mb-1 [&_h1]:text-[13px] [&_h1]:font-semibold [&_h1]:first:mt-0 [&_h2]:mt-2 [&_h2]:mb-1 [&_h2]:text-[13px] [&_h2]:font-semibold [&_h2]:first:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-xs [&_h3]:font-semibold [&_h4]:text-xs [&_h4]:font-semibold [&_h5]:text-xs [&_h6]:text-xs [&_p]:my-1">
+          <MarkdownRenderer content={previewText} className="text-xs" />
+        </div>
+      ) : (
+        <p className="py-2 text-xs text-zinc-500">Nothing staged yet.</p>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/features/todo/components/shared/TodoProposalActions.tsx
+++ b/apps/web/src/features/todo/components/shared/TodoProposalActions.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { Button } from "@heroui/button";
-import { Spinner } from "@heroui/spinner";
 import { Cancel01Icon, CheckmarkCircle02Icon } from "@icons";
 import type React from "react";
-import MarkdownRenderer from "@/features/chat/components/interface/MarkdownRenderer";
+import { StagedDeliverablePreview } from "@/features/todo/components/shared/StagedDeliverablePreview";
 import { useApproveTodo } from "@/features/todo/hooks/useApproveTodo";
 import { useDismissTodo } from "@/features/todo/hooks/useDismissTodo";
-import { useTodoCanvas } from "@/features/todo/hooks/useTodoCanvas";
 import { cn } from "@/lib/utils";
 
 interface TodoProposalActionsProps {
@@ -15,17 +13,6 @@ interface TodoProposalActionsProps {
   /** Fallback preview text (e.g. the todo's description) shown while canvas.md loads or if it's empty. */
   fallbackPreview?: string | null;
   className?: string;
-}
-
-/**
- * Drops the deliverable template's scaffolding (`# <title>` and `## Output`
- * headings) — agent bookkeeping, not content the user is approving.
- */
-function stripDeliverableScaffolding(markdown: string): string {
-  return markdown
-    .replace(/^\s*# .*\n+/, "")
-    .replace(/^\s*## Output\s*\n+/m, "")
-    .trim();
 }
 
 /**
@@ -40,15 +27,6 @@ export const TodoProposalActions: React.FC<TodoProposalActionsProps> = ({
 }) => {
   const approveTodo = useApproveTodo();
   const dismissTodo = useDismissTodo();
-  // The deliverable facet IS what Approve releases — never preview notes.
-  const { content, isLoading } = useTodoCanvas(todoId, {
-    auto: true,
-    facet: "deliverable",
-  });
-
-  const previewText = content
-    ? stripDeliverableScaffolding(content)
-    : fallbackPreview;
 
   return (
     <div
@@ -58,21 +36,11 @@ export const TodoProposalActions: React.FC<TodoProposalActionsProps> = ({
       <p className="text-xs font-medium text-amber-400">
         GAIA wants to send this — approve to release it
       </p>
-      <div className="mt-3 rounded-xl bg-zinc-900 p-3">
-        {isLoading && !previewText ? (
-          <div className="flex justify-center py-4">
-            <Spinner size="sm" color="default" />
-          </div>
-        ) : previewText ? (
-          // Headings inside a staged draft render at card scale, not the
-          // global page scale — this is a preview well, not a document.
-          <div className="max-h-72 overflow-y-auto text-xs leading-relaxed text-zinc-300 [&_h1]:mt-2 [&_h1]:mb-1 [&_h1]:text-[13px] [&_h1]:font-semibold [&_h1]:first:mt-0 [&_h2]:mt-2 [&_h2]:mb-1 [&_h2]:text-[13px] [&_h2]:font-semibold [&_h2]:first:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-xs [&_h3]:font-semibold [&_h4]:text-xs [&_h4]:font-semibold [&_h5]:text-xs [&_h6]:text-xs [&_p]:my-1">
-            <MarkdownRenderer content={previewText} className="text-xs" />
-          </div>
-        ) : (
-          <p className="py-2 text-xs text-zinc-500">Nothing staged yet.</p>
-        )}
-      </div>
+      <StagedDeliverablePreview
+        todoId={todoId}
+        fallbackPreview={fallbackPreview}
+        className="mt-3"
+      />
       <div className="mt-3 flex items-center gap-2">
         <Button
           size="sm"

--- a/apps/web/src/features/todo/hooks/useDismissOffer.ts
+++ b/apps/web/src/features/todo/hooks/useDismissOffer.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+
+import {
+  type DismissOfferResponse,
+  dismissOffer,
+} from "@/features/todo/api/todoActionsApi";
+import { toast } from "@/lib/toast";
+import { useTodoStore } from "@/stores/todoStore";
+
+/**
+ * Dismisses GAIA's takeover offer on a user todo. Patches `gaia_offer_dismissed`
+ * into the shared store so every surface (sidebar banner, dashboard rows) hides
+ * the affordance without a refetch.
+ */
+export function useDismissOffer() {
+  return useMutation<DismissOfferResponse, unknown, string>({
+    mutationFn: (todoId: string) => dismissOffer(todoId),
+    onSuccess: (_data, todoId) => {
+      useTodoStore
+        .getState()
+        .updateTodoOptimistic(todoId, { gaia_offer_dismissed: true });
+    },
+    onError: () => {
+      toast.error("Failed to dismiss offer.");
+    },
+  });
+}

--- a/apps/web/src/features/todo/hooks/useRetryTodo.ts
+++ b/apps/web/src/features/todo/hooks/useRetryTodo.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import axios from "axios";
+
+import {
+  type RetryTodoResponse,
+  retryTodo,
+} from "@/features/todo/api/todoActionsApi";
+import { toast } from "@/lib/toast";
+import { useTodoStore } from "@/stores/todoStore";
+
+/**
+ * Re-runs a failed GAIA todo. Optimistically flips it back to `queued` in the
+ * shared store (same patch mechanism as `useApproveTodo`); a 409 means the run
+ * is no longer in a retryable state and surfaces the server's `detail`.
+ */
+export function useRetryTodo() {
+  return useMutation<RetryTodoResponse, unknown, string>({
+    mutationFn: (todoId: string) => retryTodo(todoId),
+    onSuccess: (data, todoId) => {
+      useTodoStore.getState().updateTodoOptimistic(todoId, {
+        execution_status: data.execution_status,
+        error_message: null,
+      });
+      useTodoStore
+        .getState()
+        .loadCounts()
+        .catch(() => undefined);
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error) && error.response?.status === 409) {
+        const detail = (error.response.data as { detail?: string })?.detail;
+        toast.error(detail || "This task can't be retried right now.");
+        return;
+      }
+      toast.error("Failed to retry task.");
+    },
+  });
+}

--- a/apps/web/src/features/workflows/components/WorkflowPage.tsx
+++ b/apps/web/src/features/workflows/components/WorkflowPage.tsx
@@ -15,7 +15,6 @@ import React, {
   useState,
 } from "react";
 import WorkflowsHeader from "@/components/layout/headers/WorkflowsHeader";
-import { useTrackRouteVisit } from "@/features/first-steps/hooks/useTrackRouteVisit";
 import UseCaseSection from "@/features/use-cases/components/UseCaseSection";
 import { useWorkflows } from "@/features/workflows/hooks/useWorkflows";
 import { useHeader } from "@/hooks/layout/useHeader";
@@ -32,7 +31,6 @@ import UnifiedWorkflowCard from "./shared/UnifiedWorkflowCard";
 import { WorkflowListSkeleton } from "./WorkflowSkeletons";
 
 export default function WorkflowPage() {
-  useTrackRouteVisit("explore_workflows");
   const pageRef = useRef(null);
   const clearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const router = useRouter();

--- a/apps/web/src/types/features/firstStepsTypes.ts
+++ b/apps/web/src/types/features/firstStepsTypes.ts
@@ -1,4 +1,8 @@
-// ISO completion timestamp per step key, or null if the step is not yet complete.
 export interface FirstStepsResponse {
+  // ISO completion timestamp per step key, or null if the step is not yet complete.
   steps: Record<string, string | null>;
+  // Step keys the user has hidden server-side (persist across browsers).
+  hidden_steps: string[];
+  // Whether a GAIA proposal has ever existed; gates the "first approve" row.
+  has_had_proposal: boolean;
 }

--- a/libs/shared/ts/src/types/todo.ts
+++ b/libs/shared/ts/src/types/todo.ts
@@ -62,6 +62,8 @@ export interface Todo {
   last_run_conversation_id?: string | null;
   /** Present on some user-owned todos GAIA is offering to take over. */
   gaia_offer?: string | null;
+  /** Set once the user dismisses GAIA's takeover offer — suppresses the affordance. */
+  gaia_offer_dismissed?: boolean;
   /** "task" (default) or "goal" — a long-lived lane whose canvas is its strategy. */
   kind?: "task" | "goal";
   /** For a task, the goal-todo it advances. */


### PR DESCRIPTION
## What

Follow-up batch to #854 (stacked on `feat/daily-briefing-openspec`) closing the retention-loop holes found in the end-to-end product evaluation.

### Fixed
- **Honest activity signals**: winback acknowledgment now uses the canonical "user active since T" predicate (goal created / last_active_at / any user message) — GAIA's own overnight completions no longer acknowledge briefings, so winback can actually fire. The streak counts only the user's own completions; GAIA can't pad it (streak badges now mean something).
- **Lifecycle pushes**: `needs_you` (agent blocks + release honesty gate) sends a real notification with the blocking question; `done` pushes in-app for released/standalone todos (goal-lane prep stays briefing-narrated); staged proposals warn " (expires within a day)" in the brief before the 72h TTL.
- **Failed is no longer a dead end**: new `failed → queued` retry transition (capped at 3, clears the failure marker so the executor actually re-runs) + `POST /todos/{id}/retry` + Retry button in the todo sidebar.
- **One briefing, one chat channel**: briefings now resolve explicit channels — in-app + the FIRST linked+enabled platform from the user's priority order (+ email until unsubscribed) instead of fanning out to every linked platform. `GET/PATCH /briefings/preferences`; draggable priority list in Notification Settings (motion Reorder, optimistic save).
- **Day-zero hello**: linking a chat platform within 14 days of signup triggers one warm, human welcome message that references the user's goal by name (or asks one specific question), tells them the first brief lands tomorrow at 8, and is persisted to the bot conversation so their reply has context. Once ever, guarded.
- **Rollout announcement removed** — a manual email replaces it; `provision_existing_user` keeps the bootstrap-marker gating only (the unparsed "what hour" interview dies with it).
- **Legacy `gaia-tracked` label retired**: `assignee` is the sole discriminator everywhere (filters, safety-net sweeps, activity, fs views); assignee sweep index added.
- **Approve is never blind**: dashboard Approve opens a staged-deliverable preview modal sharing the same preview component as the sidebar.
- **First-24h package**: first-steps re-pointed to completable steps (`tell_gaia_goal` / `connect_integration` / `link_platform` (any chat platform) / `visit_dashboard` / `first_approve` — hidden until a proposal exists); per-step hides + GAIA-offer dismissals persist server-side; "Full briefing" link removed from TodayHeader.
- **Prompt consolidation**: the `create_tracked_todo` tool contract is the single source of truth; SKILL.md 322→132 lines, todo system prompt 61→26, per-run directives dehydrated — no normative rule lost (inventory in the plan).

### Ops preconditions
- `scripts/migrate_todo_assignee.py` MUST run in prod before deploy (assignee-only filters won't see unmigrated docs).
- Existing multi-channel users will start receiving the brief on ONE chat platform — intended fix for triple delivery.

### Verification
- `ruff check app` clean; `mypy app --ignore-missing-imports` clean (713 files).
- `tsc --noEmit` clean; biome: 0 issues in touched files (103 repo warnings pre-existing).
- No new tests per project policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)