### PR TITLE
fix(agents): stop unregistered custom_llm from killing every agent graph

### DIFF
--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -39,6 +39,18 @@ No magic strings or numbers anywhere in the codebase.
 - Group constants by domain in dedicated files (`constants/cache.py`, `constants/llm.py`, `src/config/`, `src/features/{feature}/constants.ts`)
 - Constants are the single source of truth — if the same value appears in two places, one of them should import from the other
 
+## Type Safety Ratchet
+
+Every file you touch leaves stricter than you found it, and never looser. Scope the tightening to the code you are already changing — a ratchet, not a licence to rewrite the file.
+
+- Close what is in front of you: `Any`, unparametrized generics (`dict`, `list`, `Callable`), untyped empty collections, a bare `str` holding a fixed set of values.
+- **Never introduce** a new `Any` or bare generic into a file that did not have one. Adding a hole is never in scope; closing one nearly always is.
+- A literal repeated at both a definition site and a lookup site (registry keys, event names, queue names, config keys) is an enum. Nothing else enforces that the two stay in sync, and the drift is silent until production.
+- An existing annotation is a claim, not evidence. `Any` launders wrong types downstream, so confirm the real runtime type before trusting a neighbouring declaration.
+- Prove the tightening bites. A checker that was green before *and* after proves nothing changed — a decorative annotation is exactly as green as a load-bearing one.
+
+The full canon — including the `StrEnum` vs `(str, Enum)` trade-off and the `reveal_type` probe — is in `apps/api/CLAUDE.md` (Type Safety); frontend rules are in `apps/web/CLAUDE.md`.
+
 ## Feature-Based Organization
 
 Organize code by domain/feature, not by technical type.

--- a/.claude/skills/parallel-worktrees/SKILL.md
+++ b/.claude/skills/parallel-worktrees/SKILL.md
@@ -55,7 +55,9 @@ today's defaults. Delete `.env.worktree` to fall back to defaults.
 | Service | Var | Value | Main (offset 0) |
 |---|---|---|---|
 | API (uvicorn) | `API_PORT` | `8000 + offset` | 8000 |
+| API (dockered, `dev:vm`) | `API_HOST_PORT` | `8000 + offset` | 8000 |
 | Web (Next.js) | `WEB_PORT` | `3000 + offset` | 3000 |
+| API → web URL (redirects, links) | `FRONTEND_URL` | `http://localhost:$WEB_PORT` | …:3000 |
 | Web → API URL | `NEXT_PUBLIC_API_BASE_URL` | `http://localhost:$API_PORT/api/v1/` | …8000/api/v1/ |
 | Bots/`gaia-sim` → API URL | `GAIA_API_URL` | `http://localhost:$API_PORT` | …:8000 |
 | Scripted LLM stub (`dev --sim`) | `LLM_STUB_PORT` | `9797 + offset` | 9797 |

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -412,6 +412,63 @@ Stop before forcing full type safety through:
 
 A narrower type that's provably correct beats a "complete" one that required guessing.
 
+### 15. Tighten the types in every file you touch — never widen them
+
+Type safety is a ratchet: each file you edit leaves stricter than you found it, and never looser. This is not a licence to rewrite the file. Scope the tightening to the code you are already changing plus the signatures it flows through — the same bar as any other diff (Surgical Changes), so the change stays reviewable.
+
+While you are in a function, fix what is in front of you: a `dict[str, Any]` return, an unparametrized `list`/`dict`/`Callable`, an untyped empty collection (`items = []`), a bare `str` holding a fixed value set, a magic literal that wants to be a constant or enum.
+
+The one hard rule is the ratchet direction. Never *introduce* an `Any`, a bare generic, or an untyped empty collection into a file that did not already have one — including in a hurry, including "just for now." Adding a hole is never in scope; closing one nearly always is.
+
+### 16. An existing annotation is a claim, not evidence — verify the runtime type before you trust it
+
+`dict[str, Any]` does not merely lose precision. It launders wrong types downstream: `Any` is compatible with everything, so a false declaration on the receiving end is never challenged.
+
+Real case from this codebase: `LLMProvider.instance` was declared `BaseChatModel` for months. The registry actually holds `RunnableConfigurableFields` (what `configurable_fields()` returns) — a `RunnableSerializable`, **not** a `BaseChatModel`. The `dict[str, Any]` feeding it is the only reason the lie survived; the code then called `configurable_alternatives()`, a method the declared type does not even have.
+
+So when tightening, do not derive the "real" type from the neighbouring annotation, or from a factory's declared return. Construct the value and look:
+
+```python
+inst = providers.get("gemini_llm")
+print(type(inst).__name__, isinstance(inst, BaseChatModel))  # RunnableConfigurableFields False
+```
+
+Then annotate what it *is*, and pick the type that actually declares the methods you call — `configurable_alternatives` lives on `RunnableSerializable`, not on bare `Runnable`/`LanguageModelLike`.
+
+### 17. Prove the tightened annotation can fail
+
+mypy passing before *and* after a "tightening" proves nothing changed — a decorative annotation is as green as a load-bearing one. Same rule as tests: if it cannot fail, it is not doing work.
+
+Write a throwaway probe, run mypy on it, confirm it errors, delete it:
+
+```python
+# _typeprobe.py — delete after running
+bad: LLMProvider = {"name": "x", "instance": "not-a-model"}   # expect: error
+_get_ordered_providers({"gemini": "not-a-model"}, None, True)  # expect: error
+reveal_type(_get_available_providers())                        # expect: the real type, not Any
+```
+
+`reveal_type` is the fastest way to confirm you closed the hole rather than moved it: if it still reveals `Any`, the annotation is cosmetic.
+
+### 18. A literal repeated at a definition site and a lookup site is an enum (see item 5)
+
+Item 5 covers a fixed set of *values*. This is the sharper case: the same literal written in two places that must agree. Registry keys, event names, queue names, config keys, cache-key prefixes. Nothing enforces the match, so drift is silent and reaches production.
+
+That is exactly how the `comms_agent` outage happened — `"gemini_llm"` lived in both `@lazy_provider(name="gemini_llm")` and the lookup mapping, and only one side was environment-gated. One enum, referenced from both sides, makes the drift impossible:
+
+```python
+class LLMProviderKey(StrEnum):
+    GEMINI = "gemini_llm"
+```
+
+Prefer `StrEnum` over `(str, Enum)`. Both hash equal to their string value, so members stay usable as dict keys and in plain-string lookups — but `(str, Enum)` renders as `LLMProviderKey.GEMINI` in f-strings and log messages, while `StrEnum` renders `gemini_llm`. When the value is interpolated into a log line or an error message, `(str, Enum)` silently degrades it. Verify both properties before swapping a hot string for an enum member:
+
+```python
+d = {LLMProviderKey.GEMINI: 1}
+assert d.get("gemini_llm") == 1          # dict-key compatible
+assert f"{LLMProviderKey.GEMINI}" == "gemini_llm"   # renders as the value
+```
+
 ## Anti-Patterns
 
 - No sync DB/HTTP calls in async endpoints — all I/O must be `async`.

--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -22,6 +22,7 @@ from app.agents.llm.types import (
     LLMFallback,
     LLMProvider,
     LLMProviderKey,
+    LLMProviderName,
     ProviderLLM,
 )
 from app.config.settings import settings
@@ -75,17 +76,17 @@ def is_default_model_config(configurable: AgentConfigurable) -> bool:
     )
 
 
-PROVIDER_MODELS = {
-    "gemini": DEFAULT_GEMINI_MODEL_NAME,
-    "openrouter": DEFAULT_MODEL_NAME,
+PROVIDER_MODELS: dict[LLMProviderName, str] = {
+    LLMProviderName.GEMINI: DEFAULT_GEMINI_MODEL_NAME,
+    LLMProviderName.OPENROUTER: DEFAULT_MODEL_NAME,
     # The env-defined custom dev endpoint; empty when unset — the provider is
     # only registered in development with all DEV_LLM_* settings present.
-    "custom": settings.DEV_LLM_MODEL or "",
+    LLMProviderName.CUSTOM: settings.DEV_LLM_MODEL or "",
 }
-PROVIDER_PRIORITY = {
-    1: "openrouter",
-    2: "gemini",
-    3: "custom",
+PROVIDER_PRIORITY: dict[int, LLMProviderName] = {
+    1: LLMProviderName.OPENROUTER,
+    2: LLMProviderName.GEMINI,
+    3: LLMProviderName.CUSTOM,
 }
 
 
@@ -143,7 +144,7 @@ def init_gemini_llm() -> LanguageModelLike:
     if settings.GAIA_SIM_MODE:
         return _sim_llm()
     llm = ChatGoogleGenerativeAI(
-        model=PROVIDER_MODELS["gemini"],
+        model=PROVIDER_MODELS[LLMProviderName.GEMINI],
         temperature=DEFAULT_LLM_TEMPERATURE,
         streaming=True,
     ).configurable_fields(model=_MODEL_FIELD)
@@ -173,7 +174,7 @@ def init_openrouter_llm() -> LanguageModelLike:
     # mode's job (_sim_llm); this construction is identical to pre-sim behavior.
     return _openrouter_wire_configurables(
         ChatOpenRouter(
-            model=PROVIDER_MODELS["openrouter"],
+            model=PROVIDER_MODELS[LLMProviderName.OPENROUTER],
             temperature=DEFAULT_LLM_TEMPERATURE,
             streaming=True,
             stream_usage=True,
@@ -212,7 +213,7 @@ def init_custom_llm() -> LanguageModelLike:
         return _sim_llm()
     return _openrouter_wire_configurables(
         ChatOpenRouter(
-            model=PROVIDER_MODELS["custom"],
+            model=PROVIDER_MODELS[LLMProviderName.CUSTOM],
             temperature=DEFAULT_LLM_TEMPERATURE,
             streaming=True,
             stream_usage=True,
@@ -232,13 +233,15 @@ def init_llm(
     Without a preferred_provider, uses the default priority order. Raises
     ValueError on an unknown provider, RuntimeError if none are configured.
     """
-    # Validate preferred provider if specified
+    # preferred_provider is untrusted input (a request configurable), so it stays
+    # a plain str on the signature and is narrowed to the enum once validated.
     if preferred_provider and preferred_provider not in PROVIDER_MODELS:
         valid_providers = list(PROVIDER_MODELS.keys())
         raise ValueError(
             f"Invalid preferred_provider '{preferred_provider}'. "
             f"Valid providers are: {valid_providers}"
         )
+    preferred = LLMProviderName(preferred_provider) if preferred_provider else None
 
     # Get available provider instances from global providers registry
     available_providers = _get_available_providers()
@@ -247,9 +250,7 @@ def init_llm(
         raise RuntimeError("No LLM providers are properly configured.")
 
     # Determine provider order based on preferred provider or default priority
-    ordered_providers = _get_ordered_providers(
-        available_providers, preferred_provider, fallback_enabled
-    )
+    ordered_providers = _get_ordered_providers(available_providers, preferred, fallback_enabled)
 
     if not ordered_providers:
         raise RuntimeError(
@@ -271,16 +272,16 @@ def init_llm(
     return _create_configurable_llm(primary_provider, alternative_providers)
 
 
-def _get_available_providers() -> dict[str, ProviderLLM]:
+def _get_available_providers() -> dict[LLMProviderName, ProviderLLM]:
     """Retrieve available LLM provider instances from the global registry,
     mapped by provider name."""
-    provider_instance_mapping = {
-        "gemini": LLMProviderKey.GEMINI,
-        "openrouter": LLMProviderKey.OPENROUTER,
-        "custom": LLMProviderKey.CUSTOM,
+    provider_instance_mapping: dict[LLMProviderName, LLMProviderKey] = {
+        LLMProviderName.GEMINI: LLMProviderKey.GEMINI,
+        LLMProviderName.OPENROUTER: LLMProviderKey.OPENROUTER,
+        LLMProviderName.CUSTOM: LLMProviderKey.CUSTOM,
     }
 
-    available: dict[str, ProviderLLM] = {}
+    available: dict[LLMProviderName, ProviderLLM] = {}
     for provider_name, instance_key in provider_instance_mapping.items():
         # custom_llm is only registered in development; providers.get() raises
         # KeyError on an unregistered name, which took every agent graph down.
@@ -294,8 +295,8 @@ def _get_available_providers() -> dict[str, ProviderLLM]:
 
 
 def _get_ordered_providers(
-    available_providers: dict[str, ProviderLLM],
-    preferred_provider: str | None,
+    available_providers: dict[LLMProviderName, ProviderLLM],
+    preferred_provider: LLMProviderName | None,
     fallback_enabled: bool,
 ) -> list[LLMProvider]:
     """Order providers by preference and availability, returning LLMProvider
@@ -334,8 +335,8 @@ def _create_configurable_llm(
         # Return primary instance directly if no alternatives
         return primary["instance"]
 
-    # Create configurable alternatives mapping
-    alternatives_mapping = {alt["name"]: alt["instance"] for alt in alternatives}
+    # Keyword-expanded below, so the keys must be plain str, not enum members.
+    alternatives_mapping = {str(alt["name"]): alt["instance"] for alt in alternatives}
 
     primary_instance = primary["instance"]
 

--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -1,5 +1,4 @@
 import asyncio
-from collections.abc import Callable
 from functools import cache
 from typing import Any, TypeVar, cast
 
@@ -13,12 +12,17 @@ from langchain_core.runnables.utils import ConfigurableField
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openrouter import ChatOpenRouter
 from pydantic import BaseModel, SecretStr
-from typing_extensions import TypedDict
 
 from app.agents.llm.exceptions import (
     LLM_FALLBACK_EXCEPTIONS,
     LLM_RETRYABLE_EXCEPTIONS,
     LLMNotConfiguredError,
+)
+from app.agents.llm.types import (
+    LLMFallback,
+    LLMProvider,
+    LLMProviderKey,
+    ProviderLLM,
 )
 from app.config.settings import settings
 from app.constants.llm import (
@@ -47,11 +51,6 @@ from shared.py.wide_events import log
 
 _StructuredT = TypeVar("_StructuredT", bound=BaseModel)
 _ResultT = TypeVar("_ResultT")
-
-# A fallback may be passed as a ready runnable or as a zero-arg factory, so
-# expensive preparation (e.g. re-binding the full tool list) only happens in
-# the rare case the primary actually fails.
-LLMFallback = Runnable | Callable[[], Runnable | None] | None
 
 
 def with_llm_retry(runnable: Runnable, *, max_attempts: int = LLM_RETRY_MAX_ATTEMPTS) -> Runnable:
@@ -88,11 +87,6 @@ PROVIDER_PRIORITY = {
     2: "gemini",
     3: "custom",
 }
-
-
-class LLMProvider(TypedDict):
-    name: str
-    instance: BaseChatModel
 
 
 @cache
@@ -139,7 +133,7 @@ def _openrouter_wire_configurables(llm: ChatOpenRouter) -> LanguageModelLike:
 
 
 @lazy_provider(
-    name="gemini_llm",
+    name=LLMProviderKey.GEMINI,
     required_keys=[SIM_STUB_API_KEY if settings.GAIA_SIM_MODE else settings.GOOGLE_API_KEY],
     strategy=MissingKeyStrategy.WARN,
     warning_message="Google API key not configured. Models provided by Google Gemini will not work.",
@@ -157,7 +151,7 @@ def init_gemini_llm() -> LanguageModelLike:
 
 
 @lazy_provider(
-    name="openrouter_llm",
+    name=LLMProviderKey.OPENROUTER,
     required_keys=[SIM_STUB_API_KEY if settings.GAIA_SIM_MODE else settings.OPENROUTER_API_KEY],
     strategy=MissingKeyStrategy.WARN,
     warning_message="OpenRouter API key not configured. Models provided via OpenRouter (Grok, etc.) will not work.",
@@ -199,7 +193,7 @@ def init_openrouter_llm() -> LanguageModelLike:
 
 
 @lazy_provider(
-    name="custom_llm",
+    name=LLMProviderKey.CUSTOM,
     required_keys=[SIM_STUB_API_KEY]
     if settings.GAIA_SIM_MODE
     else [settings.DEV_LLM_BASE_URL, settings.DEV_LLM_API_KEY, settings.DEV_LLM_MODEL],
@@ -277,19 +271,22 @@ def init_llm(
     return _create_configurable_llm(primary_provider, alternative_providers)
 
 
-def _get_available_providers() -> dict[str, Any]:
+def _get_available_providers() -> dict[str, ProviderLLM]:
     """Retrieve available LLM provider instances from the global registry,
     mapped by provider name."""
-    # Mapping of provider names to their instance keys in the providers registry
     provider_instance_mapping = {
-        "gemini": "gemini_llm",
-        "openrouter": "openrouter_llm",
-        "custom": "custom_llm",
+        "gemini": LLMProviderKey.GEMINI,
+        "openrouter": LLMProviderKey.OPENROUTER,
+        "custom": LLMProviderKey.CUSTOM,
     }
 
-    available = {}
+    available: dict[str, ProviderLLM] = {}
     for provider_name, instance_key in provider_instance_mapping.items():
-        instance = providers.get(instance_key)
+        # custom_llm is only registered in development; providers.get() raises
+        # KeyError on an unregistered name, which took every agent graph down.
+        if not providers.is_available(instance_key):
+            continue
+        instance = cast(ProviderLLM | None, providers.get(instance_key))
         if instance is not None:
             available[provider_name] = instance
 
@@ -297,13 +294,13 @@ def _get_available_providers() -> dict[str, Any]:
 
 
 def _get_ordered_providers(
-    available_providers: dict[str, Any],
+    available_providers: dict[str, ProviderLLM],
     preferred_provider: str | None,
     fallback_enabled: bool,
 ) -> list[LLMProvider]:
     """Order providers by preference and availability, returning LLMProvider
     objects in priority order."""
-    ordered = []
+    ordered: list[LLMProvider] = []
     remaining_providers = available_providers.copy()
 
     # If a preferred provider is specified and available, prioritize it

--- a/apps/api/app/agents/llm/types.py
+++ b/apps/api/app/agents/llm/types.py
@@ -9,6 +9,15 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 from typing_extensions import TypedDict
 
 
+class LLMProviderName(StrEnum):
+    """Logical provider names: the keys of ``PROVIDER_MODELS``/``PROVIDER_PRIORITY``
+    and the value of the ``provider`` configurable that picks a lane per request."""
+
+    GEMINI = "gemini"
+    OPENROUTER = "openrouter"
+    CUSTOM = "custom"
+
+
 class LLMProviderKey(StrEnum):
     """Lazy-loader registry keys. Single source of truth for the ``@lazy_provider``
     names and the lookup in ``_get_available_providers``."""
@@ -24,11 +33,16 @@ ProviderLLM = RunnableSerializable[LanguageModelInput, AIMessage]
 
 
 class LLMProvider(TypedDict):
-    name: str
+    name: LLMProviderName
     instance: ProviderLLM
 
 
 # A fallback may be passed as a ready runnable or as a zero-arg factory, so
 # expensive preparation (e.g. re-binding the full tool list) only happens in
-# the rare case the primary actually fails.
-LLMFallback = Runnable | Callable[[], Runnable | None] | None
+# the rare case the primary actually fails. Parametrized to match what callers
+# actually build: bind_tools() returns Runnable[LanguageModelInput, AIMessage].
+LLMFallback = (
+    Runnable[LanguageModelInput, AIMessage]
+    | Callable[[], Runnable[LanguageModelInput, AIMessage] | None]
+    | None
+)

--- a/apps/api/app/agents/llm/types.py
+++ b/apps/api/app/agents/llm/types.py
@@ -1,0 +1,34 @@
+"""Shared types for the LLM client layer."""
+
+from collections.abc import Callable
+from enum import StrEnum
+
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import Runnable, RunnableSerializable
+from typing_extensions import TypedDict
+
+
+class LLMProviderKey(StrEnum):
+    """Lazy-loader registry keys. Single source of truth for the ``@lazy_provider``
+    names and the lookup in ``_get_available_providers``."""
+
+    GEMINI = "gemini_llm"
+    OPENROUTER = "openrouter_llm"
+    CUSTOM = "custom_llm"
+
+
+# configurable_fields() returns a RunnableConfigurableFields, not a BaseChatModel,
+# and only RunnableSerializable declares configurable_alternatives().
+ProviderLLM = RunnableSerializable[LanguageModelInput, AIMessage]
+
+
+class LLMProvider(TypedDict):
+    name: str
+    instance: ProviderLLM
+
+
+# A fallback may be passed as a ready runnable or as a zero-arg factory, so
+# expensive preparation (e.g. re-binding the full tool list) only happens in
+# the rare case the primary actually fails.
+LLMFallback = Runnable | Callable[[], Runnable | None] | None

--- a/apps/api/app/core/lazy_loader.py
+++ b/apps/api/app/core/lazy_loader.py
@@ -267,6 +267,7 @@ class LazyLoader(Generic[T]):
                 f"{LogTag.STARTUP} Failed to initialize provider",
                 provider_name=self.provider_name,
                 error_type=type(e).__name__,
+                error=str(e),
             )
 
             if self.strategy == MissingKeyStrategy.ERROR:
@@ -336,6 +337,7 @@ class LazyLoader(Generic[T]):
                 f"{LogTag.STARTUP} Failed to initialize provider",
                 provider_name=self.provider_name,
                 error_type=type(e).__name__,
+                error=str(e),
             )
 
             if self.strategy == MissingKeyStrategy.ERROR:

--- a/apps/api/tests/integration/test_llm_fallback_chain.py
+++ b/apps/api/tests/integration/test_llm_fallback_chain.py
@@ -28,6 +28,7 @@ from app.agents.llm.client import (
     _get_ordered_providers,
     ainvoke_llm,
     init_llm,
+    register_llm_providers,
 )
 from app.config.model_pricing import (
     DEFAULT_PRICING,
@@ -35,6 +36,7 @@ from app.config.model_pricing import (
     calculate_token_cost,
     get_model_pricing,
 )
+from app.config.settings import settings
 from app.constants.llm import DEFAULT_LLM_PROVIDER
 from app.core.lazy_loader import MissingKeyStrategy, ProviderRegistry
 
@@ -386,6 +388,34 @@ class TestGetAvailableProviders:
             available = _get_available_providers()
 
         assert available == {}
+
+
+@pytest.mark.integration
+class TestProductionProviderRegistration:
+    """Drives the REAL register_llm_providers().
+
+    `_build_registry` above always registers all four slots and varies only the
+    keys, so production's actual state — custom_llm never registered, because it
+    is gated on ENV=development — was unrepresentable, and the KeyError it raised
+    went unseen by every tier.
+    """
+
+    @pytest.mark.regression
+    def test_production_registration_leaves_init_llm_working(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = ProviderRegistry()
+        # Registration writes to lazy_loader.providers, the lookup reads
+        # client.providers; both must point at the throwaway or the global
+        # singleton leaks into every later test.
+        monkeypatch.setattr("app.core.lazy_loader.providers", registry)
+        monkeypatch.setattr("app.agents.llm.client.providers", registry)
+        monkeypatch.setattr(settings, "ENV", "production")
+
+        register_llm_providers()
+
+        assert "custom" not in _get_available_providers()
+        assert init_llm() is not None
 
 
 @pytest.mark.integration

--- a/apps/api/tests/integration/test_llm_fallback_chain.py
+++ b/apps/api/tests/integration/test_llm_fallback_chain.py
@@ -401,7 +401,7 @@ class TestProductionProviderRegistration:
     """
 
     @pytest.mark.regression
-    def test_production_registration_leaves_init_llm_working(
+    def test_production_registration_leaves_provider_lookup_working(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         registry = ProviderRegistry()
@@ -414,8 +414,16 @@ class TestProductionProviderRegistration:
 
         register_llm_providers()
 
+        # Literals rather than LLMProviderKey/LLMProviderName: the regression
+        # gate re-runs this file against the base revision, where those enums
+        # do not exist yet, and an import error there proves nothing.
+        with pytest.raises(KeyError):
+            registry.get("custom_llm")
+
+        # That KeyError went straight out through init_llm and took every agent
+        # graph down. Which providers stay available depends on the ambient keys
+        # (CI has none), so only the never-registered slot is asserted.
         assert "custom" not in _get_available_providers()
-        assert init_llm() is not None
 
 
 @pytest.mark.integration

--- a/apps/api/tests/unit/agents/test_llm_client.py
+++ b/apps/api/tests/unit/agents/test_llm_client.py
@@ -32,6 +32,7 @@ from app.agents.llm.client import (
 )
 from app.agents.llm.exceptions import LLM_FALLBACK_EXCEPTIONS, LLMNotConfiguredError
 from app.constants.llm import DEFAULT_MODEL_NAME
+from app.core.lazy_loader import ProviderRegistry
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -97,6 +98,24 @@ class TestGetAvailableProviders:
         result = _get_available_providers()
 
         assert list(result.keys()) == ["gemini"]
+
+    @pytest.mark.regression
+    def test_unregistered_provider_is_skipped_not_fatal(self) -> None:
+        """custom_llm is registered only when ENV=development, so in production
+        the registry has no such key. Against the REAL registry (which raises
+        KeyError on an unregistered name, unlike the mock the sibling tests use)
+        that killed init_llm, and with it every agent graph.
+        """
+        registry = ProviderRegistry()
+        gemini_inst = _make_fake_provider("gemini")
+        openrouter_inst = _make_fake_provider("openrouter")
+        registry.register("gemini_llm", lambda: gemini_inst)
+        registry.register("openrouter_llm", lambda: openrouter_inst)
+
+        with patch("app.agents.llm.client.providers", registry):
+            result = _get_available_providers()
+
+        assert result == {"gemini": gemini_inst, "openrouter": openrouter_inst}
 
 
 # ---------------------------------------------------------------------------

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -42,6 +42,10 @@ services:
       # / `--sim`, which derive it from DEV_USER). Overrides the commented-out value
       # in apps/api/.env; empty means real WorkOS login. Development compose only.
       DEV_AUTH_BYPASS_EMAIL: ${DEV_AUTH_BYPASS_EMAIL:-}
+      # Post-login / OAuth redirects and notification links resolve from this.
+      # Declared here (not left to the env_file) so a worktree's .env.worktree
+      # value wins over the fixed :3000 in apps/api/.env.
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
       LOG_FORMAT: json
       LOG_COLORIZE: "false"
       # Share one copy of the embedding/reranker weights via the sidecar.

--- a/mise.toml
+++ b/mise.toml
@@ -185,7 +185,13 @@ cat > "$root/.env.worktree" <<EOF
 # Deterministic per-worktree ports (offset $offset derived from the worktree path).
 # mise loads this automatically via [env]._.file; delete it to fall back to defaults.
 API_PORT=$api_port
+# Host publish port for the dockered API (\`mise dev:vm\`). Same value as API_PORT
+# so the URLs below hold whichever way this worktree boots the API.
+API_HOST_PORT=$api_port
 WEB_PORT=$web_port
+# The API redirects here after login/OAuth and builds notification links from it,
+# so it must point at THIS worktree's web server, not the default :3000.
+FRONTEND_URL=http://localhost:$web_port
 NEXT_PUBLIC_API_BASE_URL=http://localhost:$api_port/api/v1/
 # Every backend client resolves the API from this, so \`gaia-sim\` and the bots
 # target THIS worktree's API instead of whatever owns port 8000.


### PR DESCRIPTION
## The outage

Every chat request in production was failing with `GraphUnavailableError` for `comms_agent`, behind an opaque `KeyError`.

`_get_available_providers()` looks up all three provider keys unconditionally:

```python
provider_instance_mapping = {"gemini": ..., "openrouter": ..., "custom": "custom_llm"}
for provider_name, instance_key in provider_instance_mapping.items():
    instance = providers.get(instance_key)   # raises on an unregistered name
```

But `custom_llm` is registered **only when `ENV=development`** (deliberately — so `DEV_LLM_*` can never route real traffic). `providers.get()` raises `KeyError` rather than returning `None`, so in production the mere *check* blew up `init_llm()` — taking down comms, executor, every provider subagent and the workflow subagent. Comms just surfaced first, being the front door.

Introduced in `fc937af60`.

## The fix

Gate the lookup on `providers.is_available()`, which is already `False` for both the unregistered and the unconfigured case. `get()`'s `KeyError` is left intact — it is a real guardrail against typo'd names elsewhere.

## Also in here

- **`lazy_loader` swallowed the root cause.** It built an error string containing the exception text but logged only `error_type`. `GraphUnavailableError` told you to read a log that had no cause in it. Both init paths now log `error=str(e)`.
- **`LLMProviderKey` StrEnum + `app/agents/llm/types.py`.** The key `"gemini_llm"` lived in two places that had to agree — the `@lazy_provider(name=...)` decorator and the lookup. That exact drift caused this outage. `StrEnum` (not `(str, Enum)`) because the key is interpolated into the lazy-loader's f-string error message.
- **Real types.** `LLMProvider.instance` was declared `BaseChatModel`, but the registry actually holds `RunnableConfigurableFields` — verified at runtime. `dict[str, Any]` was hiding a false declaration.

## Why no test caught it

Two fixture-shaped blind spots:

1. **Unit** — every test patched the registry with a `MagicMock`, whose `.get()` returns a mock and *never raises `KeyError`*.
2. **Integration** — `_build_registry` always registered **all four** provider slots and varied only the *keys*. So "registered but unconfigured" was well covered, while production's real state — `custom_llm` never registered — was literally unrepresentable.

The new integration test does not hand-build a registry at all; it drives the **real `register_llm_providers()`** with `ENV=production`.

## Verification

Both regression tests confirmed **red** before the fix with the exact production `KeyError`, then green.

Booted the API under `ENV=production` (with Infisical still loading the *development* slug):

```
/health  → 200 {"environment":"production"}
/docs    → 404
REGISTERED   : [gemini_llm, openrouter_llm]     # no custom_llm, correct
COMMS_AGENT  : CompiledStateGraph               # reverting the fix → None (BROKEN)
```

`mypy app` clean (831 files) · `ruff` clean · full hermetic suite **11411 passed**.

Not covered: no authenticated chat turn was driven end-to-end (production auth needs real WorkOS; the dev bypass is forbidden there). The comms graph itself — the component that was down — was built for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also on this branch (2 further commits)

**`33f33049` docs — type-safety ratchet rules.** Extends the Type Safety canon in `apps/api/CLAUDE.md` with items 15–18, plus a short cross-cutting section in `.claude/rules/general.md` (that file loads every session; the API one doesn't). Every rule is drawn from this incident — notably "a literal repeated at a definition site and a lookup site is an enum," which is the exact drift that caused the outage.

**`adcd0e0d` chore — per-worktree `FRONTEND_URL` / `API_HOST_PORT`.** ⚠️ **Not authored in this session.** These three files (`mise.toml`, `infra/docker/docker-compose.yml`, `parallel-worktrees/SKILL.md`) were already modified in the working tree when this work started, most likely by another workspace on the same checkout. Committed on request so the wiring isn't lost, and deliberately kept as a separate commit so it can be dropped independently of the fix. **Please confirm this belongs to you before merging** — if not, drop that commit.
