### PR TITLE
feat(api): support E2B_DOMAIN for the EU cluster migration

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -107,9 +107,9 @@ ENABLE_OPENUI=false
 # tools registered-but-disabled — they return a clear "sandbox not configured"
 # error at call time.
 
-# E2B cluster domain. Read directly from the env by the e2b SDK. Defaults to
-# `e2b.app` (US); GAIA runs on the EU cluster. The API key and the template ID
-# are per-cluster — all three must belong to the same cluster.
+# E2B cluster domain. Read directly from the env by the e2b SDK. GAIA runs on
+# the EU cluster; the API key and the template ID are per-cluster, so all three
+# must belong to the same cluster.
 # E2B_DOMAIN=e2b-juliett.dev
 
 # E2B sandbox template ID — produced by (with E2B_API_KEY + E2B_DOMAIN exported):

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -107,7 +107,12 @@ ENABLE_OPENUI=false
 # tools registered-but-disabled — they return a clear "sandbox not configured"
 # error at call time.
 
-# E2B sandbox template ID — produced by:
+# E2B cluster domain. Read directly from the env by the e2b SDK. Defaults to
+# `e2b.app` (US); GAIA runs on the EU cluster. The API key and the template ID
+# are per-cluster — all three must belong to the same cluster.
+# E2B_DOMAIN=e2b-juliett.dev
+
+# E2B sandbox template ID — produced by (with E2B_API_KEY + E2B_DOMAIN exported):
 #   uv run python apps/api/scripts/build_e2b_template.py
 # E2B_TEMPLATE_ID=
 

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -155,6 +155,16 @@ class CommonSettings(BaseAppSettings):
     # - Used for discovering and installing skills from GitHub
     GITHUB_TOKEN: str | None = None
 
+    # check_fields=False: E2B_DOMAIN is declared per-environment in the subclasses.
+    # Rejected rather than stripped because the e2b SDK reads os.environ verbatim —
+    # "" there silently falls back to the US cluster, padding yields a broken URL.
+    @field_validator("E2B_DOMAIN", mode="after", check_fields=False)
+    @classmethod
+    def _reject_unusable_e2b_domain(cls, v: str | None) -> str | None:
+        if v is not None and (not v or v != v.strip()):
+            raise ValueError("E2B_DOMAIN must be non-empty and free of surrounding whitespace")
+        return v
+
     # ----------------------------------------------
     # Computed Properties
     # ----------------------------------------------

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -295,6 +295,12 @@ class ProductionSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str
     E2B_TEMPLATE_ID: str  # gaia-coder template ID (run scripts/build_e2b_template.py)
+    # E2B cluster the SDK talks to. Like E2B_API_KEY, the SDK reads this
+    # straight from the process env (`e2b.ConnectionConfig._domain()`), so it is
+    # never passed at a call site — declared here so it shows up in the settings
+    # surface and in the sandbox logs. API key, template and domain are
+    # per-cluster: a template built against one domain does not exist on another.
+    E2B_DOMAIN: str = "e2b.app"
     # Idle window before a sandbox is paused. A paused sandbox must resume +
     # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single
     # most expensive step in an acquire (the metadata engine is remote). At 60s,
@@ -488,6 +494,7 @@ class DevelopmentSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str | None = None
     E2B_TEMPLATE_ID: str | None = None
+    E2B_DOMAIN: str = "e2b.app"
     # Idle window before a sandbox is paused. A paused sandbox must resume +
     # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single
     # most expensive step in an acquire (the metadata engine is remote). At 60s,

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -295,12 +295,12 @@ class ProductionSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str
     E2B_TEMPLATE_ID: str  # gaia-coder template ID (run scripts/build_e2b_template.py)
-    # E2B cluster the SDK talks to. Like E2B_API_KEY, the SDK reads this
-    # straight from the process env (`e2b.ConnectionConfig._domain()`), so it is
-    # never passed at a call site — declared here so it shows up in the settings
-    # surface and in the sandbox logs. API key, template and domain are
-    # per-cluster: a template built against one domain does not exist on another.
-    E2B_DOMAIN: str = "e2b.app"
+    # E2B cluster. Read straight from the process env by the SDK
+    # (`e2b.ConnectionConfig._domain()`), like E2B_API_KEY — never passed at a
+    # call site. No default: key, template and domain are per-cluster, and
+    # silently falling back to the SDK's `e2b.app` would point EU credentials
+    # at the US cluster.
+    E2B_DOMAIN: str
     # Idle window before a sandbox is paused. A paused sandbox must resume +
     # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single
     # most expensive step in an acquire (the metadata engine is remote). At 60s,
@@ -494,7 +494,7 @@ class DevelopmentSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str | None = None
     E2B_TEMPLATE_ID: str | None = None
-    E2B_DOMAIN: str = "e2b.app"
+    E2B_DOMAIN: str | None = None
     # Idle window before a sandbox is paused. A paused sandbox must resume +
     # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single
     # most expensive step in an acquire (the metadata engine is remote). At 60s,

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -295,11 +295,8 @@ class ProductionSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str
     E2B_TEMPLATE_ID: str  # gaia-coder template ID (run scripts/build_e2b_template.py)
-    # E2B cluster. Read straight from the process env by the SDK
-    # (`e2b.ConnectionConfig._domain()`), like E2B_API_KEY — never passed at a
-    # call site. No default: key, template and domain are per-cluster, and
-    # silently falling back to the SDK's `e2b.app` would point EU credentials
-    # at the US cluster.
+    # Never passed at a call site: the e2b SDK reads E2B_DOMAIN off the process
+    # env itself (`ConnectionConfig._domain()`), exactly like E2B_API_KEY.
     E2B_DOMAIN: str
     # Idle window before a sandbox is paused. A paused sandbox must resume +
     # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -295,8 +295,6 @@ class ProductionSettings(CommonSettings):
     # ----------------------------------------------
     E2B_API_KEY: str
     E2B_TEMPLATE_ID: str  # gaia-coder template ID (run scripts/build_e2b_template.py)
-    # Never passed at a call site: the e2b SDK reads E2B_DOMAIN off the process
-    # env itself (`ConnectionConfig._domain()`), exactly like E2B_API_KEY.
     E2B_DOMAIN: str
     # Idle window before a sandbox is paused. A paused sandbox must resume +
     # re-mount JuiceFS on the next turn, and the cold JuiceFS mount is the single

--- a/apps/api/app/services/sandbox/lifecycle.py
+++ b/apps/api/app/services/sandbox/lifecycle.py
@@ -192,7 +192,7 @@ async def _create_fresh_sandbox(user_id: str, shard_id: int) -> Any:
     # there's no implicit reliance on sandbox-wide identity for security.
     log.info(
         f"{LogTag.SANDBOX} creating fresh sandbox user={user_id} shard={shard_id} "
-        f"template={settings.E2B_TEMPLATE_ID}"
+        f"template={settings.E2B_TEMPLATE_ID} domain={settings.E2B_DOMAIN}"
     )
     async with fs_timer(FsOps.SBX_CREATE):
         sbx = await async_sandbox_cls.create(

--- a/apps/api/scripts/build_e2b_template.py
+++ b/apps/api/scripts/build_e2b_template.py
@@ -10,12 +10,12 @@ Usage:
     cd apps/api
     uv run python scripts/build_e2b_template.py [--name gaia-coder]
 
-Requires `E2B_API_KEY` in the env, plus `E2B_DOMAIN` when building against a
-non-default cluster (we run on E2B's EU cluster: `E2B_DOMAIN=e2b-juliett.dev`).
-Templates are per-cluster — one built on `e2b.app` does not exist on the EU
-cluster and vice versa, so the domain here must match the API's. Prints the
-resulting template ID — set it as `E2B_TEMPLATE_ID` in Infisical (and the
-gaia-backend container will pick it up on next boot).
+Requires `E2B_API_KEY` and `E2B_DOMAIN` in the env (we run on E2B's EU cluster:
+`E2B_DOMAIN=e2b-juliett.dev`). Templates are per-cluster — one built on
+`e2b.app` does not exist on the EU cluster and vice versa — so the domain is
+required rather than defaulted, and must match the API's. Prints the resulting
+template ID — set it as `E2B_TEMPLATE_ID` in Infisical (and the gaia-backend
+container will pick it up on next boot).
 
 Security posture
 ----------------
@@ -49,9 +49,6 @@ JUICEFS_TARBALL = (
     f"juicefs-{JUICEFS_VERSION}-linux-amd64.tar.gz"
 )
 TEMPLATE_NAME_DEFAULT = "gaia-coder"
-# Mirrors the e2b SDK's fallback when E2B_DOMAIN is unset — printed so a build
-# accidentally targeting the wrong cluster is visible before it starts.
-E2B_DEFAULT_DOMAIN = "e2b.app"
 
 MOUNT_SCRIPT_PATH = Path(__file__).parent / "mount_juicefs.sh"
 JFS_LAUNCHER_PATH = Path(__file__).parent / "jfs_launcher.py"
@@ -60,6 +57,9 @@ JFS_LAUNCHER_PATH = Path(__file__).parent / "jfs_launcher.py"
 def build(name: str) -> str:
     if not os.environ.get("E2B_API_KEY"):
         raise SystemExit("E2B_API_KEY is not set in the environment")
+    domain = os.environ.get("E2B_DOMAIN")
+    if not domain:
+        raise SystemExit("E2B_DOMAIN is not set in the environment")
     if not MOUNT_SCRIPT_PATH.exists():
         raise SystemExit(f"Mount script not found at {MOUNT_SCRIPT_PATH}")
     if not JFS_LAUNCHER_PATH.exists():
@@ -201,7 +201,6 @@ def build(name: str) -> str:
         )
     )
 
-    domain = os.environ.get("E2B_DOMAIN") or E2B_DEFAULT_DOMAIN
     print(f"Building E2B template '{name}' on {domain}...", file=sys.stderr)
 
     def _on_log(entry: object) -> None:

--- a/apps/api/scripts/build_e2b_template.py
+++ b/apps/api/scripts/build_e2b_template.py
@@ -10,9 +10,12 @@ Usage:
     cd apps/api
     uv run python scripts/build_e2b_template.py [--name gaia-coder]
 
-Requires `E2B_API_KEY` in the env. Prints the resulting template ID — set it
-as `E2B_TEMPLATE_ID` in Infisical (and the gaia-backend container will pick
-it up on next boot).
+Requires `E2B_API_KEY` in the env, plus `E2B_DOMAIN` when building against a
+non-default cluster (we run on E2B's EU cluster: `E2B_DOMAIN=e2b-juliett.dev`).
+Templates are per-cluster — one built on `e2b.app` does not exist on the EU
+cluster and vice versa, so the domain here must match the API's. Prints the
+resulting template ID — set it as `E2B_TEMPLATE_ID` in Infisical (and the
+gaia-backend container will pick it up on next boot).
 
 Security posture
 ----------------
@@ -46,6 +49,9 @@ JUICEFS_TARBALL = (
     f"juicefs-{JUICEFS_VERSION}-linux-amd64.tar.gz"
 )
 TEMPLATE_NAME_DEFAULT = "gaia-coder"
+# Mirrors the e2b SDK's fallback when E2B_DOMAIN is unset — printed so a build
+# accidentally targeting the wrong cluster is visible before it starts.
+E2B_DEFAULT_DOMAIN = "e2b.app"
 
 MOUNT_SCRIPT_PATH = Path(__file__).parent / "mount_juicefs.sh"
 JFS_LAUNCHER_PATH = Path(__file__).parent / "jfs_launcher.py"
@@ -195,7 +201,8 @@ def build(name: str) -> str:
         )
     )
 
-    print(f"Building E2B template '{name}'...", file=sys.stderr)
+    domain = os.environ.get("E2B_DOMAIN") or E2B_DEFAULT_DOMAIN
+    print(f"Building E2B template '{name}' on {domain}...", file=sys.stderr)
 
     def _on_log(entry: object) -> None:
         # E2B streams build logs; surface them so the user can see progress


### PR DESCRIPTION
## What

E2B was migrated from the US region to the EU cluster (`e2b-juliett.dev`). This wires `E2B_DOMAIN` through the API.

## How it works

No call-site plumbing was needed. The e2b SDK resolves its cluster from the **process env**, not from a constructor arg:

```python
# e2b/connection_config.py
@staticmethod
def _domain():
    return os.getenv("E2B_DOMAIN") or "e2b.app"
```

Verified live:

```
E2B_DOMAIN=e2b-juliett.dev  ->  domain = e2b-juliett.dev, api_url = https://api.e2b-juliett.dev
```

This is the same mechanism `E2B_API_KEY` already uses — the code never passes `api_key=` either. `AsyncSandbox.create`, `AsyncSandbox.connect` and `Template.build` all build a `ConnectionConfig` with no explicit domain, so all three follow the env.

`settings.py` runs `load_dotenv()` and `inject_infisical_secrets()` writes every secret into `os.environ` *before* Pydantic builds the settings object, so an Infisical value reaches the SDK. `settings = get_settings()` at module scope means the API and the ARQ worker share that path identically.

## Changes

| File | Change |
|---|---|
| `app/config/settings.py` | `E2B_DOMAIN: str` (required in prod), `str \| None = None` in dev — matching the `E2B_API_KEY` / `E2B_TEMPLATE_ID` pattern |
| `app/services/sandbox/lifecycle.py` | sandbox-create log includes `domain=`, so a wrong cluster is visible instead of surfacing as a confusing "template not found" |
| `scripts/build_e2b_template.py` | requires `E2B_DOMAIN` and prints the cluster it is building against |
| `.env.example` | documents `E2B_DOMAIN` |

**No default on purpose.** Templates and API keys are per-cluster, so falling back to the SDK's `e2b.app` would silently point EU credentials at the US cluster. Same reasoning in the build script, which now exits rather than building against the wrong cluster.

## Deploy steps

`E2B_DOMAIN` must be in Infisical **before** this merges. The field is required in `ProductionSettings`, and a missing required key makes the API **refuse to boot** — `from_env()` logs `[STARTUP] Error creating settings: ... E2B_DOMAIN Field required`, then its fallback loop skips the field (a required field's `default` is `PydanticUndefined`, so the `is not None` guard `continue`s) and the retry re-raises. Add it to every env slug (it is currently absent from `development`). Same contract as every other required prod key.

The template must be rebuilt on the EU cluster and `E2B_TEMPLATE_ID` updated (the current `0tnfu1c42a4xd07bsg5p` is a US-cluster template):

```bash
cd apps/api
E2B_DOMAIN=e2b-juliett.dev E2B_API_KEY=<EU-cluster-key> \
  uv run python scripts/build_e2b_template.py
```

Then re-run the hardening check (`scripts/verify_sandbox_hardening.sh`), since sudo-strip / hidepid are template-baked.

## Scope check

Grepped the monorepo: only `apps/api` touches e2b. No JS/TS package depends on the SDK, voice-agent and bots have no `E2B_` references, both compose files already pass `env_file: apps/api/.env`, and there are no `E2B_` references in CI. One place to set it: Infisical (plus `.env` locally).

## Verification

- `ProductionSettings.E2B_DOMAIN` -> `required=True`; `DevelopmentSettings` -> `required=False, default=None` (introspected `model_fields`)
- Dev load with the var unset -> `None`; set -> `'e2b-juliett.dev'`
- Build script without `E2B_DOMAIN` -> `E2B_DOMAIN is not set in the environment`, exit 1
- `ruff check` + `ruff format --check` clean, `mypy` clean on both touched modules, `tests/unit/sandbox` 28 passed

## Blank / padded values (added after review)

`E2B_DOMAIN` being a plain `str` was not enough — pydantic accepts `""`, and the SDK reads the env var verbatim:

```
env=''                  -> api_url='https://api.e2b.app'          # silently the US cluster
env='   '               -> api_url='https://api.   '              # malformed
env=' e2b-juliett.dev ' -> api_url='https://api. e2b-juliett.dev ' # malformed
```

The first case is exactly the silent wrong-cluster failure this PR exists to prevent, and it produced no startup signal. A validator on `CommonSettings` (`check_fields=False`, since the field is declared per-environment in the subclasses) now rejects blank and surrounding-whitespace values at boot. It rejects rather than strips, because a stripped *settings* value would not change what the SDK reads out of `os.environ`.

Verified against the real settings classes:

| `E2B_DOMAIN` | result |
|---|---|
| unset (dev) | boots, `None` |
| `''` | refuses to boot |
| `'   '` | refuses to boot |
| `' e2b-juliett.dev '` | refuses to boot |
| `'e2b-juliett.dev'` | boots |

## Known gap (not addressed here)

The `E2B Code Execution` group in `settings_validator.py` registers only `E2B_API_KEY` — neither `E2B_TEMPLATE_ID` nor `E2B_DOMAIN` gets the actionable "missing configuration" startup warning. Pre-existing; worth a follow-up.
