### PR TITLE
ci: line-scoped ratchet-allow escape hatch for unavoidable suppressions

### DIFF
--- a/scripts/ci/check-suppression-ratchet.sh
+++ b/scripts/ci/check-suppression-ratchet.sh
@@ -23,6 +23,11 @@
 # not crying wolf on every touched line, and the added one is still visible in
 # review as a changed line.
 #
+# For the suppression that genuinely cannot go, `# ratchet-allow -- <reason>` on
+# the same line exempts that one line (see ALLOW_PATTERN below). The reason is
+# mandatory. Prefer it to a per-file-ignores entry: this is line-scoped, where
+# per-file-ignores disables the rule for every other line in the file too.
+#
 # Two independent passes, each scoped to its own file types by pathspec, so
 # prose that happens to mention these words in docs/config/yaml (e.g. this
 # repo's own pyproject.toml ruff-rationale comments, or this very script) can
@@ -44,15 +49,74 @@ BASE="$1"
 PY_PATTERN='#[[:space:]]*(noqa|type:[[:space:]]*ignore)\b'
 TS_PATTERN='//[[:space:]]*biome-ignore\b'
 
-# Suppression count for one file at one revision. A path that does not exist
-# there (added file, deleted file) counts as zero.
+# The escape hatch, for the suppression that genuinely cannot be removed:
+#
+#   import app.config  # noqa: E402  # ratchet-allow -- sys.path bootstrap must precede app imports
+#
+# An allowed line is not counted, so the ratchet passes with the suppression
+# still in place — line-scoped, unlike a per-file-ignores entry, which turns the
+# rule off for every other line in the file too.
+#
+# The reason is mandatory, and this is the whole point of the marker: a bare
+# `ratchet-allow` exempts nothing and keeps failing (it is reported as a warning
+# below), so the price of the hatch is writing down why. Same contract as the
+# evlog-map-disable directives in tools/evlog_map/directives.py.
+#
+# This is self-service by design — the author writes the reason and the lane
+# goes green. It buys accountability, not permission: every allowance is one
+# greppable line that says who decided what, and the count is printed on every
+# run so they stay visible for later removal instead of going quiet once green.
+ALLOW_PATTERN='ratchet-allow[[:space:]]*--[[:space:]]*[^[:space:]]'
+ALLOW_BARE='ratchet-allow'
+
+# Suppression count for one file at one revision, excluding allowed lines. A
+# path that does not exist there (added file, deleted file) counts as zero.
 count_at() {
   local rev="$1" path="$2" pattern="$3"
   if git cat-file -e "${rev}:${path}" 2>/dev/null; then
-    git show "${rev}:${path}" | grep -cE "$pattern" || true
+    git show "${rev}:${path}" \
+      | { grep -E "$pattern" || true; } \
+      | { grep -vcE "$ALLOW_PATTERN" || true; }
   else
     echo 0
   fi
+}
+
+# Suppression lines carrying a `ratchet-allow` with no `-- reason` after it.
+# These exempt nothing; they are surfaced so the author is not left guessing why
+# the marker did not work.
+reasonless_at_head() {
+  local pattern="$1"
+  shift
+  git diff --name-only --find-renames --diff-filter=d "${BASE}...HEAD" -- "$@" \
+    | while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        git cat-file -e "HEAD:${path}" 2>/dev/null || continue
+        git show "HEAD:${path}" \
+          | { grep -nE "$pattern" || true; } \
+          | { grep -E "$ALLOW_BARE" || true; } \
+          | { grep -vE "$ALLOW_PATTERN" || true; } \
+          | while IFS= read -r hit; do
+              echo "  ${path}:${hit%%:*}"
+            done
+      done
+}
+
+# Allowed lines at HEAD, for the always-on visibility report.
+allowed_at_head() {
+  local pattern="$1"
+  shift
+  git diff --name-only --find-renames --diff-filter=d "${BASE}...HEAD" -- "$@" \
+    | while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        git cat-file -e "HEAD:${path}" 2>/dev/null || continue
+        local n
+        n="$(git show "HEAD:${path}" \
+          | { grep -E "$pattern" || true; } \
+          | { grep -cE "$ALLOW_PATTERN" || true; })"
+        (( n > 0 )) && echo "  ${path}: ${n}"
+      done
+  return 0
 }
 
 # Names every file the diff touched under the given pathspecs whose
@@ -80,17 +144,55 @@ TS_GROWN=$(grown_files "$TS_PATTERN" '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cj
 
 GROWN="$(printf '%s\n%s\n' "$PY_GROWN" "$TS_GROWN" | sed '/^$/d')"
 
+REASONLESS="$(
+  printf '%s\n%s\n' \
+    "$(reasonless_at_head "$PY_PATTERN" '*.py')" \
+    "$(reasonless_at_head "$TS_PATTERN" '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')" \
+  | sed '/^$/d'
+)"
+
+if [[ -n "$REASONLESS" ]]; then
+  echo "::warning::ratchet-allow with no reason — these exempt nothing:" >&2
+  echo "$REASONLESS" >&2
+  echo "" >&2
+  echo "Write the reason after '--', e.g. '# ratchet-allow -- why this cannot be fixed'." >&2
+  echo "" >&2
+fi
+
 if [[ -n "$GROWN" ]]; then
   echo "::error::New inline lint-suppression comment(s) introduced vs ${BASE}:" >&2
   while read -r path before after; do
     echo "  ${path}: ${before} -> ${after} (+$((after - before)))" >&2
   done <<< "$GROWN"
   echo "" >&2
-  echo "Fix the underlying issue instead of suppressing it — existing suppressions are" >&2
-  echo "grandfathered, but new ones must not slip in silently. If the suppression is" >&2
-  echo "genuinely unavoidable, that's a decision to surface for review in the PR" >&2
-  echo "description, not to add quietly." >&2
+  echo "Existing suppressions are grandfathered, but new ones must not slip in" >&2
+  echo "silently. Three ways forward, best first:" >&2
+  echo "" >&2
+  echo "  1. Fix the underlying issue — usually possible, and the reason this lane" >&2
+  echo "     exists at all." >&2
+  echo "  2. Net it out: retire another suppression in the same file." >&2
+  echo "  3. If it genuinely cannot be removed, mark the line:" >&2
+  echo "         # noqa: E402  # ratchet-allow -- why this cannot be fixed" >&2
+  echo "     The reason is mandatory; a bare 'ratchet-allow' exempts nothing." >&2
+  echo "     This is line-scoped — prefer it over a per-file-ignores entry, which" >&2
+  echo "     turns the rule off for the whole file." >&2
   exit 1
+fi
+
+ALLOWED="$(
+  printf '%s\n%s\n' \
+    "$(allowed_at_head "$PY_PATTERN" '*.py')" \
+    "$(allowed_at_head "$TS_PATTERN" '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs')" \
+  | sed '/^$/d'
+)"
+
+if [[ -n "$ALLOWED" ]]; then
+  # Reported on green runs too: a waiver that goes quiet once it passes is one
+  # nobody ever revisits.
+  n_files="$(printf '%s\n' "$ALLOWED" | wc -l | tr -d ' ')"
+  n_allows="$(printf '%s\n' "$ALLOWED" | awk -F': ' '{s+=$2} END {print s+0}')"
+  echo "${n_allows} ratchet-allow(s) across ${n_files} changed file(s):"
+  echo "$ALLOWED"
 fi
 
 echo "No new inline suppression comments vs ${BASE}."

--- a/scripts/ci/mutation-matrix.sh
+++ b/scripts/ci/mutation-matrix.sh
@@ -21,9 +21,15 @@ fi
 
 # Changed app modules only; entry points and __init__ files are not
 # mutation targets (nothing meaningful to mutate, no natural test).
+#
+# Each grep is guarded: it exits 1 when nothing matches, which under `pipefail`
+# failed the whole lane for any PR that changed Python outside apps/api/app/ and
+# nothing inside it (tools/, scripts/, libs/ — this file's own tests included).
+# An empty selection is a valid answer, and the orchestrator already handles it
+# ("no changed app modules — nothing to mutate"); only a real error should fail.
 printf '%s\n' "$CHANGED_PY" |
-  grep '^apps/api/app/.*\.py$' |
-  grep -v 'app/main\.py$' |
-  grep -v 'app/worker\.py$' |
-  grep -v '__init__\.py$' |
+  { grep '^apps/api/app/.*\.py$' || true; } |
+  { grep -v 'app/main\.py$' || true; } |
+  { grep -v 'app/worker\.py$' || true; } |
+  { grep -v '__init__\.py$' || true; } |
   python3 scripts/ci/mutation-matrix.py

--- a/tools/lints/test_suppression_ratchet.py
+++ b/tools/lints/test_suppression_ratchet.py
@@ -1,0 +1,88 @@
+"""Behaviour tests for scripts/ci/check-suppression-ratchet.sh.
+
+The ratchet is a gate whose failure mode is silent: a broken ratchet passes
+everything and nobody notices until suppressions have already accumulated. So
+the cases that matter are the ones asserting it still says NO — a suite that
+only checked the green paths would keep passing on a ratchet that never fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "check-suppression-ratchet.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A throwaway repo with one clean baseline commit, and no suppressions."""
+    _git(tmp_path, "init", "-q", ".")
+    _git(tmp_path, "config", "user.email", "t@t.t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / "a.ts").write_text("const x = 1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "base")
+    return tmp_path
+
+
+def run(repo: Path, py: str, ts: str = "const x = 1\n") -> subprocess.CompletedProcess[str]:
+    """Commit the given file contents, then ratchet HEAD against the baseline."""
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    (repo / "a.py").write_text(py)
+    (repo / "a.ts").write_text(ts)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "change")
+    return subprocess.run(
+        ["bash", str(SCRIPT), base], cwd=repo, capture_output=True, text=True, check=False
+    )
+
+
+def test_bare_suppression_fails(repo: Path) -> None:
+    assert run(repo, "x = 1  # noqa: E402\n").returncode == 1
+
+
+def test_allow_with_reason_passes(repo: Path) -> None:
+    r = run(repo, "x = 1  # noqa: E402  # ratchet-allow -- bootstrap precedes imports\n")
+    assert r.returncode == 0
+    assert "1 ratchet-allow(s) across 1 changed file(s)" in r.stdout
+
+
+def test_allow_without_reason_still_fails_and_warns(repo: Path) -> None:
+    r = run(repo, "x = 1  # noqa: E402  # ratchet-allow\n")
+    assert r.returncode == 1
+    assert "ratchet-allow with no reason" in r.stderr
+
+
+def test_allow_with_empty_reason_fails(repo: Path) -> None:
+    assert run(repo, "x = 1  # noqa: E402  # ratchet-allow --\n").returncode == 1
+
+
+def test_typescript_allow_with_reason_passes(repo: Path) -> None:
+    r = run(
+        repo,
+        "x = 1\n",
+        "// biome-ignore lint: x  // ratchet-allow -- generated shim\nconst x = 1\n",
+    )
+    assert r.returncode == 0
+
+
+def test_allowed_line_does_not_mask_a_bare_one(repo: Path) -> None:
+    """The allowance is line-scoped: it must not exempt the rest of the file."""
+    r = run(repo, "x = 1  # noqa: E402  # ratchet-allow -- ok\ny = 2  # noqa: F401\n")
+    assert r.returncode == 1
+
+
+def test_clean_tree_passes_without_allow_report(repo: Path) -> None:
+    r = run(repo, "x = 2\n")
+    assert r.returncode == 0
+    assert "ratchet-allow(s) across" not in r.stdout

--- a/tools/lints/test_suppression_ratchet.py
+++ b/tools/lints/test_suppression_ratchet.py
@@ -15,6 +15,17 @@ import pytest
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "check-suppression-ratchet.sh"
 
+# The fixtures embed real suppression syntax, so the ratchet counts this file's own
+# test data as live suppressions — precisely the unavoidable case the marker exists
+# for, and the first thing to dogfood it. Fixtures whose text already carries a
+# valid `-- reason` are exempt on their own; only these two need the marker.
+BARE = "x = 1  # noqa: E402\n"  # ratchet-allow -- fixture text, not a live suppression
+NO_REASON = "x = 1  # noqa: E402  # ratchet-allow\n"  # ratchet-allow -- fixture text
+EMPTY_REASON = "x = 1  # noqa: E402  # ratchet-allow --\n"
+ALLOWED = "x = 1  # noqa: E402  # ratchet-allow -- bootstrap precedes imports\n"
+ALLOWED_PLUS_BARE = "x = 1  # noqa: E402  # ratchet-allow -- ok\ny = 2  # noqa: F401\n"
+TS_ALLOWED = "// biome-ignore lint: x  // ratchet-allow -- generated shim\nconst x = 1\n"
+
 
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
@@ -48,37 +59,37 @@ def run(repo: Path, py: str, ts: str = "const x = 1\n") -> subprocess.CompletedP
 
 
 def test_bare_suppression_fails(repo: Path) -> None:
-    assert run(repo, "x = 1  # noqa: E402\n").returncode == 1
+    assert run(repo, BARE).returncode == 1
 
 
 def test_allow_with_reason_passes(repo: Path) -> None:
-    r = run(repo, "x = 1  # noqa: E402  # ratchet-allow -- bootstrap precedes imports\n")
+    r = run(repo, ALLOWED)
     assert r.returncode == 0
     assert "1 ratchet-allow(s) across 1 changed file(s)" in r.stdout
 
 
 def test_allow_without_reason_still_fails_and_warns(repo: Path) -> None:
-    r = run(repo, "x = 1  # noqa: E402  # ratchet-allow\n")
+    r = run(repo, NO_REASON)
     assert r.returncode == 1
     assert "ratchet-allow with no reason" in r.stderr
 
 
 def test_allow_with_empty_reason_fails(repo: Path) -> None:
-    assert run(repo, "x = 1  # noqa: E402  # ratchet-allow --\n").returncode == 1
+    assert run(repo, EMPTY_REASON).returncode == 1
 
 
 def test_typescript_allow_with_reason_passes(repo: Path) -> None:
     r = run(
         repo,
         "x = 1\n",
-        "// biome-ignore lint: x  // ratchet-allow -- generated shim\nconst x = 1\n",
+        TS_ALLOWED,
     )
     assert r.returncode == 0
 
 
 def test_allowed_line_does_not_mask_a_bare_one(repo: Path) -> None:
     """The allowance is line-scoped: it must not exempt the rest of the file."""
-    r = run(repo, "x = 1  # noqa: E402  # ratchet-allow -- ok\ny = 2  # noqa: F401\n")
+    r = run(repo, ALLOWED_PLUS_BARE)
     assert r.returncode == 1
 
 


### PR DESCRIPTION
Gives the suppression ratchet the escape hatch it never had.

## The gap

The ratchet has no way to say yes. Reading the script end to end: no allowlist, no baseline file, no pragma — if a file's count grows, `exit 1`. So for a suppression that genuinely cannot be removed, the only options were:

- **`per-file-ignores`** — turns the rule off for the *whole file*. You trade one known exception for an unbounded blind spot on every other line, now and in future. The block in `pyproject.toml` says so itself: *"SHRINK this list when you touch a file — never add to it."*
- **Admin override** — teaches that the way past CI is to bypass it, which generalises badly.

And the failure message pointed at neither. It said to *"surface it for review in the PR description"* — accountability advice that never turned the lane green, so you could do everything it asked and still be blocked.

## The change

```python
import app.config  # noqa: E402  # ratchet-allow -- sys.path bootstrap must precede app imports
```

- **Line-scoped.** Exempts that one line, so it cannot mask a second suppression elsewhere in the file (tested).
- **Reason mandatory.** A bare `ratchet-allow`, or one with an empty `--`, exempts nothing and keeps failing — surfaced as a warning so the author is not left guessing. Same contract as `evlog-map-disable` in `tools/evlog_map/directives.py`, where a reasonless directive waives nothing by design.
- **Reported on green runs too.** Prints `N ratchet-allow(s) across M changed file(s)`, mirroring evlog's `19 check(s) waived across 8 file(s)`. A waiver that goes quiet once it passes is one nobody revisits.
- **Failure message rewritten** to name all three ways forward: fix it, net it out, or mark it.

> [!NOTE]
> This is **self-service by design** — the author writes the reason and the lane goes green. It buys accountability, not permission: every allowance is one greppable line recording who decided what, instead of an invisible config entry or an admin bypass. A second-signature model (CODEOWNERS-gated allowlist) was considered and deliberately rejected as heavier than the problem.

## Tests

New `tools/lints/test_suppression_ratchet.py` — 7 cases. Picked up automatically by the existing `test-harness-tools` lane (`pytest tools/lints tools/llm-stub`), so **no workflow change**.

Covers both directions, weighted toward the ratchet still saying NO — a suite that only checked green paths would keep passing on a ratchet that never fails:

| case | expect |
|---|---|
| bare `# noqa` added | fail |
| `ratchet-allow -- reason` | pass + count reported |
| `ratchet-allow` (no reason) | fail + warning |
| `ratchet-allow --` (empty reason) | fail |
| TS `biome-ignore` + reason | pass |
| allowed line + a second bare one | fail |
| clean tree | pass, no report |

**Mutation-checked.** Run against the pre-change script, exactly the 3 new-behaviour tests fail and the 4 preserved-behaviour ones pass — so they can actually fail, and they are testing the change rather than the framework.

`pytest tools/lints` → 37 passed (7 new + 30 existing). `ruff check` and `ruff format --check` clean. Ratchet self-check on this branch vs develop → exit 0.

Not verified: no CI run has exercised this yet; the above is local.

Separate from #926, which is narrowly about unblocking the release.

---

## Two follow-up commits after the first CI run

**1. Dogfooding the marker on this PR's own tests.** The ratchet failed on the PR that adds its escape hatch: `tools/lints/test_suppression_ratchet.py: 0 -> 2 (+2)`. The fixtures embed real suppression syntax as string data, and the ratchet greps raw text, so it counted its own test data as live suppressions.

That is exactly the unavoidable case this feature is for, so the fixtures now carry the marker rather than being contorted to hide the tokens. The lane is green and reports `5 ratchet-allow(s) across 1 changed file(s)` — the visibility feature demonstrating itself.

**2. `fix(ci): empty mutation-target selection is not a lane failure`** — unrelated pre-existing bug that blocked this PR, fixed at the root rather than worked around.

`mutation-matrix.sh` pipes the changed-file list through four greps under `set -euo pipefail`. A grep that matches nothing exits 1, so **any PR changing Python outside `apps/api/app/` and nothing inside it failed the whole `test-mutation` lane** — `tools/`, `scripts/`, `libs/`. It never surfaced because most PRs touch `apps/api/app`; #926 passed the lane only because it happened to edit `mail.py`.

The orchestrator already treats an empty selection as valid (`no changed app modules — nothing to mutate`), so the matrix was contradicting its own caller.

Verified both directions:

| diff | result |
|---|---|
| tools-only (this PR) | `[]`, exit 0 — was exit 1 |
| touching `app/utils/timezone.py` | still selects it with `tests/unit/utils/test_timezone.py` + changed line ranges |

Flagging the bundling explicitly: it is a separate concern from the escape hatch, included because it blocked this PR. Say the word and I will split it out.

## CI

All lanes green, including `Quality gate (required)`, `Suppression ratchet` and `test-mutation`. Only CodeRabbit is still reviewing.