### PR TITLE
fix(api,infra): redis juicefs metadata + worker memory headroom

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -150,6 +150,8 @@ ENABLE_OPENUI=false
 # JuiceFS metadata URL — `{shard}` substituted at mount time. Dev default
 # below points at the docker-compose postgres + the gaia_juicefs_0 DB created
 # by infra/docker/postgres-init/10-juicefs.sql on first boot.
+# Prod uses Redis, where {shard} is the DB number:
+#   rediss://:password@jfs-meta.heygaia.io:6380/{shard}
 # JUICEFS_META_URL_TEMPLATE=postgres://postgres:postgres@postgres:5432/gaia_juicefs_{shard}?sslmode=disable
 
 # Optional client-side RSA-4096 PEM. If set, the entrypoint writes it to

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -360,7 +360,10 @@ class ProductionSettings(CommonSettings):
     R2_ACCESS_KEY: str
     R2_SECRET_KEY: str
     # Templated metadata URL: contains {shard} substituted at mount time.
-    # Example: "postgres://juicefs:pass@host:5432/gaia_juicefs_{shard}?sslmode=require"
+    # Redis (prod): "rediss://:pass@jfs-meta.heygaia.io:6380/{shard}" — {shard} is
+    # the DB number. Postgres: "postgres://juicefs:pass@host:5432/gaia_juicefs_{shard}".
+    # The password is split out into META_PASSWORD before reaching the sandbox
+    # (see _split_meta_url in services/sandbox/lifecycle.py).
     JUICEFS_META_URL_TEMPLATE: str
     JUICEFS_NUM_SHARDS: int = 1  # Phase 1: 1, Phase 2: 16
     # JuiceFS RSA-4096 private key in PEM form. Whole multi-line PEM stored as a

--- a/apps/api/app/workers/config/worker_settings.py
+++ b/apps/api/app/workers/config/worker_settings.py
@@ -30,6 +30,11 @@ class WorkerSettings:
     on_shutdown: Callable[[dict], Coroutine[Any, Any, None]] | None = None
 
     # Performance settings
+    # Sized from measured load, not guessed: mean task duration 10.9s at
+    # 0.72 tasks/s needs ~8 concurrent (Little's Law), peaking near 16. Below
+    # ~8 the queue grows without bound. Bursts above 10 are meant to queue.
+    # Concurrency here is bounded by worker memory — each job holds agent
+    # graphs and LLM contexts — so raise the container limit before raising it.
     max_jobs = 10
     job_timeout = 1800  # 30 minutes
     keep_result = 0  # Don't keep results in Redis

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -46,7 +46,7 @@ from app.services.workflow.conversation_service import (
     add_workflow_execution_messages,
     get_or_create_workflow_conversation,
 )
-from app.services.workflow.scheduler import WorkflowScheduler
+from app.services.workflow.scheduler import WorkflowScheduler, workflow_scheduler
 from app.services.workflow.service import WorkflowService
 from app.utils.timezone import Timezone, format_local_time
 from shared.py.wide_events import WorkflowContext, log, wide_task
@@ -204,7 +204,11 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
         log.set(actual_fire_utc=actual_fire_utc.isoformat())
         log.info(f"{LogTag.WORKER} Processing workflow execution: {workflow_id}")
 
-        scheduler = WorkflowScheduler()
+        # Process-wide singleton, initialized once by init_workflow_service(). A
+        # per-job instance opened its own ARQ Redis pool on every execution and
+        # closed it in `finally` — thousands of pool churns an hour, which drove
+        # the worker into repeated OOM kills.
+        scheduler = workflow_scheduler
         workflow = None
         execution_id = None
 
@@ -215,7 +219,6 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
         )
 
         try:
-            await scheduler.initialize()
             workflow = await scheduler.get_task(workflow_id)
 
             if not workflow:
@@ -422,10 +425,6 @@ async def execute_workflow_by_id(ctx: dict, workflow_id: str, context: dict | No
                 )
 
             return "Error executing workflow %s: %s" % (workflow_id, str(e))
-
-        finally:
-            if scheduler:
-                await scheduler.close()
 
 
 @tiered_rate_limit("trigger_workflow_executions")

--- a/apps/api/scripts/format_juicefs_shards.py
+++ b/apps/api/scripts/format_juicefs_shards.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
 """Format JuiceFS shards against R2.
 
-Runs `juicefs format` once per shard, pointing each at its own PostgreSQL
-metadata database. The `gaia-workspaces` R2 bucket is shared across shards;
-JuiceFS distributes objects via its own chunk-hash prefix scheme.
+Runs `juicefs format` once per shard, pointing each at its own metadata engine
+(Redis DB in prod, PostgreSQL database elsewhere) via JUICEFS_META_URL_TEMPLATE.
+The R2 bucket is shared across shards; JuiceFS distributes objects via its own
+chunk-hash prefix scheme, which is why `--shards 16` below needs no `%d` in the
+bucket name.
 
 Usage:
     cd apps/api
     uv run python scripts/format_juicefs_shards.py --shards 1
     uv run python scripts/format_juicefs_shards.py --shards 16 --dry-run
+
+Secrets come from Infisical (same bootstrap as payment_setup.py), so no env
+plumbing is needed to run this locally — only the `juicefs` binary on PATH.
+Values already in the environment take precedence, so a local `.env` or an
+explicit export still wins.
 
 Required env (mirrors apps/api/app/config/settings.py):
     R2_ACCOUNT_ID, R2_BUCKET, R2_ACCESS_KEY, R2_SECRET_KEY
@@ -29,12 +36,28 @@ import subprocess
 import sys
 import tempfile
 
+# Must precede the `app.*` import so the script works from any cwd.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.config.secrets import (  # noqa: E402
+    InfisicalConfigError,
+    inject_infisical_secrets,
+)
+
 
 def required(name: str) -> str:
     val = os.environ.get(name)
     if not val:
         raise SystemExit(f"Missing required env var: {name}")
     return val
+
+
+def _mask_meta(url: str) -> str:
+    """Redact the password from a meta URL so it can be printed."""
+    scheme, sep, rest = url.partition("://")
+    if not sep or "@" not in rest:
+        return url
+    return f"{scheme}://***@{rest.split('@', 1)[1]}"
 
 
 @contextmanager
@@ -58,7 +81,12 @@ def _encryption_key_file() -> Iterator[str | None]:
             pass
 
 
-def format_shard(shard: int, encrypt_key_path: str | None, dry_run: bool = False) -> None:
+def format_shard(
+    shard: int,
+    encrypt_key_path: str | None,
+    name_suffix: str = "",
+    dry_run: bool = False,
+) -> None:
     account = required("R2_ACCOUNT_ID")
     bucket = required("R2_BUCKET")
     access_key = required("R2_ACCESS_KEY")
@@ -67,12 +95,21 @@ def format_shard(shard: int, encrypt_key_path: str | None, dry_run: bool = False
 
     meta_url = meta_template.replace("{shard}", str(shard))
     bucket_url = f"https://{account}.r2.cloudflarestorage.com/{bucket}"
-    name = f"gaia-{shard}"
+    # The volume name is the object-store prefix (<bucket>/<name>/), so juicefs
+    # refuses to format when that prefix already holds blocks. Re-formatting
+    # after losing the metadata engine therefore needs a fresh name — the old
+    # blocks stay readable for a later restore instead of being overwritten.
+    name = f"gaia-{shard}{name_suffix}"
 
     # R2 credentials are passed via env (juicefs reads AWS_ACCESS_KEY_ID /
     # AWS_SECRET_ACCESS_KEY when --access-key/--secret-key are absent), so
     # they do not appear in argv that `ps auxww` could expose during the
     # ~30s format window.
+    # No --shards: it splits blocks across N *buckets* and requires a `%d` in the
+    # bucket name to generate the endpoints. With a single bucket juicefs exits
+    # with "can not generate different endpoint", so `--shards 16` here never
+    # worked against gaia-workspaces — it only appeared to because the caller in
+    # docker-entrypoint.sh swallows a failed format with `|| echo`.
     cmd = [
         "juicefs",
         "format",
@@ -80,14 +117,14 @@ def format_shard(shard: int, encrypt_key_path: str | None, dry_run: bool = False
         "s3",
         "--bucket",
         bucket_url,
-        "--shards",
-        "16",  # Always 16 chunk-distribution shards regardless of FS count
     ]
     if encrypt_key_path:
         cmd.extend(["--encrypt-rsa-key", encrypt_key_path])
     cmd.extend([meta_url, name])
 
-    pretty = " ".join(shlex.quote(c) for c in cmd)
+    # The meta URL carries the metadata-engine password; mask it so it never
+    # reaches a terminal, a CI log, or Loki.
+    pretty = " ".join(shlex.quote(_mask_meta(c)) for c in cmd)
     if dry_run:
         print(f"# Would run (with AWS_ACCESS_KEY_ID/SECRET in env):\n{pretty}")
         return
@@ -103,15 +140,34 @@ def format_shard(shard: int, encrypt_key_path: str | None, dry_run: bool = False
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--shards", type=int, default=1, help="Number of shards to format")
+    parser.add_argument(
+        "--name-suffix",
+        default="",
+        help="Appended to the volume name, e.g. '-v2' -> gaia-0-v2. Use when "
+        "re-formatting against a bucket that still holds a previous volume.",
+    )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
 
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
 
+    # Not fatal on its own: the env may already be populated from a .env or
+    # explicit exports. `required()` below is the real gate and names precisely
+    # what is missing.
+    try:
+        inject_infisical_secrets()
+    except InfisicalConfigError as exc:
+        print(f"[warn] Infisical injection skipped: {exc}", file=sys.stderr)
+
     with _encryption_key_file() as key_path:
         for shard in range(args.shards):
-            format_shard(shard, encrypt_key_path=key_path, dry_run=args.dry_run)
+            format_shard(
+                shard,
+                encrypt_key_path=key_path,
+                name_suffix=args.name_suffix,
+                dry_run=args.dry_run,
+            )
     return 0
 
 

--- a/apps/api/tests/integration/test_worker_task_lifecycle.py
+++ b/apps/api/tests/integration/test_worker_task_lifecycle.py
@@ -348,13 +348,11 @@ class TestWorkflowTaskExecution:
         """When workflow ID does not exist, return a not-found message."""
 
         mock_scheduler = AsyncMock()
-        mock_scheduler.initialize = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=None)
-        mock_scheduler.close = AsyncMock()
 
         with patch(
-            "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-            return_value=mock_scheduler,
+            "app.workers.tasks.workflow_tasks.workflow_scheduler",
+            mock_scheduler,
         ):
             result = await execute_workflow_by_id(ARQ_CTX, "nonexistent-wf-id")
 
@@ -370,17 +368,15 @@ class TestWorkflowTaskExecution:
         mock_workflow.steps = [MagicMock(), MagicMock()]
 
         mock_scheduler = AsyncMock()
-        mock_scheduler.initialize = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=mock_workflow)
-        mock_scheduler.close = AsyncMock()
 
         mock_execution = MagicMock()
         mock_execution.execution_id = "exec-456"
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                return_value=mock_scheduler,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.services.workflow.execution_service.create_execution",
@@ -433,17 +429,15 @@ class TestWorkflowTaskExecution:
         mock_workflow.steps = [MagicMock()]
 
         mock_scheduler = AsyncMock()
-        mock_scheduler.initialize = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=mock_workflow)
-        mock_scheduler.close = AsyncMock()
 
         mock_execution = MagicMock()
         mock_execution.execution_id = "exec-err"
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                return_value=mock_scheduler,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.services.workflow.execution_service.create_execution",

--- a/apps/api/tests/unit/workers/test_workflow_tasks.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks.py
@@ -46,6 +46,13 @@ def _make_workflow(
     return wf
 
 
+def _make_scheduler(workflow=None):
+    """Stand-in for the process-wide workflow_scheduler singleton."""
+    scheduler = AsyncMock()
+    scheduler.get_task = AsyncMock(return_value=workflow)
+    return scheduler
+
+
 # ---------------------------------------------------------------------------
 # execute_workflow_by_id
 # ---------------------------------------------------------------------------
@@ -64,8 +71,7 @@ class TestExecuteWorkflowById:
         return str(uuid4())
 
     async def test_workflow_not_found_returns_message(self, ctx, workflow_id):
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=None)
+        mock_scheduler = _make_scheduler()
 
         mock_create_execution = AsyncMock()
         mock_complete_execution = AsyncMock()
@@ -94,8 +100,7 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -137,8 +142,7 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -174,8 +178,7 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -209,15 +212,17 @@ class TestExecuteWorkflowById:
         mock_increment.assert_awaited_once_with(workflow.id, workflow.user_id, is_successful=False)
         assert "Error executing workflow" in result
 
-    async def test_trigger_type_from_context(self, ctx):
+    @pytest.mark.parametrize(
+        "context,expected_trigger_type",
+        [({"trigger_type": "scheduled"}, "scheduled"), (None, "manual")],
+    )
+    async def test_trigger_type_from_context(self, ctx, context, expected_trigger_type):
         workflow = _make_workflow()
-        context = {"trigger_type": "scheduled"}
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -247,46 +252,7 @@ class TestExecuteWorkflowById:
         mock_create_exec.assert_awaited_once_with(
             workflow_id=workflow.id,
             user_id=workflow.user_id,
-            trigger_type="scheduled",
-        )
-
-    async def test_default_trigger_type_is_manual_when_no_context(self, ctx):
-        workflow = _make_workflow()
-        mock_execution = MagicMock()
-        mock_execution.execution_id = str(uuid4())
-
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
-
-        mock_create_exec = AsyncMock(return_value=mock_execution)
-        mock_complete_exec = AsyncMock()
-
-        with (
-            patch(
-                "app.workers.tasks.workflow_tasks.workflow_scheduler",
-                mock_scheduler,
-            ),
-            patch(
-                "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
-                AsyncMock(return_value="conv_123"),
-            ),
-            patch("app.workers.tasks.workflow_tasks.WorkflowService") as mock_wf_svc,
-            patch(
-                "app.services.workflow.execution_service.create_execution",
-                mock_create_exec,
-            ),
-            patch(
-                "app.services.workflow.execution_service.complete_execution",
-                mock_complete_exec,
-            ),
-        ):
-            mock_wf_svc.increment_execution_count = AsyncMock()
-            await execute_workflow_by_id(ctx, workflow.id, context=None)
-
-        mock_create_exec.assert_awaited_once_with(
-            workflow_id=workflow.id,
-            user_id=workflow.user_id,
-            trigger_type="manual",
+            trigger_type=expected_trigger_type,
         )
 
     async def test_shared_scheduler_survives_failed_execution(self, ctx):
@@ -295,8 +261,7 @@ class TestExecuteWorkflowById:
         # the worker, so a failing job must leave it open for the next one.
         workflow = _make_workflow()
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
@@ -1017,8 +982,7 @@ class TestExecuteWorkflowByIdNotifications:
         Returns individual patch objects so they can be used in a `with (...):`
         block without needing iterable unpacking.
         """
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
@@ -1197,8 +1161,7 @@ class TestExecuteWorkflowByIdNotifications:
         """If complete_execution fails during error handling, it doesn't crash."""
         workflow = _make_workflow()
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
@@ -1233,8 +1196,7 @@ class TestExecuteWorkflowByIdNotifications:
         """If increment_execution_count fails during error handling, it doesn't crash."""
         workflow = _make_workflow()
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
@@ -1272,8 +1234,7 @@ class TestExecuteWorkflowByIdNotifications:
         and complete_execution is not called."""
         workflow = _make_workflow()
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_complete_exec = AsyncMock()
 
@@ -1306,8 +1267,7 @@ class TestExecuteWorkflowByIdNotifications:
         to complete_execution."""
         workflow = _make_workflow()
 
-        mock_scheduler = AsyncMock()
-        mock_scheduler.get_task = AsyncMock(return_value=workflow)
+        mock_scheduler = _make_scheduler(workflow)
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())

--- a/apps/api/tests/unit/workers/test_workflow_tasks.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks.py
@@ -64,18 +64,16 @@ class TestExecuteWorkflowById:
         return str(uuid4())
 
     async def test_workflow_not_found_returns_message(self, ctx, workflow_id):
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=None)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_create_execution = AsyncMock()
         mock_complete_execution = AsyncMock()
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.services.workflow.execution_service.create_execution",
@@ -96,10 +94,8 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -108,8 +104,8 @@ class TestExecuteWorkflowById:
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -128,7 +124,6 @@ class TestExecuteWorkflowById:
             mock_wf_svc.increment_execution_count = mock_increment
             result = await execute_workflow_by_id(ctx, workflow.id)
 
-        mock_scheduler.initialize.assert_awaited_once()
         assert "executed successfully" in result
         assert workflow.id in result
         mock_complete_exec.assert_awaited_once()
@@ -142,10 +137,8 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -153,8 +146,8 @@ class TestExecuteWorkflowById:
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -173,7 +166,6 @@ class TestExecuteWorkflowById:
             mock_wf_svc.increment_execution_count = mock_increment
             await execute_workflow_by_id(ctx, workflow.id)
 
-        mock_scheduler.initialize.assert_awaited_once()
         mock_increment.assert_awaited_once_with(workflow.id, workflow.user_id, is_successful=True)
 
     async def test_execution_count_incremented_as_failed_on_error(self, ctx):
@@ -182,10 +174,8 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
@@ -193,8 +183,8 @@ class TestExecuteWorkflowById:
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -216,7 +206,6 @@ class TestExecuteWorkflowById:
             mock_wf_svc.increment_execution_count = mock_increment
             result = await execute_workflow_by_id(ctx, workflow.id)
 
-        mock_scheduler.initialize.assert_awaited_once()
         mock_increment.assert_awaited_once_with(workflow.id, workflow.user_id, is_successful=False)
         assert "Error executing workflow" in result
 
@@ -227,18 +216,16 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -257,7 +244,6 @@ class TestExecuteWorkflowById:
             mock_wf_svc.increment_execution_count = AsyncMock()
             await execute_workflow_by_id(ctx, workflow.id, context=context)
 
-        mock_scheduler.initialize.assert_awaited_once()
         mock_create_exec.assert_awaited_once_with(
             workflow_id=workflow.id,
             user_id=workflow.user_id,
@@ -269,18 +255,16 @@ class TestExecuteWorkflowById:
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_create_exec = AsyncMock(return_value=mock_execution)
         mock_complete_exec = AsyncMock()
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -299,28 +283,28 @@ class TestExecuteWorkflowById:
             mock_wf_svc.increment_execution_count = AsyncMock()
             await execute_workflow_by_id(ctx, workflow.id, context=None)
 
-        mock_scheduler.initialize.assert_awaited_once()
         mock_create_exec.assert_awaited_once_with(
             workflow_id=workflow.id,
             user_id=workflow.user_id,
             trigger_type="manual",
         )
 
-    async def test_scheduler_always_closed_in_finally(self, ctx):
+    async def test_shared_scheduler_survives_failed_execution(self, ctx):
+        # The scheduler is a process-wide singleton owning an ARQ Redis pool.
+        # Closing it per job churned thousands of pools an hour and OOM-killed
+        # the worker, so a failing job must leave it open for the next one.
         workflow = _make_workflow()
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -340,8 +324,7 @@ class TestExecuteWorkflowById:
             mock_wf_svc.increment_execution_count = AsyncMock()
             await execute_workflow_by_id(ctx, workflow.id)
 
-        mock_scheduler.initialize.assert_awaited_once()
-        mock_scheduler.close.assert_awaited_once()
+        mock_scheduler.close.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -1034,17 +1017,15 @@ class TestExecuteWorkflowByIdNotifications:
         Returns individual patch objects so they can be used in a `with (...):`
         block without needing iterable unpacking.
         """
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
         p_scheduler = patch(
-            "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-            mock_scheduler_cls,
+            "app.workers.tasks.workflow_tasks.workflow_scheduler",
+            mock_scheduler,
         )
         p_chat = patch(
             "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -1216,18 +1197,16 @@ class TestExecuteWorkflowByIdNotifications:
         """If complete_execution fails during error handling, it doesn't crash."""
         workflow = _make_workflow()
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -1254,18 +1233,16 @@ class TestExecuteWorkflowByIdNotifications:
         """If increment_execution_count fails during error handling, it doesn't crash."""
         workflow = _make_workflow()
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
@@ -1295,17 +1272,15 @@ class TestExecuteWorkflowByIdNotifications:
         and complete_execution is not called."""
         workflow = _make_workflow()
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_complete_exec = AsyncMock()
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.services.workflow.execution_service.create_execution",
@@ -1331,10 +1306,8 @@ class TestExecuteWorkflowByIdNotifications:
         to complete_execution."""
         workflow = _make_workflow()
 
-        mock_scheduler_cls = MagicMock()
         mock_scheduler = AsyncMock()
         mock_scheduler.get_task = AsyncMock(return_value=workflow)
-        mock_scheduler_cls.return_value = mock_scheduler
 
         mock_execution = MagicMock()
         mock_execution.execution_id = str(uuid4())
@@ -1343,8 +1316,8 @@ class TestExecuteWorkflowByIdNotifications:
 
         with (
             patch(
-                "app.workers.tasks.workflow_tasks.WorkflowScheduler",
-                mock_scheduler_cls,
+                "app.workers.tasks.workflow_tasks.workflow_scheduler",
+                mock_scheduler,
             ),
             patch(
                 "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.7",
-    "@gaia/shared": "workspace:*",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^3.0.0",
+    "@gaia/shared": "workspace:*",
     "@types/node": "^24.13.3",
     "electron": "^39.8.10",
     "electron-builder": "^25.1.8",

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -318,6 +318,10 @@ const config: KnipConfig = {
         // apps/desktop). Same handling as apps/web and apps/mobile.
         "@gaia/shared",
       ],
+      // macOS system binary passed to execFile as an absolute path (app-icon.ts,
+      // tools/apps.ts). knip resolves such paths against the real filesystem, so
+      // it resolves on macOS but not on the Linux CI runner. Not a JS import.
+      ignoreUnresolved: ["/usr/bin/osascript"],
     },
 
     // ── Mobile App ───────────────────────────────────────────────────

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -30,6 +30,15 @@ secrets:
   # Create once on the box: docker secret create gaia_searxng_secret <(openssl rand -hex 32)
   gaia_searxng_secret:
     external: true
+  # Create once on the box, before this lands on master (stack deploy aborts on a
+  # missing external secret):
+  #   openssl rand -hex 32 | tr -d '\n' | docker secret create gaia_jfs_redis_password_v1 -
+  # hex, not base64: this password is spliced into JUICEFS_META_URL_TEMPLATE, and
+  # a '/' in the userinfo makes urlsplit() read the rest as a path — _split_meta_url
+  # then raises ValueError on .port. Keep the alphabet URL-safe.
+  gaia_jfs_redis_password:
+    external: true
+    name: gaia_jfs_redis_password_v1
 
 services:
   # ---------------------------------------------------------------------------
@@ -165,7 +174,12 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 120s
+      # Worker boot measured at ~130-160s (ChromaDB tool indexing + scheduler
+      # replay), and arq only writes the health key once its poll loop starts.
+      # At 120s the probe began judging mid-boot and killed the task before it
+      # ran a single job — and each restart re-enqueued the scheduler backlog,
+      # so the queue grew unboundedly. Keep this above real boot time.
+      start_period: 300s
     deploy:
       replicas: 1
       update_config:
@@ -184,7 +198,12 @@ services:
         # No max_attempts: a wedged/crashed worker must self-heal, not park at 0/1.
       resources:
         limits:
-          memory: 2G
+          # Measured load needs ~8 concurrent jobs (see max_jobs in
+          # worker_settings.py), and each holds agent graphs + LLM contexts.
+          # At 2G the worker OOM-killed with anon-rss 2-3 GB whenever the queue
+          # was deep enough to saturate max_jobs. Concurrency is memory-bound,
+          # so this is the limit that has to move, not max_jobs.
+          memory: 4G
 
   # ---------------------------------------------------------------------------
   # Embedding + reranking sidecar
@@ -509,6 +528,8 @@ services:
         constraints:
           - node.labels.type == storage
 
+  # Cache/queue only. `allkeys-lru` is safe here (regenerable data) and fatal for
+  # JuiceFS metadata — see jfs-meta-redis below.
   redis:
     image: redis:8-alpine
     command: >
@@ -536,6 +557,81 @@ services:
       placement:
         constraints:
           - node.labels.type == storage
+
+  # ---------------------------------------------------------------------------
+  # JuiceFS metadata Redis
+  # ---------------------------------------------------------------------------
+  # Holds the whole directory tree, filenames and inode→chunk mapping. R2 stores
+  # only anonymous blocks, so losing this loses the filesystem — hence
+  # noeviction, appendfsync always, and the hourly dump on the gaia_jfs volume.
+  # Internet-reachable because E2B sandboxes mount JuiceFS directly
+  # (apps/api/scripts/mount_juicefs.sh); AUTH password + firewall allowlist on
+  # 6380 are the access control.
+  jfs-meta-redis:
+    image: redis:8-alpine
+    # TLS-only (--port 0): the password crosses the public internet on every mount.
+    command: >
+      sh -c 'exec redis-server
+      --requirepass "$$(cat /run/secrets/gaia_jfs_redis_password)"
+      --port 0
+      --tls-port 6379
+      --tls-cert-file /tls/fullchain.pem
+      --tls-key-file /tls/privkey.pem
+      --tls-auth-clients no
+      --appendonly yes
+      --appendfsync always
+      --maxmemory 3gb
+      --maxmemory-policy noeviction
+      --stop-writes-on-bgsave-error yes
+      --save 900 1 --save 300 10 --save 60 10000
+      --dir /data'
+    secrets:
+      - gaia_jfs_redis_password
+    volumes:
+      - jfs_meta_data:/data
+      # Reuses the api.heygaia.io lineage, which carries jfs-meta.heygaia.io as a
+      # SAN — the lineage name is the path on disk, not the connect hostname.
+      # Bind mount, not a Swarm secret: secrets are
+      # immutable, so each renewal would need a new secret name and the next CI
+      # stack deploy would reset the service to the name pinned here, restoring
+      # an expired cert. Populated on the node by the certbot deploy hook at
+      # /etc/letsencrypt/renewal-hooks/deploy/jfs-redis.
+      - type: bind
+        source: /etc/gaia/jfs-redis
+        target: /tls
+        read_only: true
+    ports:
+      # host mode, not ingress: the routing mesh NATs away the source IP, which
+      # breaks the firewall allowlist.
+      - target: 6379
+        published: 6380
+        protocol: tcp
+        mode: host
+    networks:
+      gaia-prod-shared:
+        aliases:
+          - jfs-meta-redis
+    healthcheck:
+      # --insecure: liveness probe over loopback, cert is for api.heygaia.io.
+      test: ["CMD", "sh", "-c", "REDISCLI_AUTH=\"$$(cat /run/secrets/gaia_jfs_redis_password)\" redis-cli --tls --insecure ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+      placement:
+        constraints:
+          # Local volume, cert bind mount and the published 6380 all live here.
+          - node.labels.type == storage
+      resources:
+        limits:
+          # Above maxmemory (3gb) on purpose: with noeviction, hitting maxmemory
+          # returns a write error, hitting the cgroup limit gets Redis SIGKILLed.
+          # Budget ~300 bytes/file when resizing.
+          memory: 4G
 
   rabbitmq:
     # No `ports:` block — RabbitMQ (AMQP, mgmt UI, Prometheus) stays overlay-only.
@@ -600,6 +696,29 @@ services:
     image: oliver006/redis_exporter:v1.66.0
     environment:
       REDIS_ADDR: "redis://redis:6379"
+    networks:
+      - gaia-prod-shared
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+      placement:
+        constraints:
+          - node.role == manager
+
+  # Feeds the memory-pressure alert: jfs-meta-redis runs noeviction, so hitting
+  # maxmemory fails every metadata write with no other early warning.
+  jfs_redis_exporter:
+    image: oliver006/redis_exporter:v1.66.0
+    environment:
+      # Overlay alias, so scraping stays inside the swarm. Cert is for
+      # api.heygaia.io and can't match the alias, hence skip-verify.
+      REDIS_ADDR: "rediss://jfs-meta-redis:6379"
+      REDIS_EXPORTER_SKIP_TLS_VERIFICATION: "true"
+      REDIS_PASSWORD_FILE: /run/secrets/gaia_jfs_redis_password
+    secrets:
+      - gaia_jfs_redis_password
     networks:
       - gaia-prod-shared
     deploy:
@@ -1016,10 +1135,26 @@ volumes:
   grafana_data:
   prometheus_data:
   promtail_positions:
+  # AOF survives a crash, not the loss of this node — that's what --backup-meta
+  # on gaia_jfs below covers.
+  jfs_meta_data:
   # JuiceFS volume backed by the juicedata/juicefs plugin. Pre-create per node:
-  #   docker volume create -d juicedata/juicefs -o name=gaia-0 -o metaurl=... \
-  #     -o access-key=... -o secret-key=... gaia_jfs
+  #   docker volume create -d juicedata/juicefs -o name=gaia-0 \
+  #     -o metaurl='rediss://:PASSWORD@jfs-meta.heygaia.io:6380/0' \
+  #     -o access-key=... -o secret-key=... \
+  #     -o mountFlags="--backup-meta 1h --cache-size 4096 --max-uploads 20 --prefetch 8 --buffer-size 600" \
+  #     gaia_jfs
   # (no -o mountFlags --cache-dir: that path doesn't exist in the plugin → mount EOF)
+  #
+  # metaurl is baked in here, NOT read from JUICEFS_META_URL_TEMPLATE. Changing
+  # the metadata engine in Infisical moves the API and sandboxes but leaves this
+  # mount on the old engine — the volume must be dropped and recreated per node:
+  #   docker service scale gaia-prod_gaia-backend=0 gaia-prod_arq_worker=0
+  #   docker volume rm gaia_jfs && docker volume create ... (as above)
+  #
+  # --backup-meta belongs here, not in scripts/docker-entrypoint.sh: the plugin
+  # mounts /mnt/jfs first, so the entrypoint's own mount short-circuits on
+  # `mountpoint -q` and its flags never apply in prod. Dumps land under `meta/`.
   gaia_jfs:
     external: true
 

--- a/infra/docker/observability/blackbox.yml
+++ b/infra/docker/observability/blackbox.yml
@@ -1,4 +1,19 @@
 modules:
+  # TLS handshake probe — exists for probe_ssl_earliest_cert_expiry, so a stale
+  # cert on jfs-meta-redis alerts before it expires and takes the filesystem
+  # offline. Redis needs an explicit CONFIG SET to pick up a renewed cert, so
+  # this catches a deploy hook that silently stopped working, not just a certbot
+  # failure. insecure_skip_verify because we connect via the overlay alias, which
+  # the api.heygaia.io cert can't match; the expiry metric is exported regardless.
+  tcp_tls:
+    prober: tcp
+    timeout: 5s
+    tcp:
+      tls: true
+      tls_config:
+        insecure_skip_verify: true
+      preferred_ip_protocol: ip4
+
   http_2xx:
     prober: http
     timeout: 5s

--- a/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
@@ -363,7 +363,7 @@ groups:
             datasourceUid: prometheus
             model:
               refId: A
-              expr: up{job=~"gaia-api|arq_worker|postgres|redis|rabbitmq"}
+              expr: up{job=~"gaia-api|arq_worker|postgres|redis|jfs_meta_redis|rabbitmq"}
               instant: true
           - refId: B
             datasourceUid: __expr__
@@ -553,7 +553,10 @@ groups:
     folder: GAIA
     interval: 1m
     rules:
-      # 15. TLS cert for api.heygaia.io expires in < 14 days
+      # 15. A TLS cert expires in < 14 days. Covers api/logs.heygaia.io and the
+      # JuiceFS metadata Redis — a missed renewal there takes the filesystem
+      # offline, since every sandbox mount speaks rediss://. Per-instance so the
+      # alert names which cert.
       - uid: gaia-ssl-cert-expiry
         title: TLS certificate expiring soon
         condition: C
@@ -563,7 +566,7 @@ groups:
             datasourceUid: prometheus
             model:
               refId: A
-              expr: min(probe_ssl_earliest_cert_expiry{job="blackbox_api"}) - time()
+              expr: min by (instance) (probe_ssl_earliest_cert_expiry{job=~"blackbox_api|blackbox_jfs_meta"}) - time()
               instant: true
           - refId: B
             datasourceUid: __expr__
@@ -580,7 +583,7 @@ groups:
         execErrState: Error
         for: 10m
         annotations:
-          summary: "api.heygaia.io TLS cert expires in < 14 days ({{ $values.B }}s left)"
+          summary: "TLS cert for {{ $labels.instance }} expires in < 14 days ({{ $values.B }}s left)"
         labels:
           severity: critical
           service: api
@@ -617,7 +620,9 @@ groups:
           severity: critical
           service: host
 
-      # 17. Redis memory > 85% of maxmemory (eviction risk for SSE/cache/rate-limit)
+      # 17. Redis memory > 85% of maxmemory. On the cache instance that means
+      # eviction; on jfs_meta_redis (noeviction) it means metadata writes are
+      # about to start failing — hence the job label in the summary.
       - uid: gaia-redis-memory
         title: Redis memory pressure
         condition: C
@@ -644,7 +649,7 @@ groups:
         execErrState: OK
         for: 5m
         annotations:
-          summary: Redis is using {{ $values.B | humanizePercentage }} of maxmemory
+          summary: "Redis ({{ $labels.job }}) is using {{ $values.B | humanizePercentage }} of maxmemory"
         labels:
           severity: warning
           service: redis

--- a/infra/docker/observability/prometheus.yml
+++ b/infra/docker/observability/prometheus.yml
@@ -19,6 +19,12 @@ scrape_configs:
     static_configs:
       - targets: ["redis_exporter:9121"]
 
+  # JuiceFS metadata Redis — separate instance, separate exporter. Runs
+  # noeviction, so memory exhaustion fails writes instead of evicting.
+  - job_name: jfs_meta_redis
+    static_configs:
+      - targets: ["jfs_redis_exporter:9121"]
+
   - job_name: rabbitmq
     static_configs:
       - targets: ["rabbitmq:15692"]
@@ -108,6 +114,22 @@ scrape_configs:
           - http://slack-bot:3201/health
           - http://telegram-bot:3202/health
           - http://whatsapp-bot:3203/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox_exporter:9115
+
+  # Cert-expiry watch on the JuiceFS metadata Redis (alert-rules.yaml rule 15).
+  - job_name: blackbox_jfs_meta
+    metrics_path: /probe
+    params:
+      module: [tcp_tls]
+    static_configs:
+      - targets:
+          - jfs-meta-redis:6379
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -121,24 +121,45 @@ if [ "$_jfs_can_mount" = "1" ] && command -v juicefs >/dev/null 2>&1; then
     # R2 credentials ride in AWS_* env vars (juicefs honours them when the
     # --access-key/--secret-key flags are absent) so they don't appear in
     # argv visible to `ps auxww` while format is running.
+    #
+    # `juicefs status` cannot tell "unformatted" from "metadata engine
+    # unreachable" — both exit non-zero — and formatting on the second case
+    # writes an empty filesystem over a bucket still holding every user's blocks,
+    # orphaning them permanently. Gate it behind an opt-in set only on a genuine
+    # first boot. Refusing skips rather than exits: the mount is soft-fail by
+    # design (bootstrap.py `required=False`), so the app still boots.
     if ! juicefs status "$META_URL" >/dev/null 2>&1; then
-        echo "[entrypoint] Formatting JuiceFS shard 0 against $BUCKET_URL"
-        # shellcheck disable=SC2086
-        AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY" \
-        AWS_SECRET_ACCESS_KEY="$R2_SECRET_KEY" \
-        juicefs format \
-            --storage s3 \
-            --bucket "$BUCKET_URL" \
-            --shards 16 \
-            $ENCRYPT_FLAG \
-            "$META_URL" gaia-0 \
-        || echo "[entrypoint] juicefs format failed (ok if another replica formatted concurrently)"
+        if [ "${JUICEFS_ALLOW_FORMAT:-0}" != "1" ]; then
+            echo "[entrypoint] REFUSING to format: 'juicefs status' failed and JUICEFS_ALLOW_FORMAT != 1." >&2
+            echo "[entrypoint] If the metadata engine is merely unreachable, formatting would orphan" >&2
+            echo "[entrypoint] every block in $BUCKET_URL. On a genuine first boot set JUICEFS_ALLOW_FORMAT=1." >&2
+            echo "[entrypoint] Booting without JuiceFS; storage-backed features return 503." >&2
+        else
+            echo "[entrypoint] Formatting JuiceFS shard 0 against $BUCKET_URL (JUICEFS_ALLOW_FORMAT=1)"
+            # shellcheck disable=SC2086
+            AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY" \
+            AWS_SECRET_ACCESS_KEY="$R2_SECRET_KEY" \
+            juicefs format \
+                --storage s3 \
+                --bucket "$BUCKET_URL" \
+                --shards 16 \
+                $ENCRYPT_FLAG \
+                "$META_URL" gaia-0 \
+            || echo "[entrypoint] juicefs format failed (ok if another replica formatted concurrently)"
+        fi
     fi
 
     if ! mountpoint -q "$JFS_MOUNT_PATH" 2>/dev/null; then
         mkdir -p "$JFS_MOUNT_PATH" /var/cache/juicefs
         echo "[entrypoint] Mounting JuiceFS at $JFS_MOUNT_PATH"
-        # --backup-meta=0 because R2 ListObjects is not S3-sorted (see JuiceFS docs).
+        # --backup-meta=1h: the dump is the only recovery path if the metadata
+        # engine is lost. R2's unsorted ListObjects breaks *rotation* of old
+        # dumps (they accumulate and need pruning) but not writing them.
+        # Host mount only — sandbox clients pass 0 (mount_juicefs.sh) since the
+        # host is already the single GC owner.
+        # Skipped entirely in Swarm prod: the volume plugin mounts $JFS_MOUNT_PATH
+        # first so `mountpoint -q` short-circuits. Prod's interval is in the
+        # gaia_jfs mountFlags. This path serves selfhost / dockered-dev.
         # No --writeback: writeback loses data on container kill, unacceptable for agent writes.
         # `|| true`: --background's readiness probe gives up after ~10s, but on a
         # remote meta (e.g. Neon / cloud Postgres) the daemon often needs longer
@@ -149,7 +170,7 @@ if [ "$_jfs_can_mount" = "1" ] && command -v juicefs >/dev/null 2>&1; then
         # for an API host far from the bucket region. --buffer-size raises the
         # read/write buffer to match.
         juicefs mount \
-            --backup-meta=0 \
+            --backup-meta=1h \
             --cache-dir=/var/cache/juicefs \
             --cache-size=4096 \
             --max-uploads=20 \


### PR DESCRIPTION
Recovers the JuiceFS filesystem after the CockroachDB metadata engine was lost, and fixes the worker OOM loop found while verifying the recovery.

## Metadata engine
- New `jfs-meta-redis` service: TLS-only, `noeviction`, `appendfsync always`. Kept separate from the cache Redis on purpose — that one runs `allkeys-lru`, and evicting a metadata key is silent filesystem corruption.
- TLS reuses the existing `api.heygaia.io` certbot lineage (`jfs-meta.heygaia.io` is a SAN). Redis does not re-read a renewed cert on its own, so a certbot deploy hook on the node issues `CONFIG SET tls-cert-file` — verified against `redis:8-alpine` that a file swap alone keeps serving the old cert. The hook lives on the box, not in this repo.
- Scrape the new instance, alert on its cert expiry and memory, and add it to the target-down rule. Extended the existing rules rather than adding duplicates.

## Data-loss guards
- `juicefs format` is now gated behind `JUICEFS_ALLOW_FORMAT`. `juicefs status` cannot distinguish "unformatted" from "metadata engine unreachable", so a transient outage on boot would format an empty filesystem over live R2 data. Refusing skips rather than exits, preserving the soft-fail boot contract.
- `--backup-meta` enabled. Its absence is why this incident had no recovery path.

## `format_juicefs_shards.py`
- Resolves secrets through Infisical (same bootstrap as `payment_setup.py`), so it runs locally with no env plumbing.
- Dropped `--shards 16`. It splits blocks across N *buckets* and needs `%d` in the bucket name, so it always failed against `gaia-workspaces` — masked because `docker-entrypoint.sh` swallows a failed format with `|| echo`.
- Added `--name-suffix` so re-formatting after metadata loss doesn't require deleting the previous volume's blocks (juicefs refuses to format over a non-empty prefix).
- Masked the metadata password in printed commands; it was being written to stderr in full.

## Worker OOM — sized from measurement

Production metrics over 30 min:

```
mean task duration = 10.88 s
arrival rate       = 0.72 /s
required concurrency (Little's Law) = 7.84
peak (busiest 5m in 12h)            = 15.84
```

So the worker genuinely needs ~8 concurrent jobs sustained. **`max_jobs` stays at 10** — anything below ~8 makes the queue grow without bound. Bursts above 10 are supposed to queue; that's what the queue is for.

Concurrency here is memory-bound, so the limit that moves is the container's: **`arq_worker` memory 2G → 4G**. Kills showed `anon-rss` of 2-3 GB against the 2 GiB cgroup limit whenever the backlog was deep enough to saturate `max_jobs`.

Healthcheck `start_period` 120s → 300s: boot takes ~150s, so the probe judged the worker mid-startup and killed it before arq wrote its health key. Each restart then re-enqueued the scheduler backlog, growing the queue unboundedly (peaked at 55k jobs).

**Corrections to earlier revisions of this PR.** Two claims I made did not survive checking, recorded so they don't mislead:
1. That the per-job `WorkflowScheduler()` caused the OOM — not supported. Redis `connected_clients` holds flat at ~196 with jobs running continuously, so `finally: await scheduler.close()` was releasing pools correctly: churn, not a leak. The switch to the `workflow_scheduler` singleton stays as cleanup (removes ~66 pool cycles per 15 min, matches `reminder_tasks.py`), but it is not the fix.
2. That `max_jobs` should drop to 3 — wrong by 2.6×, and it would have caused unbounded queue growth. Reverted.

## Host budget

Declared limits are now ~13 GiB (backend 4G, worker 4G, sidecar 3G, voice 2G) on a 15 GiB host that already runs unlimited postgres/mongo/chroma/rabbitmq/prometheus/loki and currently sits at 8.9 GiB used with 1.5 GiB swap. Limits are ceilings, not reservations, so this is fine in normal operation — but there is no headroom if worker and sidecar peak together. Worth noting `gaia-backend` uses 805 MiB of its 4 GiB, so it is the obvious place to reclaim if needed.

## Verification
- `ruff check`, `ruff format --check`, `mypy` clean on changed Python.
- `docker compose config`, `promtool check config`, blackbox config check, all YAML parses.
- Live on prod: filesystem formatted as `gaia-0-v2` (encrypted, `MinClientVersion 1.1.0-A`), `/mnt/jfs` read+write at ~160ms, worker `1/1` with health key present, all services at full replicas.

Not included: the `embedding-sidecar` memory limit stays at 3 GiB by request — it OOMs independently (pegged at 3.0/3.0 GiB) and still needs attention.