### PR TITLE
fix(ci): deploy what is ready and never let publish-without-deploy go silent

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,15 +44,17 @@ flowchart TD
     B_WEB_PUB --> B_WEB_DONE["docker-web complete"]:::build
     B_WEB_SKIP --> B_WEB_DONE
 
-    B_REL_DONE --> PLAN["deployment-plan<br/>(needs docker-release + docker-web)"]:::decision
+    B_REL_DONE --> PLAN["deployment-plan (if: always())<br/>needs docker-release + docker-web + docker-grafana<br/>runs even if a lane failed/cancelled"]:::decision
     B_WEB_DONE --> PLAN
 
-    PLAN --> PLAN_BE{"backend_deploy == true?"}:::decision
+    PLAN --> PLAN_BE{"docker-release succeeded<br/>AND api/bots affected?"}:::decision
     PLAN --> PLAN_FE{"frontend_deploy == true?"}:::decision
+    PLAN --> PLAN_ORPHAN{"image published but its<br/>deploy did not run?"}:::decision
   end
 
   PLAN_BE -- "Yes" --> DEPLOY_BACKEND["trigger-deploy -> deploy-swarm-prod.yml"]:::deploy
   PLAN_FE -- "Yes" --> DEPLOY_FRONTEND["trigger-web -> deploy-frontend.yml"]:::deploy
+  PLAN_ORPHAN -- "Yes" --> NOTIFY_ORPHAN["notify-publish-without-deploy<br/>Discord alert + gh workflow run<br/>build.yml -f deployment_mode=both remedy"]:::deploy
 
   subgraph BACKEND_DEPLOY["deploy-swarm-prod.yml (Swarm app stack)"]
     direction TB
@@ -107,11 +109,17 @@ flowchart TD
 4. `Quality gate (required)` (the single required status check) fails the merge if any lane is neither `success` nor `skipped`; a lane skipped by `changes` counts as passing, but a failed `changes` job fails the gate. All lanes are enforced — there is no informational tier.
 
 ### `.github/workflows/build.yml`
-1. Start two build lanes: `docker-release` and `docker-web`.
-2. `docker-release`: detect affected backend/bot projects, publish images to GHCR via Dagger, optionally sync Discord commands.
-3. `docker-web`: detect `web` changes and build/push web image via Dagger only when affected.
-4. `deployment-plan` waits for both lanes and computes `backend_deploy` / `frontend_deploy`.
-5. Trigger `deploy-swarm-prod.yml` and/or `deploy-frontend.yml` based on plan outputs.
+1. Start three build lanes: `docker-release`, `docker-web`, `docker-grafana`.
+2. `docker-release`: detect affected backend/bot projects, publish images to GHCR, optionally sync Discord commands. Records `images_published` right after its push steps (before Discord command sync), so a later, unrelated step failure never misreports a real publish as "nothing published".
+3. `docker-web`: detect `web` changes and build/push the web image only when affected.
+4. `docker-grafana`: builds/pushes the Grafana image unconditionally every run (tiny COPY layer; kept out of orphan detection — see `.github/CLAUDE.md`).
+5. `deployment-plan` runs with `if: always()` — it is never skipped by a lane failing or being cancelled — and needs all three build lanes purely for sequencing (deploy planning must not race ahead of the build lanes). It evaluates `docker-release`'s and `docker-web`'s `.result` explicitly via `scripts/ci/compute-deploy-plan.sh`:
+   - `backend_deploy` is `true` only when `docker-release` succeeded AND api/bots affected (or a manual mode says so). A failed/cancelled `docker-release` never deploys, but a failed `docker-web` no longer blocks it either — the old implicit needs-all-success gate did.
+   - `frontend_deploy` follows the existing rule (always true on a master push) and is not gated on `docker-web`'s result — the Vercel deploy path syncs from source, not from the `docker-web` image.
+   - `backend_orphaned` / `frontend_orphaned` flag when an image lane published to GHCR as `:latest` but its corresponding deploy did not run this time, for any reason (lane failure, cancellation, or the plan itself deciding not to deploy). Scoped to `master` only.
+   - Manual `workflow_dispatch` modes (`backend-only` / `frontend-only` / `both`) bypass both affected-detection and lane-result gating — this is the intended one-command remedy for drift: `gh workflow run build.yml --ref master -f deployment_mode=both` redeploys whatever is currently tagged `:latest` in GHCR regardless of what this run's own build lanes did.
+6. `notify-publish-without-deploy` fires a Discord alert (same webhook/action the deploy workflows use) when either orphan flag is set, naming which images are published-but-undeployed and the `gh workflow run` remedy above.
+7. Trigger `deploy-swarm-prod.yml` and/or `deploy-frontend.yml` based on `backend_deploy` / `frontend_deploy`.
 
 ### `.github/workflows/deploy-swarm-prod.yml`
 1. Install SSH private key from `PROD_VM_SSH_KEY` via the `setup-swarm-context` composite action and log in to GHCR.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,13 +47,19 @@ flowchart TD
     B_REL_DONE --> PLAN["deployment-plan (if: always())<br/>needs docker-release + docker-web + docker-grafana<br/>runs even if a lane failed/cancelled"]:::decision
     B_WEB_DONE --> PLAN
 
-    PLAN --> PLAN_BE{"docker-release succeeded<br/>AND api/bots affected?"}:::decision
-    PLAN --> PLAN_FE{"frontend_deploy == true?"}:::decision
-    PLAN --> PLAN_ORPHAN{"image published but its<br/>deploy did not run?"}:::decision
+    PLAN --> PLAN_COUPLE{"backend AND web<br/>both affected?"}:::decision
+    PLAN_COUPLE -- "Yes (coupled)" --> PLAN_COUPLE_GATE{"either lane failed?"}:::decision
+    PLAN_COUPLE_GATE -- "Yes" --> PLAN_HOLD["Hold BOTH deploys back<br/>(coupled_hold, avoids forward skew)"]:::terminal
+    PLAN_COUPLE_GATE -- "No" --> PLAN_COUPLE_GO["Deploy BOTH together"]:::deploy
+    PLAN_COUPLE -- "No (single side)" --> PLAN_BE{"docker-release succeeded<br/>AND api/bots affected?"}:::decision
+    PLAN_COUPLE -- "No (single side)" --> PLAN_FE{"frontend_deploy == true?"}:::decision
+    PLAN --> PLAN_ORPHAN{"image published but its<br/>deploy did not run<br/>(incl. coupled_hold)?"}:::decision
   end
 
   PLAN_BE -- "Yes" --> DEPLOY_BACKEND["trigger-deploy -> deploy-swarm-prod.yml"]:::deploy
   PLAN_FE -- "Yes" --> DEPLOY_FRONTEND["trigger-web -> deploy-frontend.yml"]:::deploy
+  PLAN_COUPLE_GO --> DEPLOY_BACKEND
+  PLAN_COUPLE_GO --> DEPLOY_FRONTEND
   PLAN_ORPHAN -- "Yes" --> NOTIFY_ORPHAN["notify-publish-without-deploy<br/>Discord alert + gh workflow run<br/>build.yml -f deployment_mode=both remedy"]:::deploy
 
   subgraph BACKEND_DEPLOY["deploy-swarm-prod.yml (Swarm app stack)"]
@@ -112,13 +118,13 @@ flowchart TD
 1. Start three build lanes: `docker-release`, `docker-web`, `docker-grafana`.
 2. `docker-release`: detect affected backend/bot projects, publish images to GHCR, optionally sync Discord commands. Records `images_published` right after its push steps (before Discord command sync), so a later, unrelated step failure never misreports a real publish as "nothing published".
 3. `docker-web`: detect `web` changes and build/push the web image only when affected.
-4. `docker-grafana`: builds/pushes the Grafana image unconditionally every run (tiny COPY layer; kept out of orphan detection — see `.github/CLAUDE.md`).
-5. `deployment-plan` runs with `if: always()` — it is never skipped by a lane failing or being cancelled — and needs all three build lanes purely for sequencing (deploy planning must not race ahead of the build lanes). It evaluates `docker-release`'s and `docker-web`'s `.result` explicitly via `scripts/ci/compute-deploy-plan.sh`:
-   - `backend_deploy` is `true` only when `docker-release` succeeded AND api/bots affected (or a manual mode says so). A failed/cancelled `docker-release` never deploys, but a failed `docker-web` no longer blocks it either — the old implicit needs-all-success gate did.
-   - `frontend_deploy` follows the existing rule (always true on a master push) and is not gated on `docker-web`'s result — the Vercel deploy path syncs from source, not from the `docker-web` image.
-   - `backend_orphaned` / `frontend_orphaned` flag when an image lane published to GHCR as `:latest` but its corresponding deploy did not run this time, for any reason (lane failure, cancellation, or the plan itself deciding not to deploy). Scoped to `master` only.
-   - Manual `workflow_dispatch` modes (`backend-only` / `frontend-only` / `both`) bypass both affected-detection and lane-result gating — this is the intended one-command remedy for drift: `gh workflow run build.yml --ref master -f deployment_mode=both` redeploys whatever is currently tagged `:latest` in GHCR regardless of what this run's own build lanes did.
-6. `notify-publish-without-deploy` fires a Discord alert (same webhook/action the deploy workflows use) when either orphan flag is set, naming which images are published-but-undeployed and the `gh workflow run` remedy above.
+4. `docker-grafana`: builds/pushes the Grafana image unconditionally every run (tiny COPY layer over the upstream image). Not part of coupling or orphan detection — it has no "affected" concept and its `:latest` is always safe for the stack to pick up.
+5. `deployment-plan` runs with `if: always()` — it is never skipped by a lane failing or being cancelled — and needs all three build lanes purely for sequencing (deploy planning must not race ahead of the build lanes). It evaluates `docker-release`'s and `docker-web`'s `.result`, plus each side's affected-detection (`docker-release.outputs.api_affected`/`bots_affected`, `docker-web.outputs.web_affected`), via `scripts/ci/compute-deploy-plan.sh`:
+   - **Single-side push** (only backend or only web affected): each side deploys independently. `backend_deploy` is `true` only when `docker-release` succeeded AND api/bots affected. A failed/cancelled `docker-release` never deploys, but a failed `docker-web` no longer blocks it either — the old implicit needs-all-success gate did. `frontend_deploy` follows the existing rule (always true on a master push) and is not gated on `docker-web`'s result — the Vercel deploy path syncs from source, not from the `docker-web` image.
+   - **Coupled push** (both backend AND web affected by the same commit): the two deploys are treated as one unit. Both `docker-release` and `docker-web` must succeed for either to deploy; if either lane failed or was cancelled, `coupled_hold` is set and BOTH `backend_deploy`/`frontend_deploy` stay `false` — this prevents shipping one half (e.g. a new frontend) against a stale, untested other half. This is the one case where a lane failure still blocks a deploy on the healthy side, by design.
+   - `backend_orphaned` / `frontend_orphaned` flag when an image lane published to GHCR as `:latest` but its corresponding deploy did not run this time, for any reason (lane failure, cancellation, the plan itself deciding not to deploy, or a `coupled_hold` — which flags both sides even if only one side's lane actually failed, since the healthy side is held back too). Scoped to `master` only.
+   - Manual `workflow_dispatch` modes (`backend-only` / `frontend-only` / `both`) bypass affected-detection, lane-result gating, AND the coupling rule — this is the intended one-command remedy for drift: `gh workflow run build.yml --ref master -f deployment_mode=both` redeploys whatever is currently tagged `:latest` in GHCR regardless of what this run's own build lanes did. Manual `auto` mode applies the same coupling rule as an automatic push.
+6. `notify-publish-without-deploy` fires a Discord alert (same webhook/action the deploy workflows use) when either orphan flag is set, naming which images are published-but-undeployed (or held together, for a `coupled_hold`) and the `gh workflow run` remedy above.
 7. Trigger `deploy-swarm-prod.yml` and/or `deploy-frontend.yml` based on `backend_deploy` / `frontend_deploy`.
 
 ### `.github/workflows/deploy-swarm-prod.yml`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,12 @@ jobs:
     outputs:
       api_affected: ${{ steps.affected.outputs.api }}
       bots_affected: ${{ steps.affected.outputs.bots }}
+      # True only when a push step for an affected scope actually succeeded —
+      # tracked separately from this job's overall .result because a later
+      # step (e.g. Discord command sync) can fail AFTER images already landed
+      # in GHCR, which would otherwise misreport a real publish as "nothing
+      # published" and hide drift instead of surfacing it.
+      images_published: ${{ steps.publish-status.outputs.published }}
 
     steps:
       # Prepare repository + tooling so Nx can calculate affected projects.
@@ -146,17 +152,20 @@ jobs:
 
       # Publish API image tags when API-related scope changed.
       - name: Release apps Docker images
+        id: release-apps
         if: steps.affected.outputs.api == 'true'
         run: pnpm exec nx release --group=apps --dockerVersionScheme=${{ steps.version.outputs.scheme }} --yes --verbose
 
       # Publish bot image tags when bot scope changed.
       - name: Release bots Docker images
+        id: release-bots
         if: steps.affected.outputs.bots == 'true'
         run: pnpm exec nx release --group=bots --dockerVersionScheme=${{ steps.version.outputs.scheme }} --yes --verbose
 
       # Fallback: nx release may skip publishing on first run (no prior version
       # history). Ensure locally-built bot images are pushed to GHCR regardless.
       - name: Ensure bot images are pushed to GHCR
+        id: ensure-bot-images
         if: steps.affected.outputs.bots == 'true'
         run: |
           for bot in discord slack telegram whatsapp; do
@@ -168,6 +177,28 @@ jobs:
               echo "⚠️  $img not found locally, skipping"
             fi
           done
+
+      # Captured right after the push steps, before Discord command sync —
+      # that step can fail on an unrelated Discord API error and must never
+      # cause a real publish to be reported as "nothing published".
+      - name: Record image publish outcome
+        id: publish-status
+        if: always()
+        env:
+          API_AFFECTED: ${{ steps.affected.outputs.api }}
+          BOTS_AFFECTED: ${{ steps.affected.outputs.bots }}
+          API_RELEASE_OUTCOME: ${{ steps.release-apps.outcome }}
+          BOTS_RELEASE_OUTCOME: ${{ steps.release-bots.outcome }}
+          BOTS_PUSH_OUTCOME: ${{ steps.ensure-bot-images.outcome }}
+        run: |
+          published=false
+          if [ "$API_AFFECTED" = "true" ] && [ "$API_RELEASE_OUTCOME" = "success" ]; then
+            published=true
+          fi
+          if [ "$BOTS_AFFECTED" = "true" ] && [ "$BOTS_RELEASE_OUTCOME" = "success" ] && [ "$BOTS_PUSH_OUTCOME" = "success" ]; then
+            published=true
+          fi
+          echo "published=$published" >> "$GITHUB_OUTPUT"
 
       # Discord command sync is only meaningful for production bot deploys.
       - name: Register Discord slash commands
@@ -312,14 +343,29 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/gaia-grafana:${{ github.sha }}
 
   deployment-plan:
-    # Keep deploy planning behind all build lanes so trigger jobs never race ahead.
+    # Keep deploy planning behind all build lanes so trigger jobs never race
+    # ahead, but never let one failed/cancelled lane skip planning outright —
+    # a failed docker-web must not block a backend deploy that is otherwise
+    # ready, and vice versa. Each lane's result is evaluated explicitly by
+    # compute-deploy-plan.sh instead of relying on implicit all-success
+    # gating (the pre-`always()` behavior: any lane result other than
+    # 'success' skipped this whole job, and with it trigger-deploy AND
+    # trigger-web, even when the other lane was ready to ship).
     needs: [docker-release, docker-web, docker-grafana]
+    if: always()
     runs-on: ubuntu-latest
     outputs:
       backend_deploy: ${{ steps.plan.outputs.backend_deploy }}
       frontend_deploy: ${{ steps.plan.outputs.frontend_deploy }}
+      backend_orphaned: ${{ steps.plan.outputs.backend_orphaned }}
+      frontend_orphaned: ${{ steps.plan.outputs.frontend_orphaned }}
+      docker_release_result: ${{ steps.plan.outputs.docker_release_result }}
+      docker_web_result: ${{ steps.plan.outputs.docker_web_result }}
     steps:
-      # Single decision point that translates backend affected + manual mode into deploy booleans.
+      - uses: actions/checkout@v4
+      # Single decision point that translates lane results + affected +
+      # manual mode into deploy booleans, and flags any image lane that
+      # published without its deploy running.
       - name: Compute deploy plan
         id: plan
         env:
@@ -329,58 +375,37 @@ jobs:
           MANUAL_MODE_EVENT: ${{ github.event.inputs.deployment_mode || '' }}
           API_AFFECTED: ${{ needs.docker-release.outputs.api_affected || 'false' }}
           BOTS_AFFECTED: ${{ needs.docker-release.outputs.bots_affected || 'false' }}
-        run: |
-          set -euo pipefail
+          DOCKER_RELEASE_RESULT: ${{ needs.docker-release.result }}
+          DOCKER_WEB_RESULT: ${{ needs.docker-web.result }}
+          BACKEND_IMAGES_PUBLISHED: ${{ needs.docker-release.outputs.images_published || 'false' }}
+        run: bash scripts/ci/compute-deploy-plan.sh
 
-          backend_deploy=false
-          frontend_deploy=false
-          manual_mode="${MANUAL_MODE_INPUT:-}"
-
-          if [ -z "$manual_mode" ]; then
-            manual_mode="${MANUAL_MODE_EVENT:-}"
-          fi
-          if [ -z "$manual_mode" ]; then
-            manual_mode="auto"
-          fi
-
-          if [ "$REF" != "refs/heads/master" ]; then
-            echo "Not on master; deploy jobs disabled."
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            case "$manual_mode" in
-              auto)
-                if [ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ]; then
-                  backend_deploy=true
-                fi
-                # Frontend sync to Vercel source repo is always allowed on master.
-                frontend_deploy=true
-                ;;
-              backend-only)
-                backend_deploy=true
-                ;;
-              frontend-only)
-                frontend_deploy=true
-                ;;
-              both)
-                backend_deploy=true
-                frontend_deploy=true
-                ;;
-              none)
-                ;;
-              *)
-                echo "::error::Invalid deployment_mode '$manual_mode'. Use auto, backend-only, frontend-only, both, or none."
-                exit 1
-                ;;
-            esac
-          else
-            if [ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ]; then
-              backend_deploy=true
-            fi
-            frontend_deploy=true
-          fi
-
-          echo "backend_deploy=$backend_deploy" >> "$GITHUB_OUTPUT"
-          echo "frontend_deploy=$frontend_deploy" >> "$GITHUB_OUTPUT"
-          echo "Deploy plan => backend: $backend_deploy, frontend: $frontend_deploy"
+  # Loud, self-explaining alert for the exact incident this workflow used to
+  # hide: an image lane published to GHCR as :latest but its deploy did not
+  # run, for any reason (lane failure, cancellation, or the plan choosing not
+  # to deploy). Without this, production silently drifts from what's
+  # published, and any container restart on the Swarm host picks up the
+  # undeployed build with no warning.
+  notify-publish-without-deploy:
+    needs: [deployment-plan]
+    if: always() && (needs.deployment-plan.outputs.backend_orphaned == 'true' || needs.deployment-plan.outputs.frontend_orphaned == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord — publish without deploy
+        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
+          username: "Gaia Deploy Bot"
+          color: "#ff6b6b"
+          message: |
+            🚨 **Publish Without Deploy Detected**
+            **Commit:** `${{ github.sha }}`
+            **Branch:** ${{ github.ref_name }}
+            **Actor:** ${{ github.actor }}
+            ${{ needs.deployment-plan.outputs.backend_orphaned == 'true' && format('**Backend images (api/voice-agent/bots) were published to GHCR as `:latest` but the backend deploy did NOT run.** docker-release result: `{0}`.', needs.deployment-plan.outputs.docker_release_result) || '' }}
+            ${{ needs.deployment-plan.outputs.frontend_orphaned == 'true' && format('**Web image (gaia-web) was published to GHCR as `:latest` but the frontend deploy did NOT run.** docker-web result: `{0}`.', needs.deployment-plan.outputs.docker_web_result) || '' }}
+            Production may now be running a stale image while a newer one sits in GHCR tagged `:latest`. Any container restart on the Swarm host will silently pick up the undeployed build.
+            **To deploy the published image(s) now:** run `gh workflow run build.yml --ref master -f deployment_mode=both` (or `backend-only` / `frontend-only`) — this redeploys whatever is currently tagged `:latest` in GHCR regardless of this run's affected-detection or lane results.
 
   # Trigger backend production deploy only when deploy plan allows it.
   trigger-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,10 @@ jobs:
       contents: read
       packages: write
       actions: read
+    outputs:
+      # Feeds deployment-plan's coupling rule: a push that touches both
+      # backend and web must deploy them together, not independently.
+      web_affected: ${{ steps.web-affected.outputs.web }}
 
     steps:
       # Prepare repository + tooling for affected check and optional image build.
@@ -359,12 +363,14 @@ jobs:
       frontend_deploy: ${{ steps.plan.outputs.frontend_deploy }}
       backend_orphaned: ${{ steps.plan.outputs.backend_orphaned }}
       frontend_orphaned: ${{ steps.plan.outputs.frontend_orphaned }}
+      coupled_hold: ${{ steps.plan.outputs.coupled_hold }}
       docker_release_result: ${{ steps.plan.outputs.docker_release_result }}
       docker_web_result: ${{ steps.plan.outputs.docker_web_result }}
     steps:
       - uses: actions/checkout@v4
       # Single decision point that translates lane results + affected +
-      # manual mode into deploy booleans, and flags any image lane that
+      # manual mode into deploy booleans, applies the backend/web coupling
+      # rule for pushes that touch both, and flags any image lane that
       # published without its deploy running.
       - name: Compute deploy plan
         id: plan
@@ -375,6 +381,7 @@ jobs:
           MANUAL_MODE_EVENT: ${{ github.event.inputs.deployment_mode || '' }}
           API_AFFECTED: ${{ needs.docker-release.outputs.api_affected || 'false' }}
           BOTS_AFFECTED: ${{ needs.docker-release.outputs.bots_affected || 'false' }}
+          WEB_AFFECTED: ${{ needs.docker-web.outputs.web_affected || 'false' }}
           DOCKER_RELEASE_RESULT: ${{ needs.docker-release.result }}
           DOCKER_WEB_RESULT: ${{ needs.docker-web.result }}
           BACKEND_IMAGES_PUBLISHED: ${{ needs.docker-release.outputs.images_published || 'false' }}
@@ -402,10 +409,11 @@ jobs:
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
             **Actor:** ${{ github.actor }}
-            ${{ needs.deployment-plan.outputs.backend_orphaned == 'true' && format('**Backend images (api/voice-agent/bots) were published to GHCR as `:latest` but the backend deploy did NOT run.** docker-release result: `{0}`.', needs.deployment-plan.outputs.docker_release_result) || '' }}
-            ${{ needs.deployment-plan.outputs.frontend_orphaned == 'true' && format('**Web image (gaia-web) was published to GHCR as `:latest` but the frontend deploy did NOT run.** docker-web result: `{0}`.', needs.deployment-plan.outputs.docker_web_result) || '' }}
+            ${{ needs.deployment-plan.outputs.coupled_hold == 'true' && format('**This commit changes both backend and web, so their deploys are coupled — one lane failed (docker-release: `{0}`, docker-web: `{1}`), so BOTH deploys were held back together rather than shipping one half against a stale other half.**', needs.deployment-plan.outputs.docker_release_result, needs.deployment-plan.outputs.docker_web_result) || '' }}
+            ${{ needs.deployment-plan.outputs.coupled_hold != 'true' && needs.deployment-plan.outputs.backend_orphaned == 'true' && format('**Backend images (api/voice-agent/bots) were published to GHCR as `:latest` but the backend deploy did NOT run.** docker-release result: `{0}`.', needs.deployment-plan.outputs.docker_release_result) || '' }}
+            ${{ needs.deployment-plan.outputs.coupled_hold != 'true' && needs.deployment-plan.outputs.frontend_orphaned == 'true' && format('**Web image (gaia-web) was published to GHCR as `:latest` but the frontend deploy did NOT run.** docker-web result: `{0}`.', needs.deployment-plan.outputs.docker_web_result) || '' }}
             Production may now be running a stale image while a newer one sits in GHCR tagged `:latest`. Any container restart on the Swarm host will silently pick up the undeployed build.
-            **To deploy the published image(s) now:** run `gh workflow run build.yml --ref master -f deployment_mode=both` (or `backend-only` / `frontend-only`) — this redeploys whatever is currently tagged `:latest` in GHCR regardless of this run's affected-detection or lane results.
+            **To deploy now:** fix the red lane, then run `gh workflow run build.yml --ref master -f deployment_mode=both` (or `backend-only` / `frontend-only` for a non-coupled case) — this redeploys whatever is currently tagged `:latest` in GHCR regardless of this run's affected-detection or lane results.
 
   # Trigger backend production deploy only when deploy plan allows it.
   trigger-deploy:

--- a/scripts/ci/compute-deploy-plan.sh
+++ b/scripts/ci/compute-deploy-plan.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Computes build.yml's deployment plan: which production deploy workflows
+# should run, and whether any image lane published to GHCR without a
+# corresponding deploy running (a "publish without deploy" drift risk).
+#
+# Consumed by the `deployment-plan` job, which runs with `if: always()` so a
+# failed/cancelled lane (docker-release, docker-web, docker-grafana) never
+# skips planning outright -- each lane's result is evaluated explicitly here
+# instead of relying on implicit all-success gating. A failed docker-web must
+# never block a ready backend deploy, and vice versa.
+#
+# Writes backend_deploy / frontend_deploy / backend_orphaned /
+# frontend_orphaned to $GITHUB_OUTPUT. trigger-deploy and trigger-web consume
+# only backend_deploy / frontend_deploy -- keep those two names and their
+# 'true'/'false' string contract stable.
+set -euo pipefail
+
+: "${REF:?REF is required}"
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${API_AFFECTED:=false}"
+: "${BOTS_AFFECTED:=false}"
+# Job .result values: success | failure | cancelled | skipped.
+: "${DOCKER_RELEASE_RESULT:?DOCKER_RELEASE_RESULT is required}"
+: "${DOCKER_WEB_RESULT:?DOCKER_WEB_RESULT is required}"
+# Set by docker-release right after its push steps, independent of later
+# steps in that job (e.g. Discord command sync) that can fail afterwards and
+# flip the job's overall result to 'failure' even though images already
+# landed in GHCR. Empty/anything other than 'true' is treated as "no proof
+# of publish" -- never claim a publish happened without evidence.
+: "${BACKEND_IMAGES_PUBLISHED:=false}"
+: "${MANUAL_MODE_INPUT:=}"
+: "${MANUAL_MODE_EVENT:=}"
+
+backend_deploy=false
+frontend_deploy=false
+manual_mode="${MANUAL_MODE_INPUT:-}"
+if [ -z "$manual_mode" ]; then
+  manual_mode="${MANUAL_MODE_EVENT:-}"
+fi
+if [ -z "$manual_mode" ]; then
+  manual_mode="auto"
+fi
+
+on_master=false
+[ "$REF" = "refs/heads/master" ] && on_master=true
+
+if [ "$on_master" = "false" ]; then
+  echo "Not on master; deploy jobs disabled."
+elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+  # Manual overrides are an explicit operator decision -- they intentionally
+  # bypass affected-detection AND lane-result gating. This is the documented
+  # self-heal remedy for drift: `deployment_mode=both` (or backend-only /
+  # frontend-only) redeploys whatever is currently tagged :latest in GHCR,
+  # regardless of what this run's affected-detection or build lanes decided.
+  case "$manual_mode" in
+    auto)
+      if [ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ]; then
+        if [ "$DOCKER_RELEASE_RESULT" = "success" ]; then
+          backend_deploy=true
+        fi
+      fi
+      # Frontend sync to the Vercel source repo builds from source, not from
+      # docker-web's image, so it is not gated on docker-web's result.
+      frontend_deploy=true
+      ;;
+    backend-only)
+      backend_deploy=true
+      ;;
+    frontend-only)
+      frontend_deploy=true
+      ;;
+    both)
+      backend_deploy=true
+      frontend_deploy=true
+      ;;
+    none)
+      ;;
+    *)
+      echo "::error::Invalid deployment_mode '$manual_mode'. Use auto, backend-only, frontend-only, both, or none."
+      exit 1
+      ;;
+  esac
+else
+  # Automatic push-triggered plan: a failed/cancelled docker-release means no
+  # verified new backend image for this run, so never deploy on a guess.
+  if [ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ]; then
+    if [ "$DOCKER_RELEASE_RESULT" = "success" ]; then
+      backend_deploy=true
+    fi
+  fi
+  frontend_deploy=true
+fi
+
+# Orphan detection: images landed in GHCR tagged :latest but the deploy that
+# would roll them out did not run this time, for ANY reason (lane failure,
+# cancellation, or the plan above simply deciding not to deploy). Scoped to
+# master: off-master manual builds intentionally never deploy and must not be
+# reported as drift.
+backend_orphaned=false
+frontend_orphaned=false
+if [ "$on_master" = "true" ]; then
+  if [ "$BACKEND_IMAGES_PUBLISHED" = "true" ] && [ "$backend_deploy" != "true" ]; then
+    backend_orphaned=true
+  fi
+  if [ "$DOCKER_WEB_RESULT" = "success" ] && [ "$frontend_deploy" != "true" ]; then
+    frontend_orphaned=true
+  fi
+fi
+
+{
+  echo "backend_deploy=$backend_deploy"
+  echo "frontend_deploy=$frontend_deploy"
+  echo "backend_orphaned=$backend_orphaned"
+  echo "frontend_orphaned=$frontend_orphaned"
+  echo "docker_release_result=$DOCKER_RELEASE_RESULT"
+  echo "docker_web_result=$DOCKER_WEB_RESULT"
+} >> "$GITHUB_OUTPUT"
+
+echo "Deploy plan => backend: $backend_deploy, frontend: $frontend_deploy"
+echo "Orphan check => backend_orphaned: $backend_orphaned, frontend_orphaned: $frontend_orphaned"
+echo "  docker-release result: $DOCKER_RELEASE_RESULT (images_published=$BACKEND_IMAGES_PUBLISHED), docker-web result: $DOCKER_WEB_RESULT"

--- a/scripts/ci/compute-deploy-plan.sh
+++ b/scripts/ci/compute-deploy-plan.sh
@@ -6,8 +6,17 @@
 # Consumed by the `deployment-plan` job, which runs with `if: always()` so a
 # failed/cancelled lane (docker-release, docker-web, docker-grafana) never
 # skips planning outright -- each lane's result is evaluated explicitly here
-# instead of relying on implicit all-success gating. A failed docker-web must
-# never block a ready backend deploy, and vice versa.
+# instead of relying on implicit all-success gating.
+#
+# Coupling rule: a push that touches ONLY backend or ONLY web deploys that
+# side independently -- a failed docker-web must never block a ready backend
+# deploy, and vice versa (the original incident this fixes). But a push that
+# touches BOTH backend and web is a single coupled unit: if either lane
+# failed, deploy NEITHER, rather than shipping (say) a new frontend against
+# a still-old backend it wasn't built against. The old implicit
+# all-or-nothing gate accidentally provided this protection for coupled
+# pushes -- this preserves that property while still fixing the
+# single-side-failure incident.
 #
 # Writes backend_deploy / frontend_deploy / backend_orphaned /
 # frontend_orphaned to $GITHUB_OUTPUT. trigger-deploy and trigger-web consume
@@ -19,7 +28,10 @@ set -euo pipefail
 : "${EVENT_NAME:?EVENT_NAME is required}"
 : "${API_AFFECTED:=false}"
 : "${BOTS_AFFECTED:=false}"
-# Job .result values: success | failure | cancelled | skipped.
+: "${WEB_AFFECTED:=false}"
+# Job .result values: success | failure | cancelled | skipped. A 'skipped'
+# lane means "not affected", never a failure -- it must not trigger the
+# coupling hold below.
 : "${DOCKER_RELEASE_RESULT:?DOCKER_RELEASE_RESULT is required}"
 : "${DOCKER_WEB_RESULT:?DOCKER_WEB_RESULT is required}"
 # Set by docker-release right after its push steps, independent of later
@@ -31,8 +43,47 @@ set -euo pipefail
 : "${MANUAL_MODE_INPUT:=}"
 : "${MANUAL_MODE_EVENT:=}"
 
+release_failed=false
+[ "$DOCKER_RELEASE_RESULT" = "failure" ] || [ "$DOCKER_RELEASE_RESULT" = "cancelled" ] && release_failed=true
+web_failed=false
+[ "$DOCKER_WEB_RESULT" = "failure" ] || [ "$DOCKER_WEB_RESULT" = "cancelled" ] && web_failed=true
+
+backend_affected=false
+[ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ] && backend_affected=true
+
+both_touched=false
+[ "$backend_affected" = "true" ] && [ "$WEB_AFFECTED" = "true" ] && both_touched=true
+
 backend_deploy=false
 frontend_deploy=false
+coupled_hold=false
+
+# Shared by the automatic push plan and workflow_dispatch's `auto` mode --
+# both derive the plan from affected-detection + lane results the same way.
+compute_auto_plan() {
+  if [ "$both_touched" = "true" ]; then
+    if [ "$release_failed" = "true" ] || [ "$web_failed" = "true" ]; then
+      # Coupled push, one side red: hold both back rather than deploy a
+      # frontend/backend pair that was never actually tested together.
+      coupled_hold=true
+    elif [ "$DOCKER_RELEASE_RESULT" = "success" ] && [ "$DOCKER_WEB_RESULT" = "success" ]; then
+      backend_deploy=true
+      frontend_deploy=true
+    fi
+    # Neither failed nor both-succeeded (e.g. a hypothetical 'skipped' on an
+    # affected lane) -- no verified success on both sides, so don't deploy,
+    # but this isn't a failure either, so don't badge it as a coupled hold.
+  else
+    if [ "$backend_affected" = "true" ] && [ "$DOCKER_RELEASE_RESULT" = "success" ]; then
+      backend_deploy=true
+    fi
+    # Single-side push: frontend syncs from source, not docker-web's image,
+    # and isn't coupled to a backend change this time -- keep it decoupled
+    # from docker-web's result, same as before this change.
+    frontend_deploy=true
+  fi
+}
+
 manual_mode="${MANUAL_MODE_INPUT:-}"
 if [ -z "$manual_mode" ]; then
   manual_mode="${MANUAL_MODE_EVENT:-}"
@@ -47,22 +98,15 @@ on_master=false
 if [ "$on_master" = "false" ]; then
   echo "Not on master; deploy jobs disabled."
 elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-  # Manual overrides are an explicit operator decision -- they intentionally
-  # bypass affected-detection AND lane-result gating. This is the documented
-  # self-heal remedy for drift: `deployment_mode=both` (or backend-only /
-  # frontend-only) redeploys whatever is currently tagged :latest in GHCR,
-  # regardless of what this run's affected-detection or build lanes decided.
   case "$manual_mode" in
     auto)
-      if [ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ]; then
-        if [ "$DOCKER_RELEASE_RESULT" = "success" ]; then
-          backend_deploy=true
-        fi
-      fi
-      # Frontend sync to the Vercel source repo builds from source, not from
-      # docker-web's image, so it is not gated on docker-web's result.
-      frontend_deploy=true
+      compute_auto_plan
       ;;
+    # Explicit operator overrides bypass affected-detection, lane-result
+    # gating, AND the coupling rule -- this is the documented self-heal
+    # remedy for drift: `deployment_mode=both` (or backend-only /
+    # frontend-only) redeploys whatever is currently tagged :latest in
+    # GHCR, regardless of what this run's build lanes decided.
     backend-only)
       backend_deploy=true
       ;;
@@ -81,21 +125,15 @@ elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
       ;;
   esac
 else
-  # Automatic push-triggered plan: a failed/cancelled docker-release means no
-  # verified new backend image for this run, so never deploy on a guess.
-  if [ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ]; then
-    if [ "$DOCKER_RELEASE_RESULT" = "success" ]; then
-      backend_deploy=true
-    fi
-  fi
-  frontend_deploy=true
+  # Automatic push-triggered plan.
+  compute_auto_plan
 fi
 
 # Orphan detection: images landed in GHCR tagged :latest but the deploy that
 # would roll them out did not run this time, for ANY reason (lane failure,
-# cancellation, or the plan above simply deciding not to deploy). Scoped to
-# master: off-master manual builds intentionally never deploy and must not be
-# reported as drift.
+# cancellation, the plan deciding not to deploy, or a coupling hold).
+# Scoped to master: off-master manual builds intentionally never deploy and
+# must not be reported as drift.
 backend_orphaned=false
 frontend_orphaned=false
 if [ "$on_master" = "true" ]; then
@@ -105,6 +143,13 @@ if [ "$on_master" = "true" ]; then
   if [ "$DOCKER_WEB_RESULT" = "success" ] && [ "$frontend_deploy" != "true" ]; then
     frontend_orphaned=true
   fi
+  # A coupling hold strands BOTH sides together even when only one lane
+  # actually failed -- e.g. web failed, backend published fine but is held
+  # back anyway. Flag both explicitly so the healthy side isn't missed.
+  if [ "$coupled_hold" = "true" ]; then
+    backend_orphaned=true
+    frontend_orphaned=true
+  fi
 fi
 
 {
@@ -112,10 +157,11 @@ fi
   echo "frontend_deploy=$frontend_deploy"
   echo "backend_orphaned=$backend_orphaned"
   echo "frontend_orphaned=$frontend_orphaned"
+  echo "coupled_hold=$coupled_hold"
   echo "docker_release_result=$DOCKER_RELEASE_RESULT"
   echo "docker_web_result=$DOCKER_WEB_RESULT"
 } >> "$GITHUB_OUTPUT"
 
-echo "Deploy plan => backend: $backend_deploy, frontend: $frontend_deploy"
+echo "Deploy plan => backend: $backend_deploy, frontend: $frontend_deploy, coupled_hold: $coupled_hold"
 echo "Orphan check => backend_orphaned: $backend_orphaned, frontend_orphaned: $frontend_orphaned"
-echo "  docker-release result: $DOCKER_RELEASE_RESULT (images_published=$BACKEND_IMAGES_PUBLISHED), docker-web result: $DOCKER_WEB_RESULT"
+echo "  both_touched: $both_touched, docker-release result: $DOCKER_RELEASE_RESULT (images_published=$BACKEND_IMAGES_PUBLISHED), docker-web result: $DOCKER_WEB_RESULT"


### PR DESCRIPTION
## Summary

On 2026-08-10 a master push saw `docker-release` succeed (new api/voice-agent/bot
images pushed to GHCR as `:latest`) while `docker-web` failed. `deployment-plan`
had `needs: [docker-release, docker-web, docker-grafana]` with no `if:`, so
GitHub's implicit all-success gating skipped it entirely — which skipped
`trigger-deploy` and `trigger-web` too. New backend images sat in the registry
while production kept running the old ones, with no notification. Worse,
`deployment-plan` only ever set `backend_deploy=true` when *that push's*
`api_affected`/`bots_affected` was true, so a later web-only push would never
pick up the stranded backend deploy — the drift would persist indefinitely,
and any container restart on the Swarm host pulls `:latest` and silently
starts the undeployed build.

This PR implements the two additive fixes scoped for this incident, plus an
amendment covering a coupling gap the initial fix introduced:

1. **Deploy what's ready.** `deployment-plan` now runs with `if: always()`
   and evaluates each lane's `.result` explicitly instead of relying on
   implicit all-success gating. A failed `docker-web` no longer blocks a
   ready backend deploy, and vice versa — **but only when the push touches
   just one side.**
2. **Never let publish-without-deploy go silent, and self-heal.** A
   `backend_orphaned`/`frontend_orphaned` check fires a loud Discord alert
   (the same webhook/action `deploy-swarm-prod.yml` and `deploy-frontend.yml`
   already use) whenever an image lane published to GHCR but its deploy did
   not run — for any reason. The alert names the operator's one-command
   remedy, which already existed in this workflow: `gh workflow run build.yml
   --ref master -f deployment_mode=both`.
3. **Amendment — couple backend/web deploys when one commit touches both.**
   Deploying only the healthy side of a push that changes both backend and
   web recreates the exact class of bug the old all-or-nothing gate
   accidentally prevented for coupled pushes: forward skew (e.g. a new
   frontend live against an API the still-old backend doesn't serve). A push
   touching only one side is unaffected by this and keeps deploying
   independently — that's fix #1 above, unchanged.

## What changed

- **`scripts/ci/compute-deploy-plan.sh`** (new): the deploy-plan decision
  logic, extracted out of the inline workflow step per
  `.github/CLAUDE.md`'s "workflow files are thin orchestration" rule — the
  added branching was too much to keep inline. Computes `backend_deploy`,
  `frontend_deploy`, `backend_orphaned`, `frontend_orphaned`, `coupled_hold`.
- **`.github/workflows/build.yml`**:
  - `docker-release` now records an `images_published` job output right
    after its push steps (`release-apps`, `release-bots`,
    `ensure-bot-images`), *before* the Discord slash-command sync step. That
    later step can fail on an unrelated Discord API error and would
    otherwise flip the job's overall `.result` to `failure` even though the
    images had already landed in GHCR — which would have made the orphan
    check itself blind to exactly the kind of partial failure it exists to
    catch.
  - `docker-web` now exposes a `web_affected` job output (wired from its
    existing "Check if web is affected" step) so `deployment-plan` can see
    both sides' affected-detection, not just `docker-release`'s.
  - `deployment-plan` gets `if: always()`, keeps the same three-lane `needs:`
    (kept only for sequencing — deploy planning must not race ahead of the
    build lanes), and calls the script with each lane's `.result`,
    `images_published`, and both sides' affected flags (`api_affected`,
    `bots_affected`, `web_affected`) as env.
  - **Single-side push** (only backend or only web affected):
    `backend_deploy` requires `docker-release.result == 'success'` AND
    api/bots affected. `frontend_deploy` keeps its existing rule (always
    true on a master push) and stays decoupled from `docker-web`'s result —
    the frontend deploy syncs `master` to a private fork for Vercel to build
    from source, it never consumes `docker-web`'s image.
  - **Coupled push** (both backend AND web affected by the same commit):
    both `docker-release` and `docker-web` must succeed for either to
    deploy. If either failed or was cancelled, `coupled_hold=true` and BOTH
    `backend_deploy`/`frontend_deploy` stay `false` — the one case where a
    lane failure still blocks the healthy side, by design, to prevent
    forward skew.
  - New `notify-publish-without-deploy` job posts the Discord alert when
    either orphan flag is set — with a distinct message for `coupled_hold`
    ("held together because this commit couples them") versus the generic
    per-side orphan copy.
  - `trigger-deploy` / `trigger-web` are **unchanged** — they still consume
    only `deployment-plan.outputs.backend_deploy` /
    `.outputs.frontend_deploy` as `'true'`/`'false'` strings. Contract
    preserved.
- **`.github/workflows/README.md`**: flow diagram and the `build.yml`
  per-workflow steps section updated to describe `if: always()` planning,
  the single-side vs. coupled branching, orphan/coupled-hold detection, and
  the notify job (required in the same PR per this file's own header).

## Result matrix (this is workflow logic — no unit test can exercise the
GitHub Actions scheduler, so this reasoning is the evidence)

All cases below assume `github.ref == refs/heads/master` and a normal `push`
event unless noted. `images_published` is `docker-release`'s own signal
(true only if a push step for an affected scope actually succeeded), not
just its job `.result`. "Affected" columns show which side(s) this push
touched — that's what decides single-side vs. coupled handling.

### Single-side pushes (only one of backend/web affected)

| # | backend affected | web affected | docker-release | docker-web | backend_deploy | frontend_deploy | backend_orphaned | frontend_orphaned | Notes |
|---|---|---|---|---|---|---|---|---|---|
| 1 | yes | no | success | failure | true | true | false | false | The observed incident. Backend deploy runs despite the sibling lane failing; frontend still syncs from source (it never consumed docker-web's image). |
| 2 | yes | no | failure | success | false | true | false | false | No new backend image was verified this run — never deploy on a guess. |
| 3 | no | yes | success | failure | false | true | false | false | Web-only push, docker-web fails: no backend involved, nothing to couple, no orphan (nothing was published). |
| 4 | no | no | success | success | false | true | false | false | Quiet day — neither lane published anything backend-relevant; not an orphan. |
| 5 | yes | no | cancelled | success | false | true | false | false | Cancellation treated the same as failure for gating — no proof of a completed publish. |
| 6 | yes | no | failure late (Discord sync step failed) but images_published=true | success | false | true | true | false | The exact partial-failure case images_published exists to catch: images already in GHCR, job still reports failure, alert fires. |

### Coupled pushes (both backend AND web affected by the same commit) — new in this amendment

| # | docker-release | docker-web | backend_deploy | frontend_deploy | coupled_hold | backend_orphaned | frontend_orphaned | Notes |
|---|---|---|---|---|---|---|---|---|
| 7 | success | failure | false | false | true | true | true | Coupled, web lane failed. Backend images WERE published (images_published=true) but held back anyway — shipping the backend alone here still risks an untested pairing, and the alert flags both sides so the healthy one isn't missed. |
| 8 | failure | success | false | false | true | true | true | Coupled, backend lane failed. Symmetric to #7 — web is healthy but held back too. |
| 9 | success | success | true | true | false | false | false | Coupled, both green — deploy together, no different from shipping either side alone in this case. |
| 10 | cancelled | cancelled | false | false | true | true | true | Coupled, both cancelled — same hold logic, cancellation counts as a failure for the coupling decision. |

### Manual overrides and off-master

| # | Mode/context | docker-release | docker-web | backend_deploy | frontend_deploy | coupled_hold | Notes |
|---|---|---|---|---|---|---|---|
| 11 | workflow_dispatch -f deployment_mode=both, coupled push, both lanes failed this run | failure | failure | true (override) | true (override) | false | Manual override bypasses affected-detection, lane-result gating, AND the coupling rule — deploys whatever is already tagged :latest in GHCR. This is the intended self-heal remedy named in the Discord alert. |
| 12 | workflow_dispatch -f deployment_mode=auto, coupled push, web lane failed | success | failure | false | false | true | Manual auto mode uses the same coupling logic as an automatic push — it's not an override, just a manually-triggered run of the normal decision. |
| 13 | Off master (e.g. manual dispatch from a feature branch), coupled push, web lane failed | success | failure | false | false | false | Deploys are disabled by design off master; never flagged as drift regardless of coupling. |

I ran `scripts/ci/compute-deploy-plan.sh` directly (not just read it) against
all 13 of the scenarios above and confirmed the printed outputs match this
table exactly before writing it down.

## Self-heal: which option, and why

The task allowed two options: (a) a cheap, reliable "is prod actually running
`:latest`" signal (e.g. SSH digest comparison via the existing Swarm context),
or (b) if no such signal exists cheaply, a `workflow_dispatch` input that
forces a deploy regardless of affected-detection.

**I implemented (b) — but it already existed.** `build.yml`'s
`workflow_dispatch` already has a `deployment_mode` choice input
(`auto` / `backend-only` / `frontend-only` / `both` / `none`), and `both`
already bypasses affected-detection entirely (and now also bypasses the new
coupling rule), deploying whatever image is currently tagged `:latest` in
GHCR. What was missing was that operators had no way to *know* a redeploy
was needed, and no pointer to this remedy when it was. This PR's Discord
alert closes that gap by naming `gh workflow run build.yml --ref master -f
deployment_mode=both` explicitly as the fix, every time drift (or a coupled
hold) is detected.

I did not build the SSH-digest-comparison signal (option a) — reaching it
from `build.yml` would mean duplicating `deploy-swarm-prod.yml`'s
`setup-swarm-context` SSH plumbing into the build workflow purely for a
read-only probe: new secret exposure, a new failure mode, and scope creep
for a workflow whose job is to build and plan, not reach into production.
`deployment_mode=both` already gives an equivalent, simpler, already-tested
remedy.

## What I could NOT verify

- **No live GitHub Actions run.** `actionlint` confirms no new lint findings
  in the changed ranges (only pre-existing `runner-label`/`SC2086` noise
  elsewhere in the file, none introduced by this change — same 8 findings
  before and after the coupling amendment) and Python's `yaml.safe_load`
  confirms the changed YAML parses. I exercised `compute-deploy-plan.sh`
  directly against every scenario in the matrix above and confirmed its
  literal output, but did not — and could not from this environment —
  trigger an actual `workflow_dispatch`/push run of `build.yml` against
  GHCR/Discord/the Swarm host to watch the real jobs fire, the real Discord
  webhook post, or a real coupled failure produce the hold end-to-end.
- **Discord message rendering**: the `format(...)` + `&&`/`||` ternary
  expressions in the notify job's `message:` block follow the exact pattern
  already used in `deploy-frontend.yml`, but I have not seen the actual
  rendered Discord message (GitHub Actions expression evaluation quirks
  around empty-string branches are usually harmless whitespace, but only a
  live run confirms the exact formatting), including the new coupled-vs-
  generic branching in that message.

## Known gap, not fixed here

**`:latest` is applied at build time, not deploy time.** The compose file
(`infra/docker/docker-compose.prod.yml`) pins every image to a mutable
`:latest` tag, and `docker-release`/`docker-web`/`docker-grafana` overwrite
that tag the moment a build succeeds — regardless of whether a deploy
actually runs afterward. This is the structural reason the original incident
could happen at all: the registry's `:latest` can silently diverge from
what's running, and *any* container restart on the Swarm host (a crash, an
OOM, a manual `docker service update`, even Swarm's own health-check-driven
rescheduling) re-pulls `:latest` and picks up an untested, undeployed build
with zero explicit action. This PR's orphan/coupled-hold alert makes the
drift visible and gives an operator a fast manual remedy, but it does not
close the window between "image published" and "image deployed" — during
that window the risk above is still live, for both single-side and coupled
pushes.

Fixing it properly means moving tag assignment from build time to deploy
time: build lanes would publish immutable, uniquely-tagged images (e.g. by
SHA or run ID), and only the deploy workflow — at the moment it actually
runs `docker stack deploy` — would move a `:latest`-equivalent pointer (or
reference the immutable tag directly in the compose file, rendered/templated
per deploy). That touches nx release's Docker publishing config, both deploy
workflows, and `docker-compose.prod.yml` simultaneously, and a mistake in the
tag-reference wiring means production tries to pull a tag that doesn't exist
— a rollout that needs its own deliberate PR, a rehearsal (there's already a
`scripts/swarm/lab-rehearsal.sh` for exactly this), and is explicitly out of
scope for this change.
