### PR TITLE
test(api): de-flake init-chunk test by pinning the artifact forwarder offline

### DIFF
--- a/apps/api/tests/unit/services/test_chat_service.py
+++ b/apps/api/tests/unit/services/test_chat_service.py
@@ -509,6 +509,25 @@ class TestRunChatStreamBackground:
         ):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _no_live_artifact_forwarder(self) -> Iterator[None]:
+        """Force ``ArtifactForwarder`` onto its "Redis unavailable" fast path.
+
+        ``run_chat_stream_background`` spawns ``forward_artifact_events`` as a
+        background task for every turn with a ``user_id``. Its ``run()`` reads
+        the process-wide ``redis_cache`` singleton directly (not ``stream_manager``,
+        which the tests below already mock) — in a hermetic dev/test env
+        ``redis_cache.redis`` is ``None`` and it no-ops, but under CI's live-services
+        job (real Redis running, ``REDIS_URL`` pointing at it) it subscribes to a
+        real pub/sub channel and blocks in ``pubsub.listen()`` for the rest of the
+        turn, relying entirely on ``_finalize_stream``'s ``artifact_task.cancel()``
+        landing before test/CI timeouts to unblock it. ``tests/unit/`` must be fully
+        mocked and I/O-free (see ``tests/CLAUDE.md``), so pin the fast path here
+        instead of depending on ambient Redis connectivity/scheduling.
+        """
+        with patch("app.services.chat.artifact_forwarder.redis_cache.redis", None):
+            yield
+
     async def test_new_conversation_publishes_init_chunk(self, test_user, basic_body):
         """When conversation_id is None, an init chunk must be published first."""
 


### PR DESCRIPTION
## The flake
`test_new_conversation_publishes_init_chunk` hit `Timeout (>300.0s) from pytest-timeout` on the first CI run of #959 and passed on rerun — surfaced by the flake gate, which is exactly its job.

## Root cause (proven from CI logs, not theorized)
`run_chat_stream_background` spawns `forward_artifact_events` as a background task for every turn with a `user_id`. Its `run()` reads the process-wide `redis_cache` singleton **directly** — not `stream_manager`, which this test class already mocks.

In a hermetic dev env `redis_cache.redis` is `None`, so it takes a no-op fast path. But CI runs the whole suite with `USE_REAL_SERVICES=1` (`tests/conftest.py`), so even `tests/unit/` gets a live Redis — the forwarder subscribed to a real pub/sub channel and blocked in `pubsub.listen()`, relying entirely on `_finalize_stream`'s `artifact_task.cancel()` landing before the timeout.

Evidence from the failed run (31398392947, test-python): forwarder logged `subscribed` (artifact_forwarder.py:156) at 14:34:58, then `closed` (artifact_forwarder.py:354) at 14:39:58 — **exactly 300.00s later**, matching pytest-timeout's own abort rather than a normal cancel. The cancellation only landed once pytest-timeout force-unwound the stack.

## Fix
An autouse fixture pinning `app.services.chat.artifact_forwarder.redis_cache.redis` to `None`, forcing the documented fast path. `tests/unit/` must be mocked and I/O-free per `tests/CLAUDE.md`; this restores that contract instead of depending on ambient Redis connectivity and scheduling luck.

This mirrors the `_no_pending_approval` fixture already in the same class, which exists for the identical class of bug (unmocked `redis_cache` reached via a different code path).

## Evidence — and what it does NOT prove
- **Reproduced?** No. Proven by CI log timestamps + code path. With real Redis on :6380 locally, a 60-iteration targeted harness and the unfixed test both passed every time — it's a rare race under CI's load (xdist + coverage + full suite), consistent with "flaked once, passed on rerun."
- **Stability proof instead of a red-then-green pair:** ~90 consecutive runs by the investigating session + **40 more after the fix, 0 failures**. Full file: 44 passed.
- Because it could not be forced red on demand, this is a hermeticity fix backed by stability evidence, not a deterministic regression test. Stating that plainly rather than implying stronger proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)