### PR TITLE
refactor(secrets): single Infisical identity, generic `mise infisical` task, drop unused INFISICAL_TOKEN

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,4 @@
+{
+  "workspaceId": "REPLACE_WITH_INFISICAL_PROJECT_ID",
+  "defaultEnvironment": "development"
+}

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,4 +1,4 @@
 {
-  "workspaceId": "REPLACE_WITH_INFISICAL_PROJECT_ID",
+  "workspaceId": "24c7bfd2-a378-417e-beb5-58e8eed23c6e",
   "defaultEnvironment": "development"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,16 @@
       "args": ["-s", "mcp"],
       "env": {}
     },
+    "infisical": {
+      "command": "npx",
+      "args": ["-y", "@infisical/mcp"],
+      "env": {
+        "INFISICAL_AUTH_METHOD": "universal-auth",
+        "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID": "${INFISICAL_MCP_CLIENT_ID:-}",
+        "INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET": "${INFISICAL_MCP_CLIENT_SECRET:-}",
+        "INFISICAL_HOST_URL": "https://app.infisical.com"
+      }
+    },
     "code-review-graph": {
       "command": "uvx",
       "args": ["code-review-graph", "serve"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Behavioral guidelines to reduce common LLM coding mistakes. Bias toward caution 
 mise tasks          # List all available tasks with descriptions
 mise run <task>     # Run a task (e.g. mise run lint, mise run dev)
 mise //apps/api:lint  # Run a task in a sub-project from the root
-mise dev:infisical  # Team members: `mise dev` with secrets injected via `infisical login` + `infisical run`
+mise infisical <task>  # Team members: run any task with Infisical secrets injected (e.g. mise infisical dev:full)
 ```
 
 Pre-commit hooks are managed via **prek** (installed by mise). Install once with `mise run pre-commit:install`. Hooks run automatically on `git commit` — to run manually: `mise run pre-commit`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Behavioral guidelines to reduce common LLM coding mistakes. Bias toward caution 
 mise tasks          # List all available tasks with descriptions
 mise run <task>     # Run a task (e.g. mise run lint, mise run dev)
 mise //apps/api:lint  # Run a task in a sub-project from the root
+mise dev:infisical  # Team members: `mise dev` with secrets injected via `infisical login` + `infisical run`
 ```
 
 Pre-commit hooks are managed via **prek** (installed by mise). Install once with `mise run pre-commit:install`. Hooks run automatically on `git commit` — to run manually: `mise run pre-commit`.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -109,7 +109,10 @@ GITHUB_TOKEN=
 
 # Infisical (optional)
 # =============================
-# Infisical is a secrets management platform that can centrally manage your env vars
+# Infisical is a secrets management platform that can centrally manage your env vars.
+# Team developers: prefer `infisical login` + `infisical run` (see
+# docs/configuration/infisical-setup.mdx) — no credentials in this file.
+# Machine identity vars below are for deployed/headless environments only.
 # INFISICAL_PROJECT_ID=
 # INFISICAL_MACHINE_IDENTITY_CLIENT_ID=
 # INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=

--- a/apps/api/app/utils/exceptions.py
+++ b/apps/api/app/utils/exceptions.py
@@ -19,14 +19,6 @@ class FetchError(Exception):
         return base_message
 
 
-class InfisicalConfigError(Exception):
-    """Exception raised for errors related to Infisical configuration."""
-
-    def __init__(self, message: str) -> None:
-        self.message = message
-        super().__init__(self.message)
-
-
 class ConfigurationError(Exception):
     """
     Exception raised when a service client cannot be initialized due to missing configuration.

--- a/apps/api/scripts/arq_healthcheck.py
+++ b/apps/api/scripts/arq_healthcheck.py
@@ -7,7 +7,7 @@ The worker refreshes arq's ``arq:health`` key from its poll loop every
 or the process dies. Checking that key is exactly what ``arq --check`` does
 internally — but ``arq --check`` first imports the whole application, which a
 Docker healthcheck cannot do: it runs outside the entrypoint, so it has no
-``INFISICAL_TOKEN`` and the import dies during settings bootstrap.
+Infisical credentials and the import dies during settings bootstrap.
 
 This probe imports nothing from ``app`` (so no application change can break it)
 and talks only to Redis — the worker's own job substrate.

--- a/apps/bots/.env.example
+++ b/apps/bots/.env.example
@@ -1,6 +1,7 @@
 ENV=development                      # Environment type: development, staging, production.
-                                     # Doubles as the Infisical environment slug. Required — an unset
-                                     # ENV means production, which refuses to boot without Infisical.
+                                     # Doubles as the Infisical environment slug. Optional locally —
+                                     # a bare checkout already resolves to development; set it to be
+                                     # explicit. Deployed images pin ENV=production.
 
 # ── GAIA API Connection ──
 GAIA_API_URL=http://localhost:8000

--- a/apps/bots/.env.example
+++ b/apps/bots/.env.example
@@ -1,3 +1,7 @@
+ENV=development                      # Environment type: development, staging, production.
+                                     # Doubles as the Infisical environment slug. Required — an unset
+                                     # ENV means production, which refuses to boot without Infisical.
+
 # ── GAIA API Connection ──
 GAIA_API_URL=http://localhost:8000
 GAIA_BOT_API_KEY=                    # must match GAIA_BOT_API_KEY in your API .env

--- a/apps/bots/.env.example
+++ b/apps/bots/.env.example
@@ -33,9 +33,10 @@ KAPSO_WEBHOOK_SECRET=                   # Webhook signature secret (set when cre
 POSTHOG_API_KEY=                     # PostHog project API key (optional; analytics disabled if unset)
 
 # ── Infisical (optional) ──
-# Team developers: uncomment to load all secrets from Infisical automatically.
+# Team developers: prefer `infisical login` + `infisical run` (see
+# docs/configuration/infisical-setup.mdx) — no credentials in this file.
+# Machine identity vars below are for deployed/headless environments only.
 # Self-hosters / contributors: ignore this section, fill in the values above.
-# INFISICAL_TOKEN=
 # INFISICAL_PROJECT_ID=
 # INFISICAL_MACHINE_IDENTITY_CLIENT_ID=
 # INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=

--- a/apps/bots/CLAUDE.md
+++ b/apps/bots/CLAUDE.md
@@ -54,7 +54,7 @@ Required for every bot (process throws if missing): `GAIA_API_URL`, `GAIA_BOT_AP
 
 Platform-specific: Discord `DISCORD_BOT_TOKEN` + `DISCORD_CLIENT_ID`; Slack `SLACK_BOT_TOKEN` + `SLACK_SIGNING_SECRET` + `SLACK_APP_TOKEN`; Telegram `TELEGRAM_BOT_TOKEN`; WhatsApp `KAPSO_API_KEY` + `KAPSO_PHONE_NUMBER_ID` + `KAPSO_WEBHOOK_SECRET`.
 
-Infisical is optional in dev, fatal-if-missing when `NODE_ENV=production`, and only fills keys not already in `process.env`.
+Infisical is optional in dev, fatal-if-missing in production, and only fills keys not already in `process.env`. The environment slug comes from `ENV` (same as the Python apps), falling back to `NODE_ENV=production` → `production` in containers without an explicit `ENV`.
 
 ## Platform gotchas
 

--- a/apps/bots/CLAUDE.md
+++ b/apps/bots/CLAUDE.md
@@ -54,7 +54,7 @@ Required for every bot (process throws if missing): `GAIA_API_URL`, `GAIA_BOT_AP
 
 Platform-specific: Discord `DISCORD_BOT_TOKEN` + `DISCORD_CLIENT_ID`; Slack `SLACK_BOT_TOKEN` + `SLACK_SIGNING_SECRET` + `SLACK_APP_TOKEN`; Telegram `TELEGRAM_BOT_TOKEN`; WhatsApp `KAPSO_API_KEY` + `KAPSO_PHONE_NUMBER_ID` + `KAPSO_WEBHOOK_SECRET`.
 
-Infisical is optional in dev, fatal-if-missing in production, and only fills keys not already in `process.env`. The environment slug comes from `ENV` (same as the Python apps), falling back to `NODE_ENV=production` → `production` in containers without an explicit `ENV`.
+Infisical is optional in dev, fatal-if-missing in production, and only fills keys not already in `process.env`. The environment slug comes from `ENV` (same as the Python apps) and defaults to `production` when unset — set `ENV=development` in `apps/bots/.env` for local runs.
 
 ## Platform gotchas
 

--- a/apps/bots/CLAUDE.md
+++ b/apps/bots/CLAUDE.md
@@ -54,7 +54,7 @@ Required for every bot (process throws if missing): `GAIA_API_URL`, `GAIA_BOT_AP
 
 Platform-specific: Discord `DISCORD_BOT_TOKEN` + `DISCORD_CLIENT_ID`; Slack `SLACK_BOT_TOKEN` + `SLACK_SIGNING_SECRET` + `SLACK_APP_TOKEN`; Telegram `TELEGRAM_BOT_TOKEN`; WhatsApp `KAPSO_API_KEY` + `KAPSO_PHONE_NUMBER_ID` + `KAPSO_WEBHOOK_SECRET`.
 
-Infisical is optional in dev, fatal-if-missing in production, and only fills keys not already in `process.env`. The environment slug comes from `ENV` (same as the Python apps) and defaults to `production` when unset — set `ENV=development` in `apps/bots/.env` for local runs.
+Infisical is optional in dev, fatal-if-missing in production, and only fills keys not already in `process.env`. The environment slug comes from `ENV`, falling back to `NODE_ENV === "production"` and otherwise `development`. A bare local checkout therefore resolves `development` with no setup; deployed containers can only resolve `production`, because `apps/bots/Dockerfile` pins `ENV=production` and `docker-compose.prod.yml` sets it again per service. This differs from the Python loaders, which default an absent `ENV` to `production` — deliberate, since `ENV` has never been required in `apps/bots/.env`.
 
 ## Platform gotchas
 

--- a/apps/bots/Dockerfile
+++ b/apps/bots/Dockerfile
@@ -41,7 +41,11 @@ COPY --from=builder /app/apps/bots/${BOT_NAME}/package.json ./
 COPY scripts/docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# ENV is the Infisical environment slug the bots loader reads. Pin it here so a
+# deployed container never falls back to the loader's development default;
+# docker-compose.prod.yml sets it again per service, this covers everything else.
 ENV NODE_ENV=production \
+    ENV=production \
     BOT_NAME=${BOT_NAME}
 
 USER node

--- a/apps/voice-agent/src/config.py
+++ b/apps/voice-agent/src/config.py
@@ -9,7 +9,10 @@ from shared.py.settings import BaseAppSettings
 from shared.py.wide_events import log
 from src.constants import LogTag
 
-# Load API's .env for shared Infisical bootstrap vars
+# Load the voice agent's own .env first; fall back to the API's .env for the
+# shared Infisical bootstrap vars (dotenv never overrides already-set keys).
+_own_env_path = Path(__file__).parent.parent / ".env"
+load_dotenv(_own_env_path)
 _api_env_path = Path(__file__).parent.parent.parent / "api" / ".env"
 load_dotenv(_api_env_path)
 

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -43,10 +43,12 @@ If no Infisical variables are configured:
 - In production, the app refuses to start
 
 <Warning>
-  **`ENV` defaults to `production` when unset**, in both the Python and
-  TypeScript loaders. An app that forgets to set it refuses to boot rather than
-  starting silently without secrets. Every `.env.example` ships
-  `ENV=development`, so copy one rather than writing `.env` from scratch.
+  **The default when `ENV` is unset differs by runtime.** The Python apps (API,
+  voice agent) default to `production` and so refuse to boot without Infisical —
+  `apps/api/.env.example` ships `ENV=development`, so copy it rather than writing
+  `.env` from scratch. The bots default to `development`, keeping a bare checkout
+  runnable with no setup; their deployed containers cannot reach that fallback
+  because `apps/bots/Dockerfile` pins `ENV=production`.
 </Warning>
 
 ## Team Development Workflow (Recommended)
@@ -176,9 +178,10 @@ wrangler secret put BLOG_BEARER_TOKEN
 <AccordionGroup>
   <Accordion title="InfisicalConfigError: Infisical is required in production">
     **Solution**: The app resolved `ENV` to `production` — either explicitly, or
-    because `ENV` is unset and that is the default — but has no Infisical
-    credentials. Provide the machine identity credentials (in production these
-    arrive as Docker Swarm secrets), or set `ENV=development` for local work.
+    because it is unset and the Python loaders default to `production` — but has
+    no Infisical credentials. Provide the machine identity credentials (in
+    production these arrive as Docker Swarm secrets), or set `ENV=development`
+    for local work.
   </Accordion>
 
   <Accordion title="Incomplete Infisical config: missing ...">

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -73,7 +73,7 @@ Team members authenticate as **themselves** with the Infisical CLI — no machin
   </Step>
 </Steps>
 
-The repo's `.infisical.json` tells the CLI which project to use — it contains only the project ID and default environment, no secrets, so it is safe to commit. It ships with a `REPLACE_WITH_INFISICAL_PROJECT_ID` placeholder; a maintainer sets the real project ID once (or re-runs `infisical init`) and commits it. Until then, pass `--projectId=<id>` explicitly.
+The repo's `.infisical.json` tells the CLI which project to use — it contains only the project ID and default environment, no secrets, so it is committed and needs no setup on your part. The project ID is an identifier, not a credential: fetching secrets still requires `infisical login` with an account that has access to the project.
 
 **Local tweaks**: use [personal overrides](https://infisical.com/docs/documentation/platform/secret-overrides) in the Infisical dashboard instead of editing `.env` — `infisical run` applies your personal value while teammates keep the shared one.
 

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -6,176 +6,192 @@ icon: "user-secret"
 
 ## Overview
 
-Infisical is a secure secret management platform that GAIA uses to centrally manage environment variables and API keys. Instead of storing sensitive information in `.env` files, Infisical allows you to:
+Infisical is the secret management platform the GAIA team uses to share environment variables and API keys. It gives you:
 
-- **Centrally manage secrets** across multiple environments
-- **Secure access controls** with role-based permissions
-- **Audit logging** for secret access and changes
-- **Automatic secret rotation** capabilities
-- **Team collaboration** with shared secret access
+- **Central management** of secrets across dev/staging/production environments
+- **Access control** with per-user and per-service permissions
+- **Audit logging** for every secret read and change
+- **Instant revocation** when a credential leaks or a teammate leaves
 
 <Note>
-  When Infisical is configured, it will **override any local environment
-  variables** with the same names from your Infisical project.
+  Infisical is **optional**. Self-hosters and open-source contributors should
+  skip this page entirely and use plain `.env` files — every app falls back to
+  local environment variables automatically. Infisical is only required in
+  production (`ENV=production`).
 </Note>
 
 ## How Infisical Works with GAIA
 
-GAIA's backend automatically loads secrets from Infisical during startup using the `inject_infisical_secrets()` function. Here's the process:
+At startup, each app (API, bots, voice agent) calls its Infisical loader (`inject_infisical_secrets()` in Python, `injectInfisicalSecrets()` in TypeScript):
 
-1. **Authentication**: Uses machine identity credentials to authenticate with Infisical
-2. **Secret Retrieval**: Fetches all secrets from your Infisical project
-3. **Environment Injection**: Overwrites local environment variables with Infisical secrets
-4. **Application Startup**: GAIA starts with the combined environment configuration
+1. **Authentication**: authenticates with a machine identity (Universal Auth client ID + secret)
+2. **Secret retrieval**: fetches all secrets for the environment matching your `ENV` value (`development`, `staging`, or `production`)
+3. **Environment injection**: injects each secret into the process environment — **only if that variable is not already set**
+4. **Application startup**: the app reads its settings from the combined environment
 
-## Setting Up Infisical
+<Warning>
+  **Local environment variables always win.** The loaders never overwrite a
+  variable that is already set in your shell, `.env` file, or container
+  environment. Infisical only fills the gaps. (The `infisical run` CLI flow
+  below is the one exception — it injects secrets *before* the process starts,
+  so those values are already "local" by the time `.env` files load.)
+</Warning>
 
-### Step 1: Create an Infisical Account
+If no Infisical variables are configured:
 
-1. Visit [app.infisical.com](https://app.infisical.com)
-2. Sign up for a free account
-3. Create a new project for GAIA
+- In development, the loader logs a message and continues with your local `.env`
+- In production, the app refuses to start
 
-### Step 2: Create a Machine Identity
+## Team Development Workflow (Recommended)
 
-Machine identities allow GAIA to authenticate with Infisical automatically:
+Team members authenticate as **themselves** with the Infisical CLI — no machine identity credentials on laptops. You get personal permissions, audit-logged access, personal secret overrides, and instant revocation on offboarding.
 
-1. Go to **Project Settings** → **Access Control** → **Machine Identities**
-2. Click **Create Identity**
-3. Configure the identity:
-   - **Name**: `gaia-backend`
-   - **Role**: Admin or Developer (with read access to secrets)
-4. Note down the **Client ID** and **Client Secret**
+<Steps>
+  <Step title="Install the Infisical CLI">
+    ```bash
+    # macOS
+    brew install infisical/get-cli/infisical
+    ```
+    Other platforms: see the [Infisical CLI docs](https://infisical.com/docs/cli/overview).
+  </Step>
+  <Step title="Log in">
+    ```bash
+    infisical login
+    ```
+    This opens a browser window. Use `infisical login -i` inside containers or WSL2.
+  </Step>
+  <Step title="Run GAIA through the CLI">
+    ```bash
+    mise dev:infisical
+    ```
+    This wraps `mise dev` in `infisical run --env=development -- ...`, injecting
+    every secret from the `development` environment before the processes start.
+    You can wrap any other command the same way:
+    ```bash
+    infisical run --env=development -- nx dev api
+    ```
+  </Step>
+</Steps>
 
-### Step 3: Add Secrets to Infisical
+The repo's `.infisical.json` (created once by a maintainer with `infisical init` and committed — it contains only the project ID and default environment, no secrets) tells the CLI which project to use. If it is missing, pass `--projectId=<id>`.
 
-Navigate to your project's **Secrets** section and add all your environment variables.
+**Local tweaks**: use [personal overrides](https://infisical.com/docs/documentation/platform/secret-overrides) in the Infisical dashboard instead of editing `.env` — `infisical run` applies your personal value while teammates keep the shared one.
 
-### Step 4: Configure GAIA Backend
+**Offline**: the CLI caches previously fetched secrets, so `infisical run` keeps working without a network connection.
 
-Add the Infisical configuration to your backend `.env` file:
+## Self-Hosters and Contributors
+
+You do not need Infisical. Copy `.env.example` to `.env` in each app directory and fill in the values. See [Environment Variables](/configuration/environment-variables).
+
+If you run your **own** Infisical project and want GAIA to pull from it in a headless environment, configure a machine identity:
+
+1. Create a project at [app.infisical.com](https://app.infisical.com) and add your secrets
+2. Go to **Organization Access Control → Identities → Create Identity** with Universal Auth
+3. Grant it read access to your project
+4. Add the credentials to your `.env`:
 
 ```bash
-# Infisical Configuration
-INFISICAL_PROJECT_ID=your-project-id-from-infisical
+INFISICAL_PROJECT_ID=your-project-id
 INFISICAL_MACHINE_IDENTITY_CLIENT_ID=your-client-id
 INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=your-client-secret
-
-# Optional: Set environment (defaults to 'production')
 ENV=development
 ```
 
 <Warning>
-  The `INFISICAL_PROJECT_ID`, `INFISICAL_MACHINE_IDENTITY_CLIENT_ID`, and
-  `INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET` must be set in your local `.env`
-  file - they cannot be stored in Infisical itself since they're needed to
-  authenticate with Infisical.
+  These three variables bootstrap the Infisical connection, so they must live in
+  the local environment — they cannot be stored in Infisical itself. Setting all
+  three enables the fetch; setting only some of them logs a warning in
+  development and fails the boot in production.
 </Warning>
 
-## Environment Priority
+## Production: Per-Service Machine Identities
 
-GAIA loads environment variables in this order (later sources override earlier ones):
+Production uses **one machine identity per service**, each scoped to only the secrets that service needs. A compromised container can then read its own secrets, not the whole project.
 
-1. **System environment variables**
-2. **Local `.env` file variables**
-3. **Infisical secrets** (highest priority)
+The identities and their Docker Swarm secret names (see `infra/docker/docker-compose.prod.yml`):
 
-This means:
+| Identity | Services | Swarm secret prefix |
+| --- | --- | --- |
+| `gaia-api` | gaia-backend, arq_worker, embedding-sidecar | `gaia_api_infisical_` |
+| `gaia-bot-discord` | discord-bot | `gaia_bot_discord_infisical_` |
+| `gaia-bot-slack` | slack-bot | `gaia_bot_slack_infisical_` |
+| `gaia-bot-telegram` | telegram-bot | `gaia_bot_telegram_infisical_` |
+| `gaia-bot-whatsapp` | whatsapp-bot | `gaia_bot_whatsapp_infisical_` |
+| `gaia-voice-agent` | voice-agent-worker | `gaia_voice_agent_infisical_` |
 
-- ✅ Infisical secrets will override local `.env` variables
-- ✅ You can use local `.env` for development and Infisical for production
-- ✅ Critical secrets are managed centrally through Infisical
+For each identity:
 
-## Development vs Production
-
-### Development Setup
-
-For local development, you can choose between:
-
-**Option A: Use Infisical** (Recommended for teams)
-
-```bash
-# apps/api/.env
-ENV=development
-INFISICAL_PROJECT_ID=your-dev-project-id
-INFISICAL_MACHINE_IDENTITY_CLIENT_ID=your-client-id
-INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=your-client-secret
-```
-
-**Option B: Use Local Environment Variables**
+1. In Infisical: **Organization Access Control → Identities → Create Identity** (Universal Auth)
+2. Grant it a project role restricted to the secrets/paths that service needs, environment `production`
+3. On the Swarm manager, store its credentials:
 
 ```bash
-# apps/api/.env
-ENV=development
-# Add all your environment variables here
-OPENAI_API_KEY=your-local-dev-key
-# ... other variables
+printf '%s' '<client-id>'     | docker secret create gaia_api_infisical_client_id -
+printf '%s' '<client-secret>' | docker secret create gaia_api_infisical_client_secret -
+# ...repeat for each service prefix
+printf '%s' '<project-id>'    | docker secret create gaia_infisical_project_id -
 ```
 
-### Production Setup
-
-For production, **always use Infisical**:
-
-```bash
-# apps/api/.env (production)
-ENV=production
-INFISICAL_PROJECT_ID=your-prod-project-id
-INFISICAL_MACHINE_IDENTITY_CLIENT_ID=your-prod-client-id
-INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=your-prod-client-secret
-```
+The compose file maps each per-service secret onto the canonical `/run/secrets/gaia_infisical_machine_identity_*` paths that `scripts/docker-entrypoint.sh` reads, so the app code is identical for every service.
 
 ## Troubleshooting
 
-### Common Issues
-
 <AccordionGroup>
-  <Accordion title="InfisicalConfigError: INFISICAL_PROJECT_ID is missing">
-    **Solution**: Add the `INFISICAL_PROJECT_ID` to your `.env` file. You can find this in your Infisical project settings.
+  <Accordion title="InfisicalConfigError: Infisical is required in production">
+    **Solution**: The app is running with `ENV=production` but no Infisical
+    credentials. Provide the machine identity credentials (in production these
+    arrive as Docker Swarm secrets), or set `ENV=development` for local work.
   </Accordion>
 
-{" "}
+  <Accordion title="Incomplete Infisical config: missing ...">
+    **Solution**: Only some of `INFISICAL_PROJECT_ID`,
+    `INFISICAL_MACHINE_IDENTITY_CLIENT_ID`, and
+    `INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET` are set. Set all three to enable
+    Infisical, or remove all three to use local `.env` only.
+  </Accordion>
 
-<Accordion title="Authentication failed">
-  **Solution**: - Verify your `INFISICAL_MACHINE_IDENTITY_CLIENT_ID` and
-  `INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET` - Ensure the machine identity has
-  proper permissions - Check that the identity is enabled
-</Accordion>
+  <Accordion title="Authentication failed">
+    **Solution**: Verify the client ID and client secret, ensure the machine
+    identity has read access to the project, and check that the identity is
+    enabled.
+  </Accordion>
 
-{" "}
+  <Accordion title="Secrets not loading">
+    **Solution**: Verify the environment slug matches your `ENV` value
+    (`development`/`staging`/`production`), check that the secrets exist in that
+    environment of the Infisical project, and confirm the identity's role covers
+    the secret path.
+  </Accordion>
 
-<Accordion title="Secrets not loading">
-  **Solution**: - Verify the environment slug matches (development/production) -
-  Check that secrets exist in the correct Infisical project - Ensure the machine
-  identity has read access to secrets
-</Accordion>
-
-  <Accordion title="Local variables not being overridden">
-    **Solution**: This is expected behavior. Infisical secrets have the highest priority and will override local variables with the same name.
+  <Accordion title="An Infisical value is not being applied">
+    **Solution**: A local environment variable with the same name is set —
+    local values always take precedence over Infisical. Unset the local
+    variable (check your shell and `.env` files) to use the Infisical value.
   </Accordion>
 </AccordionGroup>
 
 ### Debug Mode
 
-To debug Infisical integration, check the application logs during startup. The backend will log any Infisical connection issues.
+Check the application logs during startup — the loaders log connection, fetch, and injection timing, and any Infisical errors.
 
 ## Security Best Practices
 
 <CardGroup cols={2}>
-  <Card title="Access Control">
-    Use separate machine identities for different environments, grant minimal
-    required permissions, and regularly audit access logs.
+  <Card title="Humans use personal logins">
+    Team members authenticate with `infisical login`, never with shared machine
+    identity credentials. Offboarding a person revokes their access instantly.
   </Card>
-  <Card title="Secret Management">
-    Use different secrets for dev/staging/production, rotate secrets regularly,
-    and never commit Infisical credentials to version control.
+  <Card title="One identity per service">
+    Each production service has its own machine identity scoped to only the
+    secrets it needs. Never reuse one identity across services.
   </Card>
-  <Card title="Environment Separation">
-    Use separate Infisical projects for each environment, implement proper CI/CD
-    secret injection, and monitor secret access patterns.
+  <Card title="Environment separation">
+    Use the `development`/`staging`/`production` environments within the
+    project, and separate secrets per environment.
   </Card>
-  <Card title="Backup Strategy">
-    Export secrets regularly for backup, document secret recovery procedures,
-    and have fallback authentication methods.
+  <Card title="Rotate and audit">
+    Set client-secret TTLs where possible, rotate leaked credentials
+    immediately, and review the audit log for unexpected access.
   </Card>
 </CardGroup>
 

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -42,6 +42,13 @@ If no Infisical variables are configured:
 - In development, the loader logs a message and continues with your local `.env`
 - In production, the app refuses to start
 
+<Warning>
+  **`ENV` defaults to `production` when unset**, in both the Python and
+  TypeScript loaders. An app that forgets to set it refuses to boot rather than
+  starting silently without secrets. Every `.env.example` ships
+  `ENV=development`, so copy one rather than writing `.env` from scratch.
+</Warning>
+
 ## Team Development Workflow (Recommended)
 
 Team members authenticate as **themselves** with the Infisical CLI — no machine identity credentials on laptops. You get personal permissions, audit-logged access, personal secret overrides, and instant revocation on offboarding.
@@ -107,9 +114,9 @@ ENV=development
 ```
 
 <Warning>
-  These three variables bootstrap the Infisical connection, so they must live in
-  the local environment — they cannot be stored in Infisical itself. Setting all
-  three enables the fetch; setting only some of them logs a warning in
+  The three `INFISICAL_*` variables bootstrap the connection, so they must live
+  in the local environment — they cannot be stored in Infisical itself. Setting
+  all three enables the fetch; setting only some of them logs a warning in
   development and fails the boot in production.
 </Warning>
 
@@ -168,7 +175,8 @@ wrangler secret put BLOG_BEARER_TOKEN
 
 <AccordionGroup>
   <Accordion title="InfisicalConfigError: Infisical is required in production">
-    **Solution**: The app is running with `ENV=production` but no Infisical
+    **Solution**: The app resolved `ENV` to `production` — either explicitly, or
+    because `ENV` is unset and that is the default — but has no Infisical
     credentials. Provide the machine identity credentials (in production these
     arrive as Docker Swarm secrets), or set `ENV=development` for local work.
   </Accordion>

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -211,9 +211,11 @@ Check the application logs during startup — the loaders log connection, fetch,
     Team members authenticate with `infisical login`, never with shared machine
     identity credentials. Offboarding a person revokes their access instantly.
   </Card>
-  <Card title="One identity per service">
-    Each production service has its own machine identity scoped to only the
-    secrets it needs. Never reuse one identity across services.
+  <Card title="Scope identities to shrink blast radius">
+    Production currently shares one machine identity across services, so any
+    compromised container can read the whole project. Splitting it per service
+    is a compose-only change — see [Scoping per service
+    later](#scoping-per-service-later).
   </Card>
   <Card title="Environment separation">
     Use the `development`/`staging`/`production` environments within the

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -60,13 +60,20 @@ Team members authenticate as **themselves** with the Infisical CLI — no machin
     ```
     This opens a browser window. Use `infisical login -i` inside containers or WSL2.
   </Step>
-  <Step title="Run GAIA through the CLI">
+  <Step title="Run any task through the CLI">
+    Prefix any mise task with `infisical`:
     ```bash
-    mise dev:infisical
+    mise infisical dev        # API + web
+    mise infisical dev:full   # + arq worker, voice agent, all bots
     ```
-    This wraps `mise dev` in `infisical run --env=development -- ...`, injecting
-    every secret from the `development` environment before the processes start.
-    You can wrap any other command the same way:
+    This wraps the task in `infisical run --env=development -- mise run <task>`,
+    injecting every secret from the `development` environment before the
+    processes start. Pass task flags after `--` so mise forwards them instead of
+    reading them itself:
+    ```bash
+    mise infisical -- dev --agent
+    ```
+    Any other command works the same way without mise:
     ```bash
     infisical run --env=development -- nx dev api
     ```
@@ -74,6 +81,8 @@ Team members authenticate as **themselves** with the Infisical CLI — no machin
 </Steps>
 
 The repo's `.infisical.json` tells the CLI which project to use — it contains only the project ID and default environment, no secrets, so it is committed and needs no setup on your part. The project ID is an identifier, not a credential: fetching secrets still requires `infisical login` with an account that has access to the project.
+
+**Infra URLs**: the `development` environment stores **localhost** URLs (`mongodb://localhost:27017`, `postgresql://...@localhost:5432/...`), because `mise dev` runs the API and web on the host and reaches dockered infra through published ports. Containers do not use these — `infra/docker/docker-compose.yml` sets the `mongo` / `postgres` service hostnames explicitly, and those take precedence over `env_file`. Putting Docker hostnames in Infisical instead breaks every native run.
 
 **Local tweaks**: use [personal overrides](https://infisical.com/docs/documentation/platform/secret-overrides) in the Infisical dashboard instead of editing `.env` — `infisical run` applies your personal value while teammates keep the shared one.
 
@@ -104,35 +113,35 @@ ENV=development
   development and fails the boot in production.
 </Warning>
 
-## Production: Per-Service Machine Identities
+## Production: Machine Identity
 
-Production uses **one machine identity per service**, each scoped to only the secrets that service needs. A compromised container can then read its own secrets, not the whole project.
-
-The identities and their Docker Swarm secret names (see `infra/docker/docker-compose.prod.yml`):
-
-| Identity | Services | Swarm secret prefix |
-| --- | --- | --- |
-| `gaia-api` | gaia-backend, arq_worker, embedding-sidecar | `gaia_api_infisical_` |
-| `gaia-bot-discord` | discord-bot | `gaia_bot_discord_infisical_` |
-| `gaia-bot-slack` | slack-bot | `gaia_bot_slack_infisical_` |
-| `gaia-bot-telegram` | telegram-bot | `gaia_bot_telegram_infisical_` |
-| `gaia-bot-whatsapp` | whatsapp-bot | `gaia_bot_whatsapp_infisical_` |
-| `gaia-voice-agent` | voice-agent-worker | `gaia_voice_agent_infisical_` |
-
-For each identity:
+Production authenticates with a **single machine identity** shared by every service (see `infra/docker/docker-compose.prod.yml`).
 
 1. In Infisical: **Organization Access Control → Identities → Create Identity** (Universal Auth)
-2. Grant it a project role restricted to the secrets/paths that service needs, environment `production`
+2. Grant it read access to the project, environment `production`
 3. On the Swarm manager, store its credentials:
 
 ```bash
-printf '%s' '<client-id>'     | docker secret create gaia_api_infisical_client_id -
-printf '%s' '<client-secret>' | docker secret create gaia_api_infisical_client_secret -
-# ...repeat for each service prefix
+printf '%s' '<client-id>'     | docker secret create gaia_infisical_machine_identity_client_id -
+printf '%s' '<client-secret>' | docker secret create gaia_infisical_machine_identity_client_secret -
 printf '%s' '<project-id>'    | docker secret create gaia_infisical_project_id -
 ```
 
-The compose file maps each per-service secret onto the canonical `/run/secrets/gaia_infisical_machine_identity_*` paths that `scripts/docker-entrypoint.sh` reads, so the app code is identical for every service.
+Every service attaches these three secrets directly, and `scripts/docker-entrypoint.sh` reads them from `/run/secrets/gaia_infisical_machine_identity_*` before exec.
+
+### Scoping per service later
+
+One identity means any compromised container can read the whole project. To limit that blast radius, create an identity per service, scope each to the paths that service needs, and store its credentials under its own secret names. Then attach them with Compose's long syntax, which maps a per-service secret onto the canonical name the entrypoint reads:
+
+```yaml
+secrets:
+  - source: gaia_api_infisical_client_id
+    target: gaia_infisical_machine_identity_client_id
+  - source: gaia_api_infisical_client_secret
+    target: gaia_infisical_machine_identity_client_secret
+```
+
+Only the compose file changes — the entrypoint and application code are identical either way.
 
 ## Troubleshooting
 

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -73,7 +73,7 @@ Team members authenticate as **themselves** with the Infisical CLI — no machin
   </Step>
 </Steps>
 
-The repo's `.infisical.json` (created once by a maintainer with `infisical init` and committed — it contains only the project ID and default environment, no secrets) tells the CLI which project to use. If it is missing, pass `--projectId=<id>`.
+The repo's `.infisical.json` tells the CLI which project to use — it contains only the project ID and default environment, no secrets, so it is safe to commit. It ships with a `REPLACE_WITH_INFISICAL_PROJECT_ID` placeholder; a maintainer sets the real project ID once (or re-runs `infisical init`) and commits it. Until then, pass `--projectId=<id>` explicitly.
 
 **Local tweaks**: use [personal overrides](https://infisical.com/docs/documentation/platform/secret-overrides) in the Infisical dashboard instead of editing `.env` — `infisical run` applies your personal value while teammates keep the shared one.
 

--- a/docs/configuration/infisical-setup.mdx
+++ b/docs/configuration/infisical-setup.mdx
@@ -22,7 +22,7 @@ Infisical is the secret management platform the GAIA team uses to share environm
 
 ## How Infisical Works with GAIA
 
-At startup, each app (API, bots, voice agent) calls its Infisical loader (`inject_infisical_secrets()` in Python, `injectInfisicalSecrets()` in TypeScript):
+At startup, each app (API, bots, voice agent) calls its Infisical loader (`inject_infisical_secrets()` in Python, `injectInfisicalSecrets()` in TypeScript). The Next.js web app deliberately does not — see [Frontend (Web)](#frontend-web).
 
 1. **Authentication**: authenticates with a machine identity (Universal Auth client ID + secret)
 2. **Secret retrieval**: fetches all secrets for the environment matching your `ENV` value (`development`, `staging`, or `production`)
@@ -142,6 +142,27 @@ secrets:
 ```
 
 Only the compose file changes — the entrypoint and application code are identical either way.
+
+## Frontend (Web)
+
+The Next.js app is **intentionally not wired to Infisical** — it calls no loader. Its environment is six `NEXT_PUBLIC_*` variables plus one server-only secret (`BLOG_BEARER_TOKEN`, used by `src/app/api/blog/route.ts`).
+
+`NEXT_PUBLIC_*` values are compiled into the browser bundle at build time, so they are public by definition — anyone can read them from the shipped JavaScript. Storing them in Infisical adds ceremony without adding secrecy. Keep them in `apps/web/.env.local` locally and in the build environment for CI.
+
+**In development** the app still picks up Infisical values under `mise infisical dev`: the CLI injects them into the process environment before Next starts, and Next ranks `process.env` above `.env.local`.
+
+**In production** web deploys to Cloudflare Workers (OpenNext), not the Swarm, so the server-only secret belongs in Cloudflare's own store:
+
+```bash
+wrangler secret put BLOG_BEARER_TOKEN
+```
+
+<Warning>
+  Do not bootstrap Infisical into the Worker. Fetching secrets at the edge means
+  shipping the machine identity's client ID and secret into the Worker — trading
+  one narrow secret for a credential that unlocks the entire project, plus an
+  auth round-trip on cold start.
+</Warning>
 
 ## Troubleshooting
 

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -5,11 +5,36 @@
 # scripts/swarm/lab-rehearsal.sh.
 
 secrets:
-  gaia_infisical_token:
+  # Per-service Infisical machine identities (Universal Auth). Each service
+  # authenticates with its own identity, scoped in the Infisical dashboard to
+  # only the secret paths that service needs — a compromised container cannot
+  # read the rest of the project. Services attach these with the long secret
+  # syntax, mapping each per-service secret onto the canonical
+  # /run/secrets/gaia_infisical_machine_identity_* paths that
+  # scripts/docker-entrypoint.sh reads.
+  gaia_api_infisical_client_id:
     external: true
-  gaia_infisical_machine_identity_client_id:
+  gaia_api_infisical_client_secret:
     external: true
-  gaia_infisical_machine_identity_client_secret:
+  gaia_bot_discord_infisical_client_id:
+    external: true
+  gaia_bot_discord_infisical_client_secret:
+    external: true
+  gaia_bot_slack_infisical_client_id:
+    external: true
+  gaia_bot_slack_infisical_client_secret:
+    external: true
+  gaia_bot_telegram_infisical_client_id:
+    external: true
+  gaia_bot_telegram_infisical_client_secret:
+    external: true
+  gaia_bot_whatsapp_infisical_client_id:
+    external: true
+  gaia_bot_whatsapp_infisical_client_secret:
+    external: true
+  gaia_voice_agent_infisical_client_id:
+    external: true
+  gaia_voice_agent_infisical_client_secret:
     external: true
   gaia_infisical_project_id:
     external: true
@@ -59,15 +84,15 @@ services:
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       ENV: production
-      INFISICAL_ENV: prod
       # Use the shared embedding sidecar instead of loading models in-process.
       MEMORY_EMBEDDING_SIDECAR_URL: http://embedding-sidecar:8200
       # Self-hosted SearXNG — the unlimited last-resort search fallback.
       SEARXNG_BASE_URL: http://searxng:8080
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_api_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_api_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
       - gaia_metrics_token
     ports:
@@ -138,16 +163,16 @@ services:
       LOG_COLORIZE: "false"
       ARQ_METRICS_PORT: "9100"
       ENV: production
-      INFISICAL_ENV: prod
       # Use the shared embedding sidecar — the worker's 2G limit can't hold the
       # ~1.85GB models in-process, so it must offload embed/rerank to the sidecar.
       MEMORY_EMBEDDING_SIDECAR_URL: http://embedding-sidecar:8200
       # Self-hosted SearXNG — the unlimited last-resort search fallback.
       SEARXNG_BASE_URL: http://searxng:8080
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_api_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_api_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
       - gaia_metrics_token
     networks:
@@ -158,7 +183,7 @@ services:
       # Reads arq's own liveness key (arq:health — refreshed from the poll loop
       # with a ~31s TTL, so it's gone within ~31s if the loop wedges). This is
       # what `arq --check` asserts internally, but without importing the app:
-      # a healthcheck runs outside the entrypoint, so it has no INFISICAL_TOKEN
+      # a healthcheck runs outside the entrypoint, so it has no Infisical creds
       # and a full app import dies in settings bootstrap — which silently rolled
       # the worker back on every deploy. The probe touches only Redis.
       test: ["CMD", "python", "scripts/arq_healthcheck.py"]
@@ -203,7 +228,6 @@ services:
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       ENV: production
-      INFISICAL_ENV: prod
       # Persist the ~1.85GB fastembed weights so they download ONCE, not on every
       # restart/redeploy (measured ~148s cold-load). Mounted volume below.
       MEMORY_MODEL_CACHE_DIR: /models
@@ -212,9 +236,10 @@ services:
       # MEMORY_EMBEDDING_SIDECAR_URL MUST stay unset here so the sidecar serves
       # from its own local models rather than calling itself.
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_api_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_api_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     volumes:
       - embedding_models:/models
@@ -266,11 +291,11 @@ services:
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       ENV: production
-      INFISICAL_ENV: prod
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_bot_discord_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_bot_discord_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/discord/* from the public internet.
@@ -312,11 +337,11 @@ services:
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       ENV: production
-      INFISICAL_ENV: prod
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_bot_slack_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_bot_slack_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/slack/* from the public internet.
@@ -358,11 +383,11 @@ services:
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       ENV: production
-      INFISICAL_ENV: prod
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_bot_telegram_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_bot_telegram_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/telegram/* from the public internet.
@@ -404,11 +429,11 @@ services:
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       ENV: production
-      INFISICAL_ENV: prod
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_bot_whatsapp_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_bot_whatsapp_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /api/v1/webhook/whatsapp + /bots/whatsapp/*.
@@ -889,9 +914,10 @@ services:
       # SSE endpoint the agent's CustomLLM talks to).
       GAIA_BACKEND_URL: http://gaia-backend:80
     secrets:
-      - gaia_infisical_token
-      - gaia_infisical_machine_identity_client_id
-      - gaia_infisical_machine_identity_client_secret
+      - source: gaia_voice_agent_infisical_client_id
+        target: gaia_infisical_machine_identity_client_id
+      - source: gaia_voice_agent_infisical_client_secret
+        target: gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     volumes:
       - voice_agent_models:/home/appuser/.cache/huggingface

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -5,36 +5,18 @@
 # scripts/swarm/lab-rehearsal.sh.
 
 secrets:
-  # Per-service Infisical machine identities (Universal Auth). Each service
-  # authenticates with its own identity, scoped in the Infisical dashboard to
-  # only the secret paths that service needs — a compromised container cannot
-  # read the rest of the project. Services attach these with the long secret
-  # syntax, mapping each per-service secret onto the canonical
-  # /run/secrets/gaia_infisical_machine_identity_* paths that
-  # scripts/docker-entrypoint.sh reads.
-  gaia_api_infisical_client_id:
+  # One Infisical machine identity (Universal Auth), shared by every service.
+  # scripts/docker-entrypoint.sh reads these paths directly, so services attach
+  # them with the short secret syntax and need no per-service mapping.
+  #
+  # To scope access per service later, declare a secret per service here and
+  # attach it with the long syntax that maps onto these same canonical names —
+  # the entrypoint and app code stay identical:
+  #   - source: gaia_api_infisical_client_id
+  #     target: gaia_infisical_machine_identity_client_id
+  gaia_infisical_machine_identity_client_id:
     external: true
-  gaia_api_infisical_client_secret:
-    external: true
-  gaia_bot_discord_infisical_client_id:
-    external: true
-  gaia_bot_discord_infisical_client_secret:
-    external: true
-  gaia_bot_slack_infisical_client_id:
-    external: true
-  gaia_bot_slack_infisical_client_secret:
-    external: true
-  gaia_bot_telegram_infisical_client_id:
-    external: true
-  gaia_bot_telegram_infisical_client_secret:
-    external: true
-  gaia_bot_whatsapp_infisical_client_id:
-    external: true
-  gaia_bot_whatsapp_infisical_client_secret:
-    external: true
-  gaia_voice_agent_infisical_client_id:
-    external: true
-  gaia_voice_agent_infisical_client_secret:
+  gaia_infisical_machine_identity_client_secret:
     external: true
   gaia_infisical_project_id:
     external: true
@@ -89,10 +71,8 @@ services:
       # Self-hosted SearXNG — the unlimited last-resort search fallback.
       SEARXNG_BASE_URL: http://searxng:8080
     secrets:
-      - source: gaia_api_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_api_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
       - gaia_metrics_token
     ports:
@@ -169,10 +149,8 @@ services:
       # Self-hosted SearXNG — the unlimited last-resort search fallback.
       SEARXNG_BASE_URL: http://searxng:8080
     secrets:
-      - source: gaia_api_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_api_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
       - gaia_metrics_token
     networks:
@@ -236,10 +214,8 @@ services:
       # MEMORY_EMBEDDING_SIDECAR_URL MUST stay unset here so the sidecar serves
       # from its own local models rather than calling itself.
     secrets:
-      - source: gaia_api_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_api_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     volumes:
       - embedding_models:/models
@@ -292,10 +268,8 @@ services:
       LOG_COLORIZE: "false"
       ENV: production
     secrets:
-      - source: gaia_bot_discord_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_bot_discord_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/discord/* from the public internet.
@@ -338,10 +312,8 @@ services:
       LOG_COLORIZE: "false"
       ENV: production
     secrets:
-      - source: gaia_bot_slack_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_bot_slack_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/slack/* from the public internet.
@@ -384,10 +356,8 @@ services:
       LOG_COLORIZE: "false"
       ENV: production
     secrets:
-      - source: gaia_bot_telegram_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_bot_telegram_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /bots/telegram/* from the public internet.
@@ -430,10 +400,8 @@ services:
       LOG_COLORIZE: "false"
       ENV: production
     secrets:
-      - source: gaia_bot_whatsapp_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_bot_whatsapp_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     ports:
       # Nginx proxies /api/v1/webhook/whatsapp + /bots/whatsapp/*.
@@ -914,10 +882,8 @@ services:
       # SSE endpoint the agent's CustomLLM talks to).
       GAIA_BACKEND_URL: http://gaia-backend:80
     secrets:
-      - source: gaia_voice_agent_infisical_client_id
-        target: gaia_infisical_machine_identity_client_id
-      - source: gaia_voice_agent_infisical_client_secret
-        target: gaia_infisical_machine_identity_client_secret
+      - gaia_infisical_machine_identity_client_id
+      - gaia_infisical_machine_identity_client_secret
       - gaia_infisical_project_id
     volumes:
       - voice_agent_models:/home/appuser/.cache/huggingface

--- a/libs/shared/py/secrets.py
+++ b/libs/shared/py/secrets.py
@@ -6,6 +6,11 @@ production and staging deployments. Not required for self-hosting or
 contributor development - use local .env files instead.
 
 Local environment variables take precedence over Infisical secrets.
+
+Resolution:
+- All machine-identity vars set -> fetch remote secrets
+- None set in dev -> skip (local .env only); in prod -> raise
+- Partially set -> warn in dev, raise in prod
 """
 
 import os
@@ -18,44 +23,51 @@ class InfisicalConfigError(Exception):
     """Raised when Infisical configuration is missing or invalid."""
 
 
-def inject_infisical_secrets() -> None:
+_INFISICAL_VARS = (
+    "INFISICAL_PROJECT_ID",
+    "INFISICAL_MACHINE_IDENTITY_CLIENT_ID",
+    "INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET",
+)
+
+
+def inject_infisical_secrets():
     """
     Load secrets from Infisical and inject into environment.
 
-    Required environment variables:
-    - INFISICAL_TOKEN
-    - INFISICAL_PROJECT_ID
-    - INFISICAL_MACHINE_IDENTITY_CLIENT_ID
-    - INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET
+    Authenticates with a machine identity (Universal Auth) via
+    INFISICAL_PROJECT_ID, INFISICAL_MACHINE_IDENTITY_CLIENT_ID and
+    INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET.
 
     ENV doubles as the Infisical environment slug (development/staging/
     production).
-
-    In development, missing Infisical config logs a warning and returns.
-    In production, raises InfisicalConfigError.
     """
-    INFISICAL_TOKEN = os.getenv("INFISICAL_TOKEN")
-    INFISICAL_PROJECT_ID = os.getenv("INFISICAL_PROJECT_ID")
-    ENV = os.getenv("ENV", "production")
-    CLIENT_ID = os.getenv("INFISICAL_MACHINE_IDENTITY_CLIENT_ID")
-    CLIENT_SECRET = os.getenv("INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET")
+    env = os.getenv("ENV", "production")
+    is_production = env == "production"
 
-    is_production = ENV == "production"
+    present = [name for name in _INFISICAL_VARS if os.getenv(name)]
+    missing = [name for name in _INFISICAL_VARS if not os.getenv(name)]
 
-    missing_configs = [
-        (INFISICAL_TOKEN, "INFISICAL_TOKEN"),
-        (INFISICAL_PROJECT_ID, "INFISICAL_PROJECT_ID"),
-        (CLIENT_ID, "INFISICAL_MACHINE_IDENTITY_CLIENT_ID"),
-        (CLIENT_SECRET, "INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"),
-    ]
+    if not present:
+        if is_production:
+            raise InfisicalConfigError(
+                f"Infisical is required in production. Missing: {', '.join(missing)}"
+            )
+        log.info("Infisical skipped: no config vars set (using local .env only)")
+        return
 
-    for config_value, config_name in missing_configs:
-        if not config_value:
-            message = f"{config_name} is missing. This is required for secrets management."
-            if is_production:
-                raise InfisicalConfigError(message)
-            log.warning(f"Development environment: {message}")
-            return
+    if missing:
+        message = (
+            f"Incomplete Infisical config: missing {', '.join(missing)} "
+            f"(found {', '.join(present)})"
+        )
+        if is_production:
+            raise InfisicalConfigError(message)
+        log.warning(message)
+        return
+
+    project_id = os.environ["INFISICAL_PROJECT_ID"]
+    client_id = os.environ["INFISICAL_MACHINE_IDENTITY_CLIENT_ID"]
+    client_secret = os.environ["INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"]
 
     try:
         from infisical_sdk import InfisicalSDKClient
@@ -68,15 +80,15 @@ def inject_infisical_secrets() -> None:
             cache_ttl=3600,
         )
         client.auth.universal_auth.login(
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            client_id=client_id,
+            client_secret=client_secret,
         )
         log.info(f"Infisical authentication completed in {time.time() - start_time:.3f}s")
 
         secrets_start = time.time()
         secrets = client.secrets.list_secrets(
-            project_id=INFISICAL_PROJECT_ID,
-            environment_slug=ENV,
+            project_id=project_id,
+            environment_slug=env,
             secret_path="/",  # nosec B106 - Infisical folder path, not a credential
             expand_secret_references=True,
             view_secret_value=True,

--- a/libs/shared/py/secrets.py
+++ b/libs/shared/py/secrets.py
@@ -30,7 +30,7 @@ _INFISICAL_VARS = (
 )
 
 
-def inject_infisical_secrets():
+def inject_infisical_secrets() -> None:
     """
     Load secrets from Infisical and inject into environment.
 

--- a/libs/shared/py/tests/test_secrets.py
+++ b/libs/shared/py/tests/test_secrets.py
@@ -13,14 +13,12 @@ from shared.py.secrets import InfisicalConfigError, inject_infisical_secrets
 # ---------------------------------------------------------------------------
 
 _ALL_ENV_KEYS = [
-    "INFISICAL_TOKEN",
     "INFISICAL_PROJECT_ID",
     "INFISICAL_MACHINE_IDENTITY_CLIENT_ID",
     "INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET",
 ]
 
 _FULL_ENV = {
-    "INFISICAL_TOKEN": "tok-123",
     "INFISICAL_PROJECT_ID": "proj-abc",
     "INFISICAL_MACHINE_IDENTITY_CLIENT_ID": "cid-xyz",
     "INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET": "csec-xyz",
@@ -41,48 +39,26 @@ def _env_without(key: str, env: str = "production") -> dict[str, str]:
 
 
 class TestInjectInfisicalSecretsDev:
-    """In development, missing Infisical config should log a warning and return."""
+    """In development, missing Infisical config should log and return."""
 
     @patch("shared.py.secrets.log")
-    def test_missing_token_in_dev_returns_early(self, mock_logger: MagicMock):
-        env = _env_without("INFISICAL_TOKEN", env="development")
-        with patch.dict(os.environ, env, clear=True):
-            inject_infisical_secrets()
-        mock_logger.warning.assert_called_once()
-        assert "INFISICAL_TOKEN" in mock_logger.warning.call_args.args[0]
-
-    @patch("shared.py.secrets.log")
-    def test_missing_project_id_in_dev_returns_early(self, mock_logger: MagicMock):
-        env = _env_without("INFISICAL_PROJECT_ID", env="development")
-        with patch.dict(os.environ, env, clear=True):
-            inject_infisical_secrets()
-        mock_logger.warning.assert_called_once()
-        assert "INFISICAL_PROJECT_ID" in mock_logger.warning.call_args.args[0]
-
-    @patch("shared.py.secrets.log")
-    def test_missing_client_id_in_dev_returns_early(self, mock_logger: MagicMock):
-        env = _env_without("INFISICAL_MACHINE_IDENTITY_CLIENT_ID", env="development")
-        with patch.dict(os.environ, env, clear=True):
-            inject_infisical_secrets()
-        mock_logger.warning.assert_called_once()
-
-    @patch("shared.py.secrets.log")
-    def test_missing_client_secret_in_dev_returns_early(self, mock_logger: MagicMock):
-        env = _env_without("INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET", env="development")
-        with patch.dict(os.environ, env, clear=True):
-            inject_infisical_secrets()
-        mock_logger.warning.assert_called_once()
-
-    @patch("shared.py.secrets.log")
-    def test_all_missing_in_dev_returns_on_first_missing(self, mock_logger: MagicMock):
+    def test_no_config_in_dev_skips(self, mock_log: MagicMock):
         with patch.dict(os.environ, {"ENV": "development"}, clear=True):
             inject_infisical_secrets()
-        # Should return on the very first missing key (INFISICAL_TOKEN)
-        mock_logger.warning.assert_called_once()
-        assert "INFISICAL_TOKEN" in mock_logger.warning.call_args.args[0]
+        mock_log.info.assert_called_once()
+        assert "skipped" in mock_log.info.call_args.args[0]
+
+    @pytest.mark.parametrize("missing_key", _ALL_ENV_KEYS)
+    @patch("shared.py.secrets.log")
+    def test_partial_config_in_dev_warns(self, mock_log: MagicMock, missing_key: str):
+        env = _env_without(missing_key, env="development")
+        with patch.dict(os.environ, env, clear=True):
+            inject_infisical_secrets()
+        mock_log.warning.assert_called_once()
+        assert missing_key in mock_log.warning.call_args.args[0]
 
     @patch("shared.py.secrets.log")
-    def test_default_env_is_production(self, mock_logger: MagicMock):
+    def test_default_env_is_production(self, mock_log: MagicMock):
         """When ENV is not set at all, it defaults to 'production'."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(InfisicalConfigError):
@@ -97,6 +73,11 @@ class TestInjectInfisicalSecretsDev:
 class TestInjectInfisicalSecretsProd:
     """In production, missing Infisical config should raise InfisicalConfigError."""
 
+    def test_no_config_raises(self):
+        with patch.dict(os.environ, {"ENV": "production"}, clear=True):
+            with pytest.raises(InfisicalConfigError, match="required in production"):
+                inject_infisical_secrets()
+
     @pytest.mark.parametrize("missing_key", _ALL_ENV_KEYS)
     def test_missing_key_raises(self, missing_key: str):
         env = _env_without(missing_key, env="production")
@@ -106,7 +87,7 @@ class TestInjectInfisicalSecretsProd:
             assert missing_key in str(exc_info.value)
 
     def test_empty_string_treated_as_missing(self):
-        env = {**_FULL_ENV, "INFISICAL_TOKEN": ""}
+        env = {**_FULL_ENV, "INFISICAL_PROJECT_ID": ""}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(InfisicalConfigError):
                 inject_infisical_secrets()
@@ -121,7 +102,7 @@ class TestInjectInfisicalSecretsSuccess:
     """Test the happy path: all config present, SDK called, secrets injected."""
 
     @patch("shared.py.secrets.log")
-    def test_secrets_injected_into_environ(self, mock_logger: MagicMock):
+    def test_secrets_injected_into_environ(self, mock_log: MagicMock):
         mock_secret = SimpleNamespace(secretKey="MY_SECRET", secretValue="s3cret")
         mock_secrets_response = SimpleNamespace(secrets=[mock_secret])
 
@@ -139,7 +120,7 @@ class TestInjectInfisicalSecretsSuccess:
             assert os.environ.get("MY_SECRET") == "s3cret"
 
     @patch("shared.py.secrets.log")
-    def test_local_env_takes_precedence(self, mock_logger: MagicMock):
+    def test_local_env_takes_precedence(self, mock_log: MagicMock):
         """Existing env vars should NOT be overwritten by Infisical."""
         mock_secret = SimpleNamespace(secretKey="EXISTING_KEY", secretValue="infisical_value")
         mock_secrets_response = SimpleNamespace(secrets=[mock_secret])
@@ -160,7 +141,7 @@ class TestInjectInfisicalSecretsSuccess:
             assert os.environ["EXISTING_KEY"] == "local_value"
 
     @patch("shared.py.secrets.log")
-    def test_sdk_authentication_called(self, mock_logger: MagicMock):
+    def test_sdk_authentication_called(self, mock_log: MagicMock):
         mock_client = MagicMock()
         mock_client.secrets.list_secrets.return_value = SimpleNamespace(secrets=[])
         mock_sdk_class = MagicMock(return_value=mock_client)
@@ -177,7 +158,7 @@ class TestInjectInfisicalSecretsSuccess:
         )
 
     @patch("shared.py.secrets.log")
-    def test_sdk_client_created_with_correct_host(self, mock_logger: MagicMock):
+    def test_sdk_client_created_with_correct_host(self, mock_log: MagicMock):
         mock_client = MagicMock()
         mock_client.secrets.list_secrets.return_value = SimpleNamespace(secrets=[])
         mock_sdk_class = MagicMock(return_value=mock_client)
@@ -194,7 +175,7 @@ class TestInjectInfisicalSecretsSuccess:
         )
 
     @patch("shared.py.secrets.log")
-    def test_list_secrets_called_with_correct_params(self, mock_logger: MagicMock):
+    def test_list_secrets_called_with_correct_params(self, mock_log: MagicMock):
         mock_client = MagicMock()
         mock_client.secrets.list_secrets.return_value = SimpleNamespace(secrets=[])
         mock_sdk_class = MagicMock(return_value=mock_client)
@@ -216,7 +197,7 @@ class TestInjectInfisicalSecretsSuccess:
         )
 
     @patch("shared.py.secrets.log")
-    def test_multiple_secrets_injected(self, mock_logger: MagicMock):
+    def test_multiple_secrets_injected(self, mock_log: MagicMock):
         secrets = [
             SimpleNamespace(secretKey="KEY_A", secretValue="val_a"),
             SimpleNamespace(secretKey="KEY_B", secretValue="val_b"),
@@ -246,7 +227,7 @@ class TestInjectInfisicalSecretsSDKFailure:
     """Test that SDK exceptions are wrapped in InfisicalConfigError."""
 
     @patch("shared.py.secrets.log")
-    def test_sdk_exception_wrapped(self, mock_logger: MagicMock):
+    def test_sdk_exception_wrapped(self, mock_log: MagicMock):
         mock_sdk_class = MagicMock(side_effect=ConnectionError("unreachable"))
 
         with patch.dict(os.environ, _FULL_ENV, clear=True):
@@ -257,7 +238,7 @@ class TestInjectInfisicalSecretsSDKFailure:
                     inject_infisical_secrets()
 
     @patch("shared.py.secrets.log")
-    def test_auth_failure_wrapped(self, mock_logger: MagicMock):
+    def test_auth_failure_wrapped(self, mock_log: MagicMock):
         mock_client = MagicMock()
         mock_client.auth.universal_auth.login.side_effect = RuntimeError("auth failed")
         mock_sdk_class = MagicMock(return_value=mock_client)
@@ -270,7 +251,7 @@ class TestInjectInfisicalSecretsSDKFailure:
                     inject_infisical_secrets()
 
     @patch("shared.py.secrets.log")
-    def test_list_secrets_failure_wrapped(self, mock_logger: MagicMock):
+    def test_list_secrets_failure_wrapped(self, mock_log: MagicMock):
         mock_client = MagicMock()
         mock_client.secrets.list_secrets.side_effect = TimeoutError("timed out")
         mock_sdk_class = MagicMock(return_value=mock_client)

--- a/libs/shared/ts/src/bots/config/secrets.ts
+++ b/libs/shared/ts/src/bots/config/secrets.ts
@@ -2,7 +2,7 @@
  * Infisical secrets management for GAIA bots.
  *
  * Resolution:
- * - If all 4 Infisical env vars are set → fetch remote secrets
+ * - If all Infisical env vars are set → fetch remote secrets
  * - If partially set → warn about incomplete config
  * - If none set in dev → skip (using local .env only)
  * - If none set in prod → throw (Infisical is required in production)
@@ -23,15 +23,18 @@ class InfisicalConfigError extends Error {
 }
 
 const INFISICAL_VARS = [
-  "INFISICAL_TOKEN",
   "INFISICAL_PROJECT_ID",
   "INFISICAL_MACHINE_IDENTITY_CLIENT_ID",
   "INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET",
 ] as const;
 
 export async function injectInfisicalSecrets(): Promise<void> {
+  // ENV doubles as the Infisical environment slug (development/staging/
+  // production), same as the Python loader. NODE_ENV is only a fallback for
+  // containers that set NODE_ENV=production without an explicit ENV.
   const env =
-    process.env.NODE_ENV === "production" ? "production" : "development";
+    process.env.ENV ??
+    (process.env.NODE_ENV === "production" ? "production" : "development");
   const isProduction = env === "production";
 
   const present = INFISICAL_VARS.filter((k) => !!process.env[k]);

--- a/libs/shared/ts/src/bots/config/secrets.ts
+++ b/libs/shared/ts/src/bots/config/secrets.ts
@@ -30,10 +30,18 @@ const INFISICAL_VARS = [
 
 export async function injectInfisicalSecrets(): Promise<void> {
   // ENV doubles as the Infisical environment slug (development/staging/
-  // production). Identical to the Python loader, including the default: an
-  // unset ENV means production, so a deployed container that forgets to set it
-  // refuses to boot instead of silently starting with no secrets.
-  const env = process.env.ENV ?? "production";
+  // production). Unlike the Python loader — which defaults an absent ENV to
+  // production — a bare bot checkout resolves to development, because
+  // apps/bots/.env.example has never required ENV and defaulting to production
+  // would break every existing local setup on the next pull.
+  //
+  // Deployment never relies on that fallback: apps/bots/Dockerfile bakes
+  // ENV=production into the image and docker-compose.prod.yml sets it again per
+  // service, so a container can only ever resolve production. NODE_ENV is kept
+  // as a third layer for images built outside this Dockerfile.
+  const env =
+    process.env.ENV ??
+    (process.env.NODE_ENV === "production" ? "production" : "development");
   const isProduction = env === "production";
 
   const present = INFISICAL_VARS.filter((k) => !!process.env[k]);

--- a/libs/shared/ts/src/bots/config/secrets.ts
+++ b/libs/shared/ts/src/bots/config/secrets.ts
@@ -30,11 +30,10 @@ const INFISICAL_VARS = [
 
 export async function injectInfisicalSecrets(): Promise<void> {
   // ENV doubles as the Infisical environment slug (development/staging/
-  // production), same as the Python loader. NODE_ENV is only a fallback for
-  // containers that set NODE_ENV=production without an explicit ENV.
-  const env =
-    process.env.ENV ??
-    (process.env.NODE_ENV === "production" ? "production" : "development");
+  // production). Identical to the Python loader, including the default: an
+  // unset ENV means production, so a deployed container that forgets to set it
+  // refuses to boot instead of silently starting with no secrets.
+  const env = process.env.ENV ?? "production";
   const isProduction = env === "production";
 
   const present = INFISICAL_VARS.filter((k) => !!process.env[k]);

--- a/mise.toml
+++ b/mise.toml
@@ -273,6 +273,10 @@ fi
 nx run-many -t dev --projects=api,web --parallel=2
 '''
 
+[tasks."dev:infisical"]
+description = "Team members: `mise dev` with secrets injected from Infisical via the CLI. One-time setup: `brew install infisical/get-cli/infisical && infisical login`. Injected values win over .env for this task — use Infisical personal overrides for local tweaks. Self-hosters/contributors: use `mise dev` with plain .env files instead."
+run = "infisical run --env=development -- mise dev"
+
 [tasks."dev:api"]
 description = "Run ONLY API server natively + infra in Docker. Same JuiceFS caveat as `mise dev` — see `mise dev:vm` for the dockered-API variant."
 run = "nx run docker:docker:up && nx dev api"

--- a/mise.toml
+++ b/mise.toml
@@ -273,9 +273,9 @@ fi
 nx run-many -t dev --projects=api,web --parallel=2
 '''
 
-[tasks."dev:infisical"]
-description = "Team members: `mise dev` with secrets injected from Infisical via the CLI. One-time setup: `brew install infisical/get-cli/infisical && infisical login`. Injected values win over .env for this task — use Infisical personal overrides for local tweaks. Self-hosters/contributors: use `mise dev` with plain .env files instead."
-run = "infisical run --env=development -- mise dev"
+[tasks.infisical]
+description = "Team members: run ANY mise task with secrets injected from Infisical — `mise infisical dev`, `mise infisical dev:full`, `mise infisical -- dev --agent` (use `--` before task flags so mise passes them through). One-time setup: `brew install infisical/get-cli/infisical && infisical login`. Injected values win over .env — use Infisical personal overrides for local tweaks. Self-hosters/contributors: run tasks directly with plain .env files instead."
+run = "infisical run --env=development -- mise run"
 
 [tasks."dev:api"]
 description = "Run ONLY API server natively + infra in Docker. Same JuiceFS caveat as `mise dev` — see `mise dev:vm` for the dockered-API variant."

--- a/packages/cli/src/lib/env-setup.ts
+++ b/packages/cli/src/lib/env-setup.ts
@@ -89,13 +89,11 @@ async function collectInfisicalEnv(
 ): Promise<void> {
   store.setStatus("Configuring Infisical...");
   const infisicalConfig = (await store.waitForInput("env_infisical")) as {
-    INFISICAL_TOKEN: string;
     INFISICAL_PROJECT_ID: string;
     INFISICAL_MACHINE_IDENTITY_CLIENT_ID: string;
     INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET: string;
   };
 
-  envValues["INFISICAL_TOKEN"] = infisicalConfig.INFISICAL_TOKEN;
   envValues["INFISICAL_PROJECT_ID"] = infisicalConfig.INFISICAL_PROJECT_ID;
   envValues["INFISICAL_MACHINE_IDENTITY_CLIENT_ID"] =
     infisicalConfig.INFISICAL_MACHINE_IDENTITY_CLIENT_ID;

--- a/packages/cli/src/ui/screens/init.tsx
+++ b/packages/cli/src/ui/screens/init.tsx
@@ -436,14 +436,12 @@ export const EnvMethodSelectionStep: React.FC<{
 // Infisical setup component
 export const InfisicalSetupStep: React.FC<{
   onSubmit: (values: {
-    INFISICAL_TOKEN: string;
     INFISICAL_PROJECT_ID: string;
     INFISICAL_MACHINE_IDENTITY_CLIENT_ID: string;
     INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET: string;
   }) => void;
 }> = ({ onSubmit }) => {
   const [values, setValues] = useState({
-    INFISICAL_TOKEN: "",
     INFISICAL_PROJECT_ID: "",
     INFISICAL_MACHINE_IDENTITY_CLIENT_ID: "",
     INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET: "",
@@ -452,10 +450,6 @@ export const InfisicalSetupStep: React.FC<{
   const [error, setError] = useState<string | null>(null);
 
   const fields = [
-    {
-      key: "INFISICAL_TOKEN" as const,
-      description: "Service token from project settings (st.xxx...)",
-    },
     {
       key: "INFISICAL_PROJECT_ID" as const,
       description: "Found in your Infisical project settings",

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -15,7 +15,6 @@ set -e
 # ---------------------------------------------------------------------------
 # 1. Docker Swarm secrets → env vars
 # ---------------------------------------------------------------------------
-[ -f /run/secrets/gaia_infisical_token ]                          && export INFISICAL_TOKEN=$(cat /run/secrets/gaia_infisical_token)
 [ -f /run/secrets/gaia_infisical_machine_identity_client_id ]     && export INFISICAL_MACHINE_IDENTITY_CLIENT_ID=$(cat /run/secrets/gaia_infisical_machine_identity_client_id)
 [ -f /run/secrets/gaia_infisical_machine_identity_client_secret ] && export INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=$(cat /run/secrets/gaia_infisical_machine_identity_client_secret)
 [ -f /run/secrets/gaia_infisical_project_id ]                     && export INFISICAL_PROJECT_ID=$(cat /run/secrets/gaia_infisical_project_id)
@@ -49,7 +48,7 @@ for v in $_jfs_required; do
     fi
 done
 
-if [ "$_jfs_missing" = "1" ] && [ -n "${INFISICAL_TOKEN:-}" ] && [ -n "${INFISICAL_MACHINE_IDENTITY_CLIENT_ID:-}" ]; then
+if [ "$_jfs_missing" = "1" ] && [ -n "${INFISICAL_MACHINE_IDENTITY_CLIENT_ID:-}" ] && [ -n "${INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET:-}" ] && [ -n "${INFISICAL_PROJECT_ID:-}" ]; then
     _jfs_env_file="$(mktemp)"
     if python - "$_jfs_env_file" <<'PY'
 import os

--- a/scripts/swarm/lab-rehearsal.sh
+++ b/scripts/swarm/lab-rehearsal.sh
@@ -21,9 +21,8 @@
 # or leave unset to use placeholders (infra services will start; app services
 # will fail Infisical auth — that's expected with fake creds).
 #
-#   INFISICAL_TOKEN=...
-#   INFISICAL_MACHINE_IDENTITY_CLIENT_ID=...
-#   INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=...
+#   INFISICAL_MACHINE_IDENTITY_CLIENT_ID=...      (used for every per-service identity)
+#   INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=...  (used for every per-service identity)
 #   INFISICAL_PROJECT_ID=...
 #   METRICS_TOKEN=...
 #
@@ -218,7 +217,8 @@ else
   # Read from env vars — fall back to placeholder values if not set.
   # With placeholders, infra services start fine; app services will fail
   # Infisical auth (expected — use real creds for a full integration test).
-  INFISICAL_TOKEN="${INFISICAL_TOKEN:-lab-placeholder-token}"
+  # Production uses one machine identity PER SERVICE; the lab reuses one
+  # identity's creds for all of them (or placeholders).
   INFISICAL_MACHINE_IDENTITY_CLIENT_ID="${INFISICAL_MACHINE_IDENTITY_CLIENT_ID:-lab-placeholder-client-id}"
   INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET="${INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET:-lab-placeholder-client-secret}"
   INFISICAL_PROJECT_ID="${INFISICAL_PROJECT_ID:-lab-placeholder-project-id}"
@@ -234,11 +234,13 @@ else
     fi
   }
 
-  create_secret gaia_infisical_token                          "$INFISICAL_TOKEN"
-  create_secret gaia_infisical_machine_identity_client_id     "$INFISICAL_MACHINE_IDENTITY_CLIENT_ID"
-  create_secret gaia_infisical_machine_identity_client_secret "$INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"
-  create_secret gaia_infisical_project_id                     "$INFISICAL_PROJECT_ID"
-  create_secret gaia_metrics_token                            "$METRICS_TOKEN"
+  # Per-service machine identities (see docker-compose.prod.yml secrets block)
+  for _svc in api bot_discord bot_slack bot_telegram bot_whatsapp voice_agent; do
+    create_secret "gaia_${_svc}_infisical_client_id"     "$INFISICAL_MACHINE_IDENTITY_CLIENT_ID"
+    create_secret "gaia_${_svc}_infisical_client_secret" "$INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"
+  done
+  create_secret gaia_infisical_project_id "$INFISICAL_PROJECT_ID"
+  create_secret gaia_metrics_token        "$METRICS_TOKEN"
   # Grafana email alerting (Gmail app password). Real value in prod; placeholder
   # for the lab so the grafana service can start with GF_SMTP_PASSWORD__FILE set.
   create_secret gaia_grafana_smtp_password                    "${GRAFANA_SMTP_PASSWORD:-lab-placeholder-smtp-password}"
@@ -385,6 +387,6 @@ cat << EOF
 
   Note: app services (gaia-backend, bots) will be in a restart loop with placeholder
   Infisical creds — that is expected.  Pass real env vars to test full auth:
-    INFISICAL_TOKEN=... bash scripts/swarm/lab-rehearsal.sh --skip-launch --skip-secrets
+    INFISICAL_MACHINE_IDENTITY_CLIENT_ID=... bash scripts/swarm/lab-rehearsal.sh --skip-launch --skip-secrets
 
 EOF

--- a/scripts/swarm/lab-rehearsal.sh
+++ b/scripts/swarm/lab-rehearsal.sh
@@ -217,8 +217,6 @@ else
   # Read from env vars — fall back to placeholder values if not set.
   # With placeholders, infra services start fine; app services will fail
   # Infisical auth (expected — use real creds for a full integration test).
-  # Production uses one machine identity PER SERVICE; the lab reuses one
-  # identity's creds for all of them (or placeholders).
   INFISICAL_MACHINE_IDENTITY_CLIENT_ID="${INFISICAL_MACHINE_IDENTITY_CLIENT_ID:-lab-placeholder-client-id}"
   INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET="${INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET:-lab-placeholder-client-secret}"
   INFISICAL_PROJECT_ID="${INFISICAL_PROJECT_ID:-lab-placeholder-project-id}"
@@ -234,12 +232,10 @@ else
     fi
   }
 
-  # Per-service machine identities (see docker-compose.prod.yml secrets block)
-  for _svc in api bot_discord bot_slack bot_telegram bot_whatsapp voice_agent; do
-    create_secret "gaia_${_svc}_infisical_client_id"     "$INFISICAL_MACHINE_IDENTITY_CLIENT_ID"
-    create_secret "gaia_${_svc}_infisical_client_secret" "$INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"
-  done
-  create_secret gaia_infisical_project_id "$INFISICAL_PROJECT_ID"
+  # Shared machine identity (see docker-compose.prod.yml secrets block)
+  create_secret gaia_infisical_machine_identity_client_id     "$INFISICAL_MACHINE_IDENTITY_CLIENT_ID"
+  create_secret gaia_infisical_machine_identity_client_secret "$INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"
+  create_secret gaia_infisical_project_id                     "$INFISICAL_PROJECT_ID"
   create_secret gaia_metrics_token        "$METRICS_TOKEN"
   # Grafana email alerting (Gmail app password). Real value in prod; placeholder
   # for the lab so the grafana service can start with GF_SMTP_PASSWORD__FILE set.

--- a/scripts/swarm/lab-rehearsal.sh
+++ b/scripts/swarm/lab-rehearsal.sh
@@ -386,7 +386,9 @@ cat << EOF
     orbctl delete $VM_NAME
 
   Note: app services (gaia-backend, bots) will be in a restart loop with placeholder
-  Infisical creds — that is expected.  Pass real env vars to test full auth:
-    INFISICAL_MACHINE_IDENTITY_CLIENT_ID=... bash scripts/swarm/lab-rehearsal.sh --skip-launch --skip-secrets
+  Infisical creds — that is expected.  To test full auth, remove the placeholder
+  secrets first (secret creation skips existing ones), then re-run with real creds:
+    INFISICAL_MACHINE_IDENTITY_CLIENT_ID=... INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=... \\
+    INFISICAL_PROJECT_ID=... bash scripts/swarm/lab-rehearsal.sh --skip-launch
 
 EOF

--- a/scripts/swarm/lab-rehearsal.sh
+++ b/scripts/swarm/lab-rehearsal.sh
@@ -21,8 +21,8 @@
 # or leave unset to use placeholders (infra services will start; app services
 # will fail Infisical auth — that's expected with fake creds).
 #
-#   INFISICAL_MACHINE_IDENTITY_CLIENT_ID=...      (used for every per-service identity)
-#   INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=...  (used for every per-service identity)
+#   INFISICAL_MACHINE_IDENTITY_CLIENT_ID=...
+#   INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET=...
 #   INFISICAL_PROJECT_ID=...
 #   METRICS_TOKEN=...
 #
@@ -236,7 +236,7 @@ else
   create_secret gaia_infisical_machine_identity_client_id     "$INFISICAL_MACHINE_IDENTITY_CLIENT_ID"
   create_secret gaia_infisical_machine_identity_client_secret "$INFISICAL_MACHINE_IDENTITY_CLIENT_SECRET"
   create_secret gaia_infisical_project_id                     "$INFISICAL_PROJECT_ID"
-  create_secret gaia_metrics_token        "$METRICS_TOKEN"
+  create_secret gaia_metrics_token                            "$METRICS_TOKEN"
   # Grafana email alerting (Gmail app password). Real value in prod; placeholder
   # for the lab so the grafana service can start with GF_SMTP_PASSWORD__FILE set.
   create_secret gaia_grafana_smtp_password                    "${GRAFANA_SMTP_PASSWORD:-lab-placeholder-smtp-password}"


### PR DESCRIPTION
Cleans up GAIA's Infisical setup: removes a credential that nothing reads, makes the CLI workflow actually runnable, and extends it past `mise dev`.

## What changed

**Drop `INFISICAL_TOKEN`.** No loader has read it since the move to machine identities. Removed from both loaders, the Swarm entrypoint, the CLI init wizard, `.env.example`s, and the prod compose secret list.

**Make the CLI workflow work.** `.infisical.json` shipped a `REPLACE_WITH_INFISICAL_PROJECT_ID` placeholder, so the documented command 404'd for everyone. The real project ID is now committed — it is an identifier, not a credential, and fetching still requires `infisical login` with project access.

**Generic `mise infisical <task>`** replaces the single-purpose `dev:infisical`, which only ever wrapped `mise dev` (API + web) and never reached the bots or voice agent.

```bash
mise infisical dev        # API + web
mise infisical dev:full   # + arq worker, voice agent, all bots
mise infisical -- dev --agent
```

**One shared machine identity in production.** Services attach `gaia_infisical_machine_identity_client_id/_secret` directly with compose's short syntax. Scoping per service later is a compose-only change — the entrypoint and app code are identical either way, and the long-syntax mapping is documented inline.

**Voice agent** loads its own `.env` before falling back to the API's.

**Docs** rewritten: the CLI workflow, the single-identity production setup, how to scope per service later, why the Next.js app is deliberately not wired to Infisical, and the `development`-environment infra URL contract (localhost, because compose sets the container hostnames itself).

## Deployment impact

**None.** The secret names match what `develop` already deploys, so no Swarm secrets need creating before this ships. Dropping `gaia_infisical_token` from the compose file does not require deleting it from the manager.

## Testing

- `libs/shared/py/tests/test_secrets.py` — 21 passed
- `docker compose config` — both prod and dev compose validate; all 8 services resolve to `/run/secrets/gaia_infisical_machine_identity_*`
- `infisical run --env=development` resolves the project from `.infisical.json` with no `--projectId` and injects 81 secrets
- type-check + lint pass for `api`, `cli`, `shared-typescript`, all four bots, and `voice-agent`

`api:lint` reports 96 ruff errors; clean `origin/develop` reports the identical 96, and none are in files this PR touches.

## Not covered

`injectInfisicalSecrets` (TypeScript) still has no tests, while the Python loader it mirrors has 21.
