### PR TITLE
fix(agent): stop checkpointed threads accumulating a prompt stack per run

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -92,7 +92,7 @@ Pre-model hooks in `app/agents/core/nodes/`:
 Default to **less**. The code is the documentation — docstrings and comments exist only where the code cannot speak for itself. AI-generated over-documentation (restating the signature in prose, narrating every line, "textbook" docstrings on trivial helpers) is a defect, not thoroughness. Strip it.
 
 - **Docstrings** belong on public API surface — exported services, route handlers, shared utilities, and functions whose behavior is genuinely non-obvious. Skip them on private/internal helpers, obvious wrappers, and anything whose name + signature already says everything.
-- **One line** is the default. A summary sentence is enough. Add an `Args:`/`Returns:`/`Raises:` body only when a parameter, return value, or failure mode is non-obvious — never to mechanically mirror the signature. Document *why* and the non-obvious *what*, never the obvious what.
+- **One line** is the default — and for helpers/internal functions it is a HARD CAP of two lines. A multi-paragraph docstring is reserved for genuinely complex public API; anywhere else it is a review comment waiting to happen. Add an `Args:`/`Returns:`/`Raises:` body only when a parameter, return value, or failure mode is non-obvious — never to mechanically mirror the signature. Document *why* and the non-obvious *what*, never the obvious what.
 - **Never** document params/returns/raises that don't exist or no longer match the signature. A stale or hallucinated docstring is worse than none.
 - **Comments** explain non-obvious decisions — a tricky invariant, a workaround and its cause, a "why this and not the obvious thing." A comment that restates what the line plainly does is noise; delete it. Never leave commented-out code — git already has it. `ERA001` is *not* currently enforced (213 findings in `app/`, concentrated in `models/calendar_models.py`, `agents/tools/webpage_tool.py` and the deliberately-parked `utils/calendar_utils.py`), so this one is on you rather than the linter until that backlog is cleared.
 - When editing AI-generated code, treat trimming its redundant docstrings/comments as part of the change, not a separate cleanup.
@@ -111,6 +111,8 @@ Python 3.11+: use modern syntax (`X | Y` unions, `match` statements).
 ## File & Structural Organization
 
 One domain per file. Never let a file span multiple domains.
+
+**New helpers go in the module that owns the concept, never in the caller's file by convenience.** A hook utility belongs in `hooks.py`, a helper for a constant belongs next to that constant, a message util belongs in the messages module. Appending module-level helpers to an already-large file (500+ lines) because "that's where they're used" is how monoliths grow — put them where a reader would look for them and import.
 
 - `app/models/` — SQLAlchemy / MongoDB document models, one file per domain (`todo_models.py`).
 - `app/schemas/` — Pydantic request/response schemas, one file per domain. Separate `CreateRequest`, `UpdateRequest`, `Response`.
@@ -392,6 +394,8 @@ If a parameter is unused by one implementation but required by a framework's cal
 ### 12. Narrowing `Any`/unknown values: `cast()` over `isinstance()` when already correct by construction
 
 Prefer `cast(RealType, value)` over `isinstance(value, RealType)` when you already know the value is correct by construction (a lazy-provider registry lookup, a well-known dict's `.get()` result, a value a framework's own contract guarantees). `cast()` only changes what the type checker believes; `isinstance()` changes what the code actually *does* at runtime, and can reject a structurally-compatible object — a mock, a duck-typed wrapper, a different concrete implementation of a `Protocol` — that was working fine before.
+
+Never `cast("dict[str, Any]", ...)` to bypass a TypedDict or reach an undeclared key — that re-introduces `Any` through the back door. Cast to `dict[str, object]` (the honest type) and validate/narrow what you pull out.
 
 ### 13. Never change behavior to satisfy a type checker
 

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -112,7 +112,7 @@ Python 3.11+: use modern syntax (`X | Y` unions, `match` statements).
 
 One domain per file. Never let a file span multiple domains.
 
-**New helpers go in the module that owns the concept, never in the caller's file by convenience.** A hook utility belongs in `hooks.py`, a helper for a constant belongs next to that constant, a message util belongs in the messages module. Appending module-level helpers to an already-large file (500+ lines) because "that's where they're used" is how monoliths grow — put them where a reader would look for them and import.
+**New code goes in the module that owns the concept, never in the caller's file by convenience.** Before adding a function, ask where a reader would look for it — put it there and import it. Adding to an already-large file because "that's where it's used" is how monoliths grow.
 
 - `app/models/` — SQLAlchemy / MongoDB document models, one file per domain (`todo_models.py`).
 - `app/schemas/` — Pydantic request/response schemas, one file per domain. Separate `CreateRequest`, `UpdateRequest`, `Response`.
@@ -395,7 +395,7 @@ If a parameter is unused by one implementation but required by a framework's cal
 
 Prefer `cast(RealType, value)` over `isinstance(value, RealType)` when you already know the value is correct by construction (a lazy-provider registry lookup, a well-known dict's `.get()` result, a value a framework's own contract guarantees). `cast()` only changes what the type checker believes; `isinstance()` changes what the code actually *does* at runtime, and can reject a structurally-compatible object — a mock, a duck-typed wrapper, a different concrete implementation of a `Protocol` — that was working fine before.
 
-Never `cast("dict[str, Any]", ...)` to bypass a TypedDict or reach an undeclared key — that re-introduces `Any` through the back door. Cast to `dict[str, object]` (the honest type) and validate/narrow what you pull out.
+Never cast through `Any` (or an `Any`-parametrized container) to bypass a declared type — that re-introduces `Any` through the back door. Cast to the honest narrow type and validate/narrow what you pull out.
 
 ### 13. Never change behavior to satisfy a type checker
 

--- a/apps/api/app/agents/core/nodes/manage_system_prompts.py
+++ b/apps/api/app/agents/core/nodes/manage_system_prompts.py
@@ -34,7 +34,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
 from app.constants.log_tags import LogTag
-from app.override.langgraph_bigtool.utils import State
+from app.override.langgraph_bigtool.utils import PRUNED_MESSAGE_IDS_KEY, State
 from shared.py.wide_events import log
 
 
@@ -194,6 +194,11 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         # clock line differs turn-to-turn.
         dropped_system = 0
         dropped_time = 0
+        # Ids of the dropped copies, relayed via PRUNED_MESSAGE_IDS_KEY so the
+        # model node also tombstones them out of the checkpointed thread —
+        # otherwise this filtering is per-request only and state grows by one
+        # full prompt stack per run, forever.
+        pruned_ids: list[str] = []
         static_msg: AnyMessage | None = None
         dynamic_msg: AnyMessage | None = None
         todo_msg: AnyMessage | None = None
@@ -218,11 +223,15 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
                     memory_recall_msg = msg
                 else:
                     dropped_system += 1
+                    if msg.id:
+                        pruned_ids.append(msg.id)
             elif _is_time_context(msg):
                 if idx == latest_time_idx:
                     time_msg = msg
                 else:
                     dropped_time += 1
+                    if msg.id:
+                        pruned_ids.append(msg.id)
             else:
                 non_system.append(msg)
 
@@ -265,8 +274,9 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         # for that single LLM call without going through LangGraph's
         # ``add_messages`` reducer. So returning the filtered/reordered list
         # here is what controls the per-call shape that the provider sees,
-        # which is what implicit caching keys on.
-        return cast(State, {**state, "messages": filtered})
+        # which is what implicit caching keys on. The pruned ids ride along so
+        # the model node can tombstone the stale copies out of the checkpoint.
+        return cast(State, {**state, "messages": filtered, PRUNED_MESSAGE_IDS_KEY: pruned_ids})
 
     except Exception as e:
         log.error(

--- a/apps/api/app/agents/core/nodes/manage_system_prompts.py
+++ b/apps/api/app/agents/core/nodes/manage_system_prompts.py
@@ -194,10 +194,8 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         # clock line differs turn-to-turn.
         dropped_system = 0
         dropped_time = 0
-        # Ids of the dropped copies, relayed via PRUNED_MESSAGE_IDS_KEY so the
-        # model node also tombstones them out of the checkpointed thread —
-        # otherwise this filtering is per-request only and state grows by one
-        # full prompt stack per run, forever.
+        # Relayed via PRUNED_MESSAGE_IDS_KEY so the model node tombstones the
+        # stale copies out of the checkpoint, not just the per-call view.
         pruned_ids: list[str] = []
         static_msg: AnyMessage | None = None
         dynamic_msg: AnyMessage | None = None

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -33,7 +33,13 @@ from typing import Any, cast
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models import LanguageModelLike
-from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolCall,
+    ToolMessage,
+)
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool, StructuredTool
 
@@ -70,6 +76,7 @@ from app.override.langgraph_bigtool.hooks import (
     sync_execute_hooks,
 )
 from app.override.langgraph_bigtool.utils import (
+    PRUNED_MESSAGE_IDS_KEY,
     RetrieveToolsResult,
     State,
     dedupe_str_list,
@@ -96,6 +103,45 @@ def _prepare_fallback(
     if fallback_llm is None or is_default_model_config(model_configurations):
         return None
     return lambda: fallback_llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
+
+
+def _pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
+    """Tombstones for the slot-stale messages the pre-model hooks dropped.
+
+    ``manage_system_prompts_node`` filters old prompt copies out of the
+    per-call view and relays their ids under ``PRUNED_MESSAGE_IDS_KEY``; the
+    model node emits these tombstones in its own channel update so the pruning
+    also reaches the checkpoint. Popped, never forwarded — the key is a relay,
+    not a state channel.
+    """
+    pruned = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None) or []
+    return [RemoveMessage(id=message_id) for message_id in pruned]
+
+
+_UNSET = object()
+
+
+def _changed_hook_keys(before: State, after: State) -> State:
+    """Only the keys the end-graph hooks actually changed, by identity.
+
+    The end hooks are side-effecting (follow-up streaming, fire-and-forget
+    memory ingestion) and pass state through; echoing the full state back as
+    the node's update re-serializes the entire ``messages`` list into
+    ``checkpoint_writes`` on every run — on a long-lived workflow thread that
+    was ~4.8 MB per run of pure duplication. Identity (not equality) so a hook
+    that rebuilds the dict without touching the values still counts as
+    unchanged, and a genuinely new value always survives.
+    """
+    if after is before:
+        return cast("State", {})
+    return cast(
+        "State",
+        {
+            key: value
+            for key, value in after.items()
+            if cast("dict[str, Any]", before).get(key, _UNSET) is not value
+        },
+    )
 
 
 def create_agent(
@@ -211,6 +257,7 @@ def create_agent(
 
     def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         state = sync_execute_hooks(pre_model_hooks, state, config, store)
+        tombstones = _pop_pruned_tombstones(state)
 
         if middleware_executor:
             raise RuntimeError(
@@ -240,7 +287,7 @@ def create_agent(
         if isinstance(response.content, str) and agent_name == "comms_agent":
             response.content = response.content + NEW_MESSAGE_BREAKER
 
-        return {"messages": [response]}  # type: ignore[return-value]
+        return {"messages": [*tombstones, response]}  # type: ignore[return-value]
 
     def _maybe_inject_wrapup(state: State) -> State:
         """Warn the model to finish when the recursion budget is nearly spent.
@@ -265,6 +312,7 @@ def create_agent(
     async def acall_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         """Async model invocation with middleware support."""
         state = await execute_hooks(pre_model_hooks, state, config, store)
+        tombstones = _pop_pruned_tombstones(state)
 
         if middleware_executor:
             state = await middleware_executor.execute_before_model(state, config, store)
@@ -331,8 +379,10 @@ def create_agent(
 
         # Return partial state update: new message + any keys added by
         # after_model (e.g. todos). Messages use an append reducer, so only
-        # return the new response — not the full list.
-        result: dict[str, object] = {"messages": [response]}
+        # return the new response — not the full list. Tombstones prune the
+        # slot-stale prompt copies the pre-model hooks dropped, so the
+        # checkpointed thread stays bounded too.
+        result: dict[str, object] = {"messages": [*tombstones, response]}
         base_keys = {"messages", "selected_tool_ids"}
         for key, value in updated_state.items():
             if key not in base_keys:
@@ -436,12 +486,12 @@ def create_agent(
     def execute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
-        return sync_execute_hooks(end_graph_hooks, state, config, store)
+        return _changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
 
     async def aexecute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
-        return await execute_hooks(end_graph_hooks, state, config, store)
+        return _changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
 
     def _get_bound_tool_names(state: State) -> set[str]:
         """Return the set of tool names currently bound to the model."""

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -438,6 +438,7 @@ def create_agent(
     async def aselect_tools(
         tool_calls: list[dict], config: RunnableConfig, *, store: BaseStore
     ) -> State:
+        """Async twin of ``select_tools`` — resolve retrieve_tools calls into bindings."""
         if retrieve_tools is None:
             raise RuntimeError("retrieve_tools is disabled and aselect_tools should not be called")
 
@@ -491,6 +492,7 @@ def create_agent(
     async def aexecute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
+        """Run the end-graph hooks; persist only the keys they actually changed."""
         return _changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
 
     def _get_bound_tool_names(state: State) -> set[str]:
@@ -530,6 +532,7 @@ def create_agent(
         return {"messages": messages}  # type: ignore[return-value]
 
     async def areject_unbound_tools(tool_calls: list[dict], *, store: BaseStore) -> State:
+        """Async twin of ``reject_unbound_tools`` for the async graph path."""
         return reject_unbound_tools(tool_calls, store=store)
 
     def _last_tool_calling_message(state: State) -> AIMessage | None:
@@ -638,6 +641,7 @@ def create_agent(
         return {"messages": messages}  # type: ignore[return-value]
 
     async def afinish_task_node(tool_calls: list[ToolCall], *, store: BaseStore) -> State:
+        """Async twin of ``finish_task_node`` for the async graph path."""
         return finish_task_node(tool_calls, store=store)
 
     builder = StateGraph(State, context_schema=context_schema)

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -114,8 +114,14 @@ def _pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
     also reaches the checkpoint. Popped, never forwarded — the key is a relay,
     not a state channel.
     """
-    pruned = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None) or []
-    return [RemoveMessage(id=message_id) for message_id in pruned]
+    raw = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None)
+    if raw is None:
+        # Absent is legitimate: the hook may not have run (or errored and
+        # returned state unchanged) — nothing to prune.
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise TypeError(f"{PRUNED_MESSAGE_IDS_KEY} must be list[str], got {type(raw).__name__}")
+    return [RemoveMessage(id=message_id) for message_id in raw]
 
 
 _UNSET = object()

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -36,7 +36,6 @@ from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import (
     AIMessage,
     HumanMessage,
-    RemoveMessage,
     ToolCall,
     ToolMessage,
 )
@@ -72,16 +71,17 @@ from app.override.langgraph_bigtool.dynamic_tool_node import (
 )
 from app.override.langgraph_bigtool.hooks import (
     HookType,
+    changed_hook_keys,
     execute_hooks,
     sync_execute_hooks,
 )
 from app.override.langgraph_bigtool.utils import (
-    PRUNED_MESSAGE_IDS_KEY,
     RetrieveToolsResult,
     State,
     dedupe_str_list,
     dedupe_tool_bindings,
     format_selected_tools,
+    pop_pruned_tombstones,
 )
 from app.utils.mcp_utils import canonical_tool_name_map
 from app.utils.multimodal import extract_text_content
@@ -103,51 +103,6 @@ def _prepare_fallback(
     if fallback_llm is None or is_default_model_config(model_configurations):
         return None
     return lambda: fallback_llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
-
-
-def _pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
-    """Tombstones for the slot-stale messages the pre-model hooks dropped.
-
-    ``manage_system_prompts_node`` filters old prompt copies out of the
-    per-call view and relays their ids under ``PRUNED_MESSAGE_IDS_KEY``; the
-    model node emits these tombstones in its own channel update so the pruning
-    also reaches the checkpoint. Popped, never forwarded — the key is a relay,
-    not a state channel.
-    """
-    raw = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None)
-    if raw is None:
-        # Absent is legitimate: the hook may not have run (or errored and
-        # returned state unchanged) — nothing to prune.
-        return []
-    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
-        raise TypeError(f"{PRUNED_MESSAGE_IDS_KEY} must be list[str], got {type(raw).__name__}")
-    return [RemoveMessage(id=message_id) for message_id in raw]
-
-
-_UNSET = object()
-
-
-def _changed_hook_keys(before: State, after: State) -> State:
-    """Only the keys the end-graph hooks actually changed, by identity.
-
-    The end hooks are side-effecting (follow-up streaming, fire-and-forget
-    memory ingestion) and pass state through; echoing the full state back as
-    the node's update re-serializes the entire ``messages`` list into
-    ``checkpoint_writes`` on every run — on a long-lived workflow thread that
-    was ~4.8 MB per run of pure duplication. Identity (not equality) so a hook
-    that rebuilds the dict without touching the values still counts as
-    unchanged, and a genuinely new value always survives.
-    """
-    if after is before:
-        return cast("State", {})
-    return cast(
-        "State",
-        {
-            key: value
-            for key, value in after.items()
-            if cast("dict[str, Any]", before).get(key, _UNSET) is not value
-        },
-    )
 
 
 def create_agent(
@@ -263,7 +218,7 @@ def create_agent(
 
     def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         state = sync_execute_hooks(pre_model_hooks, state, config, store)
-        tombstones = _pop_pruned_tombstones(state)
+        tombstones = pop_pruned_tombstones(state)
 
         if middleware_executor:
             raise RuntimeError(
@@ -318,7 +273,7 @@ def create_agent(
     async def acall_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         """Async model invocation with middleware support."""
         state = await execute_hooks(pre_model_hooks, state, config, store)
-        tombstones = _pop_pruned_tombstones(state)
+        tombstones = pop_pruned_tombstones(state)
 
         if middleware_executor:
             state = await middleware_executor.execute_before_model(state, config, store)
@@ -493,13 +448,13 @@ def create_agent(
     def execute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
-        return _changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
+        return changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
 
     async def aexecute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
         """Run the end-graph hooks; persist only the keys they actually changed."""
-        return _changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
+        return changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
 
     def _get_bound_tool_names(state: State) -> set[str]:
         """Return the set of tool names currently bound to the model."""

--- a/apps/api/app/override/langgraph_bigtool/hooks.py
+++ b/apps/api/app/override/langgraph_bigtool/hooks.py
@@ -7,7 +7,7 @@ Provides sync and async hook execution for pre_model, end_graph, etc.
 import asyncio
 from collections.abc import Awaitable, Callable
 import inspect
-from typing import Union
+from typing import Union, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
@@ -47,6 +47,22 @@ async def execute_hooks(
         else:
             state = result  # type: ignore[assignment]
     return state
+
+
+def changed_hook_keys(before: State, after: State) -> State:
+    """Keys the hook chain changed (by identity) — echoing unchanged channels
+    re-serializes the full message list into the checkpoint on every run."""
+    if after is before:
+        return cast("State", {})
+    before_dict = cast("dict[str, object]", before)
+    return cast(
+        "State",
+        {
+            key: value
+            for key, value in after.items()
+            if key not in before_dict or before_dict[key] is not value
+        },
+    )
 
 
 def sync_execute_hooks(

--- a/apps/api/app/override/langgraph_bigtool/utils.py
+++ b/apps/api/app/override/langgraph_bigtool/utils.py
@@ -110,6 +110,16 @@ class State(_BigtoolState):
     remaining_steps: RemainingSteps
 
 
+# In-memory relay from `manage_system_prompts_node` to the model node: ids of
+# slot-stale messages (old system prompts / clock lines) the hook dropped from
+# the per-call view. The model node turns them into RemoveMessage tombstones in
+# its own channel update so the pruning also reaches the CHECKPOINT — without
+# this, every run's prompt stack stays in the thread forever (a production
+# workflow thread accumulated 39 copies, ~4.8 MB of checkpoint writes per run).
+# Never a state channel: the model node pops it before returning its update.
+PRUNED_MESSAGE_IDS_KEY = "_pruned_message_ids"
+
+
 class RetrieveToolsResult(TypedDict):
     """Result from retrieve_tools function.
 

--- a/apps/api/app/override/langgraph_bigtool/utils.py
+++ b/apps/api/app/override/langgraph_bigtool/utils.py
@@ -110,14 +110,22 @@ class State(_BigtoolState):
     remaining_steps: RemainingSteps
 
 
-# In-memory relay from `manage_system_prompts_node` to the model node: ids of
-# slot-stale messages (old system prompts / clock lines) the hook dropped from
-# the per-call view. The model node turns them into RemoveMessage tombstones in
-# its own channel update so the pruning also reaches the CHECKPOINT — without
-# this, every run's prompt stack stays in the thread forever (a production
-# workflow thread accumulated 39 copies, ~4.8 MB of checkpoint writes per run).
-# Never a state channel: the model node pops it before returning its update.
+# In-memory relay from `manage_system_prompts_node` to the model node, which
+# tombstones the relayed ids out of the checkpoint. Overwritten each hook pass
+# and popped before the node's update — never a state channel.
 PRUNED_MESSAGE_IDS_KEY = "_pruned_message_ids"
+
+
+def pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
+    """Pop ``PRUNED_MESSAGE_IDS_KEY`` and return its ids as RemoveMessage tombstones."""
+    raw = cast("dict[str, object]", state).pop(PRUNED_MESSAGE_IDS_KEY, None)
+    if raw is None:
+        # Absent is fine: the hook may not have run this call.
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise TypeError(f"{PRUNED_MESSAGE_IDS_KEY} must be list[str], got {type(raw).__name__}")
+    pruned_ids = cast("list[str]", raw)
+    return [RemoveMessage(id=message_id) for message_id in pruned_ids]
 
 
 class RetrieveToolsResult(TypedDict):

--- a/apps/api/tests/e2e/_harness/graph_run.py
+++ b/apps/api/tests/e2e/_harness/graph_run.py
@@ -93,6 +93,11 @@ class GraphRun:
     #: it on the way in and that rewrite never reaches the checkpoint, so this is
     #: the only place a hook's effect is observable.
     prompts: list[list[BaseMessage]] = field(default_factory=list)
+    #: Every node that emitted an update, in order — including nodes whose
+    #: update carried no messages (e.g. ``end_graph_hooks``, whose hooks are
+    #: side-effecting and write no channels). ``nodes()`` covers only the
+    #: message-bearing route.
+    visited: list[str] = field(default_factory=list)
     error: BaseException | None = None
 
     def last_prompt(self) -> list[BaseMessage]:
@@ -374,6 +379,7 @@ async def comms_graph(
     script: Sequence[Any],
     store: InMemoryStore | None = None,
     model: RecordingFakeModel | None = None,
+    checkpointer_manager: Any | None = None,
 ) -> AsyncIterator[Any]:
     """The REAL comms graph, with only the model and the external edges replaced.
 
@@ -425,7 +431,11 @@ async def comms_graph(
         patch.object(
             _build_graph, "get_tools_store", AsyncMock(return_value=store or InMemoryStore())
         ),
-        patch.object(_build_graph, "get_checkpointer_manager", AsyncMock(return_value=None)),
+        patch.object(
+            _build_graph,
+            "get_checkpointer_manager",
+            AsyncMock(return_value=checkpointer_manager),
+        ),
         patch(
             f"{node_module}.ainvoke_structured",
             new=AsyncMock(return_value=FollowUpActions(actions=[])),
@@ -442,7 +452,7 @@ async def comms_graph(
         ),
     ):
         async with _build_graph.build_comms_graph(
-            chat_llm=llm, in_memory_checkpointer=True
+            chat_llm=llm, in_memory_checkpointer=checkpointer_manager is None
         ) as graph:
             _SCRIPTED_MODELS[id(graph)] = llm
             _MEMORY_DOUBLES[id(graph)] = memory
@@ -501,6 +511,8 @@ async def run_graph(
     try:
         async for _mode, payload in graph.astream(initial, stream_mode=["updates"], config=config):
             for node, update in payload.items():
+                if not run.visited or run.visited[-1] != node:
+                    run.visited.append(node)
                 if not isinstance(update, dict):
                     continue
                 if "selected_tool_ids" in update:

--- a/apps/api/tests/e2e/test_checkpoint_state_growth.py
+++ b/apps/api/tests/e2e/test_checkpoint_state_growth.py
@@ -90,9 +90,12 @@ class TestPromptFramingIsPrunedFromCheckpointState:
         assert len(clocks) == 1, f"expected 1 time-context message, found {len(clocks)}"
         assert "T03:" in str(clocks[0].content), "kept clock is not the latest run's"
 
-    @pytest.mark.regression
     async def test_conversation_itself_survives_pruning(self):
-        """Pruning removes prompt framing only — user/assistant turns all stay."""
+        """Pruning removes prompt framing only — user/assistant turns all stay.
+
+        Deliberately NOT @regression: it guards against over-pruning (a gap-fill
+        test) and legitimately passes on base, where nothing is pruned at all.
+        """
         thread_id = f"keep-{uuid4()}"
         async with comms_graph(["reply one", "reply two"]) as graph:
             for run_no in (1, 2):

--- a/apps/api/tests/e2e/test_checkpoint_state_growth.py
+++ b/apps/api/tests/e2e/test_checkpoint_state_growth.py
@@ -1,0 +1,128 @@
+"""Checkpointed threads must not accumulate per-run prompt framing.
+
+Every run injects a fresh system-prompt stack (static + dynamic context + time
+clock) into the graph input, exactly as ``_core_agent_logic`` does. The
+pre-model hooks filter those per model call, but for months the filtering was
+request-only: the checkpointed ``messages`` channel kept every run's copy, and
+the end-of-graph hook node echoed the entire accumulated list back through the
+reducer as a fresh write on every run. On a recurring workflow thread in
+production this reached 39 retained prompt copies and ~4.8 MB of checkpoint
+writes per run — 19 GB of Postgres for one database.
+
+These tests pin the durable contract:
+- stale slot messages are tombstoned out of the checkpoint, not just hidden
+  from the model;
+- the end-graph hook node — whose hooks only stream follow-ups and kick off
+  memory ingestion — never re-emits the message list as a channel write.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from langchain_core.messages import HumanMessage, SystemMessage
+import pytest
+
+from tests.e2e._harness.graph_run import comms_graph, run_graph
+
+pytestmark = pytest.mark.e2e
+
+END_HOOKS_NODE = "end_graph_hooks"
+
+
+def _run_input(run_no: int) -> dict:
+    """A graph input shaped like ``construct_langchain_messages`` output.
+
+    Fresh message objects per run (new ids), same slots: one static system
+    prompt, one dynamic-context system message, one time-context clock line,
+    then the user turn.
+    """
+    return {
+        "messages": [
+            SystemMessage(content=f"You are GAIA. (static prompt, run {run_no})"),
+            SystemMessage(
+                content=f"[dynamic context for run {run_no}]",
+                additional_kwargs={"dynamic_context": True},
+            ),
+            HumanMessage(
+                content=f"[current time: 2026-08-11T0{run_no}:00:00]",
+                additional_kwargs={"time_context": True},
+            ),
+            HumanMessage(content=f"user message {run_no}"),
+        ],
+        "todos": [],
+    }
+
+
+class TestPromptFramingIsPrunedFromCheckpointState:
+    @pytest.mark.regression
+    async def test_stale_system_prompts_are_tombstoned_out_of_the_thread(self):
+        """After N runs on one thread, each prompt slot holds ONE message.
+
+        Without durable pruning every run leaves its full prompt stack behind
+        (production reached 39 static-prompt copies on one workflow thread),
+        so the checkpoint grows by the whole prompt size per run, forever.
+        """
+        thread_id = f"prune-{uuid4()}"
+        async with comms_graph(["ok one", "ok two", "ok three"]) as graph:
+            for run_no in (1, 2, 3):
+                await run_graph(graph, "", thread_id=thread_id, state=_run_input(run_no))
+            config = {"configurable": {"thread_id": thread_id, "user_id": "u-1"}}
+            snapshot = await graph.aget_state(config)
+
+        messages = snapshot.values["messages"]
+        statics = [
+            m
+            for m in messages
+            if m.type == "system"
+            and not m.additional_kwargs.get("dynamic_context")
+            and not m.additional_kwargs.get("memory_recall")
+        ]
+        dynamics = [
+            m for m in messages if m.type == "system" and m.additional_kwargs.get("dynamic_context")
+        ]
+        clocks = [m for m in messages if m.additional_kwargs.get("time_context")]
+
+        assert len(statics) == 1, f"expected 1 static prompt in state, found {len(statics)}"
+        assert "run 3" in str(statics[0].content), "kept static prompt is not the latest run's"
+        assert len(dynamics) == 1, f"expected 1 dynamic-context message, found {len(dynamics)}"
+        assert "run 3" in str(dynamics[0].content), "kept dynamic context is not the latest run's"
+        assert len(clocks) == 1, f"expected 1 time-context message, found {len(clocks)}"
+        assert "T03:" in str(clocks[0].content), "kept clock is not the latest run's"
+
+    @pytest.mark.regression
+    async def test_conversation_itself_survives_pruning(self):
+        """Pruning removes prompt framing only — user/assistant turns all stay."""
+        thread_id = f"keep-{uuid4()}"
+        async with comms_graph(["reply one", "reply two"]) as graph:
+            for run_no in (1, 2):
+                await run_graph(graph, "", thread_id=thread_id, state=_run_input(run_no))
+            config = {"configurable": {"thread_id": thread_id, "user_id": "u-1"}}
+            snapshot = await graph.aget_state(config)
+
+        messages = snapshot.values["messages"]
+        user_turns = [
+            m for m in messages if m.type == "human" and not m.additional_kwargs.get("time_context")
+        ]
+        ai_turns = [m for m in messages if m.type == "ai"]
+        assert [str(m.content) for m in user_turns] == ["user message 1", "user message 2"]
+        assert len(ai_turns) == 2
+
+
+class TestEndGraphHooksWriteNothing:
+    @pytest.mark.regression
+    async def test_end_hooks_node_does_not_rewrite_the_message_list(self):
+        """The end-graph hook node must not emit a ``messages`` channel write.
+
+        Its hooks (follow-up streaming, fire-and-forget memory ingestion) never
+        modify messages — echoing the full state back re-serializes the entire
+        thread into ``checkpoint_writes`` on every single run.
+        """
+        async with comms_graph(["done"]) as graph:
+            run = await run_graph(graph, "", thread_id=f"echo-{uuid4()}", state=_run_input(1))
+
+        echoed = [e for e in run.events if e.node == END_HOOKS_NODE]
+        assert echoed == [], (
+            f"end_graph_hooks re-emitted {len(echoed)} messages as a channel write; "
+            "it must return only the keys its hooks actually changed"
+        )

--- a/apps/api/tests/e2e/test_comms_graph.py
+++ b/apps/api/tests/e2e/test_comms_graph.py
@@ -152,18 +152,21 @@ class TestEndOfTurnHooks:
     async def test_the_turn_runs_its_end_graph_hooks(self):
         """Follow-up suggestions and passive memory ingestion both hang off the
         end hook. If the graph stopped routing through it, chips would vanish and
-        nothing said in conversation would ever be remembered."""
+        nothing said in conversation would ever be remembered.
+
+        Asserted via ``visited``, not ``nodes()``: the end hooks are
+        side-effecting and write no channels, so the node emits an empty update
+        rather than echoing the message list back into the checkpoint."""
         async with comms_graph(["Hi there."]) as graph:
             run = await run_graph(graph, "hello")
 
-        assert "end_graph_hooks" in run.nodes()
+        assert "end_graph_hooks" in run.visited
 
     async def test_the_hooks_run_after_the_model_not_before(self):
         async with comms_graph(["Hi there."]) as graph:
             run = await run_graph(graph, "hello")
 
-        nodes = run.nodes()
-        assert nodes.index(AGENT_NODE) < nodes.index("end_graph_hooks")
+        assert run.visited.index(AGENT_NODE) < run.visited.index("end_graph_hooks")
 
 
 class TestSystemPromptSlots:

--- a/apps/api/tests/integration/agents/test_agent_graph_checkpointing.py
+++ b/apps/api/tests/integration/agents/test_agent_graph_checkpointing.py
@@ -721,9 +721,9 @@ class TestPreModelHooksExecution:
 
     async def test_manage_system_prompts_keeps_latest_only(self, pg_checkpointer):
         """Send multiple non-memory system prompts. The
-        manage_system_prompts_node keeps only the latest one before the
-        LLM call, but the checkpoint retains all of them (pre-model hooks
-        modify state ephemerally). The graph must complete without error."""
+        manage_system_prompts_node keeps only the latest one, and since the
+        prompt-accumulation fix that pruning is durable: the stale copy is
+        tombstoned out of the checkpoint too."""
         from langgraph.store.memory import InMemoryStore
 
         fake_llm = create_fake_llm(["System prompt managed"])
@@ -753,15 +753,16 @@ class TestPreModelHooksExecution:
             config=config,
         )
 
-        # Both system prompts remain in persisted state (pre-model hooks
-        # only modify ephemerally for the LLM call)
+        # Only the latest system prompt persists — the stale copy is
+        # tombstoned out of the checkpoint by the model node.
         system_msgs = [m for m in result["messages"] if m.type == "system"]
         non_memory = [
             m for m in system_msgs if not m.additional_kwargs.get("memory_message", False)
         ]
-        assert len(non_memory) == 2, (
-            f"Both system prompts should remain in persisted state, found {len(non_memory)}"
+        assert len(non_memory) == 1, (
+            f"Exactly the latest system prompt should persist, found {len(non_memory)}"
         )
+        assert "New system prompt" in str(non_memory[0].content)
 
         # Graph completed with AI response
         ai_msgs = [m for m in result["messages"] if isinstance(m, AIMessage)]

--- a/apps/api/tests/integration/agents/test_real_comms_agent.py
+++ b/apps/api/tests/integration/agents/test_real_comms_agent.py
@@ -388,15 +388,13 @@ class TestRealCommsAgent:
             "The graph should have produced a new AIMessage with no pending tool calls."
         )
 
-    async def test_pre_model_hook_does_not_persist_to_checkpoint(self, comms_graph_simple):
+    async def test_pre_model_hook_pruning_persists_to_checkpoint(self, comms_graph_simple):
         """
-        manage_system_prompts_node runs as a pre_model_hook — it modifies the
-        messages passed to the model ephemerally (filtering duplicates for the
-        LLM call), but those modifications are NOT written back to the checkpoint.
-        The persisted graph state still retains all original messages
-        (LangGraph's append reducer). This test verifies the graph completes
-        without error and produces an AI response when fed duplicate non-memory
-        system prompts, and that both system prompts remain in the checkpoint.
+        manage_system_prompts_node keeps one system prompt per slot, and since
+        the prompt-accumulation fix that pruning is DURABLE: the model node
+        tombstones the stale copies out of the checkpoint (RemoveMessage), so a
+        long-lived thread holds exactly one prompt per slot instead of one per
+        run. Conversation messages are untouched.
         """
         config = _thread_config()
 
@@ -416,16 +414,21 @@ class TestRealCommsAgent:
         ai_messages = [m for m in result["messages"] if m.type == "ai"]
         assert len(ai_messages) >= 1, "Graph should have produced at least one AIMessage"
 
-        # Both system messages remain in the persisted state because
-        # pre_model_hooks only filter for the LLM call, not the checkpoint.
+        # Only the latest static prompt survives in the persisted state; the
+        # stale copy is tombstoned out so checkpointed threads stay bounded.
         system_messages = [m for m in result["messages"] if m.type == "system"]
         non_memory = [
             m for m in system_messages if not m.additional_kwargs.get("memory_message", False)
         ]
-        assert len(non_memory) == 2, (
-            f"Both non-memory system prompts should remain in persisted state; "
-            f"found {len(non_memory)}"
+        assert len(non_memory) == 1, (
+            f"Exactly the latest non-memory system prompt should persist; found {len(non_memory)}"
         )
+        assert "New system prompt." in str(non_memory[0].content)
+
+        # The conversation itself is never pruned.
+        human_contents = [str(m.content) for m in result["messages"] if m.type == "human"]
+        assert "First message." in human_contents
+        assert "Second message." in human_contents
 
     # ------------------------------------------------------------------
     # 3. Tool routing

--- a/apps/api/tests/integration/real/test_postgres_checkpointer.py
+++ b/apps/api/tests/integration/real/test_postgres_checkpointer.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from uuid import uuid4
 
+from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.checkpoint.base import empty_checkpoint
+import psycopg
 import pytest
 
 from app.agents.core.graph_builder.checkpointer_manager import CheckpointerManager
+from tests.e2e._harness.graph_run import comms_graph, run_graph
 
 # ---------------------------------------------------------------------------
 # Fixtures (postgres_url comes from service/conftest.py)
@@ -179,3 +182,85 @@ class TestThreadIsolation:
         latest = await checkpointer.aget_tuple(config)
         assert latest is not None
         assert latest.checkpoint["id"] == cp_b["id"]
+
+
+@pytest.mark.service
+class TestCheckpointStorageStaysBounded:
+    """Recurring runs on one thread must not re-store the prompt stack per run.
+
+    Production regression: every run injects a fresh system-prompt stack into
+    the thread; the pre-model filtering was request-only, so the checkpoint
+    accumulated one full stack per run (39 copies on one workflow thread) and
+    the end-graph hook node re-serialized the whole accumulated list into
+    ``checkpoint_writes`` on every run — 19 GB of Postgres from one database.
+    This drives the REAL comms graph against the REAL Postgres checkpointer and
+    measures actual stored bytes for the thread.
+    """
+
+    @pytest.mark.regression
+    async def test_recurring_runs_store_linear_not_quadratic_bytes(
+        self, manager: CheckpointerManager, postgres_url: str
+    ) -> None:
+        runs = 4
+        static_prompt = "You are GAIA. " + "x" * 60_000
+        stack_bytes = len(static_prompt)
+        thread_id = f"bounded-{uuid4()}"
+
+        def run_input(run_no: int) -> dict:
+            return {
+                "messages": [
+                    SystemMessage(content=f"{static_prompt} (run {run_no})"),
+                    SystemMessage(
+                        content=f"[dynamic context, run {run_no}]",
+                        additional_kwargs={"dynamic_context": True},
+                    ),
+                    HumanMessage(
+                        content=f"[current time: run {run_no}]",
+                        additional_kwargs={"time_context": True},
+                    ),
+                    HumanMessage(content=f"user message {run_no}"),
+                ],
+                "todos": [],
+            }
+
+        scripts = [f"reply {i}" for i in range(1, runs + 1)]
+        async with comms_graph(scripts, checkpointer_manager=manager) as graph:
+            for run_no in range(1, runs + 1):
+                await run_graph(graph, "", thread_id=thread_id, state=run_input(run_no))
+            snapshot = await graph.aget_state(
+                {"configurable": {"thread_id": thread_id, "user_id": "u-1"}}
+            )
+
+        statics = [
+            m
+            for m in snapshot.values["messages"]
+            if m.type == "system" and not m.additional_kwargs.get("dynamic_context")
+        ]
+        assert len(statics) == 1, (
+            f"{len(statics)} static prompt copies retained in the checkpointed thread; "
+            "stale copies must be tombstoned out"
+        )
+
+        async with await psycopg.AsyncConnection.connect(postgres_url) as conn:
+            cur = await conn.execute(
+                """
+                SELECT
+                  (SELECT coalesce(sum(length(blob)), 0) FROM checkpoint_writes
+                    WHERE thread_id = %(t)s)
+                + (SELECT coalesce(sum(length(blob)), 0) FROM checkpoint_blobs
+                    WHERE thread_id = %(t)s)
+                """,
+                {"t": thread_id},
+            )
+            row = await cur.fetchone()
+        total_bytes = int(row[0]) if row else 0
+
+        # Each run legitimately stores ~one prompt stack (the graph input write
+        # and its delta blob). The regression stored the full ACCUMULATED list
+        # again per run — super-linear growth that blows straight through this
+        # linear budget (measured: ~3.5x over it at 4 runs, growing per run).
+        budget = runs * stack_bytes * 3
+        assert total_bytes < budget, (
+            f"thread stored {total_bytes} bytes after {runs} runs "
+            f"(budget {budget}); checkpoint growth is super-linear again"
+        )


### PR DESCRIPTION
## Problem

Prod's `langgraph` DB hit **19 GB** (checkpoint_blobs 11 GB, checkpoint_writes 7.9 GB) and is growing **~2.4 GB/day since Aug 6** — despite #818's DeltaChannel fix (deployed, langgraph 1.2.7). Evidence from prod:

- The recent giant writes are **~4.8 MB SystemMessage batches** containing **39 copies of the comms system prompt** on one recurring workflow thread.
- Every run injects a fresh ~125 KB prompt stack; `manage_system_prompts_node` filters stale copies **from the per-call view only** (its own docstring: "the persistent checkpoint state still grows unfiltered").
- The `end_graph_hooks` node returned the **full hook state** as its update, re-serializing the entire accumulated message list into `checkpoint_writes` every run.
- `__pregel_tasks` (5 GB) mirrors the same payloads in Send packets.

## Fix

1. **Durable pruning**: `manage_system_prompts_node` relays the ids of slot-stale messages via an in-memory key (`PRUNED_MESSAGE_IDS_KEY`, popped before any channel write); the model node emits `RemoveMessage` tombstones so each prompt slot holds exactly one message *in the checkpoint*, not just per-call.
2. **No more full-state echo**: the end-hooks node returns only the keys its hooks actually changed (identity diff). Its hooks (follow-up streaming, memory ingestion) are side-effecting and never change state, so this is normally an empty update.

## Verification (failing-first, both tiers)

- `tests/e2e/test_checkpoint_state_growth.py` — real comms graph: stale prompt copies are tombstoned out of the thread (was 3 copies after 3 runs → 1), conversation turns survive, end-hooks node emits no messages write. Red before the fix, green after.
- `tests/integration/real/test_postgres_checkpointer.py::TestCheckpointStorageStaysBounded` — **real Postgres checkpointer + real comms graph**, measures actual stored bytes for the thread across 4 recurring runs: red on master (super-linear, ~3.5× over a linear budget and growing per run), green here (~1 stack per run). Full e2e tier: 507 passed.
- Not exercised: real prod LLM/tools (fake scripted model), and the fix does not shrink existing data — see cleanup note below.

## Deliberately out of scope (needs own design)

- Each run's graph INPUT still re-sends the full Mongo-sourced history into the thread (double bookkeeping between Mongo and the checkpointer).
- No checkpoint retention/TTL exists — old threads live forever. Existing 19 GB needs a one-time cleanup + VACUUM regardless of this fix.
- `deep_research` previously produced up to 71 MB single ToolMessages (pre-compaction era); compaction middleware now bounds tool outputs, but `__pregel_tasks` payloads deserve a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FxQb4So3EUubqhrWXoP7r