### PR TITLE
test: cap local pytest workers at 2 (-n 4 -> -n 2)

### DIFF
--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -15,7 +15,7 @@ filterwarnings =
     ignore::pydantic.warnings.PydanticDeprecatedSince20
     ignore::UserWarning
     ignore::RuntimeWarning:asyncio
-addopts = -m "not composio and not model_onboarding and not schemathesis" --strict-markers -n 4 --timeout=300
+addopts = -m "not composio and not model_onboarding and not schemathesis" --strict-markers -n 2 --timeout=300
 markers =
     asyncio: marks tests as async (deselect with '-m "not asyncio"')
     unit: Unit tests (fast, no external deps)


### PR DESCRIPTION
## What

Caps the **local** pytest xdist worker count: `addopts` `-n 4` → `-n 2` in `apps/api/pytest.ini`.

## Why

Every local pytest run — even a single test file — spawned **4 xdist workers**, each importing the full app stack (FastAPI app factory, pydantic models, agents, …). On a developer MacBook that saturates CPU and memory for the duration of any test run.

Diagnostics (measured locally, in-process):
- **Collection is not the bottleneck**: ~9s across ~2,800 test modules; the cost is breadth, not a single hot import (cProfile: no pathological module).
- **Execution dominates** (~12k tests, 90–130s wall), and `-n 4` multiplied the local CPU/memory footprint of that.

## CI is unaffected

The test lane in `.github/workflows/main.yml` already overrides with its own `-n auto` — this change only affects local runs, which are now CI-only anyway.

## Notes

- `-n 2` keeps parallelism while halving the local footprint; still trivial to override per-run (`pytest -n 4 ...`).
- Full-suite local runs remain discouraged (CI-owned); this just makes accidental/targeted local runs gentler.
