### PR TITLE
feat(deploy): deploy by immutable tag; :latest becomes a deploy-time alias

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,8 +66,9 @@ flowchart TD
     direction TB
     DEPLOY_BACKEND --> D_AUTH["SSH key setup + GHCR login"]:::deploy
     D_AUTH --> D_CTX["Create Docker context over SSH"]:::deploy
-    D_CTX --> D_STACK["docker stack deploy gaia-prod"]:::deploy
-    D_STACK --> D_NOTIFY["Loki annotation + Discord notify"]:::deploy
+    D_CTX --> D_STACK["docker stack deploy gaia-prod<br/>pinned to immutable tags (or :latest fallback)"]:::deploy
+    D_STACK --> D_RETAG["after convergence:<br/>re-point :latest at deployed tags"]:::deploy
+    D_RETAG --> D_NOTIFY["Loki annotation + Discord notify"]:::deploy
   end
 
   subgraph FRONTEND_DEPLOY["deploy-frontend.yml (frontend)"]
@@ -116,29 +117,30 @@ flowchart TD
 
 ### `.github/workflows/build.yml`
 1. Start three build lanes: `docker-release`, `docker-web`, `docker-grafana`.
-2. `docker-release`: detect affected backend/bot projects, publish images to GHCR, optionally sync Discord commands. Records `images_published` right after its push steps (before Discord command sync), so a later, unrelated step failure never misreports a real publish as "nothing published".
+2. `docker-release`: detect affected backend/bot projects, publish images to GHCR, optionally sync Discord commands. Records `images_published` right after its push steps (before Discord command sync), so a later, unrelated step failure never misreports a real publish as "nothing published". After the release steps, `scripts/ci/resolve-image-tags.sh` resolves the immutable per-commit tags nx pushed (production versionScheme `YYMM.DD.<shortsha>`, read from the local image store, never recomputed) and guarantees they exist in GHCR (pushing them if nx skipped publishing), emitting `apps_tag` (gaia + gaia-voice-agent) and `bots_tag` (the four bot images) — empty when that group wasn't released this run.
 3. `docker-web`: detect `web` changes and build/push the web image only when affected.
 4. `docker-grafana`: builds/pushes the Grafana image unconditionally every run (tiny COPY layer over the upstream image). Not part of coupling or orphan detection — it has no "affected" concept and its `:latest` is always safe for the stack to pick up.
 5. `deployment-plan` runs with `if: always()` — it is never skipped by a lane failing or being cancelled — and needs all three build lanes purely for sequencing (deploy planning must not race ahead of the build lanes). It evaluates `docker-release`'s and `docker-web`'s `.result`, plus each side's affected-detection (`docker-release.outputs.api_affected`/`bots_affected`, `docker-web.outputs.web_affected`), via `scripts/ci/compute-deploy-plan.sh`:
    - **Single-side push** (only backend or only web affected): each side deploys independently. `backend_deploy` is `true` only when `docker-release` succeeded AND api/bots affected. A failed/cancelled `docker-release` never deploys, but a failed `docker-web` no longer blocks it either — the old implicit needs-all-success gate did. `frontend_deploy` follows the existing rule (always true on a master push) and is not gated on `docker-web`'s result — the Vercel deploy path syncs from source, not from the `docker-web` image.
    - **Coupled push** (both backend AND web affected by the same commit): the two deploys are treated as one unit. Both `docker-release` and `docker-web` must succeed for either to deploy; if either lane failed or was cancelled, `coupled_hold` is set and BOTH `backend_deploy`/`frontend_deploy` stay `false` — this prevents shipping one half (e.g. a new frontend) against a stale, untested other half. This is the one case where a lane failure still blocks a deploy on the healthy side, by design.
-   - `backend_orphaned` / `frontend_orphaned` flag when an image lane published to GHCR as `:latest` but its corresponding deploy did not run this time, for any reason (lane failure, cancellation, the plan itself deciding not to deploy, or a `coupled_hold` — which flags both sides even if only one side's lane actually failed, since the healthy side is held back too). Scoped to `master` only.
+   - `backend_orphaned` / `frontend_orphaned` flag when an image lane actually published to GHCR but its corresponding deploy did not run this time (lane failure, cancellation, the plan itself deciding not to deploy, or a `coupled_hold` — which flags both sides even if only one side's lane actually failed, since the healthy side is held back too). Publish evidence is required on both sides: `images_published` for backend, `web_affected` AND lane success for frontend (docker-web succeeds even when it skips the build, so its result alone proves nothing). Scoped to `master` only, and a side the operator deliberately excluded via a manual mode (`backend-only` skips frontend, `frontend-only` skips backend, `none` skips both) is never flagged — an operator choice is not drift.
    - Manual `workflow_dispatch` modes (`backend-only` / `frontend-only` / `both`) bypass affected-detection, lane-result gating, AND the coupling rule — this is the intended one-command remedy for drift: `gh workflow run build.yml --ref master -f deployment_mode=both` redeploys whatever is currently tagged `:latest` in GHCR regardless of what this run's own build lanes did. Manual `auto` mode applies the same coupling rule as an automatic push.
-6. `notify-publish-without-deploy` fires a Discord alert (same webhook/action the deploy workflows use) when either orphan flag is set, naming which images are published-but-undeployed (or held together, for a `coupled_hold`) and the `gh workflow run` remedy above.
-7. Trigger `deploy-swarm-prod.yml` and/or `deploy-frontend.yml` based on `backend_deploy` / `frontend_deploy`.
+6. `notify-publish-without-deploy` fires a Discord alert when either orphan flag is set, naming which images are published-but-undeployed (or held together, for a `coupled_hold`) and the `gh workflow run` remedy above. All deploy-pipeline Discord sends go through `scripts/ci/notify-discord.sh` (single webhook embed; the previous appleboy action 400'd on messages over 256 chars and fragmented comma-containing ones), with `continue-on-error` on the send step only — the message is fully logged in the run either way, and a dropped webhook must not turn an otherwise-green run red.
+7. Trigger `deploy-swarm-prod.yml` and/or `deploy-frontend.yml` based on `backend_deploy` / `frontend_deploy`. `trigger-deploy` passes the immutable tags through (`apps_image_tag` / `bots_image_tag` from `docker-release`, `grafana_image_tag` = the commit sha when `docker-grafana` succeeded); empty tags mean the deploy falls back to `:latest` (the manual-mode drift remedy keeps exactly its old semantics).
 
 ### `.github/workflows/deploy-swarm-prod.yml`
 1. Install SSH private key from `PROD_VM_SSH_KEY` via the `setup-swarm-context` composite action and log in to GHCR.
 2. Create Docker context pointing at the Hetzner VM over SSH.
-3. Run `docker --context prod stack deploy --with-registry-auth` for the app stack (`gaia-prod`).
-   Swarm handles rolling update; the workflow polls both `gaia-backend` and `arq_worker` for convergence and fails on auto-rollback.
-4. Push a deploy annotation to Loki and send status to Discord.
-5. Manual `workflow_dispatch` supports `action=rollback` with `rollback_mode=last` (Docker service rollback) or `rollback_mode=digest` (redeploy pinned image).
+3. Run `docker --context prod stack deploy --with-registry-auth` for the app stack (`gaia-prod`), exporting the `apps_image_tag` / `bots_image_tag` / `grafana_image_tag` inputs as `GAIA_IMAGE_TAG` / `GAIA_BOTS_IMAGE_TAG` / `GAIA_GRAFANA_IMAGE_TAG` so the stack is pinned to the exact images this run verified. Empty inputs fall through to the compose file's `${VAR:-latest}` defaults — the pre-parameterization behavior, used by manual dispatches that just want to redeploy `:latest`.
+   Swarm handles rolling update; the workflow polls `gaia-backend`, `arq_worker`, and `voice-agent-worker` for convergence and fails on auto-rollback.
+4. Only after convergence succeeds, `scripts/ci/retag-latest-alias.sh` re-points each deployed repo's `:latest` at the deployed tag registry-side (`docker buildx imagetools create`, no layer transfer) — `:latest` is a deploy-time alias meaning "what prod runs", not "what was last built". A failed deploy does not move `:latest`.
+5. Push a deploy annotation to Loki (including the deployed tags) and send status to Discord via `scripts/ci/notify-discord.sh`.
+6. Manual `workflow_dispatch` supports `action=rollback` with `rollback_mode=last` (Docker service rollback) or `rollback_mode=digest` (redeploy pinned image). After a successful rollback, the same retag script re-points `:latest` at the images the rolled-back services now run (digest mode: the pinned gaia ref; last mode: each rolled-back service's restored image spec), so the alias keeps tracking production through rollbacks too.
 
 ### `.github/workflows/deploy-frontend.yml`
 1. Sync `master` to the private fork used as Vercel source.
 2. Vercel performs deploy/no-op based on its own change detection.
-3. Send deployment status to Discord.
+3. Send deployment status to Discord via `scripts/ci/notify-discord.sh`.
 
 ### `.github/workflows/release-please.yml`
 1. Enforce `master` ref (manual runs on non-master fail fast).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,11 @@ jobs:
       # in GHCR, which would otherwise misreport a real publish as "nothing
       # published" and hide drift instead of surfacing it.
       images_published: ${{ steps.publish-status.outputs.published }}
+      # Immutable per-commit tags (nx production scheme YYMM.DD.<shortsha>)
+      # for this run's releases; empty when a group wasn't released. The
+      # deploy pins the Swarm stack to these instead of :latest.
+      apps_tag: ${{ steps.image-tags.outputs.apps_tag }}
+      bots_tag: ${{ steps.image-tags.outputs.bots_tag }}
 
     steps:
       # Prepare repository + tooling so Nx can calculate affected projects.
@@ -177,6 +182,18 @@ jobs:
               echo "⚠️  $img not found locally, skipping"
             fi
           done
+
+      # Resolve the immutable tags the release steps just pushed (read from
+      # the local image store, never recomputed) and guarantee they exist in
+      # GHCR, so the deploy can pin services to exactly this run's images.
+      - name: Resolve immutable image tags
+        id: image-tags
+        if: steps.affected.outputs.api == 'true' || steps.affected.outputs.bots == 'true'
+        env:
+          VERSION_SCHEME: ${{ steps.version.outputs.scheme }}
+          APPS_RELEASE_OUTCOME: ${{ steps.release-apps.outcome }}
+          BOTS_RELEASE_OUTCOME: ${{ steps.release-bots.outcome }}
+        run: bash scripts/ci/resolve-image-tags.sh
 
       # Captured right after the push steps, before Discord command sync —
       # that step can fail on an unrelated Discord API error and must never
@@ -366,6 +383,15 @@ jobs:
       coupled_hold: ${{ steps.plan.outputs.coupled_hold }}
       docker_release_result: ${{ steps.plan.outputs.docker_release_result }}
       docker_web_result: ${{ steps.plan.outputs.docker_web_result }}
+      # Immutable tag pass-through for trigger-deploy (it can't `needs:` the
+      # build lanes directly without re-gating on their success). Empty tags
+      # mean "deploy whatever :latest currently points at" — the manual-mode
+      # drift remedy and the pre-parameterization behavior.
+      apps_image_tag: ${{ needs.docker-release.outputs.apps_tag || '' }}
+      bots_image_tag: ${{ needs.docker-release.outputs.bots_tag || '' }}
+      # docker-grafana pushes :<full sha> unconditionally every run; pin it
+      # only when that lane actually succeeded this run.
+      grafana_image_tag: ${{ needs.docker-grafana.result == 'success' && github.sha || '' }}
     steps:
       - uses: actions/checkout@v4
       # Single decision point that translates lane results + affected +
@@ -398,13 +424,17 @@ jobs:
     if: always() && (needs.deployment-plan.outputs.backend_orphaned == 'true' || needs.deployment-plan.outputs.frontend_orphaned == 'true')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      # continue-on-error on the send step only: the alert content is fully
+      # logged by the script either way, and a webhook hiccup must not turn
+      # an otherwise-green run red — the run didn't get worse because Discord
+      # dropped a message about it.
       - name: Notify Discord — publish without deploy
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#ff6b6b"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#ff6b6b"
+          MESSAGE: |
             🚨 **Publish Without Deploy Detected**
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
@@ -414,6 +444,7 @@ jobs:
             ${{ needs.deployment-plan.outputs.coupled_hold != 'true' && needs.deployment-plan.outputs.frontend_orphaned == 'true' && format('**Web image (gaia-web) was published to GHCR as `:latest` but the frontend deploy did NOT run.** docker-web result: `{0}`.', needs.deployment-plan.outputs.docker_web_result) || '' }}
             Production may now be running a stale image while a newer one sits in GHCR tagged `:latest`. Any container restart on the Swarm host will silently pick up the undeployed build.
             **To deploy now:** fix the red lane, then run `gh workflow run build.yml --ref master -f deployment_mode=both` (or `backend-only` / `frontend-only` for a non-coupled case) — this redeploys whatever is currently tagged `:latest` in GHCR regardless of this run's affected-detection or lane results.
+        run: bash scripts/ci/notify-discord.sh
 
   # Trigger backend production deploy only when deploy plan allows it.
   trigger-deploy:
@@ -422,6 +453,9 @@ jobs:
     uses: ./.github/workflows/deploy-swarm-prod.yml
     with:
       action: deploy
+      apps_image_tag: ${{ needs.deployment-plan.outputs.apps_image_tag }}
+      bots_image_tag: ${{ needs.deployment-plan.outputs.bots_image_tag }}
+      grafana_image_tag: ${{ needs.deployment-plan.outputs.grafana_image_tag }}
     secrets: inherit
 
   # Trigger web production deploy only when deploy plan allows it.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,18 +183,6 @@ jobs:
             fi
           done
 
-      # Resolve the immutable tags the release steps just pushed (read from
-      # the local image store, never recomputed) and guarantee they exist in
-      # GHCR, so the deploy can pin services to exactly this run's images.
-      - name: Resolve immutable image tags
-        id: image-tags
-        if: steps.affected.outputs.api == 'true' || steps.affected.outputs.bots == 'true'
-        env:
-          VERSION_SCHEME: ${{ steps.version.outputs.scheme }}
-          APPS_RELEASE_OUTCOME: ${{ steps.release-apps.outcome }}
-          BOTS_RELEASE_OUTCOME: ${{ steps.release-bots.outcome }}
-        run: bash scripts/ci/resolve-image-tags.sh
-
       # Captured right after the push steps, before Discord command sync —
       # that step can fail on an unrelated Discord API error and must never
       # cause a real publish to be reported as "nothing published".
@@ -216,6 +204,22 @@ jobs:
             published=true
           fi
           echo "published=$published" >> "$GITHUB_OUTPUT"
+
+      # Resolve the immutable tags the release steps just pushed (read from the
+      # local image store, never recomputed) and guarantee they exist in GHCR,
+      # so the deploy can pin services to exactly this run's images. Placed
+      # after publish-status deliberately: this step can fail, and the publish
+      # outcome must already be recorded when it does — a resolve failure then
+      # fails the lane, blocks the deploy, and surfaces as an orphan alert
+      # rather than as a silent "nothing published".
+      - name: Resolve immutable image tags
+        id: image-tags
+        if: steps.affected.outputs.api == 'true' || steps.affected.outputs.bots == 'true'
+        env:
+          VERSION_SCHEME: ${{ steps.version.outputs.scheme }}
+          APPS_RELEASE_OUTCOME: ${{ steps.release-apps.outcome }}
+          BOTS_RELEASE_OUTCOME: ${{ steps.release-bots.outcome }}
+        run: bash scripts/ci/resolve-image-tags.sh
 
       # Discord command sync is only meaningful for production bot deploys.
       - name: Register Discord slash commands

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -44,15 +44,18 @@ jobs:
           target_branch: master
           force: true
 
-      # Always send deploy outcome to Discord for visibility.
+      # Always send deploy outcome to Discord for visibility. Sent via
+      # scripts/ci/notify-discord.sh (appleboy's action 400s on long messages
+      # and fragments comma-containing ones); continue-on-error because the
+      # message is logged by the script either way and a dropped webhook must
+      # not repaint an otherwise-decided run.
       - name: Notify Discord of deployment
         if: always()
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: ${{ job.status == 'success' && '#00d4aa' || job.status == 'cancelled' && '#ffa500' || '#ff6b6b' }}
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: ${{ job.status == 'success' && '#00d4aa' || job.status == 'cancelled' && '#ffa500' || '#ff6b6b' }}
+          MESSAGE: |
             🌐 **Web Deployment ${{ job.status == 'success' && 'Triggered' || job.status == 'cancelled' && 'Cancelled' || 'Failed' }}**
             **Repo:** ${{ github.repository }}
             **Branch:** master
@@ -60,3 +63,4 @@ jobs:
             **Status:** ${{ job.status == 'success' && 'Synced to private fork' || job.status == 'cancelled' && 'Sync cancelled' || 'Sync failed' }}
             **Next Step:** ${{ job.status == 'success' && 'Vercel will auto-deploy' || job.status == 'cancelled' && 'N/A' || 'Check logs' }}
             **Triggered by:** ${{ github.actor }}
+        run: bash scripts/ci/notify-discord.sh

--- a/.github/workflows/deploy-swarm-prod.yml
+++ b/.github/workflows/deploy-swarm-prod.yml
@@ -356,6 +356,8 @@ jobs:
         env:
           ROLLBACK_MODE: ${{ inputs.rollback_mode }}
           IMAGE_DIGEST: ${{ inputs.image_digest }}
+          DOCKER_CONTEXT: prod
+          STACK: gaia-prod
         run: bash scripts/ci/retag-latest-alias.sh rolled-back
 
       - name: Push rollback annotation to Loki

--- a/.github/workflows/deploy-swarm-prod.yml
+++ b/.github/workflows/deploy-swarm-prod.yml
@@ -133,8 +133,22 @@ jobs:
 
       - name: Wait for convergence
         id: converge
+        env:
+          BOTS_IMAGE_TAG: ${{ inputs.bots_image_tag }}
+          GRAFANA_IMAGE_TAG: ${{ inputs.grafana_image_tag }}
         run: |
-          SERVICES="gaia-backend arq_worker voice-agent-worker"
+          # Every consumer of the apps image group — the :latest retag below
+          # moves the whole group's alias, so every service that will pull it
+          # on a future restart must be proven healthy first.
+          SERVICES="gaia-backend arq_worker embedding-sidecar voice-agent-worker"
+          # Bot/grafana aliases only move when their tags were deployed this
+          # run — extend the health gate to match exactly what will be retagged.
+          if [[ -n "${BOTS_IMAGE_TAG}" ]]; then
+            SERVICES="${SERVICES} discord-bot slack-bot telegram-bot whatsapp-bot"
+          fi
+          if [[ -n "${GRAFANA_IMAGE_TAG}" ]]; then
+            SERVICES="${SERVICES} grafana"
+          fi
           echo "Waiting for ${SERVICES} to converge (up to 5 minutes)..."
           DEADLINE=$(( $(date +%s) + 300 ))
 
@@ -304,14 +318,17 @@ jobs:
         run: |
           if [ "$ROLLBACK_MODE" = "last" ]; then
             for svc in $(docker --context prod stack services gaia-prod --format '{{.Name}}' \
-              | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
+              | grep -E 'gaia-backend|arq_worker|embedding-sidecar|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
               echo "Rolling back $svc..."
               docker --context prod service rollback "$svc"
             done
           elif [ "$ROLLBACK_MODE" = "digest" ]; then
             [ -z "$IMAGE_DIGEST" ] && echo "image_digest required for digest mode" && exit 1
+            # Every service running the gaia image — a partial pin would leave
+            # the remainder on a different build than the :latest alias claims.
             docker --context prod service update --image "$IMAGE_DIGEST" gaia-prod_gaia-backend
             docker --context prod service update --image "$IMAGE_DIGEST" gaia-prod_arq_worker
+            docker --context prod service update --image "$IMAGE_DIGEST" gaia-prod_embedding-sidecar
           fi
 
       - name: Wait for rollback convergence
@@ -321,9 +338,9 @@ jobs:
         run: |
           if [ "$ROLLBACK_MODE" = "last" ]; then
             SERVICES=$(docker --context prod stack services gaia-prod --format '{{.Name}}' \
-              | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot')
+              | grep -E 'gaia-backend|arq_worker|embedding-sidecar|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot')
           else
-            SERVICES="gaia-prod_gaia-backend gaia-prod_arq_worker"
+            SERVICES="gaia-prod_gaia-backend gaia-prod_arq_worker gaia-prod_embedding-sidecar"
           fi
           echo "Waiting for services to stabilise (up to 3 minutes): $SERVICES"
           DEADLINE=$(( $(date +%s) + 180 ))
@@ -352,7 +369,10 @@ jobs:
       # otherwise :latest keeps naming the bad build and any container
       # restart (or tag-less redeploy) would re-pull it.
       - name: Re-point :latest at the rolled-back images
-        if: success()
+        # timed_out guard: a rollback that did not stabilise proves nothing
+        # about what prod runs — moving the alias then would re-introduce the
+        # exact lie this mechanism exists to kill.
+        if: success() && steps.converge.outputs.timed_out != 'true'
         env:
           ROLLBACK_MODE: ${{ inputs.rollback_mode }}
           IMAGE_DIGEST: ${{ inputs.image_digest }}

--- a/.github/workflows/deploy-swarm-prod.yml
+++ b/.github/workflows/deploy-swarm-prod.yml
@@ -23,6 +23,26 @@ on:
         description: "Full image ref for digest rollback (e.g. ghcr.io/org/gaia@sha256:...)"
         required: false
         type: string
+      # Immutable per-commit tags to pin the stack to (nx production scheme
+      # YYMM.DD.<shortsha>; grafana uses the full commit sha). Empty deploys
+      # whatever :latest currently points at — the pre-parameterization
+      # behavior and the manual drift remedy. When set, :latest is re-pointed
+      # at the deployed images only after convergence succeeds.
+      apps_image_tag:
+        description: "Tag for gaia + gaia-voice-agent (empty = :latest)"
+        required: false
+        default: ""
+        type: string
+      bots_image_tag:
+        description: "Tag for the four bot images (empty = :latest)"
+        required: false
+        default: ""
+        type: string
+      grafana_image_tag:
+        description: "Tag for gaia-grafana (empty = :latest)"
+        required: false
+        default: ""
+        type: string
   workflow_call:
     inputs:
       action:
@@ -36,6 +56,18 @@ on:
       image_digest:
         required: false
         type: string
+      apps_image_tag:
+        required: false
+        default: ""
+        type: string
+      bots_image_tag:
+        required: false
+        default: ""
+        type: string
+      grafana_image_tag:
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: swarm-prod-${{ github.ref }}
@@ -48,8 +80,10 @@ jobs:
     environment: production
     permissions:
       contents: read
-      # Pull the private gaia-grafana image on the swarm nodes via --with-registry-auth.
-      packages: read
+      # write, not read: besides pulling private images on the swarm nodes via
+      # --with-registry-auth, the post-convergence step re-points :latest at
+      # the deployed tags registry-side (docker buildx imagetools create).
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -70,6 +104,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy stack
+        env:
+          # Pin the stack to this run's immutable tags. Empty values fall
+          # through to the compose file's ${VAR:-latest} defaults, i.e. the
+          # pre-parameterization behavior.
+          GAIA_IMAGE_TAG: ${{ inputs.apps_image_tag }}
+          GAIA_BOTS_IMAGE_TAG: ${{ inputs.bots_image_tag }}
+          GAIA_GRAFANA_IMAGE_TAG: ${{ inputs.grafana_image_tag }}
         run: |
           set -euo pipefail
           # Observability configs ship as Swarm configs (stored in the cluster),
@@ -138,6 +179,17 @@ jobs:
             sleep 15
           done
 
+      # Only after convergence proved the deploy healthy does :latest move —
+      # this is what makes :latest "what prod runs" instead of "what was last
+      # built". A failed deploy leaves :latest on the previous good images.
+      - name: Point :latest at the deployed images
+        if: success() && (inputs.apps_image_tag != '' || inputs.bots_image_tag != '' || inputs.grafana_image_tag != '')
+        env:
+          APPS_IMAGE_TAG: ${{ inputs.apps_image_tag }}
+          BOTS_IMAGE_TAG: ${{ inputs.bots_image_tag }}
+          GRAFANA_IMAGE_TAG: ${{ inputs.grafana_image_tag }}
+        run: bash scripts/ci/retag-latest-alias.sh from-env
+
       - name: Push deploy annotation to Loki
         if: success()
         env:
@@ -145,8 +197,9 @@ jobs:
         run: |
           [ -z "$LOKI_PUSH_URL" ] && exit 0
           TS_NS="$(date +%s%N)"
-          LINE=$(printf '{"event":"deploy","service":"api","sha":"%s","actor":"%s","ref":"%s"}' \
-            "${{ github.sha }}" "${{ github.actor }}" "${{ github.ref_name }}")
+          LINE=$(printf '{"event":"deploy","service":"api","sha":"%s","actor":"%s","ref":"%s","apps_tag":"%s","bots_tag":"%s"}' \
+            "${{ github.sha }}" "${{ github.actor }}" "${{ github.ref_name }}" \
+            "${{ inputs.apps_image_tag || 'latest' }}" "${{ inputs.bots_image_tag || 'latest' }}")
           PAYLOAD=$(jq -n \
             --arg ts "$TS_NS" \
             --arg line "$LINE" \
@@ -155,60 +208,66 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
+      # All Discord sends go through scripts/ci/notify-discord.sh (appleboy's
+      # action 400s on long messages and fragments comma-containing ones —
+      # see the script header). continue-on-error on the send steps only: the
+      # message is fully logged by the script either way, and a dropped
+      # webhook must not repaint an otherwise-decided run.
       - name: Notify Discord — deploy succeeded
         if: success()
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#48f442"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#48f442"
+          MESSAGE: |
             **Backend Deploy Succeeded**
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
             **Actor:** ${{ github.actor }}
+            **Images:** apps `${{ inputs.apps_image_tag || 'latest' }}` / bots `${{ inputs.bots_image_tag || 'latest' }}` / grafana `${{ inputs.grafana_image_tag || 'latest' }}`
+        run: bash scripts/ci/notify-discord.sh
 
       - name: Notify Discord — Swarm auto-rollback
         if: failure() && steps.converge.outputs.rolled_back == 'true'
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#ffa500"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#ffa500"
+          MESSAGE: |
             **Backend Deploy Failed — Swarm Auto-Rolled Back**
-            The new image failed health checks and Swarm reverted to the previous revision.
+            The new image failed health checks and Swarm reverted to the previous revision. This deploy did not re-point `:latest`.
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
             **Actor:** ${{ github.actor }}
+        run: bash scripts/ci/notify-discord.sh
 
       - name: Notify Discord — convergence timeout
         if: failure() && steps.converge.outputs.timed_out == 'true'
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#ff6b6b"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#ff6b6b"
+          MESSAGE: |
             **Backend Deploy Failed — Convergence Timeout**
-            gaia-backend, arq_worker, and voice-agent-worker did not all reach Running state within 5 minutes. Check `docker service ps gaia-prod_<service>` on the VM.
+            gaia-backend, arq_worker, and voice-agent-worker did not all reach Running state within 5 minutes. Check `docker service ps gaia-prod_<service>` on the VM. This deploy did not re-point `:latest`.
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
             **Actor:** ${{ github.actor }}
+        run: bash scripts/ci/notify-discord.sh
 
       - name: Notify Discord — deploy failed
         if: failure() && steps.converge.outputs.rolled_back != 'true' && steps.converge.outputs.timed_out != 'true'
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#ff6b6b"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#ff6b6b"
+          MESSAGE: |
             **Backend Deploy Failed**
-            The deploy step failed before Swarm could start convergence (image pull, auth, or config error).
+            The deploy step failed before Swarm could start convergence (image pull, auth, or config error). This deploy did not re-point `:latest`.
             **Commit:** `${{ github.sha }}`
             **Branch:** ${{ github.ref_name }}
             **Actor:** ${{ github.actor }}
+        run: bash scripts/ci/notify-discord.sh
 
   rollback:
     if: github.event_name == 'workflow_dispatch' && inputs.action == 'rollback'
@@ -216,6 +275,9 @@ jobs:
     environment: production
     permissions:
       contents: read
+      # The post-rollback step re-points :latest at the rolled-back images
+      # registry-side (docker buildx imagetools create).
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -285,6 +347,17 @@ jobs:
             sleep 10
           done
 
+      # Keep the ":latest == what prod runs" invariant through rollbacks:
+      # re-point :latest at the images the rolled-back services now run,
+      # otherwise :latest keeps naming the bad build and any container
+      # restart (or tag-less redeploy) would re-pull it.
+      - name: Re-point :latest at the rolled-back images
+        if: success()
+        env:
+          ROLLBACK_MODE: ${{ inputs.rollback_mode }}
+          IMAGE_DIGEST: ${{ inputs.image_digest }}
+        run: bash scripts/ci/retag-latest-alias.sh rolled-back
+
       - name: Push rollback annotation to Loki
         if: success()
         env:
@@ -305,28 +378,31 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 
+      # Same notify convention as the deploy job: script send, logged either
+      # way, and a dropped webhook never repaints the run.
       - name: Notify Discord — rollback succeeded
         if: success()
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#ffa500"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#ffa500"
+          MESSAGE: |
             **Backend Rollback Succeeded**
             **Mode:** ${{ inputs.rollback_mode }}${{ inputs.image_digest && format(' (`{0}`)', inputs.image_digest) || '' }}
             **Actor:** ${{ github.actor }}
+            `:latest` now points at the rolled-back images.
             ${{ steps.converge.outputs.timed_out == 'true' && '⚠️ Note: not all services stabilised within 3 minutes — verify manually.' || '' }}
+        run: bash scripts/ci/notify-discord.sh
 
       - name: Notify Discord — rollback failed
         if: failure()
-        uses: appleboy/discord-action@afc227330777ad298156a1f5233dfa1e885616db # v1.2.0
-        with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Gaia Deploy Bot"
-          color: "#ff6b6b"
-          message: |
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          COLOR: "#ff6b6b"
+          MESSAGE: |
             **Backend Rollback Failed**
             **Mode:** ${{ inputs.rollback_mode }}
             **Actor:** ${{ github.actor }}
-            The rollback command itself failed. Production state is unknown — check the VM immediately.
+            The rollback job failed — the run log shows whether the rollback command itself or a follow-up step (`:latest` retag / Loki annotation) broke. Check the VM immediately.
+        run: bash scripts/ci/notify-discord.sh

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -3,6 +3,19 @@
 # (baked into each image) reads them and exports env vars before exec.
 # This file can also be used with `docker compose` for local rehearsal — see
 # scripts/swarm/lab-rehearsal.sh.
+#
+# Image tags are deploy-time parameters: deploy-swarm-prod.yml exports the
+# immutable per-commit tags built by CI (nx production scheme
+# YYMM.DD.<shortsha>, e.g. 2608.10.fa2b2a9) so the stack is pinned to exactly
+# the build the deploy run verified, and re-points :latest at those images
+# only AFTER convergence succeeds — :latest is a deploy-time alias for "what
+# prod runs", not "what was last built".
+#   GAIA_IMAGE_TAG          gaia + gaia-voice-agent (nx release group "apps")
+#   GAIA_BOTS_IMAGE_TAG     the four bot images (nx release group "bots")
+#   GAIA_GRAFANA_IMAGE_TAG  gaia-grafana (built every run, tagged by full sha)
+# The `:-latest` defaults are the rollout-safety property: any invocation that
+# does not pass tags (lab rehearsal, manual `docker stack deploy` on the VM,
+# older workflow runs) behaves exactly as before this parameterization.
 
 secrets:
   # One Infisical machine identity (Universal Auth), shared by every service.
@@ -64,7 +77,7 @@ services:
   # ---------------------------------------------------------------------------
 
   gaia-backend:
-    image: ghcr.io/theexperiencecompany/gaia:latest
+    image: ghcr.io/theexperiencecompany/gaia:${GAIA_IMAGE_TAG:-latest}
     working_dir: /app/apps/api
     command: python -m uvicorn app.main:app --host 0.0.0.0 --port 80 --no-access-log --workers 1 --timeout-keep-alive 65 --timeout-graceful-shutdown 30 --h11-max-incomplete-event-size 16777216
     volumes:
@@ -144,7 +157,7 @@ services:
   # ---------------------------------------------------------------------------
 
   arq_worker:
-    image: ghcr.io/theexperiencecompany/gaia:latest
+    image: ghcr.io/theexperiencecompany/gaia:${GAIA_IMAGE_TAG:-latest}
     working_dir: /app/apps/api
     command: python -m arq app.worker.WorkerSettings --custom-log-dict app.workers.config.log_config.ARQ_LOG_CONFIG
     volumes:
@@ -227,7 +240,7 @@ services:
   # their own. Memory: with the ONNX CPU mem arena OFF (see embeddings.py) RSS
   # settles near the ~2GB weights; 3G limit leaves headroom over the ~2.4GB peak.
   embedding-sidecar:
-    image: ghcr.io/theexperiencecompany/gaia:latest
+    image: ghcr.io/theexperiencecompany/gaia:${GAIA_IMAGE_TAG:-latest}
     working_dir: /app/apps/api
     command: python -m uvicorn app.services.embedding_sidecar.server:app --host 0.0.0.0 --port 8200 --workers 1
     environment:
@@ -291,7 +304,7 @@ services:
   # ---------------------------------------------------------------------------
 
   discord-bot:
-    image: ghcr.io/theexperiencecompany/gaia-bot-discord:latest
+    image: ghcr.io/theexperiencecompany/gaia-bot-discord:${GAIA_BOTS_IMAGE_TAG:-latest}
     environment:
       BOT_SERVER_PORT: "3200"
       LOG_FORMAT: json
@@ -335,7 +348,7 @@ services:
         delay: 5s
 
   slack-bot:
-    image: ghcr.io/theexperiencecompany/gaia-bot-slack:latest
+    image: ghcr.io/theexperiencecompany/gaia-bot-slack:${GAIA_BOTS_IMAGE_TAG:-latest}
     environment:
       BOT_SERVER_PORT: "3201"
       LOG_FORMAT: json
@@ -379,7 +392,7 @@ services:
         delay: 5s
 
   telegram-bot:
-    image: ghcr.io/theexperiencecompany/gaia-bot-telegram:latest
+    image: ghcr.io/theexperiencecompany/gaia-bot-telegram:${GAIA_BOTS_IMAGE_TAG:-latest}
     environment:
       BOT_SERVER_PORT: "3202"
       LOG_FORMAT: json
@@ -423,7 +436,7 @@ services:
         delay: 5s
 
   whatsapp-bot:
-    image: ghcr.io/theexperiencecompany/gaia-bot-whatsapp:latest
+    image: ghcr.io/theexperiencecompany/gaia-bot-whatsapp:${GAIA_BOTS_IMAGE_TAG:-latest}
     environment:
       BOT_SERVER_PORT: "3203"
       LOG_FORMAT: json
@@ -931,7 +944,7 @@ services:
     # Provisioning (datasources, dashboards, alerting) is baked into this image
     # — see infra/docker/observability/grafana/Dockerfile — so prod needs no host
     # bind mount and the stack deploys cleanly from CI via a remote context.
-    image: ghcr.io/theexperiencecompany/gaia-grafana:latest
+    image: ghcr.io/theexperiencecompany/gaia-grafana:${GAIA_GRAFANA_IMAGE_TAG:-latest}
     ports:
       # Loopback only — Nginx on the host proxies logs.heygaia.io to this.
       - target: 3000
@@ -1007,7 +1020,7 @@ services:
   # ---------------------------------------------------------------------------
 
   voice-agent-worker:
-    image: ghcr.io/theexperiencecompany/gaia-voice-agent:latest
+    image: ghcr.io/theexperiencecompany/gaia-voice-agent:${GAIA_IMAGE_TAG:-latest}
     working_dir: /app/apps/voice-agent
     environment:
       PYTHONUNBUFFERED: "1"

--- a/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
@@ -1048,10 +1048,11 @@ groups:
 
       # 23. Voice agent worker is not running. prometheus.yml's comment claims
       # this service is "scaled to 0 by default" — that is stale.
-      # docker-compose.prod.yml:910 declares `replicas: 1`, `docker stack deploy`
-      # reconciles the replica count back to the compose file on every deploy, and
-      # .github/workflows/deploy-swarm-prod.yml:96-121 hard-fails the deploy
-      # unless voice-agent-worker has at least one running task. The service runs
+      # docker-compose.prod.yml's `voice-agent-worker` service declares
+      # `replicas: 1`, `docker stack deploy` reconciles the replica count back to
+      # the compose file on every deploy, and the "Wait for convergence" step in
+      # .github/workflows/deploy-swarm-prod.yml hard-fails the deploy unless
+      # voice-agent-worker has at least one running task. The service runs
       # in production, so this rule is not a permanent firing state.
       # No dashboard link: the voice-agent dashboard charts lk_agents_* only,
       # nothing charts `up` for this job.
@@ -1409,7 +1410,8 @@ groups:
           service: host
 
       # 25. Redis cannot write to disk. Prod runs `--appendonly yes` alongside
-      # `--save 60 1000` (docker-compose.prod.yml:515-519), so both status gauges
+      # `--save 60 1000` (the `redis` service's command in
+      # docker-compose.prod.yml), so both status gauges
       # are present in INFO persistence. The product form is 1 only when both are
       # 1 and 0 if either fails — a single scalar with no set-operator semantics
       # to get wrong — and it degrades to an empty result if Redis is unreachable,

--- a/scripts/ci/compute-deploy-plan.sh
+++ b/scripts/ci/compute-deploy-plan.sh
@@ -57,6 +57,13 @@ both_touched=false
 backend_deploy=false
 frontend_deploy=false
 coupled_hold=false
+# Explicit operator modes deliberately skip a side. A side the operator chose
+# not to deploy is NOT drift — flagging it as an orphan turns every routine
+# `deployment_mode=backend-only` run into a false alarm (which is exactly what
+# happened: both backend-only dispatches on 2026-08-10 fired the orphan alert
+# for the deliberately-skipped frontend).
+deliberate_backend_skip=false
+deliberate_frontend_skip=false
 
 # Shared by the automatic push plan and workflow_dispatch's `auto` mode --
 # both derive the plan from affected-detection + lane results the same way.
@@ -109,15 +116,19 @@ elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
     # GHCR, regardless of what this run's build lanes decided.
     backend-only)
       backend_deploy=true
+      deliberate_frontend_skip=true
       ;;
     frontend-only)
       frontend_deploy=true
+      deliberate_backend_skip=true
       ;;
     both)
       backend_deploy=true
       frontend_deploy=true
       ;;
     none)
+      deliberate_backend_skip=true
+      deliberate_frontend_skip=true
       ;;
     *)
       echo "::error::Invalid deployment_mode '$manual_mode'. Use auto, backend-only, frontend-only, both, or none."
@@ -133,19 +144,27 @@ fi
 # would roll them out did not run this time, for ANY reason (lane failure,
 # cancellation, the plan deciding not to deploy, or a coupling hold).
 # Scoped to master: off-master manual builds intentionally never deploy and
-# must not be reported as drift.
+# must not be reported as drift. A side the operator explicitly excluded via
+# a manual mode is not drift either.
+#
+# The frontend check needs BOTH web-affected and lane success: docker-web
+# succeeds even when web isn't affected (it just skips the build/push), so
+# the job result alone is not publish evidence -- it once claimed "gaia-web
+# was published" on a run that never built a web image.
 backend_orphaned=false
 frontend_orphaned=false
 if [ "$on_master" = "true" ]; then
-  if [ "$BACKEND_IMAGES_PUBLISHED" = "true" ] && [ "$backend_deploy" != "true" ]; then
+  if [ "$BACKEND_IMAGES_PUBLISHED" = "true" ] && [ "$backend_deploy" != "true" ] && [ "$deliberate_backend_skip" != "true" ]; then
     backend_orphaned=true
   fi
-  if [ "$DOCKER_WEB_RESULT" = "success" ] && [ "$frontend_deploy" != "true" ]; then
+  if [ "$WEB_AFFECTED" = "true" ] && [ "$DOCKER_WEB_RESULT" = "success" ] && [ "$frontend_deploy" != "true" ] && [ "$deliberate_frontend_skip" != "true" ]; then
     frontend_orphaned=true
   fi
   # A coupling hold strands BOTH sides together even when only one lane
   # actually failed -- e.g. web failed, backend published fine but is held
   # back anyway. Flag both explicitly so the healthy side isn't missed.
+  # (Coupling holds only occur in auto plans, never in the explicit manual
+  # modes, so the deliberate-skip suppression can't apply here.)
   if [ "$coupled_hold" = "true" ]; then
     backend_orphaned=true
     frontend_orphaned=true

--- a/scripts/ci/compute-deploy-plan.sh
+++ b/scripts/ci/compute-deploy-plan.sh
@@ -44,15 +44,15 @@ set -euo pipefail
 : "${MANUAL_MODE_EVENT:=}"
 
 release_failed=false
-[ "$DOCKER_RELEASE_RESULT" = "failure" ] || [ "$DOCKER_RELEASE_RESULT" = "cancelled" ] && release_failed=true
+[[ "$DOCKER_RELEASE_RESULT" = "failure" ]] || [[ "$DOCKER_RELEASE_RESULT" = "cancelled" ]] && release_failed=true
 web_failed=false
-[ "$DOCKER_WEB_RESULT" = "failure" ] || [ "$DOCKER_WEB_RESULT" = "cancelled" ] && web_failed=true
+[[ "$DOCKER_WEB_RESULT" = "failure" ]] || [[ "$DOCKER_WEB_RESULT" = "cancelled" ]] && web_failed=true
 
 backend_affected=false
-[ "$API_AFFECTED" = "true" ] || [ "$BOTS_AFFECTED" = "true" ] && backend_affected=true
+[[ "$API_AFFECTED" = "true" ]] || [[ "$BOTS_AFFECTED" = "true" ]] && backend_affected=true
 
 both_touched=false
-[ "$backend_affected" = "true" ] && [ "$WEB_AFFECTED" = "true" ] && both_touched=true
+[[ "$backend_affected" = "true" ]] && [[ "$WEB_AFFECTED" = "true" ]] && both_touched=true
 
 backend_deploy=false
 frontend_deploy=false
@@ -68,12 +68,12 @@ deliberate_frontend_skip=false
 # Shared by the automatic push plan and workflow_dispatch's `auto` mode --
 # both derive the plan from affected-detection + lane results the same way.
 compute_auto_plan() {
-  if [ "$both_touched" = "true" ]; then
-    if [ "$release_failed" = "true" ] || [ "$web_failed" = "true" ]; then
+  if [[ "$both_touched" = "true" ]]; then
+    if [[ "$release_failed" = "true" ]] || [[ "$web_failed" = "true" ]]; then
       # Coupled push, one side red: hold both back rather than deploy a
       # frontend/backend pair that was never actually tested together.
       coupled_hold=true
-    elif [ "$DOCKER_RELEASE_RESULT" = "success" ] && [ "$DOCKER_WEB_RESULT" = "success" ]; then
+    elif [[ "$DOCKER_RELEASE_RESULT" = "success" ]] && [[ "$DOCKER_WEB_RESULT" = "success" ]]; then
       backend_deploy=true
       frontend_deploy=true
     fi
@@ -81,7 +81,7 @@ compute_auto_plan() {
     # affected lane) -- no verified success on both sides, so don't deploy,
     # but this isn't a failure either, so don't badge it as a coupled hold.
   else
-    if [ "$backend_affected" = "true" ] && [ "$DOCKER_RELEASE_RESULT" = "success" ]; then
+    if [[ "$backend_affected" = "true" ]] && [[ "$DOCKER_RELEASE_RESULT" = "success" ]]; then
       backend_deploy=true
     fi
     # Single-side push: frontend syncs from source, not docker-web's image,
@@ -92,19 +92,19 @@ compute_auto_plan() {
 }
 
 manual_mode="${MANUAL_MODE_INPUT:-}"
-if [ -z "$manual_mode" ]; then
+if [[ -z "$manual_mode" ]]; then
   manual_mode="${MANUAL_MODE_EVENT:-}"
 fi
-if [ -z "$manual_mode" ]; then
+if [[ -z "$manual_mode" ]]; then
   manual_mode="auto"
 fi
 
 on_master=false
-[ "$REF" = "refs/heads/master" ] && on_master=true
+[[ "$REF" = "refs/heads/master" ]] && on_master=true
 
-if [ "$on_master" = "false" ]; then
+if [[ "$on_master" = "false" ]]; then
   echo "Not on master; deploy jobs disabled."
-elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+elif [[ "$EVENT_NAME" = "workflow_dispatch" ]]; then
   case "$manual_mode" in
     auto)
       compute_auto_plan
@@ -153,11 +153,11 @@ fi
 # was published" on a run that never built a web image.
 backend_orphaned=false
 frontend_orphaned=false
-if [ "$on_master" = "true" ]; then
-  if [ "$BACKEND_IMAGES_PUBLISHED" = "true" ] && [ "$backend_deploy" != "true" ] && [ "$deliberate_backend_skip" != "true" ]; then
+if [[ "$on_master" = "true" ]]; then
+  if [[ "$BACKEND_IMAGES_PUBLISHED" = "true" ]] && [[ "$backend_deploy" != "true" ]] && [[ "$deliberate_backend_skip" != "true" ]]; then
     backend_orphaned=true
   fi
-  if [ "$WEB_AFFECTED" = "true" ] && [ "$DOCKER_WEB_RESULT" = "success" ] && [ "$frontend_deploy" != "true" ] && [ "$deliberate_frontend_skip" != "true" ]; then
+  if [[ "$WEB_AFFECTED" = "true" ]] && [[ "$DOCKER_WEB_RESULT" = "success" ]] && [[ "$frontend_deploy" != "true" ]] && [[ "$deliberate_frontend_skip" != "true" ]]; then
     frontend_orphaned=true
   fi
   # A coupling hold strands BOTH sides together even when only one lane
@@ -165,7 +165,7 @@ if [ "$on_master" = "true" ]; then
   # back anyway. Flag both explicitly so the healthy side isn't missed.
   # (Coupling holds only occur in auto plans, never in the explicit manual
   # modes, so the deliberate-skip suppression can't apply here.)
-  if [ "$coupled_hold" = "true" ]; then
+  if [[ "$coupled_hold" = "true" ]]; then
     backend_orphaned=true
     frontend_orphaned=true
   fi

--- a/scripts/ci/lib/image-repos.sh
+++ b/scripts/ci/lib/image-repos.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Single source of truth for the GHCR repos each deployable image group maps
+# to. Sourced by resolve-image-tags.sh (build) and retag-latest-alias.sh
+# (deploy/rollback) so the two ends of the pipeline can never disagree about
+# which repos share a tag. Keep in sync with the image: lines in
+# infra/docker/docker-compose.prod.yml and the nx.json release groups.
+# shellcheck disable=SC2034  # consumed by sourcing scripts
+GHCR_NAMESPACE="ghcr.io/theexperiencecompany"
+# nx release group "apps" — one commit produces the same tag for both.
+APPS_IMAGE_REPOS=(gaia gaia-voice-agent)
+# nx release group "bots" — fixed relationship, all four share the tag.
+BOTS_IMAGE_REPOS=(gaia-bot-discord gaia-bot-slack gaia-bot-telegram gaia-bot-whatsapp)
+GRAFANA_IMAGE_REPO="gaia-grafana"

--- a/scripts/ci/notify-discord.sh
+++ b/scripts/ci/notify-discord.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Sends a deploy-pipeline Discord notification as a single webhook embed.
+#
+# Replaces appleboy/discord-action for every deploy notification. That action
+# reads the message through a StringSlice env parse (urfave/cli splits env
+# values on commas) and, when `color` is set, sends each fragment as an embed
+# *title* — Discord caps embed titles at 256 chars, so any long message gets a
+# 400 and any comma fragments the message into multiple embeds. An embed
+# *description* (4096-char cap) carries rich multi-line messages intact.
+#
+# Inputs (env):
+#   DISCORD_WEBHOOK  webhook URL (required)
+#   MESSAGE          message body, markdown allowed (required)
+#   COLOR            embed color as hex, e.g. "#ff6b6b" (required)
+#   USERNAME         webhook display name (default: Gaia Deploy Bot)
+set -euo pipefail
+
+: "${DISCORD_WEBHOOK:?DISCORD_WEBHOOK is required}"
+: "${MESSAGE:?MESSAGE is required}"
+: "${COLOR:?COLOR is required}"
+USERNAME="${USERNAME:-Gaia Deploy Bot}"
+
+# Always log the full message first, so the run itself records what was (or
+# failed to be) delivered even when the webhook call is lost.
+echo "Discord notification:"
+printf '%s\n' "$MESSAGE"
+
+color_int=$((16#${COLOR#\#}))
+
+# Discord caps embed descriptions at 4096 chars — truncate instead of 400ing.
+message="$MESSAGE"
+if [ "${#message}" -gt 4000 ]; then
+  message="${message:0:4000}"$'\n'"…(truncated)"
+fi
+
+payload=$(jq -n --arg u "$USERNAME" --arg d "$message" --argjson c "$color_int" \
+  '{username: $u, embeds: [{description: $d, color: $c}]}')
+
+response_file=$(mktemp)
+status=$(curl -sS -o "$response_file" -w '%{http_code}' \
+  -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK")
+
+if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+  echo "::error::Discord webhook returned HTTP $status: $(cat "$response_file")"
+  exit 1
+fi
+echo "notify-discord: OK (HTTP $status)"

--- a/scripts/ci/notify-discord.sh
+++ b/scripts/ci/notify-discord.sh
@@ -29,7 +29,7 @@ color_int=$((16#${COLOR#\#}))
 
 # Discord caps embed descriptions at 4096 chars — truncate instead of 400ing.
 message="$MESSAGE"
-if [ "${#message}" -gt 4000 ]; then
+if [[ "${#message}" -gt 4000 ]]; then
   message="${message:0:4000}"$'\n'"…(truncated)"
 fi
 
@@ -37,10 +37,14 @@ payload=$(jq -n --arg u "$USERNAME" --arg d "$message" --argjson c "$color_int" 
   '{username: $u, embeds: [{description: $d, color: $c}]}')
 
 response_file=$(mktemp)
-status=$(curl -sS -o "$response_file" -w '%{http_code}' \
+trap 'rm -f "$response_file"' EXIT
+
+# Bounded: a stuck DNS lookup or socket must not hold a deploy workflow
+# hostage for a notification that is non-blocking by design.
+status=$(curl -sS --connect-timeout 5 --max-time 20 -o "$response_file" -w '%{http_code}' \
   -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK")
 
-if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
   echo "::error::Discord webhook returned HTTP $status: $(cat "$response_file")"
   exit 1
 fi

--- a/scripts/ci/resolve-image-tags.sh
+++ b/scripts/ci/resolve-image-tags.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Resolves the immutable per-commit Docker tags that `nx release` just built
+# (production versionScheme "{currentDate|YYMM.DD}.{shortCommitSha}", e.g.
+# 2608.10.fa2b2a9) and guarantees they exist in GHCR, so the deploy workflow
+# can pin the stack to exactly this run's images instead of :latest.
+#
+# Runs inside build.yml's docker-release job, after the release steps, on the
+# same runner that built the images — the tag is read from the local Docker
+# image store rather than recomputed, so a change to nx's scheme (or its
+# timezone handling) can never silently produce a tag the images don't carry.
+#
+# Inputs (env):
+#   VERSION_SCHEME         production | develop (deploys only run from master,
+#                          where the scheme is production; anything else
+#                          resolves to empty tags)
+#   APPS_RELEASE_OUTCOME   step outcome of "Release apps Docker images"
+#   BOTS_RELEASE_OUTCOME   step outcome of "Release bots Docker images"
+#
+# Outputs ($GITHUB_OUTPUT): apps_tag / bots_tag — empty when that group was
+# not released this run (the deploy then falls back to :latest via the
+# compose file's ${VAR:-latest} defaults).
+set -euo pipefail
+
+: "${VERSION_SCHEME:?VERSION_SCHEME is required}"
+: "${APPS_RELEASE_OUTCOME:?APPS_RELEASE_OUTCOME is required}"
+: "${BOTS_RELEASE_OUTCOME:?BOTS_RELEASE_OUTCOME is required}"
+
+# shellcheck source=scripts/ci/lib/image-repos.sh
+source "$(dirname "$0")/lib/image-repos.sh"
+
+# Production scheme: YYMM.DD.<short sha>. Anchored so :latest and dev tags
+# never match.
+TAG_RE='^[0-9]{4}\.[0-9]{2}\.[0-9a-f]{6,12}$'
+
+# Prints the group's tag on stdout (empty = group not released). Fails loud
+# when a released group's local images carry no/ambiguous/mismatched
+# production tags, or when the tag cannot be made to exist in GHCR — a deploy
+# pinned to a missing tag would fail far later, on the Swarm host.
+resolve_group() {
+  local group="$1" outcome="$2"
+  shift 2
+  local repos=("$@")
+
+  if [ "$outcome" != "success" ]; then
+    echo "resolve-image-tags: $group not released this run (outcome: $outcome)" >&2
+    echo ""
+    return 0
+  fi
+
+  local tag="" repo candidates
+  for repo in "${repos[@]}"; do
+    candidates=$(docker image ls --format '{{.Tag}}' "$GHCR_NAMESPACE/$repo" | grep -E "$TAG_RE" || true)
+    if [ -z "$candidates" ]; then
+      echo "::error::resolve-image-tags: $group released but $GHCR_NAMESPACE/$repo has no local production tag matching $TAG_RE" >&2
+      return 1
+    fi
+    if [ "$(echo "$candidates" | wc -l)" -ne 1 ]; then
+      echo "::error::resolve-image-tags: $GHCR_NAMESPACE/$repo has multiple production tags locally: $(echo "$candidates" | tr '\n' ' ')" >&2
+      return 1
+    fi
+    if [ -z "$tag" ]; then
+      tag="$candidates"
+    elif [ "$tag" != "$candidates" ]; then
+      echo "::error::resolve-image-tags: $group repos disagree on the tag ($tag vs $candidates on $repo)" >&2
+      return 1
+    fi
+  done
+
+  # The tag must be pullable at deploy time. nx release normally pushed it
+  # already; if it skipped publishing (the first-run fallback the
+  # ensure-bot-images step exists for), push the local image now.
+  for repo in "${repos[@]}"; do
+    local ref="$GHCR_NAMESPACE/$repo:$tag"
+    if ! docker manifest inspect "$ref" > /dev/null 2>&1; then
+      echo "resolve-image-tags: $ref not in GHCR yet — pushing" >&2
+      docker push "$ref" >&2
+      if ! docker manifest inspect "$ref" > /dev/null 2>&1; then
+        echo "::error::resolve-image-tags: $ref still missing from GHCR after push" >&2
+        return 1
+      fi
+    fi
+  done
+
+  echo "resolve-image-tags: $group => $tag" >&2
+  echo "$tag"
+}
+
+apps_tag=""
+bots_tag=""
+if [ "$VERSION_SCHEME" = "production" ]; then
+  apps_tag=$(resolve_group apps "$APPS_RELEASE_OUTCOME" "${APPS_IMAGE_REPOS[@]}")
+  bots_tag=$(resolve_group bots "$BOTS_RELEASE_OUTCOME" "${BOTS_IMAGE_REPOS[@]}")
+else
+  echo "resolve-image-tags: scheme is '$VERSION_SCHEME' (not production) — deploys are disabled off-master, skipping tag resolution"
+fi
+
+{
+  echo "apps_tag=$apps_tag"
+  echo "bots_tag=$bots_tag"
+} >> "$GITHUB_OUTPUT"
+echo "resolve-image-tags => apps: '${apps_tag:-<none>}', bots: '${bots_tag:-<none>}'"

--- a/scripts/ci/resolve-image-tags.sh
+++ b/scripts/ci/resolve-image-tags.sh
@@ -41,7 +41,7 @@ resolve_group() {
   shift 2
   local repos=("$@")
 
-  if [ "$outcome" != "success" ]; then
+  if [[ "$outcome" != "success" ]]; then
     echo "resolve-image-tags: $group not released this run (outcome: $outcome)" >&2
     echo ""
     return 0
@@ -50,17 +50,17 @@ resolve_group() {
   local tag="" repo candidates
   for repo in "${repos[@]}"; do
     candidates=$(docker image ls --format '{{.Tag}}' "$GHCR_NAMESPACE/$repo" | grep -E "$TAG_RE" || true)
-    if [ -z "$candidates" ]; then
+    if [[ -z "$candidates" ]]; then
       echo "::error::resolve-image-tags: $group released but $GHCR_NAMESPACE/$repo has no local production tag matching $TAG_RE" >&2
       return 1
     fi
-    if [ "$(echo "$candidates" | wc -l)" -ne 1 ]; then
+    if [[ "$(echo "$candidates" | wc -l)" -ne 1 ]]; then
       echo "::error::resolve-image-tags: $GHCR_NAMESPACE/$repo has multiple production tags locally: $(echo "$candidates" | tr '\n' ' ')" >&2
       return 1
     fi
-    if [ -z "$tag" ]; then
+    if [[ -z "$tag" ]]; then
       tag="$candidates"
-    elif [ "$tag" != "$candidates" ]; then
+    elif [[ "$tag" != "$candidates" ]]; then
       echo "::error::resolve-image-tags: $group repos disagree on the tag ($tag vs $candidates on $repo)" >&2
       return 1
     fi
@@ -87,7 +87,7 @@ resolve_group() {
 
 apps_tag=""
 bots_tag=""
-if [ "$VERSION_SCHEME" = "production" ]; then
+if [[ "$VERSION_SCHEME" = "production" ]]; then
   apps_tag=$(resolve_group apps "$APPS_RELEASE_OUTCOME" "${APPS_IMAGE_REPOS[@]}")
   bots_tag=$(resolve_group bots "$BOTS_RELEASE_OUTCOME" "${BOTS_IMAGE_REPOS[@]}")
 else

--- a/scripts/ci/retag-latest-alias.sh
+++ b/scripts/ci/retag-latest-alias.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Re-points the :latest tags in GHCR at what production actually runs, so
+# ":latest == deployed" holds as an invariant. `docker buildx imagetools
+# create` is a pure registry-side manifest operation — no layers are pulled
+# or pushed. Requires a GHCR login with packages:write.
+#
+# Modes:
+#   from-env      after a successful deploy convergence. Reads the tags the
+#                 stack was deployed with (env: APPS_IMAGE_TAG /
+#                 BOTS_IMAGE_TAG / GRAFANA_IMAGE_TAG, empty = that group was
+#                 deployed from :latest, already the alias — nothing to do).
+#   rolled-back   after a successful rollback convergence. Re-points :latest
+#                 at the images the rolled-back services now run, resolved
+#                 from the live service specs (env: ROLLBACK_MODE,
+#                 IMAGE_DIGEST, DOCKER_CONTEXT, STACK) — without this, a
+#                 rollback would leave :latest pointing at the bad build and
+#                 any container restart would re-pull it.
+set -euo pipefail
+
+MODE="${1:?usage: retag-latest-alias.sh from-env|rolled-back}"
+
+# shellcheck source=scripts/ci/lib/image-repos.sh
+source "$(dirname "$0")/lib/image-repos.sh"
+
+# repo_of ghcr.io/org/name:tag[@digest] -> ghcr.io/org/name
+repo_of() {
+  local ref="${1%%@*}"
+  local base="${ref##*/}"
+  if [[ "$base" == *:* ]]; then
+    echo "${ref%:*}"
+  else
+    echo "$ref"
+  fi
+}
+
+retag() {
+  local ref="$1" repo
+  repo=$(repo_of "$ref")
+  echo "Pointing $repo:latest -> $ref"
+  docker buildx imagetools create -t "$repo:latest" "$ref"
+}
+
+case "$MODE" in
+  from-env)
+    retagged=false
+    if [ -n "${APPS_IMAGE_TAG:-}" ]; then
+      for repo in "${APPS_IMAGE_REPOS[@]}"; do
+        retag "$GHCR_NAMESPACE/$repo:$APPS_IMAGE_TAG"
+      done
+      retagged=true
+    fi
+    if [ -n "${BOTS_IMAGE_TAG:-}" ]; then
+      for repo in "${BOTS_IMAGE_REPOS[@]}"; do
+        retag "$GHCR_NAMESPACE/$repo:$BOTS_IMAGE_TAG"
+      done
+      retagged=true
+    fi
+    if [ -n "${GRAFANA_IMAGE_TAG:-}" ]; then
+      retag "$GHCR_NAMESPACE/$GRAFANA_IMAGE_REPO:$GRAFANA_IMAGE_TAG"
+      retagged=true
+    fi
+    if [ "$retagged" = "false" ]; then
+      echo "No concrete tags were passed — stack was deployed from :latest, alias already correct."
+    fi
+    ;;
+
+  rolled-back)
+    : "${ROLLBACK_MODE:?ROLLBACK_MODE is required}"
+    DOCKER_CONTEXT="${DOCKER_CONTEXT:-prod}"
+    STACK="${STACK:-gaia-prod}"
+    if [ "$ROLLBACK_MODE" = "digest" ]; then
+      # Digest rollback only touches gaia-backend/arq_worker, both on the gaia
+      # repo — re-point exactly that repo's :latest at the pinned ref.
+      : "${IMAGE_DIGEST:?IMAGE_DIGEST is required for digest mode}"
+      retag "$IMAGE_DIGEST"
+    else
+      # `service rollback` restored each service's previous spec; read the
+      # image (repo:tag@digest) each rolled-back service now runs and
+      # re-point that repo's :latest at it. Deduped: gaia-backend and
+      # arq_worker share the gaia repo.
+      refs=$(for svc in $(docker --context "$DOCKER_CONTEXT" stack services "$STACK" --format '{{.Name}}' \
+          | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
+          docker --context "$DOCKER_CONTEXT" service inspect "$svc" \
+            --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}'
+        done | sort -u)
+      if [ -z "$refs" ]; then
+        echo "::error::rolled-back retag: no matching services found in stack $STACK"
+        exit 1
+      fi
+      while IFS= read -r ref; do
+        retag "$ref"
+      done <<< "$refs"
+    fi
+    ;;
+
+  *)
+    echo "::error::retag-latest-alias: unknown mode '$MODE' (use from-env or rolled-back)"
+    exit 1
+    ;;
+esac

--- a/scripts/ci/retag-latest-alias.sh
+++ b/scripts/ci/retag-latest-alias.sh
@@ -13,8 +13,8 @@
 #                 at the images the rolled-back services now run, resolved
 #                 from the live service specs (env: ROLLBACK_MODE,
 #                 IMAGE_DIGEST, DOCKER_CONTEXT, STACK) — without this, a
-#                 rollback would leave :latest pointing at the bad build and
-#                 any container restart would re-pull it.
+#                 rollback would leave :latest naming the bad build, and the
+#                 next tag-less `docker stack deploy` would resolve it again.
 set -euo pipefail
 
 MODE="${1:?usage: retag-latest-alias.sh from-env|rolled-back}"
@@ -65,9 +65,12 @@ case "$MODE" in
     ;;
 
   rolled-back)
+    # No defaults: the caller owns the context/stack names (they are the same
+    # literals the rollback job's own docker commands use). A silent default
+    # here could target a different cluster than the rollback just touched.
     : "${ROLLBACK_MODE:?ROLLBACK_MODE is required}"
-    DOCKER_CONTEXT="${DOCKER_CONTEXT:-prod}"
-    STACK="${STACK:-gaia-prod}"
+    : "${DOCKER_CONTEXT:?DOCKER_CONTEXT is required}"
+    : "${STACK:?STACK is required}"
     if [ "$ROLLBACK_MODE" = "digest" ]; then
       # Digest rollback only touches gaia-backend/arq_worker, both on the gaia
       # repo — re-point exactly that repo's :latest at the pinned ref.

--- a/scripts/ci/retag-latest-alias.sh
+++ b/scripts/ci/retag-latest-alias.sh
@@ -43,23 +43,23 @@ retag() {
 case "$MODE" in
   from-env)
     retagged=false
-    if [ -n "${APPS_IMAGE_TAG:-}" ]; then
+    if [[ -n "${APPS_IMAGE_TAG:-}" ]]; then
       for repo in "${APPS_IMAGE_REPOS[@]}"; do
         retag "$GHCR_NAMESPACE/$repo:$APPS_IMAGE_TAG"
       done
       retagged=true
     fi
-    if [ -n "${BOTS_IMAGE_TAG:-}" ]; then
+    if [[ -n "${BOTS_IMAGE_TAG:-}" ]]; then
       for repo in "${BOTS_IMAGE_REPOS[@]}"; do
         retag "$GHCR_NAMESPACE/$repo:$BOTS_IMAGE_TAG"
       done
       retagged=true
     fi
-    if [ -n "${GRAFANA_IMAGE_TAG:-}" ]; then
+    if [[ -n "${GRAFANA_IMAGE_TAG:-}" ]]; then
       retag "$GHCR_NAMESPACE/$GRAFANA_IMAGE_REPO:$GRAFANA_IMAGE_TAG"
       retagged=true
     fi
-    if [ "$retagged" = "false" ]; then
+    if [[ "$retagged" = "false" ]]; then
       echo "No concrete tags were passed — stack was deployed from :latest, alias already correct."
     fi
     ;;
@@ -71,7 +71,7 @@ case "$MODE" in
     : "${ROLLBACK_MODE:?ROLLBACK_MODE is required}"
     : "${DOCKER_CONTEXT:?DOCKER_CONTEXT is required}"
     : "${STACK:?STACK is required}"
-    if [ "$ROLLBACK_MODE" = "digest" ]; then
+    if [[ "$ROLLBACK_MODE" = "digest" ]]; then
       # Digest rollback only touches gaia-backend/arq_worker, both on the gaia
       # repo — re-point exactly that repo's :latest at the pinned ref.
       : "${IMAGE_DIGEST:?IMAGE_DIGEST is required for digest mode}"
@@ -86,7 +86,7 @@ case "$MODE" in
           docker --context "$DOCKER_CONTEXT" service inspect "$svc" \
             --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}'
         done | sort -u)
-      if [ -z "$refs" ]; then
+      if [[ -z "$refs" ]]; then
         echo "::error::rolled-back retag: no matching services found in stack $STACK"
         exit 1
       fi


### PR DESCRIPTION
Two deploy-pipeline changes: kill the "registry ahead of production" trap by deploying immutable per-commit tags and turning `:latest` into a deploy-time alias, and fix the orphan-notify job that failed with a Discord 400 on both manual backend-only dispatches on 2026-08-10 (runs 31433865911 / 31434695344).

## Part 1 — orphan-notify: Discord 400 + false fire

**400 root cause**, traced through the pinned action's source at the exact ref and confirmed against the logged payload. `appleboy/discord-action@afc2273` is `drone-discord` 1.4.1. Its `main.go:56` declares `message` as a `cli.StringSliceFlag` reading `INPUT_MESSAGE`, and urfave/cli v2 splits slice env values on **commas**. `plugin.go:242` then branches: when `color` is set, each fragment goes through `DefaultTemplate(txt)`, which is `EmbedObject{Title: txt}` — the message becomes an embed **title**, and Discord caps titles at 256 characters.

The failing message is 741 characters and contains two commas' worth of splitting, producing fragments of **479** and **261** characters. Both exceed 256, so Discord rejected the payload with a 400. This also explains why only this job failed: the deploy notifications are short enough that every comma fragment stays under the cap — the same latent bug sat in all of them.

Fix: `scripts/ci/notify-discord.sh` posts a single embed **description** (4096-char cap, defensively truncated at 4000), logs the full message into the run before sending, and fails loud with Discord's response body on any non-2xx. Every deploy-pipeline Discord send in build.yml, deploy-swarm-prod.yml and deploy-frontend.yml now goes through it; the third-party action is gone.

**False fire root cause.** On run 31433865911 only `api` was affected, `web=false`, and docker-web skipped its build entirely — yet the plan set `frontend_orphaned=true`. Two independent causes: the check used docker-web's **job result** as publish evidence (that job succeeds even when it skips the build, so its result proves nothing), and manual `backend-only` deliberately skips the frontend deploy, which is an operator decision rather than drift. In `compute-deploy-plan.sh` the frontend orphan now requires `web_affected AND lane success`, and any side a manual mode explicitly excluded (`backend-only` / `frontend-only` / `none`) is never flagged. Auto-path detection — coupled holds, publish-then-lane-failure — is unchanged.

**Green runs stay green.** `continue-on-error: true` on the Discord *send steps only*, with the reason commented: the script has already written the full alert into the run log, and a dropped webhook must not turn an otherwise-green deploy red. A failed send still emits a `::error::` annotation carrying Discord's response body.

## Part 2 — deploy by immutable tag

**No new tag scheme was invented.** The production `versionScheme` in `nx.json` is already `{currentDate|YYMM.DD}.{shortCommitSha}`, and last night's `docker-release` log shows nx pushing `ghcr.io/theexperiencecompany/gaia:2608.10.fa2b2a9` and `gaia-voice-agent:2608.10.fa2b2a9` alongside `:latest` ("Successfully pushed", digest `sha256:6bedc44…`). Grafana reuses the full-commit-sha tag its lane already pushes on every run. This PR consumes tags that already exist.

- `docker-release` resolves those tags from the local image store after the release steps (`scripts/ci/resolve-image-tags.sh` — read, never recomputed, so an nx scheme or timezone change can't silently produce a tag the images don't carry) and guarantees they're pullable from GHCR, pushing them if nx skipped publishing. Bots weren't released last night, so their versioned-tag publish is inferred from the shared nx machinery rather than observed; the script fails loud if it ever doesn't hold.
- `docker-compose.prod.yml` parameterizes every gaia image: `GAIA_IMAGE_TAG` (gaia across 3 services + gaia-voice-agent), `GAIA_BOTS_IMAGE_TAG` (4 bots), `GAIA_GRAFANA_IMAGE_TAG`. The `:-latest` defaults are the rollout-safety property — any caller that passes no tags (lab rehearsal, manual VM ops, an older workflow run) behaves exactly as before.
- `deploy-swarm-prod.yml` takes the tags as inputs, exports them for the stack deploy, and **only after convergence succeeds** re-points `:latest` at the deployed images via `docker buildx imagetools create` (a registry-side manifest operation, no layer transfer). Deploy and rollback jobs got `packages: write` for it.
- Rollback re-points `:latest` too, so the alias tracks production through a rollback: digest mode points it at the pinned gaia ref; `last` mode reads each rolled-back service's restored image spec live and dedupes by repo. Without this a rollback would leave `:latest` naming the bad build.

## Scenario matrix

| Scenario | Behavior after this PR |
|---|---|
| Normal push, backend affected | nx pushes `YYMM.DD.<sha>` + `:latest`; the deploy pins the stack to the tag; `:latest` is re-pointed after convergence. |
| Manual `backend-only` dispatch | Deploys backend. Frontend orphan **not** flagged — this is last night's false fire, reproduced red against the pre-change script and green against this one. Nothing rebuilt means empty tags, so it deploys `:latest` exactly as documented, and skips the retag. |
| Manual `both` dispatch | Both deploys run; backend pins to fresh tags if built this run, else `:latest`. |
| Rollback `last` | Services restore their previous spec; `:latest` re-pointed at each rolled-back service's image. |
| Rollback `digest` | `service update --image <ref>` unchanged (bypasses compose entirely); `:latest` re-pointed at the pinned ref. |
| Restart after a successful deploy | Safe. `docker stack deploy` defaults to `--resolve-image always`, so the service spec is digest-pinned and a task restart reuses that digest — it never re-resolves a tag. |
| **Restart / redeploy after a FAILED deploy** | The failed deploy never moves `:latest`, and running services keep their old digest-pinned spec. To be precise about the trap this closes: a plain Swarm task restart was already safe for the reason above; what was **not** safe is a *tag-less* `docker stack deploy` — a manual VM deploy or the manual drift-remedy dispatch — which resolves `:latest` and would have picked up a build that no deploy ever verified. **Caveat:** build-time `:latest` pushing is deliberately kept in this PR (see follow-up), so until that is removed a failed deploy still leaves the *build's* `:latest` ahead. The mechanism is in place; the trap dies fully with the follow-up. |
| Orphan alert for real drift | Delivers. Single embed, commas intact, 204 on the previously-400ing payload. |

## Verification

Everything below was executed, not reasoned about.

- **The 400 was reproduced and then fixed against a local sink that enforces Discord's documented limits** (title 256 / description 4096 / 10 embeds / content 2000, 204 on success). Replaying the appleboy code path — split on commas, each fragment as an embed title — returns `400 embeds[0].title 479 > 256`, matching production exactly. The same message through `notify-discord.sh` returns 204. Also covered: comma-heavy input (intact, 204), a 9000-char message (truncated, 204), a webhook returning 400 (exit 1 with `::error::` and the response body), an unreachable webhook (exit 7), missing env (exit 1). **This is a local sink, not Discord** — the first real alert is the end-to-end proof.
- **`compute-deploy-plan.sh`: a 10-scenario matrix**, run against both the pre-change script (`596bdbc4d`) and this one. Feeding the *exact* env from run 31433865911's job log, the pre-change script prints `frontend_orphaned: true` — reproducing production — and this one prints `false`. All other deploy decisions and auto-path orphan flags are unchanged. Re-run under **bash 5.3 in a container** (CI's shell; macOS ships bash 3.2) with identical results.
- **`docker compose config`** against the merged file: with the vars **unset**, resolved image lines are byte-identical to `origin/master`; with them **set**, all seven images pin to the passed tags; with them set to the **empty string** (what the workflow passes when a group wasn't built) they fall back to `:latest`. All three validate with exit 0.
- **`docker buildx imagetools create` was exercised against a real local registry**, not assumed. Both ref shapes the script produces work: `repo:<tag>` (the from-env path) and `repo:<tag>@sha256:…` (the rolled-back path, which is what `docker service inspect` returns once stack deploy has pinned the digest). Worth knowing: the resulting `:latest` is an OCI index *wrapping* the source manifest, so its top-level digest differs from the immutable tag's while referencing that exact manifest digest and resolving to identical layers. The alias is content-faithful, not digest-identical.
- **`resolve-image-tags.sh`** against a docker stub: last night's real shape (apps released, bots skipped → `apps_tag` set, `bots_tag` empty), both groups released, off-master develop scheme (empty, no pinning), and both fail-loud paths (a released group with no production tag; two ambiguous production tags).
- **actionlint**: 11 findings on the three changed workflows, byte-identical to `origin/master` — **zero new**. All pre-existing (unknown `blacksmith-*` runner labels, SC2086 in pre-existing inline scripts).
- **shellcheck -x** clean and **bash -n** clean on all five scripts.
- **No live deploy was possible from this environment.** The first master deploy after merge is the real proof of the full path: tag pass-through → pinned stack deploy → convergence → registry retag. Watch it.

## Review notes — changes made on top of the inherited work

Three fixes were made while verifying, each its own commit:

1. **`Resolve immutable image tags` ran before `Record image publish outcome`.** That put a step that can genuinely fail (no production tag, ambiguous tags, tag missing from GHCR) between the image pushes and the step whose entire job is to witness that they happened. `publish-status` is `if: always()`, so nothing was actually broken — but the ordering contradicted that step's own comment and left the invariant resting on the condition rather than on step order. Reordered so a resolve failure fails the lane with the publish already recorded, surfacing as an orphan alert instead of a silent "nothing published".
2. **`DOCKER_CONTEXT`/`STACK` defaulted to `prod`/`gaia-prod` inside `retag-latest-alias.sh` with no caller ever setting them** — a config knob that existed only as a silent fallback, and one that would keep addressing the old names if the context or stack were renamed. The rollback job now passes both explicitly; the script requires them.
3. **Two alert-rule comments cited `docker-compose.prod.yml:910` and `:515-519`.** Both already pointed at unrelated lines before this branch, and parameterizing the compose header shifted them further. Replaced with service and step names, which cannot go stale.

## Explicit follow-up (stated, not buried)

1. **Removing build-time `:latest` pushing is deliberately NOT in this PR.** nx release, `ensure-bot-images`, and the docker-web/grafana lanes still push `:latest` at build time. Removing it is what fully kills the restart-after-failed-deploy trap and makes the deploy the only writer of `:latest` — it should land once this has proven itself on a real deploy. That PR must also revisit build.yml's `image_missing` bootstrap checks and the orphan-alert wording, both of which encode current `:latest` semantics.
2. **`scripts/ci/*.sh` has no test harness** (pre-existing — `compute-deploy-plan.sh` included). The red/green matrix above was run ad hoc and is not repeatable in CI. Making it permanent is a team call on harness (bats vs pytest-subprocess).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
