### PR TITLE
ci(actions): pin setup-uv prune-cache: true

### DIFF
--- a/.github/actions/setup-python-test-env/action.yml
+++ b/.github/actions/setup-python-test-env/action.yml
@@ -18,6 +18,11 @@ runs:
       with:
         version: "0.8.17"
         enable-cache: true
+        # v9 flipped prune-cache's default from true to false; pin it
+        # explicitly so a future setup-uv bump can't silently let the cache
+        # grow unbounded and evict other repo caches (e.g. the Next.js
+        # compiler cache).
+        prune-cache: true
 
     - name: Sync Python dependencies
       shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -332,6 +332,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: ruff check + format (PL, RUF, FAST, S, B, A, COM, C4, DTZ, ISC, RET, SIM, ARG, PTH, TRY, PERF, UP, FURB, LOG, G + more)
         # Pinned to the uv.lock ruff version — bump both together. Unpinned,
         # a ruff release can flip this lane red with zero code changes
@@ -388,6 +389,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Install api dev + backend dependencies (uv sync)
         run: |
           echo "::group::uv sync"
@@ -460,6 +462,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Docstring coverage on public API surface
         run: |
           echo "::group::interrogate"
@@ -489,6 +492,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Complexity scan (max-absolute F, max-modules E, max-average B)
         run: |
           echo "::group::xenon"
@@ -529,6 +533,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Bandit security scan (zero-warning policy)
         run: |
           echo "::group::bandit (low severity, low confidence — no exclusions)"
@@ -592,6 +597,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       # This lane's verdict is only worth what its rules are worth, and those
       # rules have been silently wrong (a discarded-error except matrix, route
       # resolution that found 2 of 283 paths). Both still printed a score — so
@@ -674,6 +680,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Emit real events from both runtimes and diff their shapes
         run: |
           echo "::group::wide-event conformance"
@@ -699,6 +706,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Install vulture (Python dead-code detector)
         run: |
           echo "::group::uv tool install vulture"
@@ -741,6 +749,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Install pint + promtool (pinned release binaries, same versions prod runs)
         run: |
           echo "::group::install"
@@ -926,6 +935,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Sync Python dependencies
         run: uv sync --frozen --package gaia --group backend --group dev
       - name: Mutation check (zero survivors required, per changed module)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,6 +206,7 @@ jobs:
         with:
           version: "0.8.17"
           enable-cache: true
+          prune-cache: true
       - name: Sync Python dependencies
         shell: bash
         run: uv sync --frozen --package gaia --group backend --group dev


### PR DESCRIPTION
## Why

Dependabot PR #939 bumped `astral-sh/setup-uv` from 5.4.2 to 9.0.0 — but only for the composite action `.github/actions/setup-python-test-env/action.yml`. The ~11 direct `uses:` call sites in `code-quality.yml`/`main.yml` are still pinned to v5.4.2.

v9.0.0's one breaking change is that `prune-cache` flipped its default from `"true"` to `"false"`. We never set it explicitly anywhere, so:
- The composite action (already on v9.0.0) is caching without pruning **right now**.
- The other call sites will silently pick up the same behavior change the next time someone bumps them to v9, with no diff to review.

An unbounded uv cache eventually crowds out other useful GitHub Actions caches under the repo's per-repo storage cap — notably the Next.js compiler cache (`apps/web/.next/cache`) that keeps `main.yml`'s web build fast. Not a correctness problem, a cost/perf one.

## What changed

Added `prune-cache: true` explicitly to every `setup-uv` invocation that has `enable-cache: true`:

- `.github/actions/setup-python-test-env/action.yml` (1 site, v9.0.0) — plus a comment explaining why the explicit value exists.
- `.github/workflows/code-quality.yml` (10 sites, v5.4.2)
- `.github/workflows/main.yml` (1 site, v5.4.2 — the `test-fast` job)

Left untouched: `main.yml`'s `test-harness-tools` job, whose `setup-uv` call has no `with:` block at all (caching not enabled there — pruning is meaningless without it).

## Evidence prune-cache is valid at our pinned versions

Fetched each pinned version's `action.yml` directly from GitHub:

```
$ gh api "repos/astral-sh/setup-uv/contents/action.yml?ref=v9.0.0" --jq .content | base64 -d | grep -A2 prune-cache
  prune-cache:
    description: "Prune cache before saving."
    default: "false"

$ gh api "repos/astral-sh/setup-uv/contents/action.yml?ref=v5.4.2" --jq .content | base64 -d | grep -A2 prune-cache
  prune-cache:
    description: "Prune cache before saving."
    default: "true"
```

Confirms the default flip (`true` → `false`) and that the input is valid on both pinned versions.

## Verification

- `actionlint` on the three changed files: no new findings introduced by this change (pre-existing shellcheck SC2086/SC2129 style notices and composite-action-treated-as-workflow syntax warnings are unrelated noise).
- `check yaml` pre-commit hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
