### PR TITLE
fix(observability): stamp GAIA_SERVICE_NAME per service in compose

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -158,6 +158,11 @@ services:
           nocopy: true
     environment:
       WORKER_TYPE: arq_worker
+      # Wide-event identity. Must equal this service's Promtail label; without
+      # it, any import-time log line primes the cached envelope with the API
+      # default before the worker's own setdefault runs, and every event from
+      # this container claims service="gaia-backend".
+      GAIA_SERVICE_NAME: arq_worker
       PYTHONPATH: /app/apps/api
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
@@ -232,6 +237,8 @@ services:
     command: python -m uvicorn app.services.embedding_sidecar.server:app --host 0.0.0.0 --port 8200 --workers 1
     environment:
       WORKER_TYPE: embedding_sidecar
+      # Wide-event identity — same reason as arq_worker above.
+      GAIA_SERVICE_NAME: embedding-sidecar
       PYTHONPATH: /app/apps/api
       LOG_FORMAT: json
       LOG_COLORIZE: "false"

--- a/infra/docker/docker-compose.selfhost.yml
+++ b/infra/docker/docker-compose.selfhost.yml
@@ -192,6 +192,8 @@ services:
       - ../../apps/api/.env
     environment:
       WORKER_TYPE: arq_worker
+      # Wide-event identity — must equal the Promtail label (see prod compose).
+      GAIA_SERVICE_NAME: arq_worker
       PYTHONPATH: /app/apps/api
       # Session/sandbox background tasks touch the workspace, so the worker
       # needs the same JuiceFS mount as the backend.

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -297,6 +297,8 @@ services:
       - ../../apps/api/.env
     environment:
       - WORKER_TYPE=arq_worker
+      # Wide-event identity — must equal the Promtail label (see prod compose).
+      - GAIA_SERVICE_NAME=arq_worker
       - PYTHONPATH=/app/apps/api
       - LOG_FORMAT=json
       - LOG_COLORIZE=false
@@ -352,6 +354,8 @@ services:
     profiles: ["backend", "worker", "all"]
     working_dir: /app/apps/api
     environment:
+      # Wide-event identity — must equal the Promtail label (see prod compose).
+      - GAIA_SERVICE_NAME=embedding-sidecar
       - PYTHONPATH=/app/apps/api
       - LOG_FORMAT=json
       - LOG_COLORIZE=false


### PR DESCRIPTION
## Problem

`arq_worker` and `embedding-sidecar` (both running the `gaia` image) emit wide events with `"service": "gaia-backend"` in the body, while their Promtail *labels* are correct. Any dashboard/alert filtering on the JSON `service` field attributes worker and sidecar activity to the API.

Root cause: `env_context()` in `libs/shared/py/logging.py` is `lru_cache`d — the first log line freezes the envelope. Several modules log at import time, so the process's own `os.environ.setdefault("GAIA_SERVICE_NAME", ...)` (in `app/workers/lifecycle/startup.py`) loses an import-order race. The design's own comment says the variable is meant to be set per service via compose — but no compose file set it.

## Fix

Set `GAIA_SERVICE_NAME` at the deployment level (prod, dev, selfhost composes) for both services, matching their Promtail labels exactly, so `{service="X"}` and `| json | service="X"` always agree. The in-code setdefaults remain as local-run fallbacks.

## Audit

Swept every prod container's live logs: voice-agent-worker and all four bots already correct; only these two lied.

## Verification

Applied live on prod via `docker service update --env-add` and re-sampled both containers' logs: `arq_worker → "service": "arq_worker"`, `embedding-sidecar → "service": "embedding-sidecar"`. This PR makes the next stack deploy assert the same from compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FxQb4So3EUubqhrWXoP7r