### PR TITLE
feat(infra): add JuiceFS metadata redis to dev stack

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -161,11 +161,11 @@ ENABLE_OPENUI=false
 # R2_SECRET_KEY=
 
 # JuiceFS metadata URL — `{shard}` substituted at mount time. Dev default
-# below points at the docker-compose postgres + the gaia_juicefs_0 DB created
-# by infra/docker/postgres-init/10-juicefs.sql on first boot.
-# Prod uses Redis, where {shard} is the DB number:
-#   rediss://:password@jfs-meta.heygaia.io:6380/{shard}
-# JUICEFS_META_URL_TEMPLATE=postgres://postgres:postgres@postgres:5432/gaia_juicefs_{shard}?sslmode=disable
+# below points at the docker-compose jfs-meta-redis service (redis DB number =
+# shard), mirroring prod's Redis engine. Host port 6380; the dockered API/worker
+# reach it as redis://jfs-meta-redis:6379/{shard} via the compose override in
+# infra/docker/docker-compose.yml.
+# JUICEFS_META_URL_TEMPLATE=redis://localhost:6380/{shard}
 
 # Optional client-side RSA-4096 PEM. If set, the entrypoint writes it to
 # /etc/gaia/jfs-master.pem and passes --encrypt-rsa-key to JuiceFS. Whole

--- a/apps/api/app/services/sandbox/shard_router.py
+++ b/apps/api/app/services/sandbox/shard_router.py
@@ -24,13 +24,14 @@ def shard_for(user_id: str) -> int:
 
 
 def shard_meta_url(shard_id: int) -> str:
-    """Resolve the JuiceFS PostgreSQL metadata URL for the given shard.
+    """Resolve the JuiceFS metadata URL for the given shard.
 
     The template in settings contains `{shard}` which is substituted. Single-
     shard deployments may use a template with no `{shard}` placeholder.
 
-    JuiceFS expects scheme `postgres://`, not `postgresql://` — managed
-    Postgres providers (Neon, Supabase, etc.) hand out the latter, so we
+    Redis meta uses the DB number as the shard (redis://host:6379/{shard}).
+    For Postgres, JuiceFS expects scheme `postgres://`, not `postgresql://` —
+    managed providers (Neon, Supabase, etc.) hand out the latter, so we
     rewrite at the boundary.
     """
     template = settings.JUICEFS_META_URL_TEMPLATE or ""

--- a/infra/docker/CLAUDE.md
+++ b/infra/docker/CLAUDE.md
@@ -19,6 +19,7 @@ Docker Compose configuration for all GAIA environments.
 | ChromaDB | 8080 | 8000 | `CHROMADB_HOST_PORT` |
 | PostgreSQL | 5432 | 5432 | `POSTGRES_HOST_PORT` |
 | Redis | 6379 | 6379 | `REDIS_HOST_PORT` |
+| JuiceFS metadata Redis | 6380 | 6379 | `JFS_META_REDIS_HOST_PORT` |
 | MongoDB | 27017 | 27017 | `MONGO_HOST_PORT` |
 | RabbitMQ AMQP | 5672 | 5672 | `RABBITMQ_HOST_PORT` |
 | RabbitMQ Management UI | 15672 | 15672 | `RABBITMQ_MGMT_PORT` |
@@ -72,13 +73,13 @@ Services gated by profile (not started by default):
 - `observability` — `loki`, `promtail`, `grafana`
 - `all` — everything above
 
-Infrastructure services (postgres, redis, mongo, chromadb, rabbitmq) start without any profile. Observability stack (loki/promtail/grafana) is opt-in — set `COMPOSE_PROFILES=observability` in `infra/docker/.env` or run `docker compose --profile observability up -d`.
+Infrastructure services (postgres, redis, jfs-meta-redis, mongo, chromadb, rabbitmq) start without any profile. Observability stack (loki/promtail/grafana) is opt-in — set `COMPOSE_PROFILES=observability` in `infra/docker/.env` or run `docker compose --profile observability up -d`.
 
 ## Service Dependencies
 
 ```
-gaia-backend → chromadb, postgres, redis, mongo (all healthy)
-arq_worker   → redis, mongo (healthy)
+gaia-backend → chromadb, postgres, redis, jfs-meta-redis, mongo (all healthy)
+arq_worker   → redis, jfs-meta-redis, mongo (healthy)
 bots         → gaia-backend (healthy)
 voice-agent  → (no hard deps in dev; depends on gaia-backend in prod)
 grafana      → loki (healthy)

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -74,12 +74,16 @@ services:
       # ("cannot watch path on network filesystem"). Use the JuiceFS-native
       # .accesslog tail instead — the Phase 0 verdict for this stack.
       ARTIFACT_DETECTION_MODE: accesslog
-      # JUICEFS_META_URL_TEMPLATE is intentionally NOT overridden: the API host
-      # and the E2B sandboxes must share one JuiceFS namespace (the artifact
-      # watcher reads host-side what the sandbox wrote). Let Infisical supply
-      # the same cloud meta the sandboxes use. A local postgres meta would be a
-      # separate namespace over the same R2 volume — JuiceFS refuses to
-      # double-format it ("Storage ... is not empty; pick another volume name").
+      # Dev overrides the Infisical/cloud JUICEFS_META_URL_TEMPLATE (redis DB
+      # numbers, {shard} = the DB index) with the local jfs-meta-redis service.
+      # Prod keeps the cloud meta so the API host and the E2B sandboxes share
+      # one namespace — a local meta is a separate namespace over the same R2
+      # volume, so juicefs refuses to double-format it. That constraint is
+      # acceptable in dev (no sandbox mounts against the dev API); if you hit
+      # "Storage ... is not empty", point the sandbox and API at the same meta
+      # URL or format against a fresh bucket. The cache/queue redis below is
+      # NOT a valid meta store — its eviction policy can corrupt the FS.
+      JUICEFS_META_URL_TEMPLATE: redis://jfs-meta-redis:6379/{shard}
     env_file:
       - ../../apps/api/.env
     volumes:
@@ -118,6 +122,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      jfs-meta-redis:
         condition: service_healthy
       mongo:
         condition: service_healthy
@@ -161,7 +167,8 @@ services:
       POSTGRES_DB: langgraph
     volumes:
       - pgdata:/var/lib/postgresql
-      # postgres-init/*.sql runs once on first init — creates gaia_juicefs_0
+      # postgres-init/*.sql runs once on first init (test DB for the real-infra
+      # suite). JuiceFS metadata now lives in jfs-meta-redis, not Postgres.
       - ./postgres-init:/docker-entrypoint-initdb.d:ro
     ports:
       - "${POSTGRES_HOST_PORT:-5432}:5432"
@@ -174,7 +181,9 @@ services:
     networks:
       - gaia_network
 
-  # Redis Service
+  # Redis Service (app cache/queue — SSE channels, rate limits, ARQ). NOT a
+  # JuiceFS metadata store: default Redis eviction can silently corrupt the
+  # filesystem. Metadata lives in jfs-meta-redis below.
   redis:
     image: redis:8-alpine
     container_name: redis
@@ -182,6 +191,47 @@ services:
       - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    networks:
+      - gaia_network
+
+  # JuiceFS metadata Redis. Mirrors prod (docker-compose.prod.yml) minus TLS
+  # and auth — the dev API mounts over the compose network, never the public
+  # internet. Holds the whole directory tree + inode→chunk mapping; R2 stores
+  # only anonymous blocks, so losing this loses the filesystem. Hence
+  # noeviction (a cache miss is a bad read; an evicted metadata key is
+  # corruption) and appendfsync always. Every dev client uses its own DB
+  # number: redis://jfs-meta-redis:6379/{shard}.
+  jfs-meta-redis:
+    image: redis:8-alpine
+    container_name: jfs-meta-redis
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--appendfsync",
+        "always",
+        "--maxmemory-policy",
+        "noeviction",
+        "--stop-writes-on-bgsave-error",
+        "yes",
+        "--save",
+        "900 1",
+        "--save",
+        "300 10",
+        "--save",
+        "60 10000",
+      ]
+    ports:
+      - "${JFS_META_REDIS_HOST_PORT:-6380}:6379"
+    volumes:
+      - jfs_meta_data:/data
     restart: on-failure
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -262,7 +312,7 @@ services:
       - RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
       - CHROMADB_HOST=chromadb
       - CHROMADB_PORT=8000
-      - JUICEFS_META_URL_TEMPLATE=postgres://postgres:postgres@postgres:5432/gaia_juicefs_{shard}?sslmode=disable
+      - JUICEFS_META_URL_TEMPLATE=redis://jfs-meta-redis:6379/{shard}
     expose:
       - "9100"
     command: ["python", "-m", "arq", "app.worker.WorkerSettings", "--custom-log-dict", "app.workers.config.log_config.ARQ_LOG_CONFIG"]
@@ -282,6 +332,8 @@ services:
       - apparmor:unconfined
     depends_on:
       redis:
+        condition: service_healthy
+      jfs-meta-redis:
         condition: service_healthy
       mongo:
         condition: service_healthy
@@ -636,6 +688,7 @@ volumes:
   chroma_data:
   pgdata:
   redis_data:
+  jfs_meta_data:
   mongo_data:
   rabbitmq_data:
   voice_agent_models:

--- a/infra/docker/postgres-init/10-juicefs.sql
+++ b/infra/docker/postgres-init/10-juicefs.sql
@@ -1,4 +1,0 @@
--- Create the JuiceFS metadata database used by the API container's sidecar
--- mount. Runs once on first postgres boot (postgres-image init mechanism).
--- For Phase 2 (sharded) add one DB per shard: gaia_juicefs_1 ... gaia_juicefs_15.
-CREATE DATABASE gaia_juicefs_0;


### PR DESCRIPTION
## Summary

Adds a dedicated `jfs-meta-redis` service to the dev docker-compose, mirroring prod (`docker-compose.prod.yml`) minus TLS/auth — `noeviction`, `appendfsync always`, AOF + RDB snapshots on a `jfs_meta_data` volume, exposed on host port 6380.

## Changes

- **`infra/docker/docker-compose.yml`**: new `jfs-meta-redis` service + `jfs_meta_data` volume; `gaia-backend` and `arq_worker` now override `JUICEFS_META_URL_TEMPLATE` to `redis://jfs-meta-redis:6379/{shard}` (replacing the postgres template) and depend on it healthy; stale "intentionally NOT overridden" comment replaced with dev rationale.
- **`apps/api/.env.example`**: JuiceFS metadata URL dev default now documents the redis URL.
- **`apps/api/app/services/sandbox/shard_router.py`**: docstring notes redis meta (shard = DB number).
- **`infra/docker/CLAUDE.md`**: port table + service dependencies updated.
- **Deleted `infra/docker/postgres-init/10-juicefs.sql`**: created `gaia_juicefs_0`, now dead — dev meta is redis.

## Verified

- `docker compose config` passes.
- `jfs-meta-redis` boots healthy with `maxmemory-policy=noeviction` + `appendfsync=always` applied.
- API health returns `development`; JuiceFS correctly targets `redis://jfs-meta-redis:6379/0`.

## Caveat

The shared R2 bucket is formatted with the old postgres meta, so JuiceFS refuses to double-format (`Storage ... is not empty`) — the fresh redis meta stays unmounted until pointed at a fresh bucket or formatted with a name-suffix. This is a data decision, left untouched.