### PR TITLE
fix(observability): un-break Grafana alerting provisioning; stop cadvisor OOM kills

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -763,7 +763,10 @@ services:
         delay: 5s
       resources:
         limits:
-          memory: 256m
+          # cAdvisor's steady-state RSS on this node is ~245 MiB (33 containers,
+          # 30s housekeeping) — a 256m cap sat at 95% and OOM-killed it several
+          # times a day. 512m leaves real headroom for scrape/housekeeping spikes.
+          memory: 512m
           cpus: "0.25"
       placement:
         constraints:
@@ -968,6 +971,12 @@ services:
       GF_SMTP_FROM_ADDRESS: ${GRAFANA_SMTP_FROM_ADDRESS:-aryan@heygaia.io}
       GF_SMTP_FROM_NAME: "GAIA Alerts"
       GRAFANA_ALERT_EMAIL: ${GRAFANA_ALERT_EMAIL:-aryan@heygaia.io}
+      # Slack channel the alert contact points post to (contact-points.yaml →
+      # $__env{SLACK_ALERT_CHANNEL}). The webhook URL itself is the
+      # gaia_grafana_slack_webhook secret, read via $__file{} — never an env var.
+      # An unset value here makes alerting provisioning fail and Grafana
+      # crash-loop, so the default must stay in sync with the real channel.
+      SLACK_ALERT_CHANNEL: ${SLACK_ALERT_CHANNEL:-#server-alerts}
     secrets:
       - gaia_grafana_admin_password
       - gaia_grafana_slack_webhook

--- a/infra/docker/observability/grafana/provisioning/alerting/contact-points.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/contact-points.yaml
@@ -9,8 +9,10 @@ apiVersion: 1
 # AND inbox without needing `continue` route trickery.
 #
 # Secrets are NOT committed. Grafana reads them at provision time from swarm
-# secrets via $__file{}; the destination email comes from an env var via
-# $__env{}. Both are wired into the grafana service in docker-compose.prod.yml.
+# secrets via $__file{}; the destination email and Slack channel come from env
+# vars via $__env{}. All are wired into the grafana service in
+# docker-compose.prod.yml — an unset $__env{} or missing secret file makes
+# provisioning fail and Grafana crash-loop, so compose must always provide them.
 #   printf '%s' "$WEBHOOK"      | docker secret create gaia_grafana_slack_webhook -
 #   printf '%s' "$APP_PASSWORD" | docker secret create gaia_grafana_smtp_password -
 #
@@ -27,7 +29,7 @@ contactPoints:
       - uid: slack-alerts
         type: slack
         settings:
-          url: $__env{SLACK_ALERT_WEBHOOK_URL}
+          url: $__file{/run/secrets/gaia_grafana_slack_webhook}
           recipient: $__env{SLACK_ALERT_CHANNEL}
           title: '{{ template "gaia.slack.title" . }}'
           text: '{{ template "gaia.slack.message" . }}'
@@ -40,7 +42,7 @@ contactPoints:
       - uid: critical-slack
         type: slack
         settings:
-          url: $__env{SLACK_ALERT_WEBHOOK_URL}
+          url: $__file{/run/secrets/gaia_grafana_slack_webhook}
           recipient: $__env{SLACK_ALERT_CHANNEL}
           title: '{{ template "gaia.slack.title" . }}'
           text: '{{ template "gaia.slack.message" . }}'


### PR DESCRIPTION
## Problem

Prod Grafana has been crash-looping (0/1 replicas) — and with it **all alerting was down**. The contact points read `$__env{SLACK_ALERT_WEBHOOK_URL}` / `$__env{SLACK_ALERT_CHANNEL}`, but nothing provides those env vars: the compose grafana service doesn't set them and the deploy workflow doesn't export them. Empty URL makes Grafana treat the receiver as Slack chat-API mode, provisioning fails with `recipient must be specified when using the Slack chat API`, and Grafana exits on every boot.

Separately, cadvisor was OOM-killed (exit 137) 4× in ~36h: steady-state RSS is ~245 MiB against a 256m limit (95%).

## Fix

- `contact-points.yaml`: webhook URL back to `$__file{/run/secrets/gaia_grafana_slack_webhook}` — the documented design in `observability/CLAUDE.md`; the secret is already mounted by the service.
- `docker-compose.prod.yml`: set `SLACK_ALERT_CHANNEL` (default `#server-alerts`) on the grafana service; raise cadvisor memory limit 256m → 512m.

## Verification

- Built the patched `gaia-grafana` image locally and booted it with a dummy secret file: `finished to provision alerting`, both Slack contact points provision with recipient `#server-alerts` and the URL from the secret file. (Local run used a dummy webhook — delivery not exercised there.)
- On prod: rotated `gaia_grafana_slack_webhook` to the new #server-alerts webhook, service updated — Grafana is now 1/1 healthy, `/api/health` OK, and a test message through the rotated secret delivered to Slack (`ok`).

Note: prod grafana currently also carries stopgap `SLACK_ALERT_*` env vars (added to bring the old $__env-based image up immediately); the next stack deploy resets the service spec to compose, which with this PR is self-sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FxQb4So3EUubqhrWXoP7r