### PR TITLE
feat(agents): env-configurable custom dev LLM provider for cheap bulk testing

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -71,6 +71,25 @@ KAPSO_WEBHOOK_SECRET=
 WHATSAPP_PHONE_NUMBER=
 
 # =============================
+# LLM Providers
+# =============================
+# Gemini — default model + auxiliary LLM tasks
+GOOGLE_API_KEY=
+# OpenRouter — paid-plan + dev-menu models
+OPENROUTER_API_KEY=
+
+# Dev-only (honored only when ENV=development):
+# Custom OpenRouter/OpenAI-compatible endpoint for cheap bulk test usage — all three must
+# be set. Example: Nous Research's discounted DeepSeek lane (https://portal.nousresearch.com).
+# DEV_LLM_BASE_URL=https://inference-api.nousresearch.com/v1
+# DEV_LLM_API_KEY=
+# DEV_LLM_MODEL=deepseek/deepseek-v4-flash-0731
+# Default model for every dev request that doesn't pick one in the chat-header selector —
+# any DEV_MODEL_OPTIONS key from app/constants/llm.py ("custom" = the endpoint above).
+# An explicit selector choice wins.
+# DEV_DEFAULT_MODEL=custom
+
+# =============================
 # GitHub Integration (optional)
 # =============================
 # Get a token at https://github.com/settings/tokens (no scopes needed)

--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -27,6 +27,7 @@ from app.constants.llm import (
     DEFAULT_LLM_TEMPERATURE,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL_NAME,
+    DEV_LLM_MAX_OUTPUT_TOKENS,
     LLM_INVOKE_TIMEOUT_SECONDS,
     LLM_RETRY_MAX_ATTEMPTS,
     OPENROUTER_APP_CATEGORIES,
@@ -74,10 +75,14 @@ def is_default_model_config(configurable: Mapping[str, Any]) -> bool:
 PROVIDER_MODELS = {
     "gemini": DEFAULT_GEMINI_MODEL_NAME,
     "openrouter": DEFAULT_GROK_MODEL_NAME,
+    # The env-defined custom dev endpoint; empty when unset — the provider is
+    # only registered in development with all DEV_LLM_* settings present.
+    "custom": settings.DEV_LLM_MODEL or "",
 }
 PROVIDER_PRIORITY = {
     1: "gemini",
     2: "openrouter",
+    3: "custom",
 }
 
 
@@ -178,6 +183,49 @@ def init_openrouter_llm():
     )
 
 
+@lazy_provider(
+    name="custom_llm",
+    required_keys=[SIM_STUB_API_KEY]
+    if settings.GAIA_SIM_MODE
+    else [settings.DEV_LLM_BASE_URL, settings.DEV_LLM_API_KEY, settings.DEV_LLM_MODEL],
+    strategy=MissingKeyStrategy.WARN,
+    warning_message="DEV_LLM_BASE_URL / DEV_LLM_API_KEY / DEV_LLM_MODEL not configured. The custom dev LLM endpoint will not work.",
+)
+def init_custom_llm():
+    """DEV-ONLY: the env-defined custom provider — any OpenRouter/OpenAI-compatible
+    endpoint, with base URL, key, and model all from the DEV_LLM_* settings. Routes
+    bulk test traffic to heavily discounted lanes (e.g. Nous Research's DeepSeek
+    models) without spending real credits. ChatOpenRouter works against such
+    endpoints unchanged, including reasoning parsing — only the base URL and key
+    differ. The configurable-field ids mirror the OpenRouter client's exactly;
+    alternatives share one namespace (prefix_keys=False), so ids must stay
+    consistent. Registered only when ENV=development (see register_llm_providers).
+    """
+    if settings.GAIA_SIM_MODE:
+        return _sim_llm()
+    return ChatOpenRouter(
+        model=PROVIDER_MODELS["custom"],
+        temperature=DEFAULT_LLM_TEMPERATURE,
+        streaming=True,
+        stream_usage=True,
+        max_tokens=DEV_LLM_MAX_OUTPUT_TOKENS,
+        api_key=settings.DEV_LLM_API_KEY,
+        base_url=settings.DEV_LLM_BASE_URL,
+    ).configurable_fields(
+        model_name=ConfigurableField(id="model", name="Model", description="Which model to use"),
+        reasoning=ConfigurableField(
+            id="reasoning",
+            name="Reasoning",
+            description="Reasoning effort (per-agent thinking budget)",
+        ),
+        model_kwargs=ConfigurableField(
+            id="model_kwargs",
+            name="Model kwargs",
+            description="Extra request params (e.g. provider routing pin)",
+        ),
+    )
+
+
 def init_llm(
     preferred_provider: str | None = None,
     fallback_enabled: bool = True,
@@ -233,6 +281,7 @@ def _get_available_providers() -> dict[str, Any]:
     provider_instance_mapping = {
         "gemini": "gemini_llm",
         "openrouter": "openrouter_llm",
+        "custom": "custom_llm",
     }
 
     available = {}
@@ -300,6 +349,11 @@ def register_llm_providers():
     """Register LLM providers in the lazy loader."""
     init_gemini_llm()
     init_openrouter_llm()
+    # The custom endpoint is a dev/testing-only lane — never registered in
+    # production, so DEV_LLM_* vars present in a prod environment can't route
+    # real traffic.
+    if settings.ENV == "development":
+        init_custom_llm()
 
 
 def get_default_llm(*, temperature: float = DEFAULT_LLM_TEMPERATURE) -> BaseChatModel:

--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -111,6 +111,29 @@ def _sim_llm(temperature: float = DEFAULT_LLM_TEMPERATURE) -> BaseChatModel:
     return llm
 
 
+_MODEL_FIELD = ConfigurableField(id="model_name", name="Model", description="Which model to use")
+
+
+def _openrouter_wire_configurables(llm: ChatOpenRouter):
+    """Attach the per-request configurable fields shared by every OpenRouter-wire
+    client (the real OpenRouter and the env-defined custom endpoint). The field
+    ids form one namespace across provider alternatives (``prefix_keys=False``),
+    so every compatible client must expose identical ids."""
+    return llm.configurable_fields(
+        model_name=ConfigurableField(id="model", name="Model", description="Which model to use"),
+        reasoning=ConfigurableField(
+            id="reasoning",
+            name="Reasoning",
+            description="Reasoning effort (per-agent thinking budget)",
+        ),
+        model_kwargs=ConfigurableField(
+            id="model_kwargs",
+            name="Model kwargs",
+            description="Extra request params (e.g. provider routing pin)",
+        ),
+    )
+
+
 @lazy_provider(
     name="gemini_llm",
     required_keys=[SIM_STUB_API_KEY if settings.GAIA_SIM_MODE else settings.GOOGLE_API_KEY],
@@ -125,9 +148,7 @@ def init_gemini_llm():
         model=PROVIDER_MODELS["gemini"],
         temperature=DEFAULT_LLM_TEMPERATURE,
         streaming=True,
-    ).configurable_fields(
-        model=ConfigurableField(id="model_name", name="Model", description="Which model to use"),
-    )
+    ).configurable_fields(model=_MODEL_FIELD)
     return llm
 
 
@@ -152,34 +173,24 @@ def init_openrouter_llm():
     # No base_url kwarg here on purpose: passing None would override the field's
     # OPENROUTER_API_BASE env default_factory. Redirecting to the stub is sim
     # mode's job (_sim_llm); this construction is identical to pre-sim behavior.
-    return ChatOpenRouter(
-        model=PROVIDER_MODELS["openrouter"],
-        temperature=DEFAULT_LLM_TEMPERATURE,
-        streaming=True,
-        stream_usage=True,
-        # Output cap; must stay well under the model's shared input+output context
-        # window (see OPENROUTER_MAX_OUTPUT_TOKENS) or OpenRouter rejects the request.
-        max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
-        api_key=settings.OPENROUTER_API_KEY,
-        # App attribution → OpenRouter rankings/analytics. ChatOpenRouter exposes
-        # these as dedicated params (NOT `default_headers`, which it forwards to
-        # send_async and crashes on). https://openrouter.ai/docs/app-attribution
-        app_url=settings.FRONTEND_URL,
-        app_title=OPENROUTER_APP_TITLE,
-        app_categories=OPENROUTER_APP_CATEGORIES,
-        reasoning=OPENROUTER_REASONING,
-    ).configurable_fields(
-        model_name=ConfigurableField(id="model", name="Model", description="Which model to use"),
-        reasoning=ConfigurableField(
-            id="reasoning",
-            name="Reasoning",
-            description="OpenRouter reasoning effort (per-agent thinking budget)",
-        ),
-        model_kwargs=ConfigurableField(
-            id="model_kwargs",
-            name="Model kwargs",
-            description="Extra OpenRouter request params (e.g. provider routing pin)",
-        ),
+    return _openrouter_wire_configurables(
+        ChatOpenRouter(
+            model=PROVIDER_MODELS["openrouter"],
+            temperature=DEFAULT_LLM_TEMPERATURE,
+            streaming=True,
+            stream_usage=True,
+            # Output cap; must stay well under the model's shared input+output context
+            # window (see OPENROUTER_MAX_OUTPUT_TOKENS) or OpenRouter rejects the request.
+            max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
+            api_key=settings.OPENROUTER_API_KEY,
+            # App attribution → OpenRouter rankings/analytics. ChatOpenRouter exposes
+            # these as dedicated params (NOT `default_headers`, which it forwards to
+            # send_async and crashes on). https://openrouter.ai/docs/app-attribution
+            app_url=settings.FRONTEND_URL,
+            app_title=OPENROUTER_APP_TITLE,
+            app_categories=OPENROUTER_APP_CATEGORIES,
+            reasoning=OPENROUTER_REASONING,
+        )
     )
 
 
@@ -197,32 +208,20 @@ def init_custom_llm():
     bulk test traffic to heavily discounted lanes (e.g. Nous Research's DeepSeek
     models) without spending real credits. ChatOpenRouter works against such
     endpoints unchanged, including reasoning parsing — only the base URL and key
-    differ. The configurable-field ids mirror the OpenRouter client's exactly;
-    alternatives share one namespace (prefix_keys=False), so ids must stay
-    consistent. Registered only when ENV=development (see register_llm_providers).
+    differ. Registered only when ENV=development (see register_llm_providers).
     """
     if settings.GAIA_SIM_MODE:
         return _sim_llm()
-    return ChatOpenRouter(
-        model=PROVIDER_MODELS["custom"],
-        temperature=DEFAULT_LLM_TEMPERATURE,
-        streaming=True,
-        stream_usage=True,
-        max_tokens=DEV_LLM_MAX_OUTPUT_TOKENS,
-        api_key=settings.DEV_LLM_API_KEY,
-        base_url=settings.DEV_LLM_BASE_URL,
-    ).configurable_fields(
-        model_name=ConfigurableField(id="model", name="Model", description="Which model to use"),
-        reasoning=ConfigurableField(
-            id="reasoning",
-            name="Reasoning",
-            description="Reasoning effort (per-agent thinking budget)",
-        ),
-        model_kwargs=ConfigurableField(
-            id="model_kwargs",
-            name="Model kwargs",
-            description="Extra request params (e.g. provider routing pin)",
-        ),
+    return _openrouter_wire_configurables(
+        ChatOpenRouter(
+            model=PROVIDER_MODELS["custom"],
+            temperature=DEFAULT_LLM_TEMPERATURE,
+            streaming=True,
+            stream_usage=True,
+            max_tokens=DEV_LLM_MAX_OUTPUT_TOKENS,
+            api_key=settings.DEV_LLM_API_KEY,
+            base_url=settings.DEV_LLM_BASE_URL,
+        )
     )
 
 

--- a/apps/api/app/agents/llm/plan_model.py
+++ b/apps/api/app/agents/llm/plan_model.py
@@ -2,6 +2,7 @@
 by subscription plan. Set on the comms configurable; executor/subagents inherit it.
 """
 
+from app.config.settings import settings
 from app.constants.llm import (
     COMMS_REASONING,
     DEFAULT_LLM_PROVIDER,
@@ -56,7 +57,15 @@ def _apply_dev_model(configurable: dict, option: dict, reasoning_cfg: dict) -> N
     """Pin a DEV_MODEL_OPTIONS entry onto a configurable, applying role-appropriate
     reasoning. Clears `model_kwargs`/`reasoning` for models that don't use them so a
     prior plan/inherited OpenRouter pin can't leak onto a Gemini-routed model."""
-    _pin_model(configurable, option["provider"], option["model"])
+    if option["model"]:
+        _pin_model(configurable, option["provider"], option["model"])
+    else:
+        # Entry without a pinned model (the env-defined "custom" endpoint): route
+        # by provider and clear any earlier model pin so the client's own default
+        # (DEV_LLM_MODEL) serves the request.
+        configurable["provider"] = option["provider"]
+        configurable.pop("model", None)
+        configurable.pop("model_name", None)
     if option["model_kwargs"] is not None:
         configurable["model_kwargs"] = option["model_kwargs"]
     else:
@@ -74,11 +83,21 @@ def apply_dev_model_override(
     use_defaults: bool,
 ) -> None:
     """DEV-ONLY: override the comms model now and stash the executor model for the
-    executor run. No-op when use_defaults is set or an id is unknown. Runs AFTER
-    apply_plan_model so the dev selection wins over the plan model. Caller gates this
-    to ENV=development; never reached in production."""
+    executor run. Requests that don't pick a model (use_defaults) fall back to the
+    env-configured DEV_DEFAULT_MODEL for both roles, so bots/scripts/plain requests
+    route to it too; an explicit selector choice wins. No-op when neither is set or
+    an id is unknown. Runs AFTER apply_plan_model so the dev selection wins over
+    the plan model. Caller gates this to ENV=development; never reached in
+    production."""
     if use_defaults:
-        return
+        dev_default = settings.DEV_DEFAULT_MODEL
+        if dev_default and dev_default not in DEV_MODEL_OPTIONS:
+            log.warning(
+                f"{LogTag.AGENT} DEV_DEFAULT_MODEL '{dev_default}' is not a "
+                "DEV_MODEL_OPTIONS key; keeping the plan model"
+            )
+            return
+        comms_model = executor_model = dev_default
     comms_option = DEV_MODEL_OPTIONS.get(comms_model or "")
     if comms_option:
         _apply_dev_model(configurable, comms_option, COMMS_REASONING)

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -160,6 +160,21 @@ class CommonSettings(BaseAppSettings):
         return max(CRAWL4AI_MIN_MAX_BROWSERS, parsed)
 
     # ----------------------------------------------
+    # Dev-only LLM overrides (honored only when ENV=development)
+    # ----------------------------------------------
+    # Custom OpenRouter/OpenAI-compatible endpoint for cheap bulk dev/test usage
+    # (e.g. Nous Research's discounted DeepSeek lane). All three must be set; the
+    # "custom" provider is registered exclusively in development (see
+    # register_llm_providers), so these have no effect in production.
+    DEV_LLM_BASE_URL: str | None = None
+    DEV_LLM_API_KEY: str | None = None
+    DEV_LLM_MODEL: str | None = None
+    # Default model for every dev request that doesn't pick one in the chat-header
+    # selector — any DEV_MODEL_OPTIONS key from app/constants/llm.py ("custom" =
+    # the endpoint above). An explicit selector choice still wins.
+    DEV_DEFAULT_MODEL: str | None = None
+
+    # ----------------------------------------------
     # GitHub Integration (for Skill Discovery)
     # ----------------------------------------------
     # Optional: Get a token at https://github.com/settings/tokens

--- a/apps/api/app/constants/llm.py
+++ b/apps/api/app/constants/llm.py
@@ -137,6 +137,12 @@ PAID_MODEL_MODEL_KWARGS = {"provider": {"only": [PAID_MODEL_PROVIDER_SLUG]}}
 # levels if comms routing or executor tool-selection quality needs more headroom.
 COMMS_REASONING = {"effort": "low"}
 
+# Output cap for the env-defined custom dev provider (the "custom" entry below;
+# endpoint/key/model all come from the DEV_LLM_* settings). 64k fits under the
+# completion ceilings of the cheap lanes this is meant for (e.g. DeepSeek V4
+# Flash caps at 65,536).
+DEV_LLM_MAX_OUTPUT_TOKENS = 64_000
+
 # OpenRouter app attribution (https://openrouter.ai/docs/app-attribution). The
 # OpenRouter client surfaces these as the HTTP-Referer / X-Title /
 # X-OpenRouter-Categories headers so GAIA appears on OpenRouter's app rankings.
@@ -173,6 +179,23 @@ DEV_MODEL_OPTIONS: dict[str, dict] = {
     "deepseek-v4": {
         "provider": "openrouter",
         "model": "deepseek/deepseek-v4-pro",
+        "model_kwargs": None,
+        "reasoning": False,
+    },
+    "deepseek-v4-flash": {
+        # Pinned snapshot — same id also served by the cheap OpenRouter-compatible
+        # lanes (e.g. Nous Research), so the custom endpoint below can run the
+        # identical model for A/B-ing routes.
+        "provider": "openrouter",
+        "model": "deepseek/deepseek-v4-flash-0731",
+        "model_kwargs": None,
+        "reasoning": False,
+    },
+    "custom": {
+        # The env-defined endpoint (DEV_LLM_* settings). `model` None = don't pin
+        # one here; the client's own default (DEV_LLM_MODEL) serves the request.
+        "provider": "custom",
+        "model": None,
         "model_kwargs": None,
         "reasoning": False,
     },

--- a/apps/api/scripts/payment_setup.py
+++ b/apps/api/scripts/payment_setup.py
@@ -74,7 +74,7 @@ sys.path.insert(0, str(backend_dir))
 from motor.motor_asyncio import AsyncIOMotorClient  # noqa: E402
 
 from app.config.settings import settings  # noqa: E402
-from app.models.payment_models import PlanDB  # noqa: E402
+from app.models.payment_models import PlanDocument  # noqa: E402
 
 
 async def cleanup_old_indexes(collection):
@@ -217,7 +217,7 @@ async def setup_payment_plans(monthly_product_id: str, yearly_product_id: str):
                     }
                 )
 
-                plan_doc = PlanDB.model_validate(
+                plan_doc = PlanDocument.model_validate(
                     {
                         "dodo_product_id": dodo_product_id,
                         "name": plan_item["name"],

--- a/apps/api/tests/integration/test_llm_fallback_chain.py
+++ b/apps/api/tests/integration/test_llm_fallback_chain.py
@@ -331,7 +331,7 @@ class TestGetAvailableProviders:
     """Test _get_available_providers retrieves from the lazy provider registry."""
 
     def _build_registry(self, present_providers: dict[str, Any]) -> ProviderRegistry:
-        """Build a ProviderRegistry with all three LLM slots registered.
+        """Build a ProviderRegistry with all LLM slots registered.
 
         Providers listed in `present_providers` get a real loader that returns
         the given instance. Missing providers get a loader that returns None
@@ -342,6 +342,7 @@ class TestGetAvailableProviders:
             "openai_llm": present_providers.get("openai_llm"),
             "gemini_llm": present_providers.get("gemini_llm"),
             "openrouter_llm": present_providers.get("openrouter_llm"),
+            "custom_llm": present_providers.get("custom_llm"),
         }
         for name, instance in all_slots.items():
             if instance is not None:

--- a/apps/api/tests/unit/agents/test_llm_client.py
+++ b/apps/api/tests/unit/agents/test_llm_client.py
@@ -486,17 +486,38 @@ class TestAinvokeLlm:
 
 @pytest.mark.unit
 class TestRegisterLlmProviders:
+    @patch("app.agents.llm.client.init_custom_llm")
     @patch("app.agents.llm.client.init_openrouter_llm")
     @patch("app.agents.llm.client.init_gemini_llm")
     def test_calls_all_init_functions(
         self,
         mock_gemini: MagicMock,
         mock_openrouter: MagicMock,
+        mock_custom: MagicMock,
     ) -> None:
         register_llm_providers()
 
         mock_gemini.assert_called_once()
         mock_openrouter.assert_called_once()
+        # conftest sets ENV=development, where the dev-only custom provider registers.
+        mock_custom.assert_called_once()
+
+    @patch("app.agents.llm.client.init_custom_llm")
+    @patch("app.agents.llm.client.init_openrouter_llm")
+    @patch("app.agents.llm.client.init_gemini_llm")
+    def test_custom_not_registered_outside_development(
+        self,
+        mock_gemini: MagicMock,
+        mock_openrouter: MagicMock,
+        mock_custom: MagicMock,
+    ) -> None:
+        with patch("app.agents.llm.client.settings") as mock_settings:
+            mock_settings.ENV = "production"
+            register_llm_providers()
+
+        mock_gemini.assert_called_once()
+        mock_openrouter.assert_called_once()
+        mock_custom.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -507,15 +528,15 @@ class TestRegisterLlmProviders:
 @pytest.mark.unit
 class TestConstants:
     def test_provider_models_keys(self) -> None:
-        assert set(PROVIDER_MODELS.keys()) == {"gemini", "openrouter"}
+        assert set(PROVIDER_MODELS.keys()) == {"gemini", "openrouter", "custom"}
 
     def test_provider_priority_values(self) -> None:
-        assert set(PROVIDER_PRIORITY.values()) == {"gemini", "openrouter"}
+        assert set(PROVIDER_PRIORITY.values()) == {"gemini", "openrouter", "custom"}
 
     def test_provider_priority_is_ordered(self) -> None:
         sorted_keys = sorted(PROVIDER_PRIORITY.keys())
         providers_in_order = [PROVIDER_PRIORITY[k] for k in sorted_keys]
-        assert providers_in_order == ["gemini", "openrouter"]
+        assert providers_in_order == ["gemini", "openrouter", "custom"]
 
     def test_retryable_exceptions_contains_expected_types(self) -> None:
         from google.genai.errors import ServerError

--- a/apps/web/src/features/chat/constants/devModels.ts
+++ b/apps/web/src/features/chat/constants/devModels.ts
@@ -35,6 +35,18 @@ export const DEV_MODEL_OPTIONS: DevModelOption[] = [
     logo: "/images/icons/deepseek.png",
   },
   {
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash",
+    provider: "DeepSeek",
+    logo: "/images/icons/deepseek.png",
+  },
+  {
+    id: "custom",
+    name: "Custom (env)",
+    provider: "DEV_LLM_BASE_URL endpoint",
+    logo: "/images/logos/logo.webp",
+  },
+  {
     id: "gemini-3.1-flash-lite",
     name: "Gemini 3.1 Flash Lite",
     provider: "Google",


### PR DESCRIPTION
## What & why

Bulk dev/test chat traffic currently burns real OpenRouter credits. This adds a dev-only **`custom` LLM provider slot**: any OpenRouter/OpenAI-compatible endpoint, configured entirely by env —

```bash
DEV_LLM_BASE_URL=https://inference-api.nousresearch.com/v1   # e.g. Nous Research's 90%-off DeepSeek lane
DEV_LLM_API_KEY=<key>
DEV_LLM_MODEL=deepseek/deepseek-v4-flash-0731                # $0.01/M in, $0.02/M out on Nous
DEV_DEFAULT_MODEL=custom                                     # optional: route every dev request to it by default
```

The slot is deliberately generic (not Nous-specific): the same three vars point at OpenCode Zen (`https://opencode.ai/zen/v1`, `deepseek-v4-flash-free`) or any other cheap OpenRouter-compatible lane with zero code changes. The dev menu also gains **DeepSeek V4 Flash** on OpenRouter (same pinned `-0731` snapshot, $0.09/$0.18 there), so the two routes can be A/B'd on the identical model.

**Production is untouched**: the provider is registered only when `ENV=development` (`register_llm_providers`), so `DEV_LLM_*` present in a prod environment cannot route traffic.

## How it works

- `app/agents/llm/client.py` — `init_custom_llm()` registers a `ChatOpenRouter` with a `base_url` override (the Nous/Zen APIs are OpenRouter-wire-compatible, so reasoning parsing, retries, and the fallback chain behave identically to the OpenRouter client). It joins the existing `configurable_alternatives` chain as provider `custom`, follows the `GAIA_SIM_MODE` stub pattern, and shares the OpenRouter client's configurable-field ids.
- `app/agents/llm/plan_model.py` — requests that don't pick a model (`use_default_models`) now fall back to `DEV_DEFAULT_MODEL` for both comms and executor, so bots/scripts/plain requests route there too; an explicit chat-header selection still wins. A typo'd value warns and keeps the plan model. Menu entries without a pinned model (`custom`) route by provider and clear stale model pins so the client's `DEV_LLM_MODEL` default serves the request.
- `app/constants/llm.py` — `DEV_MODEL_OPTIONS` gains `deepseek-v4-flash` (OpenRouter) and `custom`; `app/config/settings.py` gains the four `DEV_LLM_*`/`DEV_DEFAULT_MODEL` fields on `CommonSettings` (optional, dev-honored only).
- `apps/web .../devModels.ts` — matching **DeepSeek V4 Flash** and **Custom (env)** picker entries.
- `.env.example` — documents the LLM provider vars (previously absent entirely). Note: comments sit **above** the empty `GOOGLE_API_KEY=`/`OPENROUTER_API_KEY=` lines because python-dotenv parses an inline comment after an *empty* value as the value itself — found live when `Bearer # OpenRouter — paid-plan + dev-menu models` became an Authorization header and broke every chat turn.

## Before / After

| Surface | Before | After |
|---|---|---|
| Dev model picker | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/c4c42545d569d2f5cff65828fbcf05fb92b731ef/claude/deepseek-v4-flash-testing-ymit8c/00-picker-before.png" width="420"> | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/c4c42545d569d2f5cff65828fbcf05fb92b731ef/claude/deepseek-v4-flash-testing-ymit8c/03-comms-options.png" width="420"> |
| Custom (env) pinned for comms + executor | — | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/c4c42545d569d2f5cff65828fbcf05fb92b731ef/claude/deepseek-v4-flash-testing-ymit8c/04-picker-custom-selected.png" width="420"> |
| Chat turn answered through the custom provider | — | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/c4c42545d569d2f5cff65828fbcf05fb92b731ef/claude/deepseek-v4-flash-testing-ymit8c/05-chat-reply.png" width="420"> |

## Verification

- Full stack booted in the sandbox (infra in Docker, native API + web, dev auth bypass, seeded dev user per `driving-gaia`). The repo's OpenRouter-wire `llm-stub` played the role of the external endpoint via `DEV_LLM_BASE_URL=http://localhost:9797/api/v1`.
- **Custom provider, explicit pin**: `POST /chat-stream` with `use_default_models: false, comms_model: "custom"` → real (non-sim) graph run made a live HTTP call to the env-configured endpoint and streamed the reply; stub log shows the request with the full comms toolset bound.
- **Custom provider, env default**: same request with *no* model fields under `DEV_DEFAULT_MODEL=custom` → routed to the endpoint, winning over the free-plan Gemini pin as designed.
- **From the browser**: drove `/c` with Playwright as the seeded dev user — selected Custom (env) for both roles in the chat-header picker, sent a message, reply rendered in the chat UI (screenshot above).
- Endpoint compatibility verified against the live `/v1/models` of both Nous (`deepseek/deepseek-v4-flash-0731`, 1M ctx, tools + reasoning params) and OpenCode Zen (`deepseek-v4-flash-free`) — both are OpenRouter-schema services.
- Local gates green: `nx type-check api`, `nx lint api`, `nx run web:type-check`, `nx lint web`; `test_llm_client.py` + `test_llm_fallback_chain.py` (69 passed, assertions updated for the new provider).
- Run modes used: `--sim`-equivalent for stack bring-up checks, then non-sim with `DEV_LLM_*` for the custom-provider path (sim mode by design replaces every factory with the stub, so it cannot exercise this provider).

## Not verified

- No real Nous/OpenCode API calls (no credentials in this sandbox) — the wire contract was exercised against the repo's OpenRouter-compatible stub and both providers' live model catalogs, not a paid completion.
- Compaction/summarization thresholds remain denominated in the default model's window for dev-menu overrides (pre-existing, documented in `constants/llm.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SHeRbCJFybQHTSqhK5KQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015SHeRbCJFybQHTSqhK5KQZ)_