### PR TITLE
refactor(agent): split create_agent node bodies into nodes.py

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -92,7 +92,7 @@ Pre-model hooks in `app/agents/core/nodes/`:
 Default to **less**. The code is the documentation — docstrings and comments exist only where the code cannot speak for itself. AI-generated over-documentation (restating the signature in prose, narrating every line, "textbook" docstrings on trivial helpers) is a defect, not thoroughness. Strip it.
 
 - **Docstrings** belong on public API surface — exported services, route handlers, shared utilities, and functions whose behavior is genuinely non-obvious. Skip them on private/internal helpers, obvious wrappers, and anything whose name + signature already says everything.
-- **One line** is the default. A summary sentence is enough. Add an `Args:`/`Returns:`/`Raises:` body only when a parameter, return value, or failure mode is non-obvious — never to mechanically mirror the signature. Document *why* and the non-obvious *what*, never the obvious what.
+- **One line** is the default — and for helpers/internal functions it is a HARD CAP of two lines. A multi-paragraph docstring is reserved for genuinely complex public API; anywhere else it is a review comment waiting to happen. Add an `Args:`/`Returns:`/`Raises:` body only when a parameter, return value, or failure mode is non-obvious — never to mechanically mirror the signature. Document *why* and the non-obvious *what*, never the obvious what.
 - **Never** document params/returns/raises that don't exist or no longer match the signature. A stale or hallucinated docstring is worse than none.
 - **Comments** explain non-obvious decisions — a tricky invariant, a workaround and its cause, a "why this and not the obvious thing." A comment that restates what the line plainly does is noise; delete it. Never leave commented-out code — git already has it. `ERA001` is *not* currently enforced (213 findings in `app/`, concentrated in `models/calendar_models.py`, `agents/tools/webpage_tool.py` and the deliberately-parked `utils/calendar_utils.py`), so this one is on you rather than the linter until that backlog is cleared.
 - When editing AI-generated code, treat trimming its redundant docstrings/comments as part of the change, not a separate cleanup.
@@ -111,6 +111,8 @@ Python 3.11+: use modern syntax (`X | Y` unions, `match` statements).
 ## File & Structural Organization
 
 One domain per file. Never let a file span multiple domains.
+
+**New helpers go in the module that owns the concept, never in the caller's file by convenience.** A hook utility belongs in `hooks.py`, a helper for a constant belongs next to that constant, a message util belongs in the messages module. Appending module-level helpers to an already-large file (500+ lines) because "that's where they're used" is how monoliths grow — put them where a reader would look for them and import.
 
 - `app/models/` — SQLAlchemy / MongoDB document models, one file per domain (`todo_models.py`).
 - `app/schemas/` — Pydantic request/response schemas, one file per domain. Separate `CreateRequest`, `UpdateRequest`, `Response`.
@@ -392,6 +394,8 @@ If a parameter is unused by one implementation but required by a framework's cal
 ### 12. Narrowing `Any`/unknown values: `cast()` over `isinstance()` when already correct by construction
 
 Prefer `cast(RealType, value)` over `isinstance(value, RealType)` when you already know the value is correct by construction (a lazy-provider registry lookup, a well-known dict's `.get()` result, a value a framework's own contract guarantees). `cast()` only changes what the type checker believes; `isinstance()` changes what the code actually *does* at runtime, and can reject a structurally-compatible object — a mock, a duck-typed wrapper, a different concrete implementation of a `Protocol` — that was working fine before.
+
+Never `cast("dict[str, Any]", ...)` to bypass a TypedDict or reach an undeclared key — that re-introduces `Any` through the back door. Cast to `dict[str, object]` (the honest type) and validate/narrow what you pull out.
 
 ### 13. Never change behavior to satisfy a type checker
 

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -112,7 +112,7 @@ Python 3.11+: use modern syntax (`X | Y` unions, `match` statements).
 
 One domain per file. Never let a file span multiple domains.
 
-**New helpers go in the module that owns the concept, never in the caller's file by convenience.** A hook utility belongs in `hooks.py`, a helper for a constant belongs next to that constant, a message util belongs in the messages module. Appending module-level helpers to an already-large file (500+ lines) because "that's where they're used" is how monoliths grow — put them where a reader would look for them and import.
+**New code goes in the module that owns the concept, never in the caller's file by convenience.** Before adding a function, ask where a reader would look for it — put it there and import it. Adding to an already-large file because "that's where it's used" is how monoliths grow.
 
 - `app/models/` — SQLAlchemy / MongoDB document models, one file per domain (`todo_models.py`).
 - `app/schemas/` — Pydantic request/response schemas, one file per domain. Separate `CreateRequest`, `UpdateRequest`, `Response`.
@@ -395,7 +395,7 @@ If a parameter is unused by one implementation but required by a framework's cal
 
 Prefer `cast(RealType, value)` over `isinstance(value, RealType)` when you already know the value is correct by construction (a lazy-provider registry lookup, a well-known dict's `.get()` result, a value a framework's own contract guarantees). `cast()` only changes what the type checker believes; `isinstance()` changes what the code actually *does* at runtime, and can reject a structurally-compatible object — a mock, a duck-typed wrapper, a different concrete implementation of a `Protocol` — that was working fine before.
 
-Never `cast("dict[str, Any]", ...)` to bypass a TypedDict or reach an undeclared key — that re-introduces `Any` through the back door. Cast to `dict[str, object]` (the honest type) and validate/narrow what you pull out.
+Never cast through `Any` (or an `Any`-parametrized container) to bypass a declared type — that re-introduces `Any` through the back door. Cast to the honest narrow type and validate/narrow what you pull out.
 
 ### 13. Never change behavior to satisfy a type checker
 

--- a/apps/api/app/agents/core/nodes/manage_system_prompts.py
+++ b/apps/api/app/agents/core/nodes/manage_system_prompts.py
@@ -34,7 +34,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
 from app.constants.log_tags import LogTag
-from app.override.langgraph_bigtool.utils import State
+from app.override.langgraph_bigtool.utils import PRUNED_MESSAGE_IDS_KEY, State
 from shared.py.wide_events import log
 
 
@@ -194,6 +194,11 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         # clock line differs turn-to-turn.
         dropped_system = 0
         dropped_time = 0
+        # Ids of the dropped copies, relayed via PRUNED_MESSAGE_IDS_KEY so the
+        # model node also tombstones them out of the checkpointed thread —
+        # otherwise this filtering is per-request only and state grows by one
+        # full prompt stack per run, forever.
+        pruned_ids: list[str] = []
         static_msg: AnyMessage | None = None
         dynamic_msg: AnyMessage | None = None
         todo_msg: AnyMessage | None = None
@@ -218,11 +223,15 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
                     memory_recall_msg = msg
                 else:
                     dropped_system += 1
+                    if msg.id:
+                        pruned_ids.append(msg.id)
             elif _is_time_context(msg):
                 if idx == latest_time_idx:
                     time_msg = msg
                 else:
                     dropped_time += 1
+                    if msg.id:
+                        pruned_ids.append(msg.id)
             else:
                 non_system.append(msg)
 
@@ -265,8 +274,9 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         # for that single LLM call without going through LangGraph's
         # ``add_messages`` reducer. So returning the filtered/reordered list
         # here is what controls the per-call shape that the provider sees,
-        # which is what implicit caching keys on.
-        return cast(State, {**state, "messages": filtered})
+        # which is what implicit caching keys on. The pruned ids ride along so
+        # the model node can tombstone the stale copies out of the checkpoint.
+        return cast(State, {**state, "messages": filtered, PRUNED_MESSAGE_IDS_KEY: pruned_ids})
 
     except Exception as e:
         log.error(

--- a/apps/api/app/agents/core/nodes/manage_system_prompts.py
+++ b/apps/api/app/agents/core/nodes/manage_system_prompts.py
@@ -194,10 +194,8 @@ def manage_system_prompts_node(state: State, config: RunnableConfig, store: Base
         # clock line differs turn-to-turn.
         dropped_system = 0
         dropped_time = 0
-        # Ids of the dropped copies, relayed via PRUNED_MESSAGE_IDS_KEY so the
-        # model node also tombstones them out of the checkpointed thread —
-        # otherwise this filtering is per-request only and state grows by one
-        # full prompt stack per run, forever.
+        # Relayed via PRUNED_MESSAGE_IDS_KEY so the model node tombstones the
+        # stale copies out of the checkpoint, not just the per-call view.
         pruned_ids: list[str] = []
         static_msg: AnyMessage | None = None
         dynamic_msg: AnyMessage | None = None

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -33,7 +33,13 @@ from typing import Any, cast
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models import LanguageModelLike
-from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    ToolCall,
+    ToolMessage,
+)
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool, StructuredTool
 
@@ -70,6 +76,7 @@ from app.override.langgraph_bigtool.hooks import (
     sync_execute_hooks,
 )
 from app.override.langgraph_bigtool.utils import (
+    PRUNED_MESSAGE_IDS_KEY,
     RetrieveToolsResult,
     State,
     dedupe_str_list,
@@ -96,6 +103,45 @@ def _prepare_fallback(
     if fallback_llm is None or is_default_model_config(model_configurations):
         return None
     return lambda: fallback_llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
+
+
+def _pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
+    """Tombstones for the slot-stale messages the pre-model hooks dropped.
+
+    ``manage_system_prompts_node`` filters old prompt copies out of the
+    per-call view and relays their ids under ``PRUNED_MESSAGE_IDS_KEY``; the
+    model node emits these tombstones in its own channel update so the pruning
+    also reaches the checkpoint. Popped, never forwarded — the key is a relay,
+    not a state channel.
+    """
+    pruned = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None) or []
+    return [RemoveMessage(id=message_id) for message_id in pruned]
+
+
+_UNSET = object()
+
+
+def _changed_hook_keys(before: State, after: State) -> State:
+    """Only the keys the end-graph hooks actually changed, by identity.
+
+    The end hooks are side-effecting (follow-up streaming, fire-and-forget
+    memory ingestion) and pass state through; echoing the full state back as
+    the node's update re-serializes the entire ``messages`` list into
+    ``checkpoint_writes`` on every run — on a long-lived workflow thread that
+    was ~4.8 MB per run of pure duplication. Identity (not equality) so a hook
+    that rebuilds the dict without touching the values still counts as
+    unchanged, and a genuinely new value always survives.
+    """
+    if after is before:
+        return cast("State", {})
+    return cast(
+        "State",
+        {
+            key: value
+            for key, value in after.items()
+            if cast("dict[str, Any]", before).get(key, _UNSET) is not value
+        },
+    )
 
 
 def create_agent(
@@ -211,6 +257,7 @@ def create_agent(
 
     def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         state = sync_execute_hooks(pre_model_hooks, state, config, store)
+        tombstones = _pop_pruned_tombstones(state)
 
         if middleware_executor:
             raise RuntimeError(
@@ -240,7 +287,7 @@ def create_agent(
         if isinstance(response.content, str) and agent_name == "comms_agent":
             response.content = response.content + NEW_MESSAGE_BREAKER
 
-        return {"messages": [response]}  # type: ignore[return-value]
+        return {"messages": [*tombstones, response]}  # type: ignore[return-value]
 
     def _maybe_inject_wrapup(state: State) -> State:
         """Warn the model to finish when the recursion budget is nearly spent.
@@ -265,6 +312,7 @@ def create_agent(
     async def acall_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         """Async model invocation with middleware support."""
         state = await execute_hooks(pre_model_hooks, state, config, store)
+        tombstones = _pop_pruned_tombstones(state)
 
         if middleware_executor:
             state = await middleware_executor.execute_before_model(state, config, store)
@@ -331,8 +379,10 @@ def create_agent(
 
         # Return partial state update: new message + any keys added by
         # after_model (e.g. todos). Messages use an append reducer, so only
-        # return the new response — not the full list.
-        result: dict[str, object] = {"messages": [response]}
+        # return the new response — not the full list. Tombstones prune the
+        # slot-stale prompt copies the pre-model hooks dropped, so the
+        # checkpointed thread stays bounded too.
+        result: dict[str, object] = {"messages": [*tombstones, response]}
         base_keys = {"messages", "selected_tool_ids"}
         for key, value in updated_state.items():
             if key not in base_keys:
@@ -436,12 +486,12 @@ def create_agent(
     def execute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
-        return sync_execute_hooks(end_graph_hooks, state, config, store)
+        return _changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
 
     async def aexecute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
-        return await execute_hooks(end_graph_hooks, state, config, store)
+        return _changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
 
     def _get_bound_tool_names(state: State) -> set[str]:
         """Return the set of tool names currently bound to the model."""

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -438,6 +438,7 @@ def create_agent(
     async def aselect_tools(
         tool_calls: list[dict], config: RunnableConfig, *, store: BaseStore
     ) -> State:
+        """Async twin of ``select_tools`` — resolve retrieve_tools calls into bindings."""
         if retrieve_tools is None:
             raise RuntimeError("retrieve_tools is disabled and aselect_tools should not be called")
 
@@ -491,6 +492,7 @@ def create_agent(
     async def aexecute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
+        """Run the end-graph hooks; persist only the keys they actually changed."""
         return _changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
 
     def _get_bound_tool_names(state: State) -> set[str]:
@@ -530,6 +532,7 @@ def create_agent(
         return {"messages": messages}  # type: ignore[return-value]
 
     async def areject_unbound_tools(tool_calls: list[dict], *, store: BaseStore) -> State:
+        """Async twin of ``reject_unbound_tools`` for the async graph path."""
         return reject_unbound_tools(tool_calls, store=store)
 
     def _last_tool_calling_message(state: State) -> AIMessage | None:
@@ -638,6 +641,7 @@ def create_agent(
         return {"messages": messages}  # type: ignore[return-value]
 
     async def afinish_task_node(tool_calls: list[ToolCall], *, store: BaseStore) -> State:
+        """Async twin of ``finish_task_node`` for the async graph path."""
         return finish_task_node(tool_calls, store=store)
 
     builder = StateGraph(State, context_schema=context_schema)

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -114,8 +114,14 @@ def _pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
     also reaches the checkpoint. Popped, never forwarded — the key is a relay,
     not a state channel.
     """
-    pruned = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None) or []
-    return [RemoveMessage(id=message_id) for message_id in pruned]
+    raw = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None)
+    if raw is None:
+        # Absent is legitimate: the hook may not have run (or errored and
+        # returned state unchanged) — nothing to prune.
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise TypeError(f"{PRUNED_MESSAGE_IDS_KEY} must be list[str], got {type(raw).__name__}")
+    return [RemoveMessage(id=message_id) for message_id in raw]
 
 
 _UNSET = object()

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -36,7 +36,6 @@ from langchain_core.language_models import LanguageModelLike
 from langchain_core.messages import (
     AIMessage,
     HumanMessage,
-    RemoveMessage,
     ToolCall,
     ToolMessage,
 )
@@ -72,16 +71,17 @@ from app.override.langgraph_bigtool.dynamic_tool_node import (
 )
 from app.override.langgraph_bigtool.hooks import (
     HookType,
+    changed_hook_keys,
     execute_hooks,
     sync_execute_hooks,
 )
 from app.override.langgraph_bigtool.utils import (
-    PRUNED_MESSAGE_IDS_KEY,
     RetrieveToolsResult,
     State,
     dedupe_str_list,
     dedupe_tool_bindings,
     format_selected_tools,
+    pop_pruned_tombstones,
 )
 from app.utils.mcp_utils import canonical_tool_name_map
 from app.utils.multimodal import extract_text_content
@@ -103,51 +103,6 @@ def _prepare_fallback(
     if fallback_llm is None or is_default_model_config(model_configurations):
         return None
     return lambda: fallback_llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
-
-
-def _pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
-    """Tombstones for the slot-stale messages the pre-model hooks dropped.
-
-    ``manage_system_prompts_node`` filters old prompt copies out of the
-    per-call view and relays their ids under ``PRUNED_MESSAGE_IDS_KEY``; the
-    model node emits these tombstones in its own channel update so the pruning
-    also reaches the checkpoint. Popped, never forwarded — the key is a relay,
-    not a state channel.
-    """
-    raw = cast("dict[str, Any]", state).pop(PRUNED_MESSAGE_IDS_KEY, None)
-    if raw is None:
-        # Absent is legitimate: the hook may not have run (or errored and
-        # returned state unchanged) — nothing to prune.
-        return []
-    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
-        raise TypeError(f"{PRUNED_MESSAGE_IDS_KEY} must be list[str], got {type(raw).__name__}")
-    return [RemoveMessage(id=message_id) for message_id in raw]
-
-
-_UNSET = object()
-
-
-def _changed_hook_keys(before: State, after: State) -> State:
-    """Only the keys the end-graph hooks actually changed, by identity.
-
-    The end hooks are side-effecting (follow-up streaming, fire-and-forget
-    memory ingestion) and pass state through; echoing the full state back as
-    the node's update re-serializes the entire ``messages`` list into
-    ``checkpoint_writes`` on every run — on a long-lived workflow thread that
-    was ~4.8 MB per run of pure duplication. Identity (not equality) so a hook
-    that rebuilds the dict without touching the values still counts as
-    unchanged, and a genuinely new value always survives.
-    """
-    if after is before:
-        return cast("State", {})
-    return cast(
-        "State",
-        {
-            key: value
-            for key, value in after.items()
-            if cast("dict[str, Any]", before).get(key, _UNSET) is not value
-        },
-    )
 
 
 def create_agent(
@@ -263,7 +218,7 @@ def create_agent(
 
     def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         state = sync_execute_hooks(pre_model_hooks, state, config, store)
-        tombstones = _pop_pruned_tombstones(state)
+        tombstones = pop_pruned_tombstones(state)
 
         if middleware_executor:
             raise RuntimeError(
@@ -318,7 +273,7 @@ def create_agent(
     async def acall_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
         """Async model invocation with middleware support."""
         state = await execute_hooks(pre_model_hooks, state, config, store)
-        tombstones = _pop_pruned_tombstones(state)
+        tombstones = pop_pruned_tombstones(state)
 
         if middleware_executor:
             state = await middleware_executor.execute_before_model(state, config, store)
@@ -493,13 +448,13 @@ def create_agent(
     def execute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
-        return _changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
+        return changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
 
     async def aexecute_end_graph_hooks_node(
         state: State, config: RunnableConfig, *, store: BaseStore
     ) -> State:
         """Run the end-graph hooks; persist only the keys they actually changed."""
-        return _changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
+        return changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
 
     def _get_bound_tool_names(state: State) -> set[str]:
         """Return the set of tool names currently bound to the model."""

--- a/apps/api/app/override/langgraph_bigtool/create_agent.py
+++ b/apps/api/app/override/langgraph_bigtool/create_agent.py
@@ -10,9 +10,11 @@ WHY THIS EXISTS:
 - Support LangChain's official AgentMiddleware system (before_model, after_model, wrap_model_call, wrap_tool_call)
 
 WHAT'S MODIFIED:
-In acall_model():
+In acall_model() (nodes.py):
 - Dynamic model configuration from config.configurable
 - Middleware execution via MiddlewareExecutor
+
+Node bodies live in nodes.py; this module wires them into the StateGraph.
 
 IMPORT CHANGE REQUIRED:
 Replace library import in build_graph.py:
@@ -28,18 +30,11 @@ NOTE: Type/linting errors in this file are expected since it's copied from exter
 """
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-import functools
-from typing import Any, cast
+from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models import LanguageModelLike
-from langchain_core.messages import (
-    AIMessage,
-    HumanMessage,
-    ToolCall,
-    ToolMessage,
-)
-from langchain_core.runnables import Runnable, RunnableConfig
+from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool, StructuredTool
 
 # Imported from the defining module, as langgraph's own prebuilt/ package does.
@@ -48,61 +43,36 @@ from langchain_core.tools import BaseTool, StructuredTool
 # to no_implicit_reexport.
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.graph import END, StateGraph
-from langgraph.prebuilt.tool_node import ToolCallWithContext
-from langgraph.store.base import BaseStore
-from langgraph.types import RetryPolicy, Send
+from langgraph.types import RetryPolicy
 from langgraph_bigtool.tools import get_default_retrieval_tool, get_store_arg
 
-from app.agents.llm.client import (
-    ainvoke_llm,
-    get_default_llm,
-    invoke_llm,
-    is_default_model_config,
-)
+from app.agents.llm.client import get_default_llm
 from app.agents.llm.exceptions import LLMNotConfiguredError
 from app.agents.middleware.executor import MiddlewareExecutor
-from app.constants.general import FINISH_TASK_NAME, NEW_MESSAGE_BREAKER
-from app.constants.llm import RECURSION_WRAPUP_THRESHOLD_STEPS
-from app.models.agent_models import AgentConfigurable, agent_configurable
+from app.constants.general import FINISH_TASK_NAME
 from app.override.langgraph_bigtool.dynamic_tool_node import (
     DynamicToolNode,
     format_tool_error,
     hil_and_timeout_guarded_tool_call,
 )
-from app.override.langgraph_bigtool.hooks import (
-    HookType,
-    changed_hook_keys,
-    execute_hooks,
-    sync_execute_hooks,
+from app.override.langgraph_bigtool.hooks import HookType
+from app.override.langgraph_bigtool.nodes import (
+    afinish_task_node,
+    areject_unbound_tools,
+    finish_task_node,
+    make_bound_tool_names,
+    make_build_tools_to_bind,
+    make_dispatch_tools,
+    make_end_graph_hooks_nodes,
+    make_executable_calls,
+    make_model_nodes,
+    make_select_tools_nodes,
+    make_should_continue,
+    reject_unbound_tools,
 )
-from app.override.langgraph_bigtool.utils import (
-    RetrieveToolsResult,
-    State,
-    dedupe_str_list,
-    dedupe_tool_bindings,
-    format_selected_tools,
-    pop_pruned_tombstones,
-)
-from app.utils.mcp_utils import canonical_tool_name_map
-from app.utils.multimodal import extract_text_content
-from shared.py.wide_events import log
+from app.override.langgraph_bigtool.utils import RetrieveToolsResult, State
 
 RetrieveToolsResponse = RetrieveToolsResult | list[str]
-
-
-def _prepare_fallback(
-    fallback_llm: Runnable | None,
-    tools_to_bind: list[BaseTool],
-    model_configurations: AgentConfigurable,
-) -> Callable[[], Runnable] | None:
-    """Factory that binds the default fallback model with the same tools as the
-    primary. Returned as a zero-arg callable so the (per-turn, tool-list-sized)
-    binding only happens if the primary actually fails. None when no fallback is
-    configured or the selected model already is the default model (no point
-    falling back to itself)."""
-    if fallback_llm is None or is_default_model_config(model_configurations):
-        return None
-    return lambda: fallback_llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
 
 
 def create_agent(
@@ -181,34 +151,6 @@ def create_agent(
         )
         store_arg = get_store_arg(retrieve_tools)
 
-    def build_tools_to_bind(state: State) -> list[BaseTool]:
-        """Assemble the bound-tool list with a cache-stable ordering.
-
-        Fixed tools (``retrieve_tools``, the agent's initial set, middleware)
-        are bound first so they form a byte-stable prefix for the whole
-        conversation. Dynamically retrieved tools (``selected_tool_ids``, which
-        only ever grows via the append-only reducer) are bound LAST, so each
-        retrieval appends to the tail instead of shifting the fixed tools. That
-        keeps the request's function-declaration prefix stable and lets the
-        provider's implicit prompt cache survive across turns instead of
-        resetting on every tool retrieval.
-        """
-        # Skip unknown ids (a stale id in the append-only selected_tool_ids must
-        # not crash the model invocation) rather than indexing blindly.
-        initial_tools = [
-            tool_registry[id] for id in (initial_tool_ids or []) if id in tool_registry
-        ]
-        selected_tools = [
-            tool_registry[id] for id in state["selected_tool_ids"] if id in tool_registry
-        ]
-        tools_to_bind: list[BaseTool] = []
-        if retrieve_tools is not None:
-            tools_to_bind.append(retrieve_tools)
-        tools_to_bind.extend(initial_tools)
-        tools_to_bind.extend(middleware_tools)
-        tools_to_bind.extend(selected_tools)
-        return dedupe_tool_bindings(tools_to_bind)
-
     # Default model used as the last-resort fallback when the selected model
     # keeps failing; None when Google isn't configured (fallback then skipped).
     try:
@@ -216,394 +158,24 @@ def create_agent(
     except LLMNotConfiguredError:
         fallback_llm = None
 
-    def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
-        state = sync_execute_hooks(pre_model_hooks, state, config, store)
-        tombstones = pop_pruned_tombstones(state)
-
-        if middleware_executor:
-            raise RuntimeError(
-                "Agent middleware is configured but sync execution was requested. "
-                "Use the async graph execution path (ainvoke/astream)."
-            )
-
-        # The raw bag goes back to LangChain untouched (it owns the keys it
-        # merged in); the typed view is what GAIA reads its own keys through.
-        _llm = llm.with_config(configurable=config.get("configurable", {}))
-        model_configurations = agent_configurable(config)
-        tools_to_bind = build_tools_to_bind(state)
-        llm_with_tools = _llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
-        fallback = _prepare_fallback(fallback_llm, tools_to_bind, model_configurations)
-        state = _maybe_inject_wrapup(state)
-        response = invoke_llm(
-            llm_with_tools,
-            state["messages"],
-            fallback=fallback,
-            config=config,
-            label=agent_name,
-        )
-
-        if not response.tool_calls and not response.content:
-            response.content = "Empty response from model."
-
-        if isinstance(response.content, str) and agent_name == "comms_agent":
-            response.content = response.content + NEW_MESSAGE_BREAKER
-
-        return {"messages": [*tombstones, response]}  # type: ignore[return-value]
-
-    def _maybe_inject_wrapup(state: State) -> State:
-        """Warn the model to finish when the recursion budget is nearly spent.
-
-        Injected per model call (never persisted): a trailing HumanMessage,
-        because Gemini drops trailing SystemMessages. Without this, the run
-        dies mid-exploration with a hard GraphRecursionError the model never
-        saw coming.
-        """
-        remaining = state.get("remaining_steps")
-        if not isinstance(remaining, int) or remaining > RECURSION_WRAPUP_THRESHOLD_STEPS:
-            return state
-        notice = HumanMessage(
-            content=(
-                "[System notice: you are almost out of steps for this run "
-                f"(~{remaining} left). Stop exploring now — summarize what you "
-                "found and what remains to be done, and finish your reply.]"
-            )
-        )
-        return cast(State, {**state, "messages": [*state.get("messages", []), notice]})
-
-    async def acall_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
-        """Async model invocation with middleware support."""
-        state = await execute_hooks(pre_model_hooks, state, config, store)
-        tombstones = pop_pruned_tombstones(state)
-
-        if middleware_executor:
-            state = await middleware_executor.execute_before_model(state, config, store)
-
-        state = _maybe_inject_wrapup(state)
-
-        # The raw bag goes back to LangChain untouched (it owns the keys it
-        # merged in); the typed view is what GAIA reads its own keys through.
-        _llm = llm.with_config(configurable=config.get("configurable", {}))
-        model_configurations = agent_configurable(config)
-
-        tools_to_bind = build_tools_to_bind(state)
-        llm_with_tools = _llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
-        fallback = _prepare_fallback(fallback_llm, tools_to_bind, model_configurations)
-        invoke_fn = functools.partial(
-            ainvoke_llm, llm_with_tools, fallback=fallback, config=config, label=agent_name
-        )
-
-        try:
-            recent_messages = state.get("messages", [])[-6:]
-            preview = []
-            for msg in recent_messages:
-                role = msg.__class__.__name__
-                # extract_text_content, not the raw content: a tool result carrying
-                # inline media holds megabytes of base64 that must never reach a log.
-                content = extract_text_content(getattr(msg, "content", ""))
-                if len(content) > 200:
-                    content = content[:197] + "..."
-                preview.append({"role": role, "content": content})
-            log.info("acall_model message preview", preview=preview)
-        except Exception as e:
-            log.debug("Failed to log message preview", error_type=type(e).__name__, error=str(e))
-
-        if middleware_executor and middleware_executor.has_wrap_model_call():
-            middleware_tools_for_request: list[BaseTool | dict[str, Any]] = [
-                tool for tool in tools_to_bind
-            ]
-            response = await middleware_executor.wrap_model_invocation(
-                model=_llm,  # type: ignore[arg-type]
-                state=state,
-                config=config,
-                store=store,
-                tools=middleware_tools_for_request,
-                invoke_fn=invoke_fn,
-            )
-        else:
-            response = await invoke_fn(state["messages"])
-
-        if not response.tool_calls and not response.content:
-            response.content = "Empty response from model."
-
-        if isinstance(response.content, str) and agent_name == "comms_agent":
-            response.content = response.content + NEW_MESSAGE_BREAKER
-
-        # Build updated state with response for after_model hooks
-        updated_state: State = dict(state)  # type: ignore[assignment]
-        updated_state["messages"] = list(state.get("messages", [])) + [response]
-
-        # Execute middleware after_model hooks
-        if middleware_executor:
-            updated_state = await middleware_executor.execute_after_model(
-                updated_state, config, store
-            )
-
-        # Return partial state update: new message + any keys added by
-        # after_model (e.g. todos). Messages use an append reducer, so only
-        # return the new response — not the full list. Tombstones prune the
-        # slot-stale prompt copies the pre-model hooks dropped, so the
-        # checkpointed thread stays bounded too.
-        result: dict[str, object] = {"messages": [*tombstones, response]}
-        base_keys = {"messages", "selected_tool_ids"}
-        for key, value in updated_state.items():
-            if key not in base_keys:
-                result[key] = value
-        return result  # type: ignore[return-value]
-
-    def select_tools(tool_calls: list[dict], config: RunnableConfig, *, store: BaseStore) -> State:
-        if retrieve_tools is None:
-            raise RuntimeError("retrieve_tools is disabled and select_tools should not be called")
-
-        selected_tools = {}
-        response_tools = {}
-        for tool_call in tool_calls:
-            kwargs = {**tool_call["args"]}
-            if store_arg:
-                kwargs[store_arg] = store
-            if config:
-                user_id = agent_configurable(config).get("user_id")
-                if user_id:
-                    kwargs["user_id"] = user_id
-
-            result = retrieve_tools.invoke(kwargs, config=config)
-
-            # Handle both RetrieveToolsResult dict and plain list
-            if isinstance(result, dict):
-                tools_to_bind = [
-                    tool_id
-                    for tool_id in result.get("tools_to_bind", [])
-                    if isinstance(tool_id, str)
-                ]
-                response = [
-                    tool_id for tool_id in result.get("response", []) if isinstance(tool_id, str)
-                ]
-            else:
-                tools_to_bind = [
-                    tool_id
-                    for tool_id in (result if isinstance(result, list) else [])
-                    if isinstance(tool_id, str)
-                ]
-                response = tools_to_bind
-
-            # Filter out subagent: prefixed tools from binding
-            filtered_bind = [
-                tool_id for tool_id in tools_to_bind if not tool_id.startswith("subagent:")
-            ]
-            selected_tools[tool_call["id"]] = dedupe_str_list(filtered_bind)
-            response_tools[tool_call["id"]] = dedupe_str_list(response)
-
-        tool_messages, _ = format_selected_tools(response_tools, tool_registry)  # type: ignore[arg-type]
-        _, bind_ids = format_selected_tools(selected_tools, tool_registry)  # type: ignore[arg-type]
-        return {"messages": tool_messages, "selected_tool_ids": bind_ids}  # type: ignore[return-value]
-
-    async def aselect_tools(
-        tool_calls: list[dict], config: RunnableConfig, *, store: BaseStore
-    ) -> State:
-        """Async twin of ``select_tools`` — resolve retrieve_tools calls into bindings."""
-        if retrieve_tools is None:
-            raise RuntimeError("retrieve_tools is disabled and aselect_tools should not be called")
-
-        selected_tools = {}
-        response_tools = {}
-        for tool_call in tool_calls:
-            kwargs = {**tool_call["args"]}
-            if store_arg:
-                kwargs[store_arg] = store
-            if config:
-                user_id = agent_configurable(config).get("user_id")
-                if user_id:
-                    kwargs["user_id"] = user_id
-
-            result = await retrieve_tools.ainvoke(kwargs, config=config)
-
-            # Handle both RetrieveToolsResult dict and plain list
-            if isinstance(result, dict):
-                tools_to_bind = [
-                    tool_id
-                    for tool_id in result.get("tools_to_bind", [])
-                    if isinstance(tool_id, str)
-                ]
-                response = [
-                    tool_id for tool_id in result.get("response", []) if isinstance(tool_id, str)
-                ]
-            else:
-                tools_to_bind = [
-                    tool_id
-                    for tool_id in (result if isinstance(result, list) else [])
-                    if isinstance(tool_id, str)
-                ]
-                response = tools_to_bind
-
-            # Filter out subagent: prefixed tools from binding
-            filtered_bind = [
-                tool_id for tool_id in tools_to_bind if not tool_id.startswith("subagent:")
-            ]
-            selected_tools[tool_call["id"]] = dedupe_str_list(filtered_bind)
-            response_tools[tool_call["id"]] = dedupe_str_list(response)
-
-        tool_messages, _ = format_selected_tools(response_tools, tool_registry)  # type: ignore[arg-type]
-        _, bind_ids = format_selected_tools(selected_tools, tool_registry)  # type: ignore[arg-type]
-        return {"messages": tool_messages, "selected_tool_ids": bind_ids}  # type: ignore[return-value]
-
-    def execute_end_graph_hooks_node(
-        state: State, config: RunnableConfig, *, store: BaseStore
-    ) -> State:
-        return changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
-
-    async def aexecute_end_graph_hooks_node(
-        state: State, config: RunnableConfig, *, store: BaseStore
-    ) -> State:
-        """Run the end-graph hooks; persist only the keys they actually changed."""
-        return changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
-
-    def _get_bound_tool_names(state: State) -> set[str]:
-        """Return the set of tool names currently bound to the model."""
-        bound: set[str] = set()
-        # retrieve_tools itself is always bound when enabled
-        if retrieve_tools is not None:
-            bound.add(retrieve_tools.name)
-        # Tools selected via retrieve_tools
-        for tool_id in state.get("selected_tool_ids", []):
-            if tool_id in tool_registry:
-                bound.add(tool_registry[tool_id].name)
-        # Always-bound initial tools
-        for tool_id in initial_tool_ids or []:
-            if tool_id in tool_registry:
-                bound.add(tool_registry[tool_id].name)
-        # Middleware tools (e.g. spawn_subagent, plan_tasks)
-        for tool in middleware_tools:
-            if hasattr(tool, "name"):
-                bound.add(tool.name)
-        return bound
-
-    def reject_unbound_tools(tool_calls: list[dict], *, store: BaseStore) -> State:
-        """Return error ToolMessages for tool calls that were not bound."""
-        messages = [
-            ToolMessage(
-                content=(
-                    f"Tool '{call['name']}' is not bound. "
-                    "You must call retrieve_tools(exact_tool_names=['{name}']) "
-                    "to bind it before calling it.".format(name=call["name"])
-                ),
-                tool_call_id=call["id"],
-                name=call["name"],
-            )
-            for call in tool_calls
-        ]
-        return {"messages": messages}  # type: ignore[return-value]
-
-    async def areject_unbound_tools(tool_calls: list[dict], *, store: BaseStore) -> State:
-        """Async twin of ``reject_unbound_tools`` for the async graph path."""
-        return reject_unbound_tools(tool_calls, store=store)
-
-    def _last_tool_calling_message(state: State) -> AIMessage | None:
-        """The AI message whose calls this turn is executing.
-
-        NOT ``messages[-1]``: a resume prepends a current-time HumanMessage
-        (``subagent_runner._with_current_time``), so by the time the approvals node has
-        paused and woken, the tool-calling message is no longer last. Matches
-        ``hil/utils.current_tool_calls``, which the gate resolves siblings with — the two
-        must agree on which message is being executed or they gate different call sets.
-        """
-        for message in reversed(state["messages"]):
-            if isinstance(message, AIMessage) and message.tool_calls:
-                return message
-        return None
-
-    def _executable_calls(state: State) -> list[ToolCall]:
-        """The message's tool calls that the tools node will run, names canonicalized.
-
-        Mutates each call's name in place when it maps to a bound tool, so the tools
-        node's registry lookup hits the actual BaseTool. Separate from routing because
-        both the router and the approvals node's outgoing edge need this same list.
-        """
-        last_message = _last_tool_calling_message(state)
-        if last_message is None:
-            return []
-        bound_names = _get_bound_tool_names(state)
-        canonical_to_bound = canonical_tool_name_map(bound_names)
-        runnable: list[ToolCall] = []
-        for call in last_message.tool_calls:
-            if retrieve_tools is not None and call["name"] == retrieve_tools.name:
-                continue
-            if call["name"] not in bound_names:
-                canonical = canonical_to_bound.get(call["name"].replace("-", "_"))
-                if canonical is None:
-                    continue
-                call["name"] = canonical
-            runnable.append(call)
-        return runnable
-
-    def dispatch_tools(state: State, *, store: BaseStore) -> list[Send]:
-        """Fan the message's calls out to the tools node, one task each.
-
-        ToolCallWithContext carries the full state dict so ToolNode can do InjectedState
-        injection. Each call becomes its own task, and a task that pauses for approval
-        leaves its completed siblings alone — LangGraph persists their writes.
-        """
-        del store
-        return [
-            Send(
-                "tools",
-                ToolCallWithContext(__type="tool_call_with_context", tool_call=call, state=state),
-            )
-            for call in _executable_calls(state)
-        ]
-
-    def should_continue(state: State, *, store: BaseStore) -> str | Send | list[Send]:
-        messages = state["messages"]
-        last_message = messages[-1]
-        if not isinstance(last_message, AIMessage) or not last_message.tool_calls:
-            return "end_graph_hooks" if end_graph_hooks else END
-        bound_names = _get_bound_tool_names(state)
-        canonical_to_bound = canonical_tool_name_map(bound_names)
-        destinations: list[Send] = []
-        unbound_calls: list[ToolCall] = []
-
-        finish_calls: list[ToolCall] = [
-            call for call in last_message.tool_calls if call.get("name") == FINISH_TASK_NAME
-        ]
-        if finish_calls:
-            return Send(FINISH_TASK_NAME, finish_calls)
-
-        for call in last_message.tool_calls:
-            if retrieve_tools is not None and call["name"] == retrieve_tools.name:
-                destinations.append(Send("select_tools", [call]))
-                continue
-            if call["name"] not in bound_names and not canonical_to_bound.get(
-                call["name"].replace("-", "_")
-            ):
-                unbound_calls.append(call)
-
-        # ONE task for the whole message, and it runs before any tool: the approvals node
-        # settles every HIL decision in its own superstep, then fans out to the tools node.
-        # Sending straight to "tools" here is what used to let an ungated call execute
-        # beside one that paused — and a pause discards and replays that whole step.
-        destinations.extend(dispatch_tools(state, store=store))
-
-        if unbound_calls:
-            destinations.append(Send("reject_unbound_tools", unbound_calls))
-
-        return destinations
-
-    def finish_task_node(tool_calls: list[ToolCall], *, store: BaseStore) -> State:
-        messages = []
-        for call in tool_calls:
-            args = call.get("args", {}) if isinstance(call, dict) else {}
-            result = args.get("result")
-            content = str(result) if result is not None else "Task completed."
-            messages.append(
-                ToolMessage(
-                    content=content,
-                    tool_call_id=call.get("id", ""),
-                    name=FINISH_TASK_NAME,
-                )
-            )
-        return {"messages": messages}  # type: ignore[return-value]
-
-    async def afinish_task_node(tool_calls: list[ToolCall], *, store: BaseStore) -> State:
-        """Async twin of ``finish_task_node`` for the async graph path."""
-        return finish_task_node(tool_calls, store=store)
+    build_tools_to_bind = make_build_tools_to_bind(
+        tool_registry, retrieve_tools, middleware_tools, initial_tool_ids
+    )
+    call_model, acall_model = make_model_nodes(
+        llm, agent_name, pre_model_hooks, middleware_executor, build_tools_to_bind, fallback_llm
+    )
+    select_tools, aselect_tools = make_select_tools_nodes(retrieve_tools, store_arg, tool_registry)
+    execute_end_graph_hooks_node, aexecute_end_graph_hooks_node = make_end_graph_hooks_nodes(
+        end_graph_hooks
+    )
+    get_bound_tool_names = make_bound_tool_names(
+        retrieve_tools, tool_registry, initial_tool_ids, middleware_tools
+    )
+    executable_calls = make_executable_calls(get_bound_tool_names, retrieve_tools)
+    dispatch_tools = make_dispatch_tools(executable_calls)
+    should_continue = make_should_continue(
+        get_bound_tool_names, retrieve_tools, dispatch_tools, bool(end_graph_hooks)
+    )
 
     builder = StateGraph(State, context_schema=context_schema)
 

--- a/apps/api/app/override/langgraph_bigtool/hooks.py
+++ b/apps/api/app/override/langgraph_bigtool/hooks.py
@@ -7,7 +7,7 @@ Provides sync and async hook execution for pre_model, end_graph, etc.
 import asyncio
 from collections.abc import Awaitable, Callable
 import inspect
-from typing import Union
+from typing import Union, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
@@ -47,6 +47,22 @@ async def execute_hooks(
         else:
             state = result  # type: ignore[assignment]
     return state
+
+
+def changed_hook_keys(before: State, after: State) -> State:
+    """Keys the hook chain changed (by identity) — echoing unchanged channels
+    re-serializes the full message list into the checkpoint on every run."""
+    if after is before:
+        return cast("State", {})
+    before_dict = cast("dict[str, object]", before)
+    return cast(
+        "State",
+        {
+            key: value
+            for key, value in after.items()
+            if key not in before_dict or before_dict[key] is not value
+        },
+    )
 
 
 def sync_execute_hooks(

--- a/apps/api/app/override/langgraph_bigtool/nodes.py
+++ b/apps/api/app/override/langgraph_bigtool/nodes.py
@@ -1,0 +1,541 @@
+"""Node implementations for the bigtool agent graph.
+
+Bodies moved verbatim out of ``create_agent()`` (create_agent.py), where they
+lived as closures; each ``make_*`` factory takes exactly the values its closure
+captured. ``create_agent`` is now assembly only.
+"""
+
+from collections.abc import Callable, Mapping
+import functools
+from typing import Any, cast
+
+from langchain_core.language_models import LanguageModelLike
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.runnables import Runnable, RunnableConfig
+from langchain_core.tools import BaseTool, StructuredTool
+from langgraph.graph import END
+from langgraph.prebuilt.tool_node import ToolCallWithContext
+from langgraph.store.base import BaseStore
+from langgraph.types import Send
+
+from app.agents.llm.client import ainvoke_llm, invoke_llm, is_default_model_config
+from app.agents.middleware.executor import MiddlewareExecutor
+from app.constants.general import FINISH_TASK_NAME, NEW_MESSAGE_BREAKER
+from app.constants.llm import RECURSION_WRAPUP_THRESHOLD_STEPS
+from app.models.agent_models import AgentConfigurable, agent_configurable
+from app.override.langgraph_bigtool.hooks import (
+    HookType,
+    changed_hook_keys,
+    execute_hooks,
+    sync_execute_hooks,
+)
+from app.override.langgraph_bigtool.utils import (
+    State,
+    dedupe_str_list,
+    dedupe_tool_bindings,
+    format_selected_tools,
+    pop_pruned_tombstones,
+)
+from app.utils.mcp_utils import canonical_tool_name_map
+from app.utils.multimodal import extract_text_content
+from shared.py.wide_events import log
+
+SyncAsyncNodePair = tuple[
+    Callable[..., State],
+    Callable[..., Any],
+]
+
+
+def _prepare_fallback(
+    fallback_llm: Runnable | None,
+    tools_to_bind: list[BaseTool],
+    model_configurations: AgentConfigurable,
+) -> Callable[[], Runnable] | None:
+    """Factory that binds the default fallback model with the same tools as the
+    primary. Returned as a zero-arg callable so the (per-turn, tool-list-sized)
+    binding only happens if the primary actually fails. None when no fallback is
+    configured or the selected model already is the default model (no point
+    falling back to itself)."""
+    if fallback_llm is None or is_default_model_config(model_configurations):
+        return None
+    return lambda: fallback_llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
+
+
+def _maybe_inject_wrapup(state: State) -> State:
+    """Warn the model to finish when the recursion budget is nearly spent.
+
+    Injected per model call (never persisted): a trailing HumanMessage,
+    because Gemini drops trailing SystemMessages. Without this, the run
+    dies mid-exploration with a hard GraphRecursionError the model never
+    saw coming.
+    """
+    remaining = state.get("remaining_steps")
+    if not isinstance(remaining, int) or remaining > RECURSION_WRAPUP_THRESHOLD_STEPS:
+        return state
+    notice = HumanMessage(
+        content=(
+            "[System notice: you are almost out of steps for this run "
+            f"(~{remaining} left). Stop exploring now — summarize what you "
+            "found and what remains to be done, and finish your reply.]"
+        )
+    )
+    return cast(State, {**state, "messages": [*state.get("messages", []), notice]})
+
+
+def make_build_tools_to_bind(
+    tool_registry: Mapping[str, BaseTool],
+    retrieve_tools: StructuredTool | None,
+    middleware_tools: list[BaseTool],
+    initial_tool_ids: list[str] | None,
+) -> Callable[[State], list[BaseTool]]:
+    """Build the per-call bound-tool assembler."""
+
+    def build_tools_to_bind(state: State) -> list[BaseTool]:
+        """Assemble the bound-tool list with a cache-stable ordering.
+
+        Fixed tools (``retrieve_tools``, the agent's initial set, middleware)
+        are bound first so they form a byte-stable prefix for the whole
+        conversation. Dynamically retrieved tools (``selected_tool_ids``, which
+        only ever grows via the append-only reducer) are bound LAST, so each
+        retrieval appends to the tail instead of shifting the fixed tools. That
+        keeps the request's function-declaration prefix stable and lets the
+        provider's implicit prompt cache survive across turns instead of
+        resetting on every tool retrieval.
+        """
+        # Skip unknown ids (a stale id in the append-only selected_tool_ids must
+        # not crash the model invocation) rather than indexing blindly.
+        initial_tools = [
+            tool_registry[id] for id in (initial_tool_ids or []) if id in tool_registry
+        ]
+        selected_tools = [
+            tool_registry[id] for id in state["selected_tool_ids"] if id in tool_registry
+        ]
+        tools_to_bind: list[BaseTool] = []
+        if retrieve_tools is not None:
+            tools_to_bind.append(retrieve_tools)
+        tools_to_bind.extend(initial_tools)
+        tools_to_bind.extend(middleware_tools)
+        tools_to_bind.extend(selected_tools)
+        return dedupe_tool_bindings(tools_to_bind)
+
+    return build_tools_to_bind
+
+
+def make_model_nodes(
+    llm: LanguageModelLike,
+    agent_name: str,
+    pre_model_hooks: list[HookType] | None,
+    middleware_executor: MiddlewareExecutor | None,
+    build_tools_to_bind: Callable[[State], list[BaseTool]],
+    fallback_llm: Runnable | None,
+) -> SyncAsyncNodePair:
+    """Build the (sync, async) model-invocation nodes."""
+
+    def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
+        state = sync_execute_hooks(pre_model_hooks, state, config, store)
+        tombstones = pop_pruned_tombstones(state)
+
+        if middleware_executor:
+            raise RuntimeError(
+                "Agent middleware is configured but sync execution was requested. "
+                "Use the async graph execution path (ainvoke/astream)."
+            )
+
+        # The raw bag goes back to LangChain untouched (it owns the keys it
+        # merged in); the typed view is what GAIA reads its own keys through.
+        _llm = llm.with_config(configurable=config.get("configurable", {}))
+        model_configurations = agent_configurable(config)
+        tools_to_bind = build_tools_to_bind(state)
+        llm_with_tools = _llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
+        fallback = _prepare_fallback(fallback_llm, tools_to_bind, model_configurations)
+        state = _maybe_inject_wrapup(state)
+        response = invoke_llm(
+            llm_with_tools,
+            state["messages"],
+            fallback=fallback,
+            config=config,
+            label=agent_name,
+        )
+
+        if not response.tool_calls and not response.content:
+            response.content = "Empty response from model."
+
+        if isinstance(response.content, str) and agent_name == "comms_agent":
+            response.content = response.content + NEW_MESSAGE_BREAKER
+
+        return {"messages": [*tombstones, response]}  # type: ignore[return-value]
+
+    async def acall_model(state: State, config: RunnableConfig, *, store: BaseStore) -> State:
+        """Async model invocation with middleware support."""
+        state = await execute_hooks(pre_model_hooks, state, config, store)
+        tombstones = pop_pruned_tombstones(state)
+
+        if middleware_executor:
+            state = await middleware_executor.execute_before_model(state, config, store)
+
+        state = _maybe_inject_wrapup(state)
+
+        # The raw bag goes back to LangChain untouched (it owns the keys it
+        # merged in); the typed view is what GAIA reads its own keys through.
+        _llm = llm.with_config(configurable=config.get("configurable", {}))
+        model_configurations = agent_configurable(config)
+
+        tools_to_bind = build_tools_to_bind(state)
+        llm_with_tools = _llm.bind_tools(tools_to_bind)  # type: ignore[attr-defined]
+        fallback = _prepare_fallback(fallback_llm, tools_to_bind, model_configurations)
+        invoke_fn = functools.partial(
+            ainvoke_llm, llm_with_tools, fallback=fallback, config=config, label=agent_name
+        )
+
+        try:
+            recent_messages = state.get("messages", [])[-6:]
+            preview = []
+            for msg in recent_messages:
+                role = msg.__class__.__name__
+                # extract_text_content, not the raw content: a tool result carrying
+                # inline media holds megabytes of base64 that must never reach a log.
+                content = extract_text_content(getattr(msg, "content", ""))
+                if len(content) > 200:
+                    content = content[:197] + "..."
+                preview.append({"role": role, "content": content})
+            log.info("acall_model message preview", preview=preview)
+        except Exception as e:
+            log.debug("Failed to log message preview", error_type=type(e).__name__, error=str(e))
+
+        if middleware_executor and middleware_executor.has_wrap_model_call():
+            middleware_tools_for_request: list[BaseTool | dict[str, Any]] = [
+                tool for tool in tools_to_bind
+            ]
+            response = await middleware_executor.wrap_model_invocation(
+                model=_llm,  # type: ignore[arg-type]
+                state=state,
+                config=config,
+                store=store,
+                tools=middleware_tools_for_request,
+                invoke_fn=invoke_fn,
+            )
+        else:
+            response = await invoke_fn(state["messages"])
+
+        if not response.tool_calls and not response.content:
+            response.content = "Empty response from model."
+
+        if isinstance(response.content, str) and agent_name == "comms_agent":
+            response.content = response.content + NEW_MESSAGE_BREAKER
+
+        # Build updated state with response for after_model hooks
+        updated_state: State = dict(state)  # type: ignore[assignment]
+        updated_state["messages"] = list(state.get("messages", [])) + [response]
+
+        # Execute middleware after_model hooks
+        if middleware_executor:
+            updated_state = await middleware_executor.execute_after_model(
+                updated_state, config, store
+            )
+
+        # Return partial state update: new message + any keys added by
+        # after_model (e.g. todos). Messages use an append reducer, so only
+        # return the new response — not the full list. Tombstones prune the
+        # slot-stale prompt copies the pre-model hooks dropped, so the
+        # checkpointed thread stays bounded too.
+        result: dict[str, object] = {"messages": [*tombstones, response]}
+        base_keys = {"messages", "selected_tool_ids"}
+        for key, value in updated_state.items():
+            if key not in base_keys:
+                result[key] = value
+        return result  # type: ignore[return-value]
+
+    return call_model, acall_model
+
+
+def make_select_tools_nodes(
+    retrieve_tools: StructuredTool | None,
+    store_arg: str | None,
+    tool_registry: Mapping[str, BaseTool],
+) -> SyncAsyncNodePair:
+    """Build the (sync, async) retrieve_tools resolution nodes."""
+
+    def select_tools(tool_calls: list[dict], config: RunnableConfig, *, store: BaseStore) -> State:
+        if retrieve_tools is None:
+            raise RuntimeError("retrieve_tools is disabled and select_tools should not be called")
+
+        selected_tools = {}
+        response_tools = {}
+        for tool_call in tool_calls:
+            kwargs = {**tool_call["args"]}
+            if store_arg:
+                kwargs[store_arg] = store
+            if config:
+                user_id = agent_configurable(config).get("user_id")
+                if user_id:
+                    kwargs["user_id"] = user_id
+
+            result = retrieve_tools.invoke(kwargs, config=config)
+            selected, response = _split_retrieval_result(result)
+            selected_tools[tool_call["id"]] = selected
+            response_tools[tool_call["id"]] = response
+
+        tool_messages, _ = format_selected_tools(response_tools, tool_registry)  # type: ignore[arg-type]
+        _, bind_ids = format_selected_tools(selected_tools, tool_registry)  # type: ignore[arg-type]
+        return {"messages": tool_messages, "selected_tool_ids": bind_ids}  # type: ignore[return-value]
+
+    async def aselect_tools(
+        tool_calls: list[dict], config: RunnableConfig, *, store: BaseStore
+    ) -> State:
+        """Async twin of ``select_tools`` — resolve retrieve_tools calls into bindings."""
+        if retrieve_tools is None:
+            raise RuntimeError("retrieve_tools is disabled and aselect_tools should not be called")
+
+        selected_tools = {}
+        response_tools = {}
+        for tool_call in tool_calls:
+            kwargs = {**tool_call["args"]}
+            if store_arg:
+                kwargs[store_arg] = store
+            if config:
+                user_id = agent_configurable(config).get("user_id")
+                if user_id:
+                    kwargs["user_id"] = user_id
+
+            result = await retrieve_tools.ainvoke(kwargs, config=config)
+            selected, response = _split_retrieval_result(result)
+            selected_tools[tool_call["id"]] = selected
+            response_tools[tool_call["id"]] = response
+
+        tool_messages, _ = format_selected_tools(response_tools, tool_registry)  # type: ignore[arg-type]
+        _, bind_ids = format_selected_tools(selected_tools, tool_registry)  # type: ignore[arg-type]
+        return {"messages": tool_messages, "selected_tool_ids": bind_ids}  # type: ignore[return-value]
+
+    return select_tools, aselect_tools
+
+
+def _split_retrieval_result(result: object) -> tuple[list[str], list[str]]:
+    """Normalize a retrieval result (RetrieveToolsResult dict or plain list) into
+    deduped (bindable ids, response ids), dropping subagent:-prefixed bindings."""
+    if isinstance(result, dict):
+        tools_to_bind = [
+            tool_id for tool_id in result.get("tools_to_bind", []) if isinstance(tool_id, str)
+        ]
+        response = [tool_id for tool_id in result.get("response", []) if isinstance(tool_id, str)]
+    else:
+        tools_to_bind = [
+            tool_id
+            for tool_id in (result if isinstance(result, list) else [])
+            if isinstance(tool_id, str)
+        ]
+        response = tools_to_bind
+
+    filtered_bind = [tool_id for tool_id in tools_to_bind if not tool_id.startswith("subagent:")]
+    return dedupe_str_list(filtered_bind), dedupe_str_list(response)
+
+
+def make_end_graph_hooks_nodes(end_graph_hooks: list[HookType] | None) -> SyncAsyncNodePair:
+    """Build the (sync, async) end-graph hook nodes."""
+
+    def execute_end_graph_hooks_node(
+        state: State, config: RunnableConfig, *, store: BaseStore
+    ) -> State:
+        return changed_hook_keys(state, sync_execute_hooks(end_graph_hooks, state, config, store))
+
+    async def aexecute_end_graph_hooks_node(
+        state: State, config: RunnableConfig, *, store: BaseStore
+    ) -> State:
+        """Run the end-graph hooks; persist only the keys they actually changed."""
+        return changed_hook_keys(state, await execute_hooks(end_graph_hooks, state, config, store))
+
+    return execute_end_graph_hooks_node, aexecute_end_graph_hooks_node
+
+
+def make_bound_tool_names(
+    retrieve_tools: StructuredTool | None,
+    tool_registry: Mapping[str, BaseTool],
+    initial_tool_ids: list[str] | None,
+    middleware_tools: list[BaseTool],
+) -> Callable[[State], set[str]]:
+    """Build the resolver for the tool names currently bound to the model."""
+
+    def get_bound_tool_names(state: State) -> set[str]:
+        bound: set[str] = set()
+        # retrieve_tools itself is always bound when enabled
+        if retrieve_tools is not None:
+            bound.add(retrieve_tools.name)
+        # Tools selected via retrieve_tools
+        for tool_id in state.get("selected_tool_ids", []):
+            if tool_id in tool_registry:
+                bound.add(tool_registry[tool_id].name)
+        # Always-bound initial tools
+        for tool_id in initial_tool_ids or []:
+            if tool_id in tool_registry:
+                bound.add(tool_registry[tool_id].name)
+        # Middleware tools (e.g. spawn_subagent, plan_tasks)
+        for tool in middleware_tools:
+            if hasattr(tool, "name"):
+                bound.add(tool.name)
+        return bound
+
+    return get_bound_tool_names
+
+
+def reject_unbound_tools(tool_calls: list[dict], *, store: BaseStore) -> State:
+    """Return error ToolMessages for tool calls that were not bound."""
+    del store
+    messages = [
+        ToolMessage(
+            content=(
+                f"Tool '{call['name']}' is not bound. "
+                "You must call retrieve_tools(exact_tool_names=['{name}']) "
+                "to bind it before calling it.".format(name=call["name"])
+            ),
+            tool_call_id=call["id"],
+            name=call["name"],
+        )
+        for call in tool_calls
+    ]
+    return {"messages": messages}  # type: ignore[return-value]
+
+
+async def areject_unbound_tools(tool_calls: list[dict], *, store: BaseStore) -> State:
+    """Async twin of ``reject_unbound_tools`` for the async graph path."""
+    return reject_unbound_tools(tool_calls, store=store)
+
+
+def _last_tool_calling_message(state: State) -> AIMessage | None:
+    """The AI message whose calls this turn is executing.
+
+    NOT ``messages[-1]``: a resume prepends a current-time HumanMessage
+    (``subagent_runner._with_current_time``), so by the time the approvals node has
+    paused and woken, the tool-calling message is no longer last. Matches
+    ``hil/utils.current_tool_calls``, which the gate resolves siblings with — the two
+    must agree on which message is being executed or they gate different call sets.
+    """
+    for message in reversed(state["messages"]):
+        if isinstance(message, AIMessage) and message.tool_calls:
+            return message
+    return None
+
+
+def make_executable_calls(
+    get_bound_tool_names: Callable[[State], set[str]],
+    retrieve_tools: StructuredTool | None,
+) -> Callable[[State], list[ToolCall]]:
+    """Build the resolver for the calls the tools node will actually run."""
+
+    def executable_calls(state: State) -> list[ToolCall]:
+        """The message's tool calls that the tools node will run, names canonicalized.
+
+        Mutates each call's name in place when it maps to a bound tool, so the tools
+        node's registry lookup hits the actual BaseTool. Separate from routing because
+        both the router and the approvals node's outgoing edge need this same list.
+        """
+        last_message = _last_tool_calling_message(state)
+        if last_message is None:
+            return []
+        bound_names = get_bound_tool_names(state)
+        canonical_to_bound = canonical_tool_name_map(bound_names)
+        runnable: list[ToolCall] = []
+        for call in last_message.tool_calls:
+            if retrieve_tools is not None and call["name"] == retrieve_tools.name:
+                continue
+            if call["name"] not in bound_names:
+                canonical = canonical_to_bound.get(call["name"].replace("-", "_"))
+                if canonical is None:
+                    continue
+                call["name"] = canonical
+            runnable.append(call)
+        return runnable
+
+    return executable_calls
+
+
+def make_dispatch_tools(
+    executable_calls: Callable[[State], list[ToolCall]],
+) -> Callable[..., list[Send]]:
+    """Build the fan-out that sends each executable call to the tools node."""
+
+    def dispatch_tools(state: State, *, store: BaseStore) -> list[Send]:
+        """Fan the message's calls out to the tools node, one task each.
+
+        ToolCallWithContext carries the full state dict so ToolNode can do InjectedState
+        injection. Each call becomes its own task, and a task that pauses for approval
+        leaves its completed siblings alone — LangGraph persists their writes.
+        """
+        del store
+        return [
+            Send(
+                "tools",
+                ToolCallWithContext(__type="tool_call_with_context", tool_call=call, state=state),
+            )
+            for call in executable_calls(state)
+        ]
+
+    return dispatch_tools
+
+
+def make_should_continue(
+    get_bound_tool_names: Callable[[State], set[str]],
+    retrieve_tools: StructuredTool | None,
+    dispatch_tools: Callable[..., list[Send]],
+    has_end_graph_hooks: bool,
+) -> Callable[..., str | Send | list[Send]]:
+    """Build the post-model router."""
+
+    def should_continue(state: State, *, store: BaseStore) -> str | Send | list[Send]:
+        messages = state["messages"]
+        last_message = messages[-1]
+        if not isinstance(last_message, AIMessage) or not last_message.tool_calls:
+            return "end_graph_hooks" if has_end_graph_hooks else END
+        bound_names = get_bound_tool_names(state)
+        canonical_to_bound = canonical_tool_name_map(bound_names)
+        destinations: list[Send] = []
+        unbound_calls: list[ToolCall] = []
+
+        finish_calls: list[ToolCall] = [
+            call for call in last_message.tool_calls if call.get("name") == FINISH_TASK_NAME
+        ]
+        if finish_calls:
+            return Send(FINISH_TASK_NAME, finish_calls)
+
+        for call in last_message.tool_calls:
+            if retrieve_tools is not None and call["name"] == retrieve_tools.name:
+                destinations.append(Send("select_tools", [call]))
+                continue
+            if call["name"] not in bound_names and not canonical_to_bound.get(
+                call["name"].replace("-", "_")
+            ):
+                unbound_calls.append(call)
+
+        # ONE task for the whole message, and it runs before any tool: the approvals node
+        # settles every HIL decision in its own superstep, then fans out to the tools node.
+        # Sending straight to "tools" here is what used to let an ungated call execute
+        # beside one that paused — and a pause discards and replays that whole step.
+        destinations.extend(dispatch_tools(state, store=store))
+
+        if unbound_calls:
+            destinations.append(Send("reject_unbound_tools", unbound_calls))
+
+        return destinations
+
+    return should_continue
+
+
+def finish_task_node(tool_calls: list[ToolCall], *, store: BaseStore) -> State:
+    """Convert finish_task calls into their terminal ToolMessages."""
+    del store
+    messages = []
+    for call in tool_calls:
+        args = call.get("args", {}) if isinstance(call, dict) else {}
+        result = args.get("result")
+        content = str(result) if result is not None else "Task completed."
+        messages.append(
+            ToolMessage(
+                content=content,
+                tool_call_id=call.get("id", ""),
+                name=FINISH_TASK_NAME,
+            )
+        )
+    return {"messages": messages}  # type: ignore[return-value]
+
+
+async def afinish_task_node(tool_calls: list[ToolCall], *, store: BaseStore) -> State:
+    """Async twin of ``finish_task_node`` for the async graph path."""
+    return finish_task_node(tool_calls, store=store)

--- a/apps/api/app/override/langgraph_bigtool/utils.py
+++ b/apps/api/app/override/langgraph_bigtool/utils.py
@@ -110,6 +110,16 @@ class State(_BigtoolState):
     remaining_steps: RemainingSteps
 
 
+# In-memory relay from `manage_system_prompts_node` to the model node: ids of
+# slot-stale messages (old system prompts / clock lines) the hook dropped from
+# the per-call view. The model node turns them into RemoveMessage tombstones in
+# its own channel update so the pruning also reaches the CHECKPOINT — without
+# this, every run's prompt stack stays in the thread forever (a production
+# workflow thread accumulated 39 copies, ~4.8 MB of checkpoint writes per run).
+# Never a state channel: the model node pops it before returning its update.
+PRUNED_MESSAGE_IDS_KEY = "_pruned_message_ids"
+
+
 class RetrieveToolsResult(TypedDict):
     """Result from retrieve_tools function.
 

--- a/apps/api/app/override/langgraph_bigtool/utils.py
+++ b/apps/api/app/override/langgraph_bigtool/utils.py
@@ -110,14 +110,22 @@ class State(_BigtoolState):
     remaining_steps: RemainingSteps
 
 
-# In-memory relay from `manage_system_prompts_node` to the model node: ids of
-# slot-stale messages (old system prompts / clock lines) the hook dropped from
-# the per-call view. The model node turns them into RemoveMessage tombstones in
-# its own channel update so the pruning also reaches the CHECKPOINT — without
-# this, every run's prompt stack stays in the thread forever (a production
-# workflow thread accumulated 39 copies, ~4.8 MB of checkpoint writes per run).
-# Never a state channel: the model node pops it before returning its update.
+# In-memory relay from `manage_system_prompts_node` to the model node, which
+# tombstones the relayed ids out of the checkpoint. Overwritten each hook pass
+# and popped before the node's update — never a state channel.
 PRUNED_MESSAGE_IDS_KEY = "_pruned_message_ids"
+
+
+def pop_pruned_tombstones(state: State) -> list[RemoveMessage]:
+    """Pop ``PRUNED_MESSAGE_IDS_KEY`` and return its ids as RemoveMessage tombstones."""
+    raw = cast("dict[str, object]", state).pop(PRUNED_MESSAGE_IDS_KEY, None)
+    if raw is None:
+        # Absent is fine: the hook may not have run this call.
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise TypeError(f"{PRUNED_MESSAGE_IDS_KEY} must be list[str], got {type(raw).__name__}")
+    pruned_ids = cast("list[str]", raw)
+    return [RemoveMessage(id=message_id) for message_id in pruned_ids]
 
 
 class RetrieveToolsResult(TypedDict):

--- a/apps/api/tests/e2e/_harness/graph_run.py
+++ b/apps/api/tests/e2e/_harness/graph_run.py
@@ -93,6 +93,11 @@ class GraphRun:
     #: it on the way in and that rewrite never reaches the checkpoint, so this is
     #: the only place a hook's effect is observable.
     prompts: list[list[BaseMessage]] = field(default_factory=list)
+    #: Every node that emitted an update, in order — including nodes whose
+    #: update carried no messages (e.g. ``end_graph_hooks``, whose hooks are
+    #: side-effecting and write no channels). ``nodes()`` covers only the
+    #: message-bearing route.
+    visited: list[str] = field(default_factory=list)
     error: BaseException | None = None
 
     def last_prompt(self) -> list[BaseMessage]:
@@ -374,6 +379,7 @@ async def comms_graph(
     script: Sequence[Any],
     store: InMemoryStore | None = None,
     model: RecordingFakeModel | None = None,
+    checkpointer_manager: Any | None = None,
 ) -> AsyncIterator[Any]:
     """The REAL comms graph, with only the model and the external edges replaced.
 
@@ -425,7 +431,11 @@ async def comms_graph(
         patch.object(
             _build_graph, "get_tools_store", AsyncMock(return_value=store or InMemoryStore())
         ),
-        patch.object(_build_graph, "get_checkpointer_manager", AsyncMock(return_value=None)),
+        patch.object(
+            _build_graph,
+            "get_checkpointer_manager",
+            AsyncMock(return_value=checkpointer_manager),
+        ),
         patch(
             f"{node_module}.ainvoke_structured",
             new=AsyncMock(return_value=FollowUpActions(actions=[])),
@@ -442,7 +452,7 @@ async def comms_graph(
         ),
     ):
         async with _build_graph.build_comms_graph(
-            chat_llm=llm, in_memory_checkpointer=True
+            chat_llm=llm, in_memory_checkpointer=checkpointer_manager is None
         ) as graph:
             _SCRIPTED_MODELS[id(graph)] = llm
             _MEMORY_DOUBLES[id(graph)] = memory
@@ -501,6 +511,8 @@ async def run_graph(
     try:
         async for _mode, payload in graph.astream(initial, stream_mode=["updates"], config=config):
             for node, update in payload.items():
+                if not run.visited or run.visited[-1] != node:
+                    run.visited.append(node)
                 if not isinstance(update, dict):
                     continue
                 if "selected_tool_ids" in update:

--- a/apps/api/tests/e2e/test_checkpoint_state_growth.py
+++ b/apps/api/tests/e2e/test_checkpoint_state_growth.py
@@ -1,0 +1,128 @@
+"""Checkpointed threads must not accumulate per-run prompt framing.
+
+Every run injects a fresh system-prompt stack (static + dynamic context + time
+clock) into the graph input, exactly as ``_core_agent_logic`` does. The
+pre-model hooks filter those per model call, but for months the filtering was
+request-only: the checkpointed ``messages`` channel kept every run's copy, and
+the end-of-graph hook node echoed the entire accumulated list back through the
+reducer as a fresh write on every run. On a recurring workflow thread in
+production this reached 39 retained prompt copies and ~4.8 MB of checkpoint
+writes per run — 19 GB of Postgres for one database.
+
+These tests pin the durable contract:
+- stale slot messages are tombstoned out of the checkpoint, not just hidden
+  from the model;
+- the end-graph hook node — whose hooks only stream follow-ups and kick off
+  memory ingestion — never re-emits the message list as a channel write.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from langchain_core.messages import HumanMessage, SystemMessage
+import pytest
+
+from tests.e2e._harness.graph_run import comms_graph, run_graph
+
+pytestmark = pytest.mark.e2e
+
+END_HOOKS_NODE = "end_graph_hooks"
+
+
+def _run_input(run_no: int) -> dict:
+    """A graph input shaped like ``construct_langchain_messages`` output.
+
+    Fresh message objects per run (new ids), same slots: one static system
+    prompt, one dynamic-context system message, one time-context clock line,
+    then the user turn.
+    """
+    return {
+        "messages": [
+            SystemMessage(content=f"You are GAIA. (static prompt, run {run_no})"),
+            SystemMessage(
+                content=f"[dynamic context for run {run_no}]",
+                additional_kwargs={"dynamic_context": True},
+            ),
+            HumanMessage(
+                content=f"[current time: 2026-08-11T0{run_no}:00:00]",
+                additional_kwargs={"time_context": True},
+            ),
+            HumanMessage(content=f"user message {run_no}"),
+        ],
+        "todos": [],
+    }
+
+
+class TestPromptFramingIsPrunedFromCheckpointState:
+    @pytest.mark.regression
+    async def test_stale_system_prompts_are_tombstoned_out_of_the_thread(self):
+        """After N runs on one thread, each prompt slot holds ONE message.
+
+        Without durable pruning every run leaves its full prompt stack behind
+        (production reached 39 static-prompt copies on one workflow thread),
+        so the checkpoint grows by the whole prompt size per run, forever.
+        """
+        thread_id = f"prune-{uuid4()}"
+        async with comms_graph(["ok one", "ok two", "ok three"]) as graph:
+            for run_no in (1, 2, 3):
+                await run_graph(graph, "", thread_id=thread_id, state=_run_input(run_no))
+            config = {"configurable": {"thread_id": thread_id, "user_id": "u-1"}}
+            snapshot = await graph.aget_state(config)
+
+        messages = snapshot.values["messages"]
+        statics = [
+            m
+            for m in messages
+            if m.type == "system"
+            and not m.additional_kwargs.get("dynamic_context")
+            and not m.additional_kwargs.get("memory_recall")
+        ]
+        dynamics = [
+            m for m in messages if m.type == "system" and m.additional_kwargs.get("dynamic_context")
+        ]
+        clocks = [m for m in messages if m.additional_kwargs.get("time_context")]
+
+        assert len(statics) == 1, f"expected 1 static prompt in state, found {len(statics)}"
+        assert "run 3" in str(statics[0].content), "kept static prompt is not the latest run's"
+        assert len(dynamics) == 1, f"expected 1 dynamic-context message, found {len(dynamics)}"
+        assert "run 3" in str(dynamics[0].content), "kept dynamic context is not the latest run's"
+        assert len(clocks) == 1, f"expected 1 time-context message, found {len(clocks)}"
+        assert "T03:" in str(clocks[0].content), "kept clock is not the latest run's"
+
+    @pytest.mark.regression
+    async def test_conversation_itself_survives_pruning(self):
+        """Pruning removes prompt framing only — user/assistant turns all stay."""
+        thread_id = f"keep-{uuid4()}"
+        async with comms_graph(["reply one", "reply two"]) as graph:
+            for run_no in (1, 2):
+                await run_graph(graph, "", thread_id=thread_id, state=_run_input(run_no))
+            config = {"configurable": {"thread_id": thread_id, "user_id": "u-1"}}
+            snapshot = await graph.aget_state(config)
+
+        messages = snapshot.values["messages"]
+        user_turns = [
+            m for m in messages if m.type == "human" and not m.additional_kwargs.get("time_context")
+        ]
+        ai_turns = [m for m in messages if m.type == "ai"]
+        assert [str(m.content) for m in user_turns] == ["user message 1", "user message 2"]
+        assert len(ai_turns) == 2
+
+
+class TestEndGraphHooksWriteNothing:
+    @pytest.mark.regression
+    async def test_end_hooks_node_does_not_rewrite_the_message_list(self):
+        """The end-graph hook node must not emit a ``messages`` channel write.
+
+        Its hooks (follow-up streaming, fire-and-forget memory ingestion) never
+        modify messages — echoing the full state back re-serializes the entire
+        thread into ``checkpoint_writes`` on every single run.
+        """
+        async with comms_graph(["done"]) as graph:
+            run = await run_graph(graph, "", thread_id=f"echo-{uuid4()}", state=_run_input(1))
+
+        echoed = [e for e in run.events if e.node == END_HOOKS_NODE]
+        assert echoed == [], (
+            f"end_graph_hooks re-emitted {len(echoed)} messages as a channel write; "
+            "it must return only the keys its hooks actually changed"
+        )

--- a/apps/api/tests/e2e/test_comms_graph.py
+++ b/apps/api/tests/e2e/test_comms_graph.py
@@ -152,18 +152,21 @@ class TestEndOfTurnHooks:
     async def test_the_turn_runs_its_end_graph_hooks(self):
         """Follow-up suggestions and passive memory ingestion both hang off the
         end hook. If the graph stopped routing through it, chips would vanish and
-        nothing said in conversation would ever be remembered."""
+        nothing said in conversation would ever be remembered.
+
+        Asserted via ``visited``, not ``nodes()``: the end hooks are
+        side-effecting and write no channels, so the node emits an empty update
+        rather than echoing the message list back into the checkpoint."""
         async with comms_graph(["Hi there."]) as graph:
             run = await run_graph(graph, "hello")
 
-        assert "end_graph_hooks" in run.nodes()
+        assert "end_graph_hooks" in run.visited
 
     async def test_the_hooks_run_after_the_model_not_before(self):
         async with comms_graph(["Hi there."]) as graph:
             run = await run_graph(graph, "hello")
 
-        nodes = run.nodes()
-        assert nodes.index(AGENT_NODE) < nodes.index("end_graph_hooks")
+        assert run.visited.index(AGENT_NODE) < run.visited.index("end_graph_hooks")
 
 
 class TestSystemPromptSlots:

--- a/apps/api/tests/integration/agents/test_agent_graph_checkpointing.py
+++ b/apps/api/tests/integration/agents/test_agent_graph_checkpointing.py
@@ -791,7 +791,7 @@ class TestPreModelHooksExecution:
         config = _thread_config()
 
         with patch(
-            "app.override.langgraph_bigtool.create_agent.execute_hooks",
+            "app.override.langgraph_bigtool.nodes.execute_hooks",
             side_effect=sentinel,
         ):
             with pytest.raises(RuntimeError, match="hooks-execution-sentinel-error"):

--- a/apps/api/tests/integration/agents/test_real_comms_agent.py
+++ b/apps/api/tests/integration/agents/test_real_comms_agent.py
@@ -388,15 +388,13 @@ class TestRealCommsAgent:
             "The graph should have produced a new AIMessage with no pending tool calls."
         )
 
-    async def test_pre_model_hook_does_not_persist_to_checkpoint(self, comms_graph_simple):
+    async def test_pre_model_hook_pruning_persists_to_checkpoint(self, comms_graph_simple):
         """
-        manage_system_prompts_node runs as a pre_model_hook — it modifies the
-        messages passed to the model ephemerally (filtering duplicates for the
-        LLM call), but those modifications are NOT written back to the checkpoint.
-        The persisted graph state still retains all original messages
-        (LangGraph's append reducer). This test verifies the graph completes
-        without error and produces an AI response when fed duplicate non-memory
-        system prompts, and that both system prompts remain in the checkpoint.
+        manage_system_prompts_node keeps one system prompt per slot, and since
+        the prompt-accumulation fix that pruning is DURABLE: the model node
+        tombstones the stale copies out of the checkpoint (RemoveMessage), so a
+        long-lived thread holds exactly one prompt per slot instead of one per
+        run. Conversation messages are untouched.
         """
         config = _thread_config()
 
@@ -416,16 +414,21 @@ class TestRealCommsAgent:
         ai_messages = [m for m in result["messages"] if m.type == "ai"]
         assert len(ai_messages) >= 1, "Graph should have produced at least one AIMessage"
 
-        # Both system messages remain in the persisted state because
-        # pre_model_hooks only filter for the LLM call, not the checkpoint.
+        # Only the latest static prompt survives in the persisted state; the
+        # stale copy is tombstoned out so checkpointed threads stay bounded.
         system_messages = [m for m in result["messages"] if m.type == "system"]
         non_memory = [
             m for m in system_messages if not m.additional_kwargs.get("memory_message", False)
         ]
-        assert len(non_memory) == 2, (
-            f"Both non-memory system prompts should remain in persisted state; "
-            f"found {len(non_memory)}"
+        assert len(non_memory) == 1, (
+            f"Exactly the latest non-memory system prompt should persist; found {len(non_memory)}"
         )
+        assert "New system prompt." in str(non_memory[0].content)
+
+        # The conversation itself is never pruned.
+        human_contents = [str(m.content) for m in result["messages"] if m.type == "human"]
+        assert "First message." in human_contents
+        assert "Second message." in human_contents
 
     # ------------------------------------------------------------------
     # 3. Tool routing

--- a/apps/api/tests/integration/agents/test_real_comms_agent.py
+++ b/apps/api/tests/integration/agents/test_real_comms_agent.py
@@ -708,7 +708,7 @@ class TestRealCommsAgent:
             io_patches,
             extra_patches=[
                 patch(
-                    "app.override.langgraph_bigtool.create_agent.execute_hooks",
+                    "app.override.langgraph_bigtool.nodes.execute_hooks",
                     side_effect=sentinel,
                 ),
             ],

--- a/apps/api/tests/integration/real/test_postgres_checkpointer.py
+++ b/apps/api/tests/integration/real/test_postgres_checkpointer.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from uuid import uuid4
 
+from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.checkpoint.base import empty_checkpoint
+import psycopg
 import pytest
 
 from app.agents.core.graph_builder.checkpointer_manager import CheckpointerManager
+from tests.e2e._harness.graph_run import comms_graph, run_graph
 
 # ---------------------------------------------------------------------------
 # Fixtures (postgres_url comes from service/conftest.py)
@@ -179,3 +182,85 @@ class TestThreadIsolation:
         latest = await checkpointer.aget_tuple(config)
         assert latest is not None
         assert latest.checkpoint["id"] == cp_b["id"]
+
+
+@pytest.mark.service
+class TestCheckpointStorageStaysBounded:
+    """Recurring runs on one thread must not re-store the prompt stack per run.
+
+    Production regression: every run injects a fresh system-prompt stack into
+    the thread; the pre-model filtering was request-only, so the checkpoint
+    accumulated one full stack per run (39 copies on one workflow thread) and
+    the end-graph hook node re-serialized the whole accumulated list into
+    ``checkpoint_writes`` on every run — 19 GB of Postgres from one database.
+    This drives the REAL comms graph against the REAL Postgres checkpointer and
+    measures actual stored bytes for the thread.
+    """
+
+    @pytest.mark.regression
+    async def test_recurring_runs_store_linear_not_quadratic_bytes(
+        self, manager: CheckpointerManager, postgres_url: str
+    ) -> None:
+        runs = 4
+        static_prompt = "You are GAIA. " + "x" * 60_000
+        stack_bytes = len(static_prompt)
+        thread_id = f"bounded-{uuid4()}"
+
+        def run_input(run_no: int) -> dict:
+            return {
+                "messages": [
+                    SystemMessage(content=f"{static_prompt} (run {run_no})"),
+                    SystemMessage(
+                        content=f"[dynamic context, run {run_no}]",
+                        additional_kwargs={"dynamic_context": True},
+                    ),
+                    HumanMessage(
+                        content=f"[current time: run {run_no}]",
+                        additional_kwargs={"time_context": True},
+                    ),
+                    HumanMessage(content=f"user message {run_no}"),
+                ],
+                "todos": [],
+            }
+
+        scripts = [f"reply {i}" for i in range(1, runs + 1)]
+        async with comms_graph(scripts, checkpointer_manager=manager) as graph:
+            for run_no in range(1, runs + 1):
+                await run_graph(graph, "", thread_id=thread_id, state=run_input(run_no))
+            snapshot = await graph.aget_state(
+                {"configurable": {"thread_id": thread_id, "user_id": "u-1"}}
+            )
+
+        statics = [
+            m
+            for m in snapshot.values["messages"]
+            if m.type == "system" and not m.additional_kwargs.get("dynamic_context")
+        ]
+        assert len(statics) == 1, (
+            f"{len(statics)} static prompt copies retained in the checkpointed thread; "
+            "stale copies must be tombstoned out"
+        )
+
+        async with await psycopg.AsyncConnection.connect(postgres_url) as conn:
+            cur = await conn.execute(
+                """
+                SELECT
+                  (SELECT coalesce(sum(length(blob)), 0) FROM checkpoint_writes
+                    WHERE thread_id = %(t)s)
+                + (SELECT coalesce(sum(length(blob)), 0) FROM checkpoint_blobs
+                    WHERE thread_id = %(t)s)
+                """,
+                {"t": thread_id},
+            )
+            row = await cur.fetchone()
+        total_bytes = int(row[0]) if row else 0
+
+        # Each run legitimately stores ~one prompt stack (the graph input write
+        # and its delta blob). The regression stored the full ACCUMULATED list
+        # again per run — super-linear growth that blows straight through this
+        # linear budget (measured: ~3.5x over it at 4 runs, growing per run).
+        budget = runs * stack_bytes * 3
+        assert total_bytes < budget, (
+            f"thread stored {total_bytes} bytes after {runs} runs "
+            f"(budget {budget}); checkpoint growth is super-linear again"
+        )


### PR DESCRIPTION
> **STACKED ON #972 — merge #972 first.** This branch contains #972's commits, so the diff shown here includes them until that PR merges. Review only the `nodes.py` / `create_agent.py` commit.

`apps/api/app/override/langgraph_bigtool/create_agent.py` had grown to 686 lines, most of it ~18 node closures nested inside the factory. This splits it:

- **`nodes.py` (new)** — the node bodies, moved **verbatim** as module-level functions and `make_*` factories. Each factory takes exactly what its closure previously captured, so the nodes are now readable and testable without constructing a whole graph.
- **`create_agent.py`** — graph assembly only (686 → 258 lines).

These are pure mechanical moves: **no behavior change**.

### One deliberate dedup

The retrieval-result parsing was copy-pasted identically into `select_tools` and `aselect_tools`. Both now call a single `_split_retrieval_result` helper. This is the only non-move change in the diff.

### Two test patch targets followed the code

`execute_hooks` no longer lives in `create_agent`, so `patch("...create_agent.execute_hooks")` in `test_real_comms_agent.py` and `test_agent_graph_checkpointing.py` now targets `...nodes.execute_hooks`. Without this the tests fail with `AttributeError` — the patch target moved with the symbol; the assertions are unchanged.

### `store` on two nodes

`reject_unbound_tools` and `finish_task_node` don't read their `store` parameter, but LangGraph injects it, so the parameter must stay (`apps/api/CLAUDE.md` Type Safety §11). They use `del store` — matching the pattern already used by `dispatch_tools` in the same file — rather than a new `per-file-ignores` entry, which would blanket-disable ARG001 for the whole file and grow a list the `ignore-ratchet` hook only lets shrink.

## Verified

- `uv run pytest tests/e2e/` → **507 passed, 5 skipped**
- `uv run pytest tests/e2e/ tests/integration/agents/ tests/unit/override/ tests/unit/agents/` → **1626 passed, 22 skipped**
- `uv run pytest tests/integration/agents/test_real_comms_agent.py -n 0` → **15 passed**
- `pnpm nx type-check api --skip-nx-cache` → **Success, no issues in 829 source files**
- `uv run ruff check app/override/` → **All checks passed**

**Live drive against a booted stack** (`GAIA_SIM_MODE=1`, scripted LLM stub, dev auth bypass, Docker infra):

- `POST /api/v1/chat-stream` returned **HTTP 200** with an `x-stream-id`, streamed **9 SSE frames**, and the scripted reply arrived token-by-token (`"refactor"` / `" stream "` / `"verified"`) before `main_response_complete` and `[DONE]`.
- Persistence confirmed in Mongo, not stdout: the conversation document holds both messages, with the bot's `response` = `"refactor stream verified"` and message ids matching the SSE frames.

**What this did NOT prove:** the LLM was the scripted stub, so this verifies streaming *plumbing* through the refactored graph — not model behavior, prompts, or tool selection. It ran the native API (no JuiceFS), drove the HTTP endpoint directly rather than the browser UI, and exercised a plain reply — no tool-calling or executor hand-off path was driven live (those are covered by the e2e suite above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FxQb4So3EUubqhrWXoP7r
