### PR TITLE
fix(ci): flake-gate coverage misdiagnosis + lane DX cleanup

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -163,6 +163,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - name: Per-file line count (default 400, relaxed 700, hard cap 1200)
         run: |
+          trap 'echo "::error::repro: pnpm run quality:size"' ERR
           echo "::group::File size scan"
           FILES=$(scripts/ci/changed-files.sh ts tsx js jsx mjs cjs)
           if [ "$FILES" = "__FULL__" ]; then
@@ -189,6 +190,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - name: Type / interface / enum location enforcer
         run: |
+          trap 'echo "::error::repro: node scripts/ci/check-types-location.mjs --enforce"' ERR
           echo "::group::types-location check"
           FILES=$(scripts/ci/changed-files.sh ts tsx)
           if [ "$FILES" = "__FULL__" ]; then
@@ -215,6 +217,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - name: Components-per-file enforcer
         run: |
+          trap 'echo "::error::repro: pnpm run quality:components"' ERR
           echo "::group::components-per-file check"
           FILES=$(scripts/ci/changed-files.sh tsx)
           if [ "$FILES" = "__FULL__" ]; then
@@ -241,6 +244,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
       - name: Copy-paste detection (jscpd, fails over 3% on changed lines)
         run: |
+          trap 'echo "::error::repro: pnpm run quality:dupe"' ERR
           echo "::group::jscpd"
           # Timeout + low-speed guard: a stalled HTTPS fetch dies in <=60s rather
           # than hanging until the job's timeout-minutes cap (a `cancelled` lane
@@ -606,6 +610,7 @@ jobs:
       - name: Full observability score — API + voice-agent + bots (details in job summary)
         run: |
           set -euo pipefail
+          trap 'echo "::error::repro: python3 tools/evlog_map --min-score 100  /  node scripts/ci/evlog-map-bots.mjs --min-score 100"' ERR
           echo "evlog map — python surface (apps/api + apps/voice-agent)"
           python3 tools/evlog_map --github-summary --no-write --min-score 100
           echo "evlog map — bots surface (apps/bots + libs/shared/ts)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,6 +358,7 @@ jobs:
 
   # --- Quality gate (branch protection target) ----------------------------
   quality-gate:
+    name: quality-gate
     if: always()
     needs:
       - detect

--- a/scripts/ci/mutation-matrix.sh
+++ b/scripts/ci/mutation-matrix.sh
@@ -14,7 +14,20 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 CHANGED_PY="$(scripts/ci/changed-files.sh py)"
-if [ -z "$CHANGED_PY" ] || [ "$CHANGED_PY" = "__FULL__" ]; then
+if [ -z "$CHANGED_PY" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "$CHANGED_PY" = "__FULL__" ]; then
+  # Push / workflow_dispatch events have no PR diff to target mutants at, and
+  # this check is inherently diff-based (mutation-matrix.py mutates only
+  # changed lines) — there is no "full repo" equivalent to run instead, and
+  # faking one across every apps/api/app module would blow the lane's 30 min
+  # budget many times over. The gate already ran against this exact diff on
+  # the PR before merge; skip rather than silently report zero mutants as if
+  # nothing needed proving. Logged so a push-triggered run doesn't read as
+  # "nothing to mutate" when it actually means "not applicable here".
+  echo "mutation-matrix: push/full-scan event — skipping (diff-based check; already gated on the originating PR)" >&2
   echo '[]'
   exit 0
 fi

--- a/scripts/ci/run-tests-flake-gate.sh
+++ b/scripts/ci/run-tests-flake-gate.sh
@@ -3,17 +3,36 @@
 # pass-on-rerun as a flaky-test failure (CPython's --fail-rerun lesson).
 #
 # Usage: run-tests-flake-gate.sh <pytest-args...>
-# Exit codes: 0 all green; 7 genuine failure (same code as the rerun); 1 flaky.
+# Exit codes: 0 all green; whatever pytest returns on a genuine/coverage
+# failure (1 for both); 1 flaky.
 set -uo pipefail
+
+# Capture the first run's output (while still streaming it live) so we can
+# tell a coverage-threshold failure apart from an actual test failure: both
+# exit pytest with 1, but only one of them is a flake-gate concern.
+tmp_out="$(mktemp)"
+trap 'rm -f "$tmp_out"' EXIT
 
 # Capture the first run's exit code without tripping `set -e` on the `if`.
 set +e
-"$@"
-first=$?
+"$@" 2>&1 | tee "$tmp_out"
+first=${PIPESTATUS[0]}
 set -e
 
 if [ "$first" -eq 0 ]; then
   exit 0
+fi
+
+# pytest-cov exits 1 on a coverage-threshold miss even when every test
+# passed. Rerunning with --lf against an empty/stale lastfailed cache would
+# then replay the WHOLE suite (which passes) and get misreported as
+# "FLAKY TESTS DETECTED" — while main.yml's diff-cover step, which would
+# give the correct diagnosis, never runs because this step already failed.
+if grep -qE '^FAIL Required test coverage of [0-9.]+% not reached\.' "$tmp_out" \
+  && ! grep -qE '^FAILED ' "$tmp_out" \
+  && ! grep -qE '^[0-9]+ failed' "$tmp_out"; then
+  echo "::error::Coverage gate failed (coverage below threshold) — not a test failure, not a flake. Write tests covering your changed lines."
+  exit "$first"
 fi
 
 echo "::group::First run failed (exit $first) — rerunning only failures once"
@@ -43,10 +62,10 @@ set -e
 echo "::endgroup::"
 
 if [ "$rerun" -eq 0 ]; then
-  echo "ERROR: FLAKY TESTS DETECTED — the following passed only on rerun:"
+  echo "::error::FLAKY TESTS DETECTED — the following passed only on rerun:"
   echo "       (see the first-run traceback above)"
   exit 1
 fi
 
-echo "First run and rerun both failed — genuine failure, exit code $rerun"
+echo "::error::First run and rerun both failed — genuine failure, exit code $rerun"
 exit "$rerun"


### PR DESCRIPTION
## Summary

**Main fix — flake gate coverage misdiagnosis.** `scripts/ci/run-tests-flake-gate.sh` reruns failures after any nonzero pytest exit and treats a pass-on-rerun as a flake. But pytest also exits nonzero when every test passes and `--cov-fail-under` isn't met. The rerun strips coverage flags (so it can't measure the gate) and runs `--lf` against an empty lastfailed cache — since no test actually failed, `--lf` falls back to the whole suite, which passes, and the script reports "FLAKY TESTS DETECTED". Wrong diagnosis, and `main.yml`'s diff-cover step (which would give the correct one) never runs because this step already failed the job.

Fix: capture the first run's output, and if it contains pytest-cov's threshold-failure line with **no** accompanying test-failure summary (no `FAILED ...` line, no `N failed` in the short summary), skip the rerun entirely and exit with a clear `::error::` pointing at the coverage gate instead of a phantom flake.

Also: corrected the header comment's stale claim of exit code 7 for genuine failures (real pytest failure exit is 1; the script just propagates whatever it gets — comment-only fix, no behavior change), and added `::error::` prefixes to the existing FLAKY/genuine-failure terminal messages so they surface as GitHub annotations.

**DX cleanup (small-fry, same PR):**
- `main.yml`: pinned `quality-gate` job's `name:` explicitly to the literal string `quality-gate` (branch protection requires that exact check-run name; this stops a future job rename from silently breaking required-status enforcement).
- `code-quality.yml`: script-only lanes that failed without saying how to reproduce locally (file-size, types-location, components-per-file, duplicates/jscpd, observability) now print the exact local command on failure via a one-line `trap ... ERR`. Did **not** touch `suppression-ratchet` — another branch is rewriting that lane in parallel.
- `scripts/ci/mutation-matrix.sh`: found and fixed a real gap while reading the mutation module-list computation (see finding below).

## Coverage-misdiagnosis repro (evidence)

Reproduced against a throwaway venv (pytest + pytest-cov + pytest-xdist, matching the flags main.yml actually passes: `-n auto --cov=... --cov-fail-under=N -q`), since `scripts/ci` has no existing test harness for shell scripts (checked `tools/` and `scripts/` — none found; didn't invent a new framework per the task constraint).

**Case 1 — coverage-only failure (the bug):** one passing test, coverage below threshold.
```
$ ./venv/bin/python -m pytest -n auto --cov=mymod --cov-report=term-missing --cov-fail-under=90 -q
...
FAIL Required test coverage of 90% not reached. Total coverage: 75.00%
1 passed in 0.76s
EXIT=1
$ ls .pytest_cache/v/cache/     # confirms no lastfailed entry — nothing "failed"
nodeids
```
Old script: reran with `--lf` against the empty cache → replayed the whole (passing) suite → reported `FLAKY TESTS DETECTED`. **New script**: detects the coverage-only signature and exits immediately with `::error::Coverage gate failed (coverage below threshold) — not a test failure, not a flake. Write tests covering your changed lines.` (exit 1, no rerun).

**Case 2 — genuine failure**, verified unchanged: rerun happens, both runs fail, script exits with the rerun's code (1) and the corrected `::error::First run and rerun both failed — genuine failure, exit code 1`.

**Case 3 — real flake**, verified unchanged: a test that fails once then passes (a file-flag toggle) still reruns, passes on rerun, and reports `::error::FLAKY TESTS DETECTED — the following passed only on rerun:` exactly as before.

All three cases were run end-to-end against the actual fixed script (`bash scripts/ci/run-tests-flake-gate.sh <pytest invocation>`), not a simulation of its logic.

## test-mutation finding

Read `scripts/ci/mutation-check.sh` and `scripts/ci/mutation-matrix.sh` (the module-list computation for the `test-mutation` lane). Found a real gap: `mutation-matrix.sh` treated `changed-files.sh`'s `__FULL__` sentinel (push / `workflow_dispatch` events — "scan the whole repo" per that script's documented caller contract) identically to a genuinely empty diff, silently emitting `[]` and reporting "no changed app modules — nothing to mutate" with zero indication that this was a full-scan event.

Fixed in this PR (small, no behavior change — mutation testing is inherently diff-based, mutating only changed lines, so there's no meaningful "full repo" fallback to run instead, and faking one across every `apps/api/app` module would blow the lane's 30-minute budget many times over given a single 745-mutant module already takes ~13 min). The fix just separates the two branches and logs *why* a push-triggered run reports zero modules, so it reads as "not applicable here" instead of "nothing to mutate" — the latter is misleading on a push/dispatch event where mutation coverage was never actually evaluated at that ref.

## Validation
- `bash -n` on all three touched shell scripts: OK
- `actionlint` on both workflow files: only pre-existing SC2086/runner-label findings (unrelated to changed lines, confirmed by line number)
- YAML parses cleanly (`yaml.safe_load`) for both workflow files
- Pre-commit hooks passed on both commits

Not run: the actual GitHub Actions lanes themselves (would need a live PR run against the real runners/services) — this PR's own CI run is the first real-environment check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)