### PR TITLE
ci: suppression-ratchet exemption for release PRs + declare the 500 on gmail/send-json

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -792,7 +792,16 @@ jobs:
   suppression-ratchet:
     name: "Suppression ratchet (no new # noqa / # type: ignore / biome-ignore)"
     needs: [changes]
-    if: needs.changes.outputs.has_typescript == 'true' || needs.changes.outputs.has_python == 'true'
+    # The develop -> master promotion PR is exempt. Its diff is every commit
+    # since the last release, and each of those was already ratcheted against
+    # develop on the way in — re-measuring the whole range against master
+    # reports ~27 files of grandfathered suppressions as new, failing the
+    # release for work that was reviewed weeks ago. head_ref/base_ref are set
+    # only on pull_request, so pushes to develop/master stay ratcheted, as do
+    # all feature PRs into develop.
+    if: >-
+      (needs.changes.outputs.has_typescript == 'true' || needs.changes.outputs.has_python == 'true')
+      && !(github.base_ref == 'master' && github.head_ref == 'develop')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/apps/api/app/api/v1/endpoints/mail.py
+++ b/apps/api/app/api/v1/endpoints/mail.py
@@ -362,7 +362,11 @@ async def send_email_route(
         raise HTTPException(status_code=500, detail=f"Failed to send email: {e!s}") from e
 
 
-@router.post("/gmail/send-json", summary="Send an email using JSON payload")
+@router.post(
+    "/gmail/send-json",
+    summary="Send an email using JSON payload",
+    responses={500: {"description": "Gmail rejected the send, or the send failed upstream"}},
+)
 @tiered_rate_limit("mail_actions")
 async def send_email_json(
     request: SendEmailRequest,


### PR DESCRIPTION
Picks up the two commits that missed #926. It merged at `280e40b80`, a few minutes before these were pushed, so despite its title the suppression-ratchet exemption never landed.

Both are cherry-picked unchanged from the merged branch.

## 1. Suppression-ratchet exemption for the release PR

`3e9d42804` — the one #926's title advertised but did not contain.

The ratchet diffs against the PR base ref. On a `develop` → `master` release PR that is master, so every suppression added to develop since the last release reads as new — **27 files on #922** — even though each was ratcheted against develop when it merged. The lane fails the release for work reviewed weeks ago.

Verified both directions on this branch:

| base | result |
|---|---|
| `origin/master` | fail — 27 files grew |
| `origin/develop` | pass — no new suppressions |

Scoped via `head_ref`/`base_ref`, set on `pull_request` only, so pushes to develop/master and every feature PR into develop stay ratcheted. The quality gate counts a skipped lane as passing (`"$r" != "success" && "$r" != "skipped"`).

> [!IMPORTANT]
> This is the one change that loosens a guardrail, flagged explicitly per the ratchet's own instruction to surface such decisions in review. The alternative was stripping 27 files of legitimate grandfathered suppressions.

Note this is *not* made redundant by the new `ratchet-allow` marker from #927: that is for a handful of genuinely unavoidable lines, not 27 files of already-reviewed history.

## 2. SonarCloud: declare the 500 on `gmail/send-json`

`b211be320` — SonarCloud failed `new_maintainability_rating` (3, needs A) on **one** MAJOR issue:

```
apps/api/app/api/v1/endpoints/mail.py:411
Document this HTTPException with status code 500 in the "responses" parameter.
```

Pre-existing, but adding `from e` to that line pulled it into Sonar's new-code window. Declared via `responses=`, matching the pattern already in `memory.py` and `onboarding.py`, so it lands in the OpenAPI schema too.

## Verification

- Workflow YAML parses; the `if` expression reads back correctly after the edit.
- Ratchet base comparison table above.
- `ruff check` / `ruff format --check` clean on `mail.py`.

Not verified: the release-PR path itself, which only executes when #922 re-runs against a develop containing this.