### PR TITLE
feat(skills): add ship-feature skill for autonomous end-to-end feature shipping

### DIFF
--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: ship-feature
+description: >
+  Autonomously ship a feature end-to-end with zero human intervention: plan it,
+  implement it, review it with a team of subagents, boot the full stack, drive
+  it in a real browser like a user (agent-browser + the driving-gaia skill),
+  capture before/after screenshots, open a PR to develop, and drive CI and
+  CodeRabbit to green. Use this skill whenever the user asks to "ship" a
+  feature, "one-shot" a feature, build something "end to end", implement
+  something "autonomously", take an idea "from spec to PR", or asks for a
+  complete feature with PR, screenshots, and passing CI — even if they don't
+  name this skill. Also use it when a cloud session is handed a feature
+  request and expected to deliver a finished, verified PR without a human in
+  the loop.
+---
+
+# Ship Feature
+
+**Announce at start:** "I'm using the ship-feature skill to take this feature from request to green PR."
+
+This skill turns a feature request into a merge-ready PR with no human in the
+loop. The output is not "code that should work" — it is a PR whose claims are
+all backed by evidence: the feature was exercised in a running product, the
+screenshots are real captures, CI is green, and every reviewer comment has a
+resolution. You orchestrate; subagents do the wide work; other skills own the
+mechanics:
+
+| Need | Use |
+|---|---|
+| Boot the stack, zero-login auth, seed users, drive API/browser/bots, sim LLM | `driving-gaia` skill — the cookbook; don't reinvent any of it |
+| Browser driving + screenshots | agent-browser (per driving-gaia §6) |
+| A misbehaving run | `reading-gaia-logs` skill |
+| The implementation plan | `writing-plans` skill, into `.agents/plans/` |
+| CI lanes, local repro, CodeRabbit loop | [references/ci-and-review.md](references/ci-and-review.md) |
+| Screenshot protocol + PR format | [references/screenshots-and-pr.md](references/screenshots-and-pr.md) |
+
+## Non-Negotiables
+
+- **Branch from and PR into `develop`.** Never `master`. **Never merge the PR.**
+- **Never fake evidence.** No mocked-up screenshots, no "verified" claims for
+  paths you did not run. Whatever you could not exercise, the PR says so.
+- **No debt as a shipping strategy.** Root-cause fixes, no lint suppressions,
+  no stubs, CLAUDE.md discipline at full strength — precisely because nobody
+  is watching in real time.
+- **Done means green.** The job ends when CI passes, CodeRabbit is answered,
+  and the PR is mergeable — or when you are genuinely blocked and have
+  reported exactly what blocks you.
+
+## Pipeline
+
+Track each phase as a task and keep statuses current — the task list is how
+an absent user sees where the ship is.
+
+### 0. Intake
+
+Turn the request into something falsifiable: (a) concrete acceptance criteria,
+(b) the click-path a real user takes through the feature — this becomes the
+E2E script and the screenshot shot-list — and (c) the affected surfaces. If
+scope is genuinely ambiguous, pick the smallest interpretation with real user
+value, state the choice in the plan and PR, and proceed; do not block on
+questions nobody is there to answer.
+
+### 1. Bootstrap (start first, runs while you plan)
+
+`git fetch origin develop` and branch from it. Then `pnpm install` and
+`uv sync --project apps/api --group backend --group dev`, create env files
+(`mise setup:env`, then `cp -f apps/api/.env.example apps/api/.env`; dummy
+WorkOS values are fine — the dev bypass never calls WorkOS). Boot per
+driving-gaia §1: `mise dev --sim` for deterministic chat flows, `mise dev
+--agent` when judging real model behavior, then `mise seed`.
+
+Cloud sandbox note: if the Docker daemon isn't running, start it with
+`nohup dockerd --iptables=false --bridge=none &`. If infra ports then aren't
+reachable from the host (bridge port-publishing needs IPv4 forwarding, often
+disabled in sandboxes), run the infra containers directly with
+`--network=host` instead of the compose port map — and move ChromaDB off its
+default port 8000 so it doesn't collide with the API.
+
+### 2. Plan, then attack the plan
+
+Explore with code-review-graph tools and parallel Explore subagents per layer.
+Read the area rules you'll touch (`apps/web/CLAUDE.md`, `apps/api/CLAUDE.md`,
+`DESIGN.md`, chat-bubble/OpenUI CLAUDE.mds). Write the plan with
+`writing-plans`. Then spawn one subagent to attack it — architectural fit,
+duplication against existing code, simpler alternatives, blast radius —
+verifying its claims against the codebase, not just opining. Fold in what
+survives. A plan flaw costs minutes here and hours in phase 9.
+
+### 3. BEFORE screenshots
+
+With the stack running **clean base-branch code**, walk the journey script
+and capture every surface the feature will change
+([references/screenshots-and-pr.md](references/screenshots-and-pr.md)). For a
+brand-new surface, "before" is whatever exists today. Never reconstruct a
+before-state from memory after the fact — `git stash` if you must.
+
+### 4. Implement
+
+Execute the plan task by task on the feature branch. Write to CI's bars from
+the start rather than remediating after: files ≤ 400 lines, ≤ 2 React
+components per file, > 3 exported types → `*.types.ts`, xenon complexity
+caps, 80% Python docstring coverage, no copy-paste, strict dead-code. HeroUI
+first, icons from `@icons`, Sileo toasts. Commit in Conventional-Commit
+increments. Do not write new test files unless the user asked (repo rule).
+
+### 5. Local gates
+
+Run the CI-equivalent commands locally before any push
+([references/ci-and-review.md](references/ci-and-review.md)). Fix at the
+root; auto-fixers first where they exist.
+
+### 6. Review team
+
+Spawn reviewer subagents in parallel on the full diff vs `origin/develop`,
+one lens each — correctness (real user-reachable failures, not theoretical
+races), architecture/debt (duplication, wrong-layer logic, missed
+`libs/shared` reuse, dead code), design-system compliance vs DESIGN.md (UI
+diffs only), security (only when the diff adds surface). Each returns
+findings with file:line and a concrete failure scenario. Then adversarially
+verify: a fresh subagent per finding tries to refute it against the code. Fix
+what survives, drop what doesn't — single-pass reviewers confidently report
+plausible non-bugs. Re-run affected gates after fixes.
+
+### 7. E2E as a user + AFTER screenshots
+
+Drive the running app through the full journey script with agent-browser
+(driving-gaia §6) as the seeded dev user — hot reload has your changes. On
+every page: act like the user, exercise the unhappy paths (empty states,
+invalid input, the second submit), and check for console errors and failed
+network requests (chrome-devtools MCP when you need that introspection; a
+feature that renders but errors underneath is not done). Verify data landed
+in Mongo, not stdout (driving-gaia §4). Run the existing Playwright smoke
+(`mise e2e:web`, `E2E_SIM=1` under sim). Fix → re-drive until clean, then
+capture the AFTER shot-list.
+
+### 8. Ship the PR
+
+Conventional-Commit title, base `develop`, body with the before/after table
+and an honest verification section
+([references/screenshots-and-pr.md](references/screenshots-and-pr.md)).
+Subscribe to PR activity immediately.
+
+### 9. Drive to green, then stop
+
+Remediate CI failures at the root, answer every CodeRabbit thread — fix or
+reasoned pushback, never silence — and keep the branch mergeable with plain
+`git merge origin/develop` (rebase is banned)
+([references/ci-and-review.md](references/ci-and-review.md)). When both
+required gates are green and all threads are resolved, post one final status
+comment and stop. Do not merge.
+
+## Definition of Done
+
+- [ ] Every acceptance criterion verified against the running app; anything
+      not exercised is named in the PR
+- [ ] BEFORE and AFTER screenshots captured live, published, rendering in the
+      PR body
+- [ ] Local gates green for every touched language; review findings fixed or
+      refuted
+- [ ] PR open against `develop`, both CI gates green, CodeRabbit threads all
+      resolved or answered
+- [ ] Branch pushed, tree clean, no stray files in the diff (plans,
+      screenshots, scratch scripts)

--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -99,9 +99,10 @@ survives. A plan flaw costs minutes here and hours in phase 9.
 
 ### 3. BEFORE screenshots
 
-Valid only while the fresh branch is still byte-identical to `develop` —
-capture before your first edit (`git stash` around the capture if you
-already edited). Walk the journey script and shoot every surface the
+Valid only while the branch's tracked tree still matches `develop` —
+untracked bootstrap artifacts (`.env` files, installed deps) don't count.
+Capture before your first source edit (`git stash` around the capture if
+you already edited). Walk the journey script and shoot every surface the
 feature will change, per the protocol in
 [references/screenshots-and-pr.md](references/screenshots-and-pr.md).
 
@@ -127,7 +128,9 @@ Spawn reviewer subagents in parallel on the full diff vs `origin/develop`,
 one lens each — correctness (real user-reachable failures, not theoretical
 races), architecture/debt (duplication, wrong-layer logic, missed
 `libs/shared` reuse, dead code), design-system compliance vs DESIGN.md (UI
-diffs only), security (only when the diff adds surface). Each returns
+diffs only), security (when the diff adds surface — endpoints, queries, file
+handling, external calls — or touches security-sensitive code: authz,
+validation, secrets, dependencies, infra). Each returns
 findings with file:line and a concrete failure scenario. Then adversarially
 verify: a fresh skeptic subagent takes the batched findings and tries to
 refute each against the code. Fix what survives, drop what doesn't —

--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -11,7 +11,9 @@ description: >
   complete feature with PR, screenshots, and passing CI — even if they don't
   name this skill. Also use it when a cloud session is handed a feature
   request and expected to deliver a finished, verified PR without a human in
-  the loop.
+  the loop. Do not use it when the user just wants code written or an
+  ordinary PR without the full verified-shipping pipeline (live E2E,
+  screenshots, drive-to-green).
 ---
 
 # Ship Feature
@@ -31,8 +33,16 @@ mechanics:
 | Browser driving + screenshots | agent-browser (per driving-gaia §6) |
 | A misbehaving run | `reading-gaia-logs` skill |
 | The implementation plan | `writing-plans` skill, into `.agents/plans/` |
+| UI design brief, building UI, design iteration | `shape` → `impeccable` → `critique`/`polish` (see Frontend Craft) |
 | CI lanes, local repro, CodeRabbit loop | [references/ci-and-review.md](references/ci-and-review.md) |
 | Screenshot protocol + PR format | [references/screenshots-and-pr.md](references/screenshots-and-pr.md) |
+
+**Subagent economy.** A team of agents is not a license to burn tokens.
+Match the model to the job: wide mechanical fan-outs (exploration, claim
+verification, lane repro) run on a small model; judgment-heavy singletons
+(plan attack, review lenses, design critique) use the session's model.
+Spawn the agents the task needs, no more — parallelism is for wall-clock,
+not volume.
 
 ## Non-Negotiables
 
@@ -63,7 +73,7 @@ questions nobody is there to answer.
 ### 1. Bootstrap (start first, runs while you plan)
 
 `git fetch origin develop` and branch from it. Then `pnpm install` and
-`uv sync --project apps/api --group backend --group dev`, create env files
+`pnpm exec nx run api:sync`, create env files
 (`cp -f apps/api/.env.example apps/api/.env` first — `mise setup:env` errors
 without it, and only auto-copies the others; dummy WorkOS values are fine —
 the dev bypass never calls WorkOS). Boot per
@@ -89,11 +99,11 @@ survives. A plan flaw costs minutes here and hours in phase 9.
 
 ### 3. BEFORE screenshots
 
-With the stack running **clean base-branch code**, walk the journey script
-and capture every surface the feature will change
-([references/screenshots-and-pr.md](references/screenshots-and-pr.md)). For a
-brand-new surface, "before" is whatever exists today. Never reconstruct a
-before-state from memory after the fact — `git stash` if you must.
+Valid only while the fresh branch is still byte-identical to `develop` —
+capture before your first edit (`git stash` around the capture if you
+already edited). Walk the journey script and shoot every surface the
+feature will change, per the protocol in
+[references/screenshots-and-pr.md](references/screenshots-and-pr.md).
 
 ### 4. Implement
 
@@ -101,9 +111,9 @@ Execute the plan task by task on the feature branch. Write to CI's structural
 bars from the start rather than remediating after — the Code Quality lanes
 enforce limits on file size, components per file, type placement, complexity,
 docstring coverage, duplication, and dead code (current thresholds live in
-the lane scripts/configs, see the CI reference). HeroUI first, icons from
-`@icons`, Sileo toasts. Commit in Conventional-Commit increments. Do not
-write new test files unless the user asked (repo rule).
+the lane scripts/configs, see the CI reference). UI-touching work follows
+Frontend Craft (below). Commit in Conventional-Commit increments; no new
+test files unless the user asked (repo Testing rule).
 
 ### 5. Local gates
 
@@ -119,24 +129,32 @@ races), architecture/debt (duplication, wrong-layer logic, missed
 `libs/shared` reuse, dead code), design-system compliance vs DESIGN.md (UI
 diffs only), security (only when the diff adds surface). Each returns
 findings with file:line and a concrete failure scenario. Then adversarially
-verify: a fresh subagent per finding tries to refute it against the code. Fix
-what survives, drop what doesn't — single-pass reviewers confidently report
-plausible non-bugs. Re-run affected gates after fixes.
+verify: a fresh skeptic subagent takes the batched findings and tries to
+refute each against the code. Fix what survives, drop what doesn't —
+single-pass reviewers confidently report plausible non-bugs. Re-run affected
+gates after fixes.
 
 ### 7. E2E as a user + AFTER screenshots
 
-Drive the running app through the full journey script with agent-browser
-(driving-gaia §6) as the seeded dev user — hot reload has your changes. On
-every page: act like the user, exercise the unhappy paths (empty states,
-invalid input, the second submit), and check for console errors and failed
-network requests (chrome-devtools MCP when you need that introspection; a
-feature that renders but errors underneath is not done). Verify data landed
-in Mongo, not stdout (driving-gaia §4). Run the existing Playwright smoke
-(`mise e2e:web`, `E2E_SIM=1` under sim). Fix → re-drive until clean, then
-capture the AFTER shot-list.
+Run the existing Playwright smoke first (`mise e2e:web`, `E2E_SIM=1` under
+sim) — its global setup **resets and re-seeds the dev user**, wiping
+anything driven before it; smoke first, journey second. Then drive the app
+through the full journey script with agent-browser (driving-gaia §6) as the
+seeded dev user. Hot reload covers code edits only — after dependency, env,
+or settings changes, re-sync and restart the stack. On every page: act like
+the user, exercise the unhappy paths (empty states, invalid input, the
+second submit), and check for console errors and failed network requests
+(chrome-devtools MCP when you need that introspection; a feature that
+renders but errors underneath is not done). Verify data landed in Mongo, not
+stdout (driving-gaia §4). If the journey needs state the dev seed cannot
+create (OAuth integrations, external data), fabricate it under `--sim`
+directives or verify that layer directly via the dev routes (driving-gaia
+§5) — and name the un-exercised surface under Not verified. Fix → re-drive
+until clean, then capture the AFTER shot-list.
 
 ### 8. Ship the PR
 
+Push the branch first (`git push -u origin <branch>`), then open the PR:
 Conventional-Commit title, base `develop`, body with the before/after table
 and an honest verification section
 ([references/screenshots-and-pr.md](references/screenshots-and-pr.md)).
@@ -145,18 +163,37 @@ Subscribe to PR activity immediately.
 ### 9. Drive to green, then stop
 
 Remediate CI failures at the root, answer every CodeRabbit thread — fix or
-reasoned pushback, never silence — and keep the branch mergeable with plain
-`git merge origin/develop` (rebase is banned)
+reasoned pushback, never silence — and keep the branch mergeable
 ([references/ci-and-review.md](references/ci-and-review.md)). When both
 required gates are green and all threads are resolved, post one final status
 comment and stop. Do not merge.
+
+## Frontend Craft (UI features)
+
+Unattended AI-generated UI defaults to slop — generic layouts, timid
+typography, no hierarchy, elements added because sections like them usually
+exist. Design is a gate in this pipeline, not a coat of paint:
+
+- **Before UI code:** run `shape` for the design brief — direction,
+  hierarchy, what to leave out — grounded in `DESIGN.md` tokens. Every
+  element must have a reason to exist; if it's there "for completeness",
+  cut it.
+- **While building:** use the `impeccable` skill. Typography scale, spacing
+  rhythm, and visual hierarchy are decisions made from principles — the bar
+  is Linear/Notion/Apple-level consideration — never framework defaults.
+- **After it renders:** iterate. Screenshot → critique with the design
+  skills (`critique`, `polish`, `make-interfaces-feel-better`) → refine →
+  re-drive. Expect several rounds; one-pass UI is how slop ships. The
+  phase-6 design lens and the AFTER screenshots are the exit gate, not the
+  first render.
 
 ## Definition of Done
 
 - [ ] Every acceptance criterion verified against the running app; anything
       not exercised is named in the PR
-- [ ] BEFORE and AFTER screenshots captured live, published, rendering in the
-      PR body
+- [ ] BEFORE and AFTER screenshots captured live and rendering in the PR for
+      every changed UI surface; features with no UI surface substitute
+      equivalent live evidence (bot transcript, curl + Mongo output) and say so
 - [ ] Local gates green for every touched language; review findings fixed or
       refuted
 - [ ] PR open against `develop`, both CI gates green, CodeRabbit threads all

--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -64,8 +64,9 @@ questions nobody is there to answer.
 
 `git fetch origin develop` and branch from it. Then `pnpm install` and
 `uv sync --project apps/api --group backend --group dev`, create env files
-(`mise setup:env`, then `cp -f apps/api/.env.example apps/api/.env`; dummy
-WorkOS values are fine — the dev bypass never calls WorkOS). Boot per
+(`cp -f apps/api/.env.example apps/api/.env` first — `mise setup:env` errors
+without it, and only auto-copies the others; dummy WorkOS values are fine —
+the dev bypass never calls WorkOS). Boot per
 driving-gaia §1: `mise dev --sim` for deterministic chat flows, `mise dev
 --agent` when judging real model behavior, then `mise seed`.
 
@@ -96,12 +97,13 @@ before-state from memory after the fact — `git stash` if you must.
 
 ### 4. Implement
 
-Execute the plan task by task on the feature branch. Write to CI's bars from
-the start rather than remediating after: files ≤ 400 lines, ≤ 2 React
-components per file, > 3 exported types → `*.types.ts`, xenon complexity
-caps, 80% Python docstring coverage, no copy-paste, strict dead-code. HeroUI
-first, icons from `@icons`, Sileo toasts. Commit in Conventional-Commit
-increments. Do not write new test files unless the user asked (repo rule).
+Execute the plan task by task on the feature branch. Write to CI's structural
+bars from the start rather than remediating after — the Code Quality lanes
+enforce limits on file size, components per file, type placement, complexity,
+docstring coverage, duplication, and dead code (current thresholds live in
+the lane scripts/configs, see the CI reference). HeroUI first, icons from
+`@icons`, Sileo toasts. Commit in Conventional-Commit increments. Do not
+write new test files unless the user asked (repo rule).
 
 ### 5. Local gates
 

--- a/.claude/skills/ship-feature/references/ci-and-review.md
+++ b/.claude/skills/ship-feature/references/ci-and-review.md
@@ -48,7 +48,7 @@ diff are not yours to fix in this PR.
 ## The drive-to-green loop
 
 1. `subscribe_pr_activity` right after opening the PR. Where `send_later`
-   exists, arm a ~1h fallback self check-in in case events don't arrive;
+   exists, arm a ~1h fallback self-check-in in case events don't arrive;
    re-arm silently until the PR is done.
 2. **CI failure** → pull the job log, find the lane's command in the
    workflow, reproduce locally, fix at the root, re-run, push. Never push a

--- a/.claude/skills/ship-feature/references/ci-and-review.md
+++ b/.claude/skills/ship-feature/references/ci-and-review.md
@@ -76,3 +76,6 @@ CodeRabbit auto-reviews PRs; its comments arrive as PR activity events. Apply
   repo wins; say so in one line.
 - After pushing a batch of fixes, comment `@coderabbitai review` to trigger a
   re-review, and confirm no thread remains unanswered.
+- If no CodeRabbit review has arrived by the time CI is green plus one
+  check-in cycle, it may not be installed on the repo — note its absence in
+  the final status comment and finish without it.

--- a/.claude/skills/ship-feature/references/ci-and-review.md
+++ b/.claude/skills/ship-feature/references/ci-and-review.md
@@ -2,75 +2,56 @@
 
 ## What runs on a PR to develop
 
-- **Quality Checks** (`main.yml`) — affected-project build (TS), full pytest
-  suite vs live services (`uv run --frozen pytest -n auto -m 'not composio'`
-  from `apps/api`), vitest for affected TS projects, and harness-tool tests
-  (`tools/lints` + `tools/llm-stub`, always on). Required check:
-  **`quality-gate`** (skipped jobs pass).
-- **Code Quality** (`code-quality.yml`) — 16 lanes, all enforced via marker
-  files in `.github/quality-gate/enforced/`. Required check:
-  **`Quality gate (required)`** — here a skipped enforced lane **fails**,
-  unlike the other gate.
-- **Validate PR Title** — Conventional Commit type from: `feat fix docs style
-  refactor test chore ci build revert perf release deps infra security env
-  i18n ux config assets meta`.
-- **Desktop PR Build** — only when `apps/desktop/**` or `libs/shared/ts/**`
-  changed.
+Source of truth: `.github/workflows/` — read the workflow when you need a
+lane's exact command; don't trust memory or this file for specifics.
 
-Non-blocking noise — never remediate: `changelog-sync` (self-heals via its
-own PR and still exits 1; excluded from the gate), `trivy-scan`, `pip-audit`.
+- **Quality Checks** (`main.yml`) — build + test jobs over affected projects
+  (Python tests run the full suite against live services). Required check:
+  **`quality-gate`**; skipped jobs pass it.
+- **Code Quality** (`code-quality.yml`) — many independent lint/analysis
+  lanes. A lane is enforced iff a marker file exists in
+  `.github/quality-gate/enforced/`. Required check:
+  **`Quality gate (required)`**. In both gates a skipped lane passes (skipped
+  = your diff didn't touch that lane's language).
+- **PR title check** (`pr-naming-conventions.yml`) — Conventional Commit
+  title; the allowed type list lives in that workflow.
+- **Desktop PR Build** — only when its path filters match (desktop app +
+  shared TS).
+
+Jobs that are red by design or advisory (e.g. changelog-sync, security
+scanners marked `continue-on-error`) are excluded from the gates — check the
+gate job's `needs` list before remediating anything, and never "fix" a check
+the gate ignores.
 
 ## Run the gates locally BEFORE pushing
 
-Typical web+api feature sweep:
+Mirror what CI will run, scoped to what you touched:
 
-```bash
-pnpm exec nx run-many -t lint type-check --projects=web,api --parallel=3
-pnpm exec nx build web
-(cd apps/api && uv run pytest tests/unit --tb=short -q)   # full suite needs live infra
+- Per-project basics: `pnpm exec nx run-many -t lint type-check build
+  --projects=<touched>` and the project's test target. `nx run
+  <proj>:lint:fix` first where a fixer exists.
+- Code-quality lanes: each lane maps to a root `quality:*` script in
+  `package.json` — run the ones for your languages (`pnpm run` with no args
+  lists them). Lanes without a fixer (file size, components-per-file, type
+  placement, complexity, docstring coverage, duplication, dead code) are
+  design feedback: restructure the code, never suppress or split cosmetically.
+- `mise tasks` lists the aggregate runners if you want one command per area.
 
-pnpm run quality:circular
-pnpm run quality:size
-pnpm run quality:components        # tsx changed
-pnpm run quality:types-location    # ts/tsx changed
-pnpm run quality:type-coverage
-pnpm run quality:dead:strict
-pnpm run quality:py:interrogate    # py changed
-pnpm run quality:py:xenon          # py changed
-uvx bandit -c pyproject.toml -r apps/api/app libs/shared/py --severity-level low --confidence-level low   # py changed
-```
-
-Auto-fixers — reach for these first: `nx run <proj>:lint:fix` (biome/ruff),
-`pnpm run quality:deps:fix` (syncpack/manypkg), `uvx ruff format <files>`.
-
-No auto-fix — these are design feedback, fix the code: file-size (400-line
-target), components-per-file (max 2), types-location (> 3 exported types →
-`*.types.ts`), type-coverage, xenon complexity, interrogate docstrings, jscpd
-duplication, dead-code.
-
-**The diff-scoping trap:** most Code Quality lanes run only on files changed
-vs the PR base (`scripts/ci/changed-files.sh`). Locally that variable is
-unset, so the same command runs repo-wide and can fail on files you never
-touched. Reproduce a lane exactly as CI sees it:
-
-```bash
-git fetch origin develop
-GITHUB_BASE_REF=develop scripts/ci/changed-files.sh ts tsx   # prints CI's file list
-```
-
-Pre-existing repo-wide failures outside your diff are not yours to fix in
-this PR — confirm CI scopes them out rather than "fixing" half the codebase.
-
-Also: `nx affected` defaults to base `master` locally (`nx.json`); always
-pass `--base=origin/develop`.
+**The diff-scoping trap:** many Code Quality lanes run only on files changed
+vs the PR base (see `scripts/ci/changed-files.sh`). Locally the base-ref env
+var is unset, so the same command runs repo-wide and can fail on files you
+never touched. Reproduce a lane exactly as CI sees it by exporting the
+base-ref variable the script reads (with `develop` fetched), or by limiting
+the tool to your changed files. Pre-existing repo-wide failures outside your
+diff are not yours to fix in this PR.
 
 ## The drive-to-green loop
 
 1. `subscribe_pr_activity` right after opening the PR. Where `send_later`
    exists, arm a ~1h fallback self check-in in case events don't arrive;
    re-arm silently until the PR is done.
-2. **CI failure** → pull the job log, reproduce locally with the matching
-   command above, fix at the root, re-run the local gate, push. Never push a
+2. **CI failure** → pull the job log, find the lane's command in the
+   workflow, reproduce locally, fix at the root, re-run, push. Never push a
    blind retry. Every failure event ends in a pushed fix or a PR comment
    explaining precisely why not — no third option.
 3. **Merge conflict / base moved** → `git fetch origin && git merge
@@ -81,9 +62,8 @@ pass `--base=origin/develop`.
 
 ## CodeRabbit
 
-CodeRabbit auto-reviews PRs with default settings (the checked-in config at
-`config/.coderabbit.yaml` is not at repo root, so it is inert). Its comments
-arrive as PR activity events. Apply `receiving-code-review` discipline:
+CodeRabbit auto-reviews PRs; its comments arrive as PR activity events. Apply
+`receiving-code-review` discipline:
 
 - **Verify before implementing.** Read the referenced code and confirm the
   claim — CodeRabbit is confidently wrong at a meaningful rate, and blindly

--- a/.claude/skills/ship-feature/references/ci-and-review.md
+++ b/.claude/skills/ship-feature/references/ci-and-review.md
@@ -1,0 +1,98 @@
+# CI Gates, Local Repro, and the Drive-to-Green Loop
+
+## What runs on a PR to develop
+
+- **Quality Checks** (`main.yml`) — affected-project build (TS), full pytest
+  suite vs live services (`uv run --frozen pytest -n auto -m 'not composio'`
+  from `apps/api`), vitest for affected TS projects, and harness-tool tests
+  (`tools/lints` + `tools/llm-stub`, always on). Required check:
+  **`quality-gate`** (skipped jobs pass).
+- **Code Quality** (`code-quality.yml`) — 16 lanes, all enforced via marker
+  files in `.github/quality-gate/enforced/`. Required check:
+  **`Quality gate (required)`** — here a skipped enforced lane **fails**,
+  unlike the other gate.
+- **Validate PR Title** — Conventional Commit type from: `feat fix docs style
+  refactor test chore ci build revert perf release deps infra security env
+  i18n ux config assets meta`.
+- **Desktop PR Build** — only when `apps/desktop/**` or `libs/shared/ts/**`
+  changed.
+
+Non-blocking noise — never remediate: `changelog-sync` (self-heals via its
+own PR and still exits 1; excluded from the gate), `trivy-scan`, `pip-audit`.
+
+## Run the gates locally BEFORE pushing
+
+Typical web+api feature sweep:
+
+```bash
+pnpm exec nx run-many -t lint type-check --projects=web,api --parallel=3
+pnpm exec nx build web
+(cd apps/api && uv run pytest tests/unit --tb=short -q)   # full suite needs live infra
+
+pnpm run quality:circular
+pnpm run quality:size
+pnpm run quality:components        # tsx changed
+pnpm run quality:types-location    # ts/tsx changed
+pnpm run quality:type-coverage
+pnpm run quality:dead:strict
+pnpm run quality:py:interrogate    # py changed
+pnpm run quality:py:xenon          # py changed
+uvx bandit -c pyproject.toml -r apps/api/app libs/shared/py --severity-level low --confidence-level low   # py changed
+```
+
+Auto-fixers — reach for these first: `nx run <proj>:lint:fix` (biome/ruff),
+`pnpm run quality:deps:fix` (syncpack/manypkg), `uvx ruff format <files>`.
+
+No auto-fix — these are design feedback, fix the code: file-size (400-line
+target), components-per-file (max 2), types-location (> 3 exported types →
+`*.types.ts`), type-coverage, xenon complexity, interrogate docstrings, jscpd
+duplication, dead-code.
+
+**The diff-scoping trap:** most Code Quality lanes run only on files changed
+vs the PR base (`scripts/ci/changed-files.sh`). Locally that variable is
+unset, so the same command runs repo-wide and can fail on files you never
+touched. Reproduce a lane exactly as CI sees it:
+
+```bash
+git fetch origin develop
+GITHUB_BASE_REF=develop scripts/ci/changed-files.sh ts tsx   # prints CI's file list
+```
+
+Pre-existing repo-wide failures outside your diff are not yours to fix in
+this PR — confirm CI scopes them out rather than "fixing" half the codebase.
+
+Also: `nx affected` defaults to base `master` locally (`nx.json`); always
+pass `--base=origin/develop`.
+
+## The drive-to-green loop
+
+1. `subscribe_pr_activity` right after opening the PR. Where `send_later`
+   exists, arm a ~1h fallback self check-in in case events don't arrive;
+   re-arm silently until the PR is done.
+2. **CI failure** → pull the job log, reproduce locally with the matching
+   command above, fix at the root, re-run the local gate, push. Never push a
+   blind retry. Every failure event ends in a pushed fix or a PR comment
+   explaining precisely why not — no third option.
+3. **Merge conflict / base moved** → `git fetch origin && git merge
+   origin/develop` (plain merge — rebase is banned in this repo), resolve,
+   re-run affected gates, push.
+4. Green + mergeable + all threads answered → one concise status comment
+   (what shipped, what was verified, evidence links) and stop. **Never merge.**
+
+## CodeRabbit
+
+CodeRabbit auto-reviews PRs with default settings (the checked-in config at
+`config/.coderabbit.yaml` is not at repo root, so it is inert). Its comments
+arrive as PR activity events. Apply `receiving-code-review` discipline:
+
+- **Verify before implementing.** Read the referenced code and confirm the
+  claim — CodeRabbit is confidently wrong at a meaningful rate, and blindly
+  applied suggestions introduce bugs and style drift.
+- Valid → fix at the root (repo standards beat its suggested patch when they
+  differ), push, reply briefly, resolve the thread.
+- Invalid → reply with the specific refuting evidence, resolve. Reasoned
+  pushback is a resolution; silence is not.
+- Conflicts with repo conventions (CLAUDE.md, DESIGN.md, biome/ruff) → the
+  repo wins; say so in one line.
+- After pushing a batch of fixes, comment `@coderabbitai review` to trigger a
+  re-review, and confirm no thread remains unanswered.

--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -1,0 +1,64 @@
+# Screenshots and the PR
+
+## Capture protocol
+
+Screenshots come from the running app driven with agent-browser
+(driving-gaia §6), authenticated as the seeded dev user. Never mock a state
+the code cannot reach.
+
+- **BEFORE** (pipeline phase 3): clean base-branch code running; capture
+  every surface the feature will change, at the routes/states you will
+  re-capture after. For a brand-new surface, "before" is whatever exists
+  today — the page it will be added to, or a 404. That is honest and fine.
+- **AFTER** (phase 7): same shot-list, same viewport — plus the states that
+  show the feature working: filled, empty, error. Desktop-width always; add
+  mobile-width shots for UI-heavy features.
+- Under `--sim`, scripted directives (driving-gaia §3) reproduce identical
+  chat states in both passes — use them for deterministic before/after pairs.
+- Name pairs so they sort together: `todo-panel-before.png`,
+  `todo-panel-after.png`, `todo-panel-empty-after.png`. Keep files in the
+  scratchpad, never in the repo tree.
+
+## Publishing
+
+The repo is public, so SHA-pinned raw URLs render in PR bodies. Screenshots
+travel on a dedicated branch so they never touch the PR diff:
+
+1. Create branch `screenshots/<feature-branch-name>` from `develop` (GitHub
+   MCP `create_branch`). Nothing triggers CI on `screenshots/*`.
+2. Upload each PNG with `create_or_update_file` (base64 content) under
+   `<feature-branch-name>/`.
+3. Embed via the **commit SHA** from the upload response — immutable, and
+   unambiguous even with slashes in the branch name:
+   `https://raw.githubusercontent.com/theexperiencecompany/gaia/<sha>/<path>.png`
+
+## The PR
+
+Title: Conventional Commit from the repo's allowed types — a CI check
+validates it. Base: `develop`. No PR template exists. Body structure:
+
+```markdown
+## What & why
+<the feature, the user problem, key decisions and any scope choices made>
+
+## How it works
+<data flow end to end, files/layers touched>
+
+## Before / After
+| Surface | Before | After |
+|---|---|---|
+| <name> | <img src="...before.png" width="420"> | <img src="...after.png" width="420"> |
+
+## Verification
+- <each acceptance criterion, with how it was verified against the running app>
+- Journey driven end to end via agent-browser as the dev user: <summary>
+- Console and network clean on all driven pages: <yes / details>
+- Local gates green: lint / type-check / build / tests / code-quality lanes
+- <run mode used: --sim or --agent, and why>
+
+## Not verified
+<anything you could not exercise, stated plainly; "nothing" if nothing>
+```
+
+After opening the PR, subscribe to its activity and enter the drive-to-green
+loop (ci-and-review.md).

--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -31,6 +31,8 @@ travel on a dedicated branch so they never touch the PR diff:
 3. Embed via the **commit SHA** from the upload response — immutable, and
    unambiguous even with slashes in the branch name:
    `https://raw.githubusercontent.com/theexperiencecompany/gaia/<sha>/<path>.png`
+4. Leave the branch in place after merge — the SHA-pinned URLs stay valid
+   only while the commit is reachable.
 
 ## The PR
 

--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -36,8 +36,9 @@ travel on a dedicated branch so they never touch the PR diff:
 
 ## The PR
 
-Title: Conventional Commit — a CI check validates the type against the list
-in `pr-naming-conventions.yml`. Base: `develop`. Use the repo's PR template
+Title: `<type>(<optional scope>): <description>` — a CI check validates the
+type against the allowed list in `pr-naming-conventions.yml` (read the list
+there; it drifts). Base: `develop`. Use the repo's PR template
 if one exists; otherwise this body structure:
 
 ```markdown

--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -38,8 +38,10 @@ travel on a dedicated branch so they never touch the PR diff:
 
 Title: `<type>(<optional scope>): <description>` — a CI check validates the
 type against the allowed list in `pr-naming-conventions.yml` (read the list
-there; it drifts). Base: `develop`. Use the repo's PR template
-if one exists; otherwise this body structure:
+there; it drifts). Base: `develop`. If a repo PR template exists, fill it in
+— but the `## Before / After`, `## Verification`, and `## Not verified`
+sections below are mandatory evidence and always appear, template or not.
+With no template, use this body structure:
 
 ```markdown
 ## What & why

--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -34,8 +34,9 @@ travel on a dedicated branch so they never touch the PR diff:
 
 ## The PR
 
-Title: Conventional Commit from the repo's allowed types — a CI check
-validates it. Base: `develop`. No PR template exists. Body structure:
+Title: Conventional Commit — a CI check validates the type against the list
+in `pr-naming-conventions.yml`. Base: `develop`. Use the repo's PR template
+if one exists; otherwise this body structure:
 
 ```markdown
 ## What & why


### PR DESCRIPTION
## What & why

Adds `.claude/skills/ship-feature/` — a project skill that lets a cloud agent session take a feature request from spec to a merge-ready PR with zero human intervention: plan → implement → multi-agent review → live-stack E2E → before/after screenshots → PR to `develop` → drive CI and CodeRabbit to green.

The skill is a lean orchestrator that delegates instead of duplicating: stack boot, zero-login auth, seeding, sim-LLM scripting, and browser driving all defer to the existing `driving-gaia` cookbook (agent-browser first), debugging to `reading-gaia-logs`, planning to `writing-plans`, and design work to `shape`/`impeccable`/`critique`.

## How it works

- **`SKILL.md`** — the 10-phase pipeline with non-negotiables (base `develop`, never merge, never fake evidence, no debt as a shipping strategy), a subagent-economy rule (small models for mechanical fan-outs, session model only for judgment-heavy work), and a Frontend Craft gate requiring principle-driven UI (shape brief → impeccable build → screenshot/critique/refine iteration) instead of one-pass generic layouts.
- **`references/ci-and-review.md`** — the two required CI gates and how enforcement works, local reproduction guidance pointing at durable sources of truth (`.github/workflows/`, `quality:*` scripts, `.github/quality-gate/enforced/`), the diff-scoping trap in `scripts/ci/changed-files.sh`, the drive-to-green loop, and CodeRabbit triage discipline (verify before implementing, reasoned pushback counts as resolution).
- **`references/screenshots-and-pr.md`** — before/after capture protocol from the running app, publishing to a `screenshots/<branch>` branch via the GitHub API with SHA-pinned raw URLs (no CI triggers, nothing in the PR diff), and the PR body format with an honest verification section.

Every operational claim was adversarially verified against the repo by independent review passes; defects found (env-setup ordering, a false gate-behavior claim, `mise e2e:web`'s dev-user reset racing the AFTER captures, missing push-before-PR step) are fixed in this diff.

Also merges `origin/develop` into the branch, which the skill depends on (`driving-gaia`, `mise dev --agent/--sim`, `apps/web/e2e/`).

## Verification

- All commands, paths, workflow/gate names, thresholds, and skill cross-references checked against the tree by two independent verification passes; three factual defects and three pipeline-ordering defects caught and fixed.
- Docker-in-sandbox guidance (daemon start flags, `--network=host` fallback) verified by actually running containers in a cloud session.
- Screenshot URL rendering verified: repo is public, unauthenticated raw fetch returns 200.
- Not verified: a full end-to-end invocation of the skill (each run is a multi-hour feature ship); its first real use is the true test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8Gbt8Fd886LTrm5fA6A9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8Gbt8Fd886LTrm5fA6A9L)_