### PR TITLE
fix(web): pin pnpm in the web Dockerfile via corepack

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 FROM node:24-alpine AS base
-RUN npm install -g pnpm
+# Pinned via corepack, same as apps/bots/Dockerfile. Unpinned `npm install -g
+# pnpm` pulled pnpm 11 against this repo's pnpm@10 lockfile and the install
+# died on native-binary identity verification (the never-run-unpinned lesson
+# from .github/CLAUDE.md). Keep in sync with package.json `packageManager`.
+RUN corepack enable && corepack prepare pnpm@10.17.1 --activate
 
 # ===================================
 # Stage 1: Builder


### PR DESCRIPTION
docker-web on the #959 master push failed inside the image build:

```
[ERROR] Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml.
```

Root cause: `apps/web/Dockerfile` installed pnpm unpinned (`npm install -g pnpm`) and pulled pnpm 11.21.0 against the repo's pnpm@10.17.1 lockfile. The bots Dockerfile already pins via corepack — web now uses the identical pattern.

Verified locally: base stage builds, `pnpm --version` → 10.17.1. The full image build is proven by this PR's master push after merge.

Latent since the Dockerfile was written; surfaced now because the fetch-depth fix (#958) let docker-web reach the build step for the first time in days, by which point pnpm 11 was latest.

Hotfix to master per promotion policy; must also land on develop (or arrive there via the master-flow migration PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)