### PR TITLE
fix(api): URL-encode calendar/event IDs at the two sites #930 missed

### DIFF
--- a/apps/api/app/agents/tools/integrations/calendar_tool.py
+++ b/apps/api/app/agents/tools/integrations/calendar_tool.py
@@ -48,12 +48,12 @@ from app.templates.docstrings.calendar_tool_docs import (
     CUSTOM_LIST_CALENDARS as CUSTOM_LIST_CALENDARS_DOC,
     CUSTOM_PATCH_EVENT as CUSTOM_PATCH_EVENT_DOC,
 )
+from app.utils.calendar_utils import calendar_events_endpoint
 from app.utils.context_utils import execute_tool
 from app.utils.errors import AppError
 from app.utils.timezone import Timezone, home_timezone_from_config
 from shared.py.wide_events import log
 
-CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
 CALENDAR_TOOLKIT = "GOOGLECALENDAR"
 
 _T = TypeVar("_T")
@@ -302,7 +302,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
         result = _run_sync(
             calendar_service.get_calendar_events(
                 user_id=user_id,
-                selected_calendars=request.calendar_ids if request.calendar_ids else None,
+                selected_calendars=request.calendar_ids or None,
                 time_min=time_min,
                 time_max=request.time_max,
                 max_results=request.max_results,
@@ -388,10 +388,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
                 event = proxy_request_sync(
                     user_id=user_id,
                     toolkit=CALENDAR_TOOLKIT,
-                    endpoint=(
-                        f"{CALENDAR_API_BASE}/calendars/"
-                        f"{event_ref.calendar_id}/events/{event_ref.event_id}"
-                    ),
+                    endpoint=calendar_events_endpoint(event_ref.calendar_id, event_ref.event_id),
                     method="GET",
                 )
                 results.append(
@@ -441,10 +438,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
                 proxy_request_sync(
                     user_id=user_id,
                     toolkit=CALENDAR_TOOLKIT,
-                    endpoint=(
-                        f"{CALENDAR_API_BASE}/calendars/"
-                        f"{event_ref.calendar_id}/events/{event_ref.event_id}"
-                    ),
+                    endpoint=calendar_events_endpoint(event_ref.calendar_id, event_ref.event_id),
                     method="DELETE",
                     query={"sendUpdates": request.send_updates},
                 )
@@ -501,9 +495,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
         event = proxy_request_sync(
             user_id=user_id,
             toolkit=CALENDAR_TOOLKIT,
-            endpoint=(
-                f"{CALENDAR_API_BASE}/calendars/{request.calendar_id}/events/{request.event_id}"
-            ),
+            endpoint=calendar_events_endpoint(request.calendar_id, request.event_id),
             method="PATCH",
             body=body,
             query={"sendUpdates": request.send_updates},
@@ -521,7 +513,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
         del execute_request  # unused: framework-mandated custom-tool signature
         log.set(tool={"integration": "google_calendar", "action": "add_recurrence"})
         user_id = _get_user_id(auth_credentials)
-        endpoint = f"{CALENDAR_API_BASE}/calendars/{request.calendar_id}/events/{request.event_id}"
+        endpoint = calendar_events_endpoint(request.calendar_id, request.event_id)
 
         event = proxy_request_sync(
             user_id=user_id,
@@ -633,7 +625,7 @@ def register_calendar_custom_tools(composio: Composio) -> list[str]:
                 created_event = proxy_request_sync(
                     user_id=user_id,
                     toolkit=CALENDAR_TOOLKIT,
-                    endpoint=f"{CALENDAR_API_BASE}/calendars/{event.calendar_id}/events",
+                    endpoint=calendar_events_endpoint(event.calendar_id),
                     method="POST",
                     body=body,
                     query=query,

--- a/apps/api/app/services/calendar_service.py
+++ b/apps/api/app/services/calendar_service.py
@@ -685,7 +685,10 @@ async def delete_calendar_event(
     try:
         await _proxy(
             user_id,
-            endpoint=f"{CALENDAR_API_BASE}/calendars/{calendar_id}/events/{event.event_id}",
+            endpoint=(
+                f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}"
+                f"/events/{quote(event.event_id, safe='')}"
+            ),
             method="DELETE",
         )
         return EventDeleteResponse(success=True, message="Event deleted successfully")
@@ -763,7 +766,10 @@ async def update_calendar_event(
 ) -> GoogleCalendarEventResource:
     """Update a calendar event using the Google Calendar API."""
     calendar_id = event.calendar_id or "primary"
-    endpoint = f"{CALENDAR_API_BASE}/calendars/{calendar_id}/events/{event.event_id}"
+    endpoint = (
+        f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}"
+        f"/events/{quote(event.event_id, safe='')}"
+    )
 
     try:
         existing_event = GoogleCalendarEventResource.model_validate(

--- a/apps/api/app/services/calendar_service.py
+++ b/apps/api/app/services/calendar_service.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from urllib.parse import quote
 
 from fastapi import HTTPException
 
@@ -31,11 +30,11 @@ from app.models.calendar_models import (
     GoogleConferenceSolutionKey,
 )
 from app.services.composio.proxy_client import ProxyMethod, proxy_request
+from app.utils.calendar_utils import CALENDAR_API_BASE, calendar_events_endpoint
 from app.utils.errors import AppError
 from shared.py.wide_events import log
 
 CALENDAR_TOOLKIT = "GOOGLECALENDAR"
-CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
 _DATE_FORMAT = "%Y-%m-%d"
 _EVENT_NOT_FOUND_DETAIL = "Event not found or access denied"
 
@@ -144,7 +143,7 @@ async def fetch_calendar_events(
     return GoogleCalendarEventsPage.model_validate(
         await _proxy(
             user_id,
-            endpoint=f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}/events",
+            endpoint=calendar_events_endpoint(calendar_id),
             method="GET",
             query=query,
         )
@@ -500,7 +499,7 @@ async def create_calendar_event(
     created_event = GoogleCalendarEventResource.model_validate(
         await _proxy(
             user_id,
-            endpoint=f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}/events",
+            endpoint=calendar_events_endpoint(calendar_id),
             method="POST",
             body=payload,
             query=query_params or None,
@@ -664,7 +663,7 @@ async def search_events_in_calendar(
     result = GoogleCalendarEventsPage.model_validate(
         await _proxy(
             user_id,
-            endpoint=f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}/events",
+            endpoint=calendar_events_endpoint(calendar_id),
             method="GET",
             query=params,
         )
@@ -685,10 +684,7 @@ async def delete_calendar_event(
     try:
         await _proxy(
             user_id,
-            endpoint=(
-                f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}"
-                f"/events/{quote(event.event_id, safe='')}"
-            ),
+            endpoint=calendar_events_endpoint(calendar_id, event.event_id),
             method="DELETE",
         )
         return EventDeleteResponse(success=True, message="Event deleted successfully")
@@ -766,10 +762,7 @@ async def update_calendar_event(
 ) -> GoogleCalendarEventResource:
     """Update a calendar event using the Google Calendar API."""
     calendar_id = event.calendar_id or "primary"
-    endpoint = (
-        f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}"
-        f"/events/{quote(event.event_id, safe='')}"
-    )
+    endpoint = calendar_events_endpoint(calendar_id, event.event_id)
 
     try:
         existing_event = GoogleCalendarEventResource.model_validate(

--- a/apps/api/app/utils/calendar_utils.py
+++ b/apps/api/app/utils/calendar_utils.py
@@ -1,4 +1,23 @@
-# Calendar helpers — unwired as of 2026-06; kept for the planned calendar feature.
+"""Calendar URL helpers shared by calendar_service.py and calendar_tool.py."""
+
+from urllib.parse import quote
+
+CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
+
+
+def calendar_events_endpoint(calendar_id: str, event_id: str | None = None) -> str:
+    """Build a Google Calendar events endpoint, percent-encoding the calendar
+    and event IDs. Google calendar IDs commonly contain '@'/'#' (e.g.
+    "user@group.calendar.google.com", "#contacts@group.v.calendar.google.com"),
+    which break the URL path if interpolated raw.
+    """
+    endpoint = f"{CALENDAR_API_BASE}/calendars/{quote(calendar_id, safe='')}/events"
+    if event_id is not None:
+        endpoint += f"/{quote(event_id, safe='')}"
+    return endpoint
+
+
+# The functions below are unwired as of 2026-06; kept for the planned calendar feature.
 # Fully commented so vulture does not flag them; re-enable when the calendar
 # event-resolution flow is wired back in.
 #

--- a/apps/api/tests/unit/services/test_calendar_service.py
+++ b/apps/api/tests/unit/services/test_calendar_service.py
@@ -318,6 +318,23 @@ class TestDeleteCalendarEvent:
         assert exc.value.status_code == 404
         assert "Event not found" in str(exc.value.detail)
 
+    async def test_percent_encodes_calendar_id_with_reserved_chars(self, mock_proxy):
+        """Google calendar IDs like 'user@group.calendar.google.com' or
+        '#contacts@group.v.calendar.google.com' contain '@'/'#'. Unencoded,
+        those characters break the URL path (404s or a truncated path)."""
+        mock_proxy.return_value = None
+        await delete_calendar_event(
+            EventDeleteRequest(
+                event_id="evt-1", calendar_id="#contacts@group.v.calendar.google.com"
+            ),
+            USER_ID,
+        )
+        endpoint = mock_proxy.call_args.kwargs["endpoint"]
+        assert "#contacts@group.v.calendar.google.com" not in endpoint
+        assert endpoint.endswith(
+            "/calendars/%23contacts%40group.v.calendar.google.com/events/evt-1"
+        )
+
 
 class TestUpdateCalendarEvent:
     async def test_updates_summary(self, mock_proxy):
@@ -334,6 +351,25 @@ class TestUpdateCalendarEvent:
         assert mock_proxy.call_args_list[0].kwargs["method"] == "GET"
         assert mock_proxy.call_args_list[1].kwargs["method"] == "PUT"
         assert mock_proxy.call_args_list[1].kwargs["body"]["summary"] == "New"
+
+    async def test_percent_encodes_calendar_id_with_reserved_chars(self, mock_proxy):
+        """Same bug as delete_calendar_event: the GET-existing + PUT-update
+        endpoint interpolates calendar_id/event_id unencoded."""
+        mock_proxy.side_effect = [
+            {"summary": "Old", "description": "d", "start": {}, "end": {}},
+            {"id": "evt", "summary": "New"},
+        ]
+        await update_calendar_event(
+            EventUpdateRequest(
+                event_id="evt",
+                calendar_id="user@group.calendar.google.com",
+                summary="New",
+            ),
+            USER_ID,
+        )
+        get_endpoint = mock_proxy.call_args_list[0].kwargs["endpoint"]
+        assert "user@group.calendar.google.com" not in get_endpoint
+        assert get_endpoint.endswith("/calendars/user%40group.calendar.google.com/events/evt")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/tools/test_calendar_tool.py
+++ b/apps/api/tests/unit/tools/test_calendar_tool.py
@@ -20,7 +20,6 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from app.agents.tools.integrations.calendar_tool import (
-    CALENDAR_API_BASE,
     _extract_datetime,
     _format_calendar_for_stream,
     _format_calendar_option_for_stream,
@@ -49,6 +48,7 @@ from app.models.calendar_models import (
     SingleEventInput,
 )
 from app.models.common_models import GatherContextInput
+from app.utils.calendar_utils import CALENDAR_API_BASE
 from app.utils.errors import AppError
 
 MODULE = "app.agents.tools.integrations.calendar_tool"
@@ -862,6 +862,29 @@ class TestGetEvent:
         proxy.assert_not_called()
         assert out["events"] == []
 
+    def test_percent_encodes_calendar_id_with_reserved_chars(self, tools) -> None:
+        # Google calendar IDs like "user@group.calendar.google.com" or
+        # "#contacts@group.v.calendar.google.com" contain '@'/'#'. Unencoded,
+        # those characters break the URL path (same bug as calendar_service.py,
+        # fixed at the root by routing every endpoint through
+        # calendar_events_endpoint()).
+        with patch(f"{MODULE}.proxy_request_sync", return_value={"id": "e1"}) as proxy:
+            tools["CUSTOM_GET_EVENT"](
+                GetEventInput(
+                    events=[
+                        EventReference(
+                            event_id="e1",
+                            calendar_id="user@group.calendar.google.com",
+                        )
+                    ]
+                ),
+                EXECUTE_REQUEST,
+                AUTH,
+            )
+        endpoint = proxy.call_args.kwargs["endpoint"]
+        assert "user@group.calendar.google.com" not in endpoint
+        assert endpoint.endswith("/calendars/user%40group.calendar.google.com/events/e1")
+
 
 # ---------------------------------------------------------------------------
 # CUSTOM_DELETE_EVENT
@@ -930,6 +953,24 @@ class TestDeleteEvent:
                 tools["CUSTOM_DELETE_EVENT"](
                     DeleteEventInput(events=[EventReference(event_id="e1")]), EXECUTE_REQUEST, AUTH
                 )
+
+    def test_percent_encodes_calendar_id_with_reserved_chars(self, tools) -> None:
+        with patch(f"{MODULE}.proxy_request_sync", return_value=None) as proxy:
+            tools["CUSTOM_DELETE_EVENT"](
+                DeleteEventInput(
+                    events=[
+                        EventReference(
+                            event_id="e1",
+                            calendar_id="#contacts@group.v.calendar.google.com",
+                        )
+                    ]
+                ),
+                EXECUTE_REQUEST,
+                AUTH,
+            )
+        endpoint = proxy.call_args.kwargs["endpoint"]
+        assert "#contacts@group.v.calendar.google.com" not in endpoint
+        assert endpoint.endswith("/calendars/%23contacts%40group.v.calendar.google.com/events/e1")
 
 
 # ---------------------------------------------------------------------------
@@ -1003,6 +1044,21 @@ class TestPatchEvent:
                     PatchEventInput(event_id="e1", summary="x"), EXECUTE_REQUEST, AUTH
                 )
 
+    def test_percent_encodes_calendar_id_with_reserved_chars(self, tools) -> None:
+        with patch(f"{MODULE}.proxy_request_sync", return_value={"id": "e1"}) as proxy:
+            tools["CUSTOM_PATCH_EVENT"](
+                PatchEventInput(
+                    event_id="e1",
+                    calendar_id="user@group.calendar.google.com",
+                    summary="New title",
+                ),
+                EXECUTE_REQUEST,
+                AUTH,
+            )
+        endpoint = proxy.call_args.kwargs["endpoint"]
+        assert "user@group.calendar.google.com" not in endpoint
+        assert endpoint.endswith("/calendars/user%40group.calendar.google.com/events/e1")
+
 
 # ---------------------------------------------------------------------------
 # CUSTOM_ADD_RECURRENCE
@@ -1069,6 +1125,20 @@ class TestAddRecurrence:
                     AddRecurrenceInput(event_id="e1", frequency="DAILY"), EXECUTE_REQUEST, AUTH
                 )
         assert proxy.call_count == 1
+
+    def test_percent_encodes_calendar_id_with_reserved_chars(self, tools) -> None:
+        out, proxy = self._run(
+            tools,
+            AddRecurrenceInput(
+                event_id="e1",
+                calendar_id="#contacts@group.v.calendar.google.com",
+                frequency="DAILY",
+            ),
+        )
+        endpoint = proxy.call_args_list[0].kwargs["endpoint"]
+        assert "#contacts@group.v.calendar.google.com" not in endpoint
+        assert endpoint.endswith("/calendars/%23contacts%40group.v.calendar.google.com/events/e1")
+        assert out["event"] == {"id": "e1", "updated": True}
 
 
 # ---------------------------------------------------------------------------
@@ -1299,6 +1369,26 @@ class TestCreateEvent:
                 }
             ]
         }
+
+    def test_percent_encodes_calendar_id_with_reserved_chars(self, tools, writer) -> None:
+        with patch(f"{MODULE}.get_config", return_value={"configurable": {}}):
+            _, proxy = self._run(
+                tools,
+                CreateEventInput(
+                    events=[
+                        SingleEventInput(
+                            summary="Sync",
+                            start_datetime="2026-01-15T10:00:00",
+                            calendar_id="user@group.calendar.google.com",
+                        )
+                    ],
+                    confirm_immediately=True,
+                ),
+                metadata=({"user@group.calendar.google.com": "#ff0000"}, {}),
+            )
+        endpoint = proxy.call_args.kwargs["endpoint"]
+        assert "user@group.calendar.google.com" not in endpoint
+        assert endpoint.endswith("/calendars/user%40group.calendar.google.com/events")
 
     # -- draft path --------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Google calendar IDs commonly contain '@'/'#' (e.g. `user@group.calendar.google.com`, `#contacts@group.v.calendar.google.com`). Interpolated raw into a Google Calendar API URL path, these truncate or 404 the request.

PR #930 fixed three sites in `calendar_service.py` inline with `urllib.parse.quote(calendar_id, safe="")`. Two more sites in the same file (`delete_calendar_event`, `update_calendar_event`) were added by a later refactor while #930 sat conflicted and missed the fix. A further five sites in `apps/api/app/agents/tools/integrations/calendar_tool.py` (`CUSTOM_GET_EVENT`, `CUSTOM_DELETE_EVENT`, `CUSTOM_PATCH_EVENT`, `CUSTOM_ADD_RECURRENCE`, and event creation) had the identical bug and were never touched by #930 at all.

That's 8 call sites across 2 modules hand-building the same URL shape. Rather than patching each one with another inline `quote()` call, this PR extracts one canonical helper:

**`calendar_events_endpoint(calendar_id, event_id=None)`** in `apps/api/app/utils/calendar_utils.py`, alongside the `CALENDAR_API_BASE` constant (previously duplicated verbatim in both `calendar_service.py` and `calendar_tool.py`). It percent-encodes every dynamic segment with `quote(..., safe="")` and builds `.../calendars/{calendar_id}/events` or `.../calendars/{calendar_id}/events/{event_id}`.

All 8 sites — including the 3 in `calendar_service.py` that #930 already fixed inline — now call this one function. No behavior change beyond the encoding the 5 previously-broken `calendar_tool.py` sites gain.

## Why #930 missed the calendar_service.py sites

`delete_calendar_event` and `update_calendar_event` were introduced/refactored in a change that landed while #930 was open with conflicts, so the two new interpolation sites never went through #930's fix pass. The `calendar_tool.py` sites are a separate module entirely and were out of #930's scope from the start.

## Red-then-green evidence

**`calendar_service.py`** — added `test_percent_encodes_calendar_id_with_reserved_chars` to `TestDeleteCalendarEvent` and `TestUpdateCalendarEvent` in `tests/unit/services/test_calendar_service.py`. RED before the fix:
```
AssertionError: assert '#contacts@group.v.calendar.google.com' not in endpoint
  '#contacts@group.v.calendar.google.com' is contained here:
    https://www.googleapis.com/calendar/v3/calendars/#contacts@group.v.calendar.google.com/events/evt-1
```

**`calendar_tool.py`** — added `test_percent_encodes_calendar_id_with_reserved_chars` to `TestGetEvent`, `TestDeleteEvent`, `TestPatchEvent`, `TestAddRecurrence`, and `TestCreateEvent` in `tests/unit/tools/test_calendar_tool.py` (one per fixed site). RED-first proof on the representative site (`TestGetEvent`, temporarily reverted to the raw f-string):
```
AssertionError: assert 'user@group.calendar.google.com' not in endpoint
  'user@group.calendar.google.com' is contained here:
    https://www.googleapis.com/calendar/v3/calendars/user@group.calendar.google.com/events/e1
```

GREEN after the fix, both files together:
```
148 passed in 7.40s
```

Full calendar-related unit suite (`tests/unit -k calendar`): **365 passed**.

`nx lint api` (ruff) and `mypy --ignore-missing-imports` both pass clean on every changed file (`calendar_service.py`, `calendar_tool.py`, `calendar_utils.py`, and both test files).

## Test plan

- [x] `uv run pytest tests/unit/services/test_calendar_service.py tests/unit/tools/test_calendar_tool.py` — 148 passed
- [x] `uv run pytest tests/unit -k calendar` — 365 passed
- [x] `nx lint api` (ruff) on all changed files — clean
- [x] `mypy --ignore-missing-imports` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)