### PR TITLE
ci: migrate to GitHub Flow — master is the single base branch

### DIFF
--- a/.claude/skills/parallel-worktrees/SKILL.md
+++ b/.claude/skills/parallel-worktrees/SKILL.md
@@ -17,14 +17,13 @@ has it. Run it via the mise shim (`wt ...`) or `mise exec -- wt ...`.
 
 ```bash
 wt config shell install   # enables `wt switch` to cd for you; restart the shell after
-wt config state default-branch set develop   # GAIA merges everything into `develop` — see below
+wt config state default-branch set master   # GAIA merges everything into `master`
 ```
 
-**GAIA's base branch is `develop`, never `master`/`main`.** The remote's `origin/HEAD`
-points at `master`, so a fresh clone makes worktrunk mis-detect `develop` and every
-`wt switch -c` would branch from `master`. Always run the `default-branch` one-liner
-above on a new clone. New feature branches are cut from `develop` — fetch it fresh
-before branching, and merge `develop` back in to keep the PR mergeable.
+**GAIA's base branch is `master`** — the remote's `origin/HEAD` points at `master`,
+so worktrunk detects it correctly on fresh clones. New feature branches are cut from
+`master` — fetch it fresh before branching, and merge `master` back in to keep the
+PR mergeable.
 
 ## Create a worktree and start working
 
@@ -111,16 +110,16 @@ deferred; until then this is the constraint.
 
 Repo git rules apply (see root `CLAUDE.md`):
 
-- `develop` is the base branch — branch from and merge into `develop`, not `master`.
-  If `wt switch -c` ever creates branches from `master`, the default-branch state is
-  wrong on this clone: run `wt config state default-branch set develop` (see One-time setup).
-- Plain merge only. Never `git rebase` / `git pull --rebase` against `origin/develop`.
+- `master` is the single base branch — branch from and merge into `master`.
+  If `wt switch -c` creates branches from anything else, the default-branch state is
+  wrong on this clone: run `wt config state default-branch set master` (see One-time setup).
+- Plain merge only. Never `git rebase` / `git pull --rebase` against `origin/master`.
 - Never merge PRs (`gh pr merge` and `wt merge` are both off-limits) — the team merges.
 
-Hand-off flow: sync with develop, push the branch, open a PR:
+Hand-off flow: sync with master, push the branch, open a PR:
 
 ```bash
-git fetch origin && git merge origin/develop && git push -u origin HEAD
+git fetch origin && git merge origin/master && git push -u origin HEAD
 ```
 
 ```bash
@@ -144,7 +143,7 @@ wt remove         # remove the current worktree; deletes the branch if merged
 - **`no task //:wt:env found` during `wt switch -c`** — the branch predates the worktree
   infra (added Jul 2026 in `7f3cd4115`), so its `mise.toml` lacks the `wt:env` task,
   the `_.file = ".env.worktree"` auto-load, and the `--port=${WEB_PORT:-3000}` dev script.
-  Run the port script manually (or `git merge origin/develop` to bring the infra in),
+  Run the port script manually (or `git merge origin/master` to bring the infra in),
   then export the port when running the dev server: `pnpm nx run web:next:dev --port=3040`.
 - **New worktree has no secrets** — the `copy-ignored` hook only copies files that
   are both gitignored and in `.worktreeinclude`. If you added a new secret file,

--- a/.claude/skills/pr-image-embedding/SKILL.md
+++ b/.claude/skills/pr-image-embedding/SKILL.md
@@ -26,7 +26,7 @@ will not render — it degrades to alt text that links to the source.
    duplicated. **Do not create a custom branch per PR.** Every PR's images live
    on `pr-assets`, each under its own folder named for the PR
    (`<pr-number>-<topic>/`, e.g. `890-anydoc-parsing/`). The branch already
-   exists and is cut from `develop`; update it in place:
+   exists and is cut from `master`; update it in place:
 
    ```bash
    git fetch origin pr-assets

--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Autonomously ship a feature end-to-end with zero human intervention: plan it,
   implement it, review it with a team of subagents, boot the full stack, drive
   it in a real browser like a user (agent-browser + the driving-gaia skill),
-  capture before/after screenshots, open a PR to develop, and drive CI and
+  capture before/after screenshots, open a PR to master, and drive CI and
   CodeRabbit to green. Use this skill whenever the user asks to "ship" a
   feature, "one-shot" a feature, build something "end to end", implement
   something "autonomously", take an idea "from spec to PR", or asks for a
@@ -46,7 +46,7 @@ not volume.
 
 ## Non-Negotiables
 
-- **Branch from and PR into `develop`.** Never `master`. **Never merge the PR.**
+- **Branch from and PR into `master`.** **Never merge the PR.**
 - **Never fake evidence.** No mocked-up screenshots, no "verified" claims for
   paths you did not run. Whatever you could not exercise, the PR says so.
 - **No debt as a shipping strategy.** Root-cause fixes, no lint suppressions,
@@ -72,7 +72,7 @@ questions nobody is there to answer.
 
 ### 1. Bootstrap (start first, runs while you plan)
 
-`git fetch origin develop` and branch from it. Then `pnpm install` and
+`git fetch origin master` and branch from it. Then `pnpm install` and
 `pnpm exec nx run api:sync`, create env files
 (`cp -f apps/api/.env.example apps/api/.env` first — `mise setup:env` errors
 without it, and only auto-copies the others; dummy WorkOS values are fine —
@@ -99,7 +99,7 @@ survives. A plan flaw costs minutes here and hours in phase 9.
 
 ### 3. BEFORE screenshots
 
-Valid only while the branch's tracked tree still matches `develop` —
+Valid only while the branch's tracked tree still matches `master` —
 untracked bootstrap artifacts (`.env` files, installed deps) don't count.
 Capture before your first source edit (`git stash` around the capture if
 you already edited). Walk the journey script and shoot every surface the
@@ -124,7 +124,7 @@ root; auto-fixers first where they exist.
 
 ### 6. Review team
 
-Spawn reviewer subagents in parallel on the full diff vs `origin/develop`,
+Spawn reviewer subagents in parallel on the full diff vs `origin/master`,
 one lens each — correctness (real user-reachable failures, not theoretical
 races), architecture/debt (duplication, wrong-layer logic, missed
 `libs/shared` reuse, dead code), design-system compliance vs DESIGN.md (UI
@@ -158,7 +158,7 @@ until clean, then capture the AFTER shot-list.
 ### 8. Ship the PR
 
 Push the branch first (`git push -u origin <branch>`), then open the PR:
-Conventional-Commit title, base `develop`, body with the before/after table
+Conventional-Commit title, base `master`, body with the before/after table
 and an honest verification section
 ([references/screenshots-and-pr.md](references/screenshots-and-pr.md)).
 Subscribe to PR activity immediately.
@@ -199,7 +199,7 @@ exist. Design is a gate in this pipeline, not a coat of paint:
       equivalent live evidence (bot transcript, curl + Mongo output) and say so
 - [ ] Local gates green for every touched language; review findings fixed or
       refuted
-- [ ] PR open against `develop`, both CI gates green, CodeRabbit threads all
+- [ ] PR open against `master`, both CI gates green, CodeRabbit threads all
       resolved or answered
 - [ ] Branch pushed, tree clean, no stray files in the diff (plans,
       screenshots, scratch scripts)

--- a/.claude/skills/ship-feature/references/ci-and-review.md
+++ b/.claude/skills/ship-feature/references/ci-and-review.md
@@ -1,6 +1,6 @@
 # CI Gates, Local Repro, and the Drive-to-Green Loop
 
-## What runs on a PR to develop
+## What runs on a PR to master
 
 Source of truth: `.github/workflows/` — read the workflow when you need a
 lane's exact command; don't trust memory or this file for specifics.
@@ -41,7 +41,7 @@ Mirror what CI will run, scoped to what you touched:
 vs the PR base (see `scripts/ci/changed-files.sh`). Locally the base-ref env
 var is unset, so the same command runs repo-wide and can fail on files you
 never touched. Reproduce a lane exactly as CI sees it by exporting the
-base-ref variable the script reads (with `develop` fetched), or by limiting
+base-ref variable the script reads (with `master` fetched), or by limiting
 the tool to your changed files. Pre-existing repo-wide failures outside your
 diff are not yours to fix in this PR.
 
@@ -55,7 +55,7 @@ diff are not yours to fix in this PR.
    blind retry. Every failure event ends in a pushed fix or a PR comment
    explaining precisely why not — no third option.
 3. **Merge conflict / base moved** → `git fetch origin && git merge
-   origin/develop` (plain merge — rebase is banned in this repo), resolve,
+   origin/master` (plain merge — rebase is banned in this repo), resolve,
    re-run affected gates, push.
 4. Green + mergeable + all threads answered → one concise status comment
    (what shipped, what was verified, evidence links) and stop. **Never merge.**

--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -24,7 +24,7 @@ the code cannot reach.
 The repo is public, so SHA-pinned raw URLs render in PR bodies. Screenshots
 travel on a dedicated branch so they never touch the PR diff:
 
-1. Create branch `screenshots/<feature-branch-name>` from `develop` (GitHub
+1. Create branch `screenshots/<feature-branch-name>` from `master` (GitHub
    MCP `create_branch`). Nothing triggers CI on `screenshots/*`.
 2. Upload each PNG with `create_or_update_file` (base64 content) under
    `<feature-branch-name>/`.
@@ -38,7 +38,7 @@ travel on a dedicated branch so they never touch the PR diff:
 
 Title: `<type>(<optional scope>): <description>` — a CI check validates the
 type against the allowed list in `pr-naming-conventions.yml` (read the list
-there; it drifts). Base: `develop`. If a repo PR template exists, fill it in
+there; it drifts). Base: `master`. If a repo PR template exists, fill it in
 — but the `## Before / After`, `## Verification`, and `## Not verified`
 sections below are mandatory evidence and always appear, template or not.
 With no template, use this body structure:

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -41,7 +41,7 @@ times on this repo: when the PR's `mergeable` state is `CONFLICTING`,
 `pull_request`-triggered runs are not created — silently, with no error,
 no queued entry, nothing. If CI "stopped" with no new runs, the first thing
 to check is `gh pr view --json mergeable`. Keep the branch merged with
-`develop`; re-merge and resolve before pushing further.
+`master`; re-merge and resolve before pushing further.
 
 ## Skipping work that isn't needed
 
@@ -52,7 +52,7 @@ Three layers, from cheap to precise:
    versa). Lanes skipped this way count as PASSING in the gate; a failed
    `changes` job fails the gate.
 2. **`main.yml` `detect` job** — `nx show projects --affected` (via
-   `nrwl/nx-set-shas`, base `develop`) computes the affected project lists
+   `nrwl/nx-set-shas`, base `master`) computes the affected project lists
    that gate build/test jobs and scope their `-p` arguments.
 3. **`scripts/ci/changed-files.sh` inside lanes** — scopes each tool to the
    exact changed files. Contract: prints `__FULL__` (push/dispatch → full
@@ -127,7 +127,7 @@ rule/why/exact-fix/doc-pointer on failure (see `tools/lints/`).
   re-enable). There is NO remote nx cache: each CI job recomputes everything.
   The Next.js compiler cache IS persisted (`actions/cache` on
   `apps/web/.next/cache` in main.yml build + desktop-pr-build prepare).
-- `nx.json` `defaultBase` is `develop` (the integration branch). CI passes
+- `nx.json` `defaultBase` is `master` (the single base branch). CI passes
   explicit bases; `defaultBase` matters for local `nx affected` / mise tasks.
 - Versions are pinned where a trusted SHA/number was resolvable (nx 22.7.7 in
   nx.json `installation`, uv 0.8.17, `uvx ruff@<uv.lock version>` in the ruff

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,5 @@
 version: 2
 
-# All entries target develop: it is the integration branch, and main.yml's
-# "Enforce master promotion policy" check rejects any PR to master that is not
-# from develop/release-please/hotfix — dependabot PRs against the default
-# branch (master) were permanently BLOCKED.
-#
-# target-branch only routes VERSION updates. Dependabot SECURITY updates
-# always target the default branch (GitHub behavior, not configurable here),
-# so a security PR still lands on master and fails the promotion policy by
-# design — close it and take the bump through develop, where the weekly
-# version updates pick up patched releases anyway. If that noise isn't worth
-# it, turn off "Dependabot security updates" in repo Settings > Advanced
-# Security (version updates below are unaffected).
 updates:
   # --- JavaScript/TypeScript (pnpm workspace) ------------------------------
   # Single pnpm-lock.yaml at the repo root covers every workspace member
@@ -22,7 +10,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
 
   # --- Python (uv workspace) ------------------------------------------------
   # Single uv.lock at the repo root covers every uv workspace member
@@ -33,7 +20,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
 
   # --- GitHub Actions --------------------------------------------------------
   # "/" covers .github/workflows/*.yml. Composite actions under
@@ -43,22 +29,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
 
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-node-pnpm"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
 
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/restore-nextjs-cache"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
 
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/setup-python-test-env"
     schedule:
       interval: "weekly"
-    target-branch: "develop"

--- a/.github/quality-gate/README.md
+++ b/.github/quality-gate/README.md
@@ -1,7 +1,7 @@
 # Quality gate
 
 The `quality-gate` job in `.github/workflows/code-quality.yml` is one of the
-two branch-protection gate jobs on `develop` (the other is `main.yml`'s
+two branch-protection gate jobs on `master` (the other is `main.yml`'s
 `quality-gate`). It aggregates every code-quality lane and **fails the merge
 if any lane is red**.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,19 +14,10 @@ flowchart TD
   classDef external fill:#F0FDF4,stroke:#22C55E,color:#14532D,stroke-width:1.2px;
   classDef terminal fill:#F8FAFC,stroke:#94A3B8,color:#334155,stroke-width:1px;
 
-  START["Feature branch changes"]:::event --> PR_DEV["PR to develop"]:::event
-  PR_DEV --> PR_TITLE["pr-naming-conventions.yml<br/>Validate PR title"]:::ci
-  PR_DEV --> MAIN_PR_DEV["main.yml<br/>quality-checks (PR)"]:::ci
-  MAIN_PR_DEV --> DEV_MERGED{"Merged to develop?"}:::decision
-  DEV_MERGED -- "No" --> STOP1["Stop"]:::terminal
-  DEV_MERGED -- "Yes" --> PR_MASTER["PR develop -> master"]:::event
-
-  HOTFIX["hotfix/* cut from master<br/>(production defect, skips the develop backlog)"]:::event --> PR_MASTER
-  HOTFIX --> BACKPORT["Land on develop too<br/>(else the next develop -> master merge regresses it)"]:::event
-
-  PR_MASTER --> PR_TITLE
-  PR_MASTER --> MAIN_PR_MASTER["main.yml<br/>quality-checks (PR + master source policy)"]:::ci
-  MAIN_PR_MASTER --> MASTER_MERGED{"Merged to master?"}:::decision
+  START["Feature branch changes<br/>(humans, contributors, bots)"]:::event --> PR_MASTER["PR to master"]:::event
+  PR_MASTER --> PR_TITLE["pr-naming-conventions.yml<br/>Validate PR title"]:::ci
+  PR_MASTER --> MAIN_PR["main.yml + code-quality.yml<br/>quality gates (PR)"]:::ci
+  MAIN_PR --> MASTER_MERGED{"Merged to master?"}:::decision
   MASTER_MERGED -- "No" --> STOP2["Stop"]:::terminal
   MASTER_MERGED -- "Yes" --> PUSH_MASTER["push -> master"]:::event
 
@@ -102,14 +93,14 @@ flowchart TD
 
 ## Per-Workflow Steps
 ### `.github/workflows/main.yml`
-1. Enter from PRs targeting `develop`/`master` and pushes to `master`.
-2. `detect`: run master promotion policy guard (`develop`, `release-please--*`, or `hotfix/*` to `master`), validate the release manifest, and compute Nx-affected Python/TypeScript project lists (fail-loud — an nx error fails the job rather than silently skipping every lane).
+1. Enter from PRs targeting `master` and pushes to `master`.
+2. `detect`: validate the release manifest and compute Nx-affected Python/TypeScript project lists (fail-loud — an nx error fails the job rather than silently skipping every lane).
 3. Correctness lanes, each gated on the affected lists: `build` (TS builds), `test-typescript` (vitest via Nx), and `test-python` — pytest run directly on the runner against live PostgreSQL/Redis/MongoDB/ChromaDB/RabbitMQ containers started by `scripts/ci/start-test-services.sh` (same images/credentials as the local `dagger call test-python` harness), with coverage measured in the same run and gated at `--cov-fail-under=80` (a separate coverage job would re-run the whole suite a second time per PR, so it lives here instead). Static checks (ruff, mypy, Biome, tsc, custom AST lints, dead code) intentionally do NOT run here — they are enforced lanes in `code-quality.yml`.
 4. `quality-gate` (branch protection target) fails on any failed/cancelled lane; skipped lanes pass.
 5. If run is a successful push on `master`, call `build.yml`.
 
 ### `.github/workflows/code-quality.yml`
-1. Enter from PRs targeting `develop`/`master`, pushes to those branches, and manual dispatch.
+1. Enter from PRs targeting `master`, pushes to `master`, and manual dispatch.
 2. `changes`: one cheap no-toolchain job detects which languages a PR touches; Python lanes and TypeScript lanes are skipped wholesale when their language is untouched (on push/dispatch everything runs).
 3. Eighteen hygiene lanes (Biome, deps, circular, file-size, types-location, components-per-file, jscpd, type-coverage, package hygiene, tsc, ruff + custom AST lints, mypy, interrogate, xenon, bandit, evlog-map observability score, wide-event cross-runtime conformance, knip/vulture dead code), each self-scoping to changed files via `scripts/ci/changed-files.sh`. The `wide-event-conformance` lane runs the Python and TypeScript logging stacks for real and diffs the log shapes they actually emit against each other and against `scripts/ci/wide-event-conformance/contract.json`, so the two halves cannot drift apart. The observability lane (`tools/evlog_map`, enforced) posts the full-repo score to the job summary and fails PRs whose changed files score below the same files at the merge-base.
 
@@ -160,7 +151,7 @@ flowchart TD
 2. Validate PR title against configured semantic type list.
 
 ## File Map
-- `.github/workflows/main.yml`: CI correctness gate (build + tests) and master promotion policy. Python tests run runner-native against live service containers.
+- `.github/workflows/main.yml`: CI correctness gate (build + tests). Python tests run runner-native against live service containers.
 - `.github/workflows/code-quality.yml`: code-hygiene lanes (lint/type/dead-code/complexity/security) behind the ratcheted `Quality gate (required)` check.
 - `.github/workflows/build.yml`: Docker image build/publish via Dagger, deploy planning, and deploy triggers.
 - `.github/workflows/deploy-swarm-prod.yml`: production backend deploy and rollback via Docker Swarm stack on Hetzner VM.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,6 @@
 name: Code Quality
 
-# Tech-debt prevention gates that run on every PR to develop or master.
+# Tech-debt prevention gates that run on every PR to master.
 # Each lane is independent so failures are isolated and parallelised. The
 # `quality-gate` job at the bottom is the single required check.
 #
@@ -16,11 +16,9 @@ name: Code Quality
 on:
   pull_request:
     branches:
-      - develop
       - master
   push:
     branches:
-      - develop
       - master
   workflow_dispatch:
 
@@ -792,16 +790,7 @@ jobs:
   suppression-ratchet:
     name: "Suppression ratchet (no new # noqa / # type: ignore / biome-ignore)"
     needs: [changes]
-    # The develop -> master promotion PR is exempt. Its diff is every commit
-    # since the last release, and each of those was already ratcheted against
-    # develop on the way in — re-measuring the whole range against master
-    # reports ~27 files of grandfathered suppressions as new, failing the
-    # release for work that was reviewed weeks ago. head_ref/base_ref are set
-    # only on pull_request, so pushes to develop/master stay ratcheted, as do
-    # all feature PRs into develop.
-    if: >-
-      (needs.changes.outputs.has_typescript == 'true' || needs.changes.outputs.has_python == 'true')
-      && !(github.base_ref == 'master' && github.head_ref == 'develop')
+    if: needs.changes.outputs.has_typescript == 'true' || needs.changes.outputs.has_python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -811,12 +800,9 @@ jobs:
       - name: Diff vs base for newly introduced inline suppression comments
         env:
           # Push events have no PR base ref; diff against the pre-push SHA
-          # instead so a direct push to develop/master is ratcheted too.
-          # Exception: a push to master is the develop -> master promotion
-          # landing, so its base is the merge-base with develop — everything
-          # in that range was already ratcheted on the way into develop, and
-          # the pre-push master SHA would re-report all of it as new (the
-          # push-event twin of the promotion-PR exemption in `if:` above).
+          # instead so a direct push to master is ratcheted too. Every commit
+          # in that range arrived via a PR that was itself ratcheted, so no
+          # promotion-range exemption is needed under master-only flow.
           # Through env, not inline ${{ }}, per this file's injection-safety
           # convention (see the type-check / build.yml AFFECTED_* comments).
           EVENT_BEFORE: ${{ github.event.before }}
@@ -826,10 +812,6 @@ jobs:
             timeout 60 git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=20 \
               fetch --no-tags origin "$GITHUB_BASE_REF"
             BASE="origin/$GITHUB_BASE_REF"
-          elif [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            timeout 60 git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=20 \
-              fetch --no-tags origin develop
-            BASE="$(git merge-base HEAD origin/develop)"
           else
             BASE="$EVENT_BEFORE"
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,9 @@
 name: Quality Checks
 
-# Primary CI gate: validates code quality and enforces branch promotion policy.
+# Primary CI gate: validates code quality on every PR to master.
 on:
   pull_request:
     branches:
-      - develop
       - master
   push:
     branches:
@@ -39,31 +38,9 @@ jobs:
           # checkout, so never leave the token in git config (zizmor artipacked).
           persist-credentials: false
 
-      - name: Enforce master promotion policy
-        if: github.event_name == 'pull_request' && github.base_ref == 'master'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // hotfix/* is the escape hatch for production defects that cannot
-            // wait for the develop backlog to be release-ready. It still gets
-            // the full quality gate — it only skips the promotion ordering.
-            // Every hotfix must be landed on develop too, or the next
-            // develop -> master merge ships a regression.
-            const isAllowed = (ref) =>
-              ref === "develop" ||
-              ref.startsWith("release-please--") ||
-              ref.startsWith("hotfix/");
-            const pr = context.payload.pull_request;
-            if (pr.base.ref === "master" && !isAllowed(pr.head.ref)) {
-              core.setFailed(
-                `PRs to master must come from develop, release-please, or hotfix/*. Got '${pr.head.ref}'.`
-              );
-            }
-
       - uses: nrwl/nx-set-shas@v4
         with:
-          main-branch-name: develop
+          main-branch-name: master
 
       - uses: ./.github/actions/setup-node-pnpm
 
@@ -193,7 +170,7 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: apps/api
         run: |
-          uv tool run diff-cover coverage.xml --compare-branch=origin/develop --fail-under=90
+          uv tool run diff-cover coverage.xml --compare-branch=origin/master --fail-under=90
           echo "diff-cover: OK"
       - name: Run gaia-shared tests
         working-directory: apps/api
@@ -356,7 +333,7 @@ jobs:
           scan-ref: "."
 
   # --- Regression-proof: changed tests must FAIL on base -------------------
-  # FastAPI's lesson: run the PR's changed test files against origin/develop
+  # FastAPI's lesson: run the PR's changed test files against origin/master
   # and report any that PASS there (the fix may no longer be needed).
   # ENFORCED. It was informational because it checked EVERY changed test file,
   # and gap-fill/restructure branches legitimately add tests for behavior the
@@ -377,7 +354,7 @@ jobs:
       - uses: ./.github/actions/setup-python-test-env
       - name: Changed test files must fail on base
         working-directory: apps/api
-        run: bash ../../scripts/ci/regression-proof.sh origin/develop
+        run: bash ../../scripts/ci/regression-proof.sh origin/master
 
   # --- Quality gate (branch protection target) ----------------------------
   quality-gate:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,13 +347,13 @@ Only use the `bd` CLI when the user explicitly asks for it. `bd` is a project-in
 ## Git Conventions
 
 - **Never add Claude as a co-author in commits.** Do not include `Co-Authored-By: Claude` or any similar line in commit messages.
-- **`develop` is the base branch, not `master`.** All feature branches are created from and merged into `develop`. When comparing branches, analyzing diffs, or creating PRs, always use `develop` as the base — not `master` or `main`.
+- **`master` is the single base branch.** All feature branches are created from and merged into `master`. There is no `develop`. When comparing branches, analyzing diffs, or creating PRs, always use `master` as the base.
 - **NEVER merge pull requests.** Do not run `gh pr merge`, do not call any GitHub API merge endpoint, and do not take any action that merges a PR into any branch. PRs are merged by the team — not by Claude. This is an absolute rule with no exceptions.
 - Work is **not complete until `git push` succeeds.** Always push before ending a session.
-- **Never use `git pull --rebase` or `git rebase` when pulling/merging `origin/develop`.** Always use plain `git merge` — rebase inverts conflict markers (HEAD vs incoming) and causes confusion. Session close sequence (mandatory when code changed):
+- **Never use `git pull --rebase` or `git rebase` when pulling/merging `origin/master`.** Always use plain `git merge` — rebase inverts conflict markers (HEAD vs incoming) and causes confusion. Session close sequence (mandatory when code changed):
   ```bash
   git fetch origin
-  git merge origin/develop  # if syncing with develop; plain merge, no rebase
+  git merge origin/master  # if syncing with master; plain merge, no rebase
   git push
   git status  # must show "up to date with origin"
   ```

--- a/config/.coderabbit.yaml
+++ b/config/.coderabbit.yaml
@@ -6,7 +6,6 @@ reviews:
   # Configure which branches to review
   branches:
     - "master"
-    - "develop"
 
   # Whether to review draft PRs
   draft: false

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -53,7 +53,7 @@ gaia init
 | `--branch <name>` | Clone a specific branch |
 
 ```bash
-gaia init --branch develop
+gaia init --branch master
 ```
 
 The wizard walks through:

--- a/docs/design-system.mdx
+++ b/docs/design-system.mdx
@@ -11,7 +11,7 @@ icon: "palette"
 */}
 
 <Note>
-  Source of truth is [`DESIGN.md`](https://github.com/heygaia/gaia/blob/develop/DESIGN.md) at the repo root. This page renders it visually. Keep them in sync when tokens change.
+  Source of truth is [`DESIGN.md`](https://github.com/heygaia/gaia/blob/master/DESIGN.md) at the repo root. This page renders it visually. Keep them in sync when tokens change.
 </Note>
 
 ## Philosophy

--- a/docs/self-hosting/cli-setup.mdx
+++ b/docs/self-hosting/cli-setup.mdx
@@ -22,7 +22,7 @@ The GAIA CLI is the primary way to set up GAIA. It handles repository setup, env
 gaia init
 
 # Clone a specific branch
-gaia init --branch develop
+gaia init --branch master
 ```
 
 ## What the Wizard Does

--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,7 @@
     }
   },
   "useDaemonProcess": false,
-  "defaultBase": "develop",
+  "defaultBase": "master",
   "namedInputs": {
     "default": ["{projectRoot}/**/*"],
     "production": ["!{projectRoot}/**/*.spec.ts", "!{projectRoot}/**/*.test.ts"]


### PR DESCRIPTION
Executes `.agents/plans/2026-08-08-master-flow-migration.md` (amended for the CI fixes that landed today via #958/#959/#960 — the convergence already happened, so this PR is the flow change only).

## What changes
- **main.yml**: "Enforce master promotion policy" guard deleted — every PR (humans, contributors, bots, dependabot) now merges directly to master. nx-set-shas / diff-cover / regression-proof compare against `origin/master`.
- **code-quality.yml**: triggers master-only; both develop-flow ratchet exemptions removed (promotion-PR `if:` + push-to-master merge-base) — `EVENT_BEFORE` is universally correct when PRs merge straight to master.
- **nx.json**: `defaultBase: master`. **CodeRabbit**: monitors master only.
- **dependabot.yml**: the develop retarget (added earlier today) removed — PRs to the default branch are the normal flow now, and the security-updates caveat dissolves.
- **Docs/skills sweep**: CLAUDE.md git conventions, workflows README + Mermaid diagram, quality-gate README, parallel-worktrees / ship-feature / pr-image-embedding skills, CLI doc examples.
- **Kept intentionally**: release-please untouched, deploy-on-master-push untouched, `develop-{shortCommitSha}` docker scheme name, tag-gated desktop/CLI distribution.

## Bootstrap
This PR runs its own workflow file from the merge ref, so the deleted guard never evaluates it — no admin override needed. **Merge with a plain merge** (matches the `chore: merge develop` history pattern).

## After merge (in order)
1. Verify the master push goes green end-to-end
2. Repoint every open develop-based PR: `gh pr edit <n> --base master` (GitHub closes, not retargets, PRs whose base is deleted)
3. Delete `origin/develop`
4. Per machine: `wt config state default-branch set master`
5. Expected: release-please may open release PRs for converged components — merge them, that's the first release under the new flow, not an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)