### PR TITLE
feat(pricing): yearly plan gives 2 months free instead of 3

### DIFF
--- a/apps/api/scripts/payment_setup.py
+++ b/apps/api/scripts/payment_setup.py
@@ -156,7 +156,7 @@ async def setup_payment_plans(monthly_product_id: str, yearly_product_id: str):
             "dodo_product_id": yearly_product_id,  # Yearly plan
             "name": "Pro",
             "description": "For serious users who want to save time.",
-            "amount": 27000,  # $270.00 in cents (3 months free, 25% discount)
+            "amount": 30000,  # $300.00 in cents (2 months free, ~16.7% discount)
             "currency": "USD",
             "duration": "yearly",
             "max_users": 1,

--- a/apps/web/src/features/pricing/components/PricingCard.tsx
+++ b/apps/web/src/features/pricing/components/PricingCard.tsx
@@ -60,7 +60,7 @@ function getPriceDisplay(
     yearlyTotalDollars,
     priceSubLine,
     showSavings: !!yearlyTotalDollars && savePercent > 0,
-    // 25% off a year = pay for 9 months, get 12 → 3 months free.
+    // ~16.7% off a year = pay for 10 months, get 12 → 2 months free.
     monthsFree: Math.round((savePercent / 100) * MONTHS_PER_YEAR),
   };
 }

--- a/apps/web/src/features/pricing/components/PricingModal.tsx
+++ b/apps/web/src/features/pricing/components/PricingModal.tsx
@@ -55,7 +55,7 @@ export function PricingModal({ isOpen, onClose, plans }: PricingModalProps) {
                   <div className="flex items-center gap-2">
                     Yearly
                     <Chip color="primary" size="sm" variant="shadow">
-                      <span className="text-xs font-medium">Save 25%</span>
+                      <span className="text-xs font-medium">2 months free</span>
                     </Chip>
                   </div>
                 }

--- a/apps/web/src/features/pricing/components/PricingPage.tsx
+++ b/apps/web/src/features/pricing/components/PricingPage.tsx
@@ -67,7 +67,7 @@ export default function PricingPage({ initialPlans = [] }: PricingPageProps) {
                 <div className="flex items-center gap-2">
                   Yearly
                   <Chip color="primary" size="sm" variant="solid">
-                    Save 25%
+                    2 months free
                   </Chip>
                 </div>
               }

--- a/apps/web/src/features/pricing/constants.ts
+++ b/apps/web/src/features/pricing/constants.ts
@@ -8,7 +8,7 @@ export const MONTHS_PER_YEAR = 12;
 export const CENTS_PER_DOLLAR = 100;
 
 /** Discount every paid annual plan carries versus paying monthly. */
-const ANNUAL_DISCOUNT_RATE = 0.25;
+const ANNUAL_DISCOUNT_RATE = 1 / 6;
 
 /**
  * Fraction of the monthly list price an annual plan actually charges


### PR DESCRIPTION
## What

Annual Pro discount drops from 25% to ~16.7%

## Why

Product decision: give 2 months free on yearly instead of 3.

## Changes (5 files, 5 lines)

| File | Change |
|---|---|
| `pricing/constants.ts` | `ANNUAL_DISCOUNT_RATE` 0.25 → 1/6 (single source of truth) |
| `scripts/payment_setup.py` | yearly seed amount 27000 → 30000 cents |
| `PricingCard.tsx` | comment update (derived "2 months free" chip follows the constant) |
| `PricingModal.tsx` | toggle chip "Save 25%" → "2 months free" |
| `PricingPage.tsx` | toggle chip "Save 25%" → "2 months free" |

Verified live: yearly tab shows "2 months free", Pro card $300 billed yearly, $25/mo equivalent.