### PR TITLE
ci: drop bandit/pip-audit/mypy from pre-commit (CI owns the heavy checks)

### DIFF
--- a/apps/api/.pre-commit-config.yaml
+++ b/apps/api/.pre-commit-config.yaml
@@ -12,20 +12,7 @@ repos:
 
   - repo: local
     hooks:
-      - id: bandit
-        name: Bandit Security Check
-        language: system
-        entry: uvx bandit -c pyproject.toml -r app --exclude app/agents/prompts
-        types: [python]
-        pass_filenames: false
-        priority: 0
 
-      - id: pip-audit
-        name: Pip Audit
-        language: system
-        entry: bash -c "uv export --no-dev --frozen --no-emit-header 2>/dev/null | uvx pip-audit --disable-pip --no-deps -r /dev/stdin"
-        pass_filenames: false
-        priority: 0
 
       - id: outbound-topology-parity
         name: Outbound topology parity (Python <-> TypeScript)
@@ -49,17 +36,4 @@ repos:
         entry: python3 tools/lints/check_ignore_ratchet.py
         files: ^(pyproject\.toml|tools/lints/(check_ignore_ratchet\.py|ignore_ratchet_baseline\.txt))$
         pass_filenames: false
-        priority: 0
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
-    hooks:
-      - id: mypy
-        args: [--ignore-missing-imports]
-        files: ^apps/api/app/
-        additional_dependencies:
-          - types-redis
-          - types-requests
-          - types-pytz
-          - types-croniter
         priority: 0


### PR DESCRIPTION
## What

Moves the three heavyweight verification steps **out of pre-commit** and leaves them to CI — pre-commit was re-running them on every single commit:

- **`bandit`** — full-app security scan (`uvx bandit -r app`)
- **`pip-audit`** — full lockfile export (`uv export --no-dev --frozen`) + advisory audit, with network access, on every commit
- **`mypy`** — full type-check of `apps/api/app`

## Why

All three are already enforced in CI (`.github/workflows/code-quality.yml`):
- **python-mypy lane** — runs the identical mypy command (staged-strict + shared strict override), including the new `disallow_any_explicit` global
- **Python security section** — bandit gates and pip-audit advisory checks

The heavy hooks were the slowest part of every commit (pip-audit alone is a full dependency export + network audit). Keeping them local adds latency without adding coverage.

## What stays

All fast feedback loops remain in pre-commit: ruff lint + format, the GAIA custom Python lints (route contract, service classes, wide events), outbound topology parity, the ruff ignore-list ratchet, and the generic check-yaml/json/toml/merge-conflict/ast hooks.

## Verification

- YAML parses clean
- Remaining hooks are unaffected (they only trigger on their scoped file patterns)
- CI lanes already exercise the removed checks
