### PR TITLE
fix(chat): always surface LLM failures in the UI, and stop compounding retries

### DIFF
--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -56,21 +56,17 @@ _ResultT = TypeVar("_ResultT")
 
 
 def without_sdk_retry(llm: ChatOpenRouter) -> ChatOpenRouter:
-    """Hand the OpenRouter SDK's own retry loop off to :func:`with_llm_retry`.
-
-    ``langchain-openrouter`` defaults ``max_retries=2``, which becomes an SDK
-    backoff window of ``max_retries * 150_000`` ms — 300 seconds of retrying
-    inside a SINGLE ``ainvoke``, nested under our 3 attempts and then repeated
-    for the fallback model. One failing turn measured 40 upstream requests over
-    4 minutes, bounded only by the 120 s timeout in :func:`ainvoke_llm`.
-
-    Note ``max_retries=0`` is NOT the fix and makes it worse: it only stops
-    langchain passing a ``retry_config``, and the SDK then falls back to its own
-    default of a **one hour** elapsed budget. Retry is off only when the config
-    it actually reads names a strategy other than ``backoff``.
-    """
+    """Leave retrying to :func:`with_llm_retry`; the SDK's own loop nests under
+    ours and turned 3 attempts into 40 requests. ``max_retries=0`` does NOT
+    disable it — the SDK then applies a one-hour default; only this does."""
     llm.client.sdk_configuration.retry_config = RetryConfig(
-        "none", BackoffStrategy(0, 0, 1.0, 0), False
+        # Any strategy but "backoff" skips the retry path, so the (required)
+        # backoff values below are never read.
+        strategy="none",
+        backoff=BackoffStrategy(
+            initial_interval=0, max_interval=0, exponent=1.0, max_elapsed_time=0
+        ),
+        retry_connection_errors=False,
     )
     return llm
 

--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -11,6 +11,7 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.runnables.utils import ConfigurableField
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openrouter import ChatOpenRouter
+from openrouter.utils import BackoffStrategy, RetryConfig
 from pydantic import BaseModel, SecretStr
 
 from app.agents.llm.exceptions import (
@@ -52,6 +53,26 @@ from shared.py.wide_events import log
 
 _StructuredT = TypeVar("_StructuredT", bound=BaseModel)
 _ResultT = TypeVar("_ResultT")
+
+
+def without_sdk_retry(llm: ChatOpenRouter) -> ChatOpenRouter:
+    """Hand the OpenRouter SDK's own retry loop off to :func:`with_llm_retry`.
+
+    ``langchain-openrouter`` defaults ``max_retries=2``, which becomes an SDK
+    backoff window of ``max_retries * 150_000`` ms — 300 seconds of retrying
+    inside a SINGLE ``ainvoke``, nested under our 3 attempts and then repeated
+    for the fallback model. One failing turn measured 40 upstream requests over
+    4 minutes, bounded only by the 120 s timeout in :func:`ainvoke_llm`.
+
+    Note ``max_retries=0`` is NOT the fix and makes it worse: it only stops
+    langchain passing a ``retry_config``, and the SDK then falls back to its own
+    default of a **one hour** elapsed budget. Retry is off only when the config
+    it actually reads names a strategy other than ``backoff``.
+    """
+    llm.client.sdk_configuration.retry_config = RetryConfig(
+        "none", BackoffStrategy(0, 0, 1.0, 0), False
+    )
+    return llm
 
 
 def with_llm_retry(runnable: Runnable, *, max_attempts: int = LLM_RETRY_MAX_ATTEMPTS) -> Runnable:
@@ -96,13 +117,15 @@ def _sim_llm(temperature: float = DEFAULT_LLM_TEMPERATURE) -> BaseChatModel:
     client pointed at the local scripted stub (tools/llm-stub). Deliberately
     exposes no configurable fields — provider/model pinning is meaningless when
     every request lands on the stub, so pinned config is silently ignored."""
-    llm = ChatOpenRouter(
-        model=SIM_STUB_MODEL_NAME,
-        temperature=temperature,
-        streaming=True,
-        stream_usage=True,
-        api_key=SecretStr(settings.OPENROUTER_API_KEY or SIM_STUB_API_KEY),
-        base_url=settings.OPENROUTER_BASE_URL or SIM_STUB_BASE_URL,
+    llm = without_sdk_retry(
+        ChatOpenRouter(
+            model=SIM_STUB_MODEL_NAME,
+            temperature=temperature,
+            streaming=True,
+            stream_usage=True,
+            api_key=SecretStr(settings.OPENROUTER_API_KEY or SIM_STUB_API_KEY),
+            base_url=settings.OPENROUTER_BASE_URL or SIM_STUB_BASE_URL,
+        )
     )
     # Same reason as _build_default_llm: fractional-window middleware needs a
     # context-window profile at graph-build time.
@@ -173,22 +196,24 @@ def init_openrouter_llm() -> LanguageModelLike:
     # OPENROUTER_API_BASE env default_factory. Redirecting to the stub is sim
     # mode's job (_sim_llm); this construction is identical to pre-sim behavior.
     return _openrouter_wire_configurables(
-        ChatOpenRouter(
-            model=PROVIDER_MODELS[LLMProviderName.OPENROUTER],
-            temperature=DEFAULT_LLM_TEMPERATURE,
-            streaming=True,
-            stream_usage=True,
-            # Output cap; must stay well under the model's shared input+output context
-            # window (see OPENROUTER_MAX_OUTPUT_TOKENS) or OpenRouter rejects the request.
-            max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
-            api_key=settings.OPENROUTER_API_KEY,
-            # App attribution → OpenRouter rankings/analytics. ChatOpenRouter exposes
-            # these as dedicated params (NOT `default_headers`, which it forwards to
-            # send_async and crashes on). https://openrouter.ai/docs/app-attribution
-            app_url=settings.FRONTEND_URL,
-            app_title=OPENROUTER_APP_TITLE,
-            app_categories=OPENROUTER_APP_CATEGORIES,
-            reasoning=OPENROUTER_REASONING,
+        without_sdk_retry(
+            ChatOpenRouter(
+                model=PROVIDER_MODELS[LLMProviderName.OPENROUTER],
+                temperature=DEFAULT_LLM_TEMPERATURE,
+                streaming=True,
+                stream_usage=True,
+                # Output cap; must stay well under the model's shared input+output context
+                # window (see OPENROUTER_MAX_OUTPUT_TOKENS) or OpenRouter rejects the request.
+                max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
+                api_key=settings.OPENROUTER_API_KEY,
+                # App attribution → OpenRouter rankings/analytics. ChatOpenRouter exposes
+                # these as dedicated params (NOT `default_headers`, which it forwards to
+                # send_async and crashes on). https://openrouter.ai/docs/app-attribution
+                app_url=settings.FRONTEND_URL,
+                app_title=OPENROUTER_APP_TITLE,
+                app_categories=OPENROUTER_APP_CATEGORIES,
+                reasoning=OPENROUTER_REASONING,
+            )
         )
     )
 
@@ -212,14 +237,16 @@ def init_custom_llm() -> LanguageModelLike:
     if settings.GAIA_SIM_MODE:
         return _sim_llm()
     return _openrouter_wire_configurables(
-        ChatOpenRouter(
-            model=PROVIDER_MODELS[LLMProviderName.CUSTOM],
-            temperature=DEFAULT_LLM_TEMPERATURE,
-            streaming=True,
-            stream_usage=True,
-            max_tokens=DEV_LLM_MAX_OUTPUT_TOKENS,
-            api_key=settings.DEV_LLM_API_KEY,
-            base_url=settings.DEV_LLM_BASE_URL,
+        without_sdk_retry(
+            ChatOpenRouter(
+                model=PROVIDER_MODELS[LLMProviderName.CUSTOM],
+                temperature=DEFAULT_LLM_TEMPERATURE,
+                streaming=True,
+                stream_usage=True,
+                max_tokens=DEV_LLM_MAX_OUTPUT_TOKENS,
+                api_key=settings.DEV_LLM_API_KEY,
+                base_url=settings.DEV_LLM_BASE_URL,
+            )
         )
     )
 
@@ -378,18 +405,20 @@ def get_default_llm(*, temperature: float = DEFAULT_LLM_TEMPERATURE) -> BaseChat
 
 @cache
 def _build_default_llm(temperature: float) -> BaseChatModel:
-    llm = ChatOpenRouter(
-        model=DEFAULT_MODEL_NAME,
-        temperature=temperature,
-        # ChatOpenRouter defaults streaming to False, and stream_usage only
-        # attaches usage metadata to a stream — set alone it is inert. Both are
-        # set so this matches init_openrouter_llm, and so the model fallback
-        # (create_agent resolves it from here) streams like the primary it
-        # replaces instead of arriving as one lump.
-        streaming=True,
-        stream_usage=True,
-        max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
-        api_key=settings.OPENROUTER_API_KEY,
+    llm = without_sdk_retry(
+        ChatOpenRouter(
+            model=DEFAULT_MODEL_NAME,
+            temperature=temperature,
+            # ChatOpenRouter defaults streaming to False, and stream_usage only
+            # attaches usage metadata to a stream — set alone it is inert. Both are
+            # set so this matches init_openrouter_llm, and so the model fallback
+            # (create_agent resolves it from here) streams like the primary it
+            # replaces instead of arriving as one lump.
+            streaming=True,
+            stream_usage=True,
+            max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
+            api_key=settings.OPENROUTER_API_KEY,
+        )
     )
     # LangChain resolves a model's context window from its curated profile registry,
     # which lags new model releases (it has no profile for the current default model).

--- a/apps/api/app/agents/tools/coding/_filter.py
+++ b/apps/api/app/agents/tools/coding/_filter.py
@@ -154,7 +154,7 @@ async def _run(
             _read_bounded(proc), timeout=FILTER_TIMEOUT_SECONDS
         )
     except TimeoutError:
-        await _terminate(proc)
+        await _kill_and_reap(proc)
         return f"Error: {error_label} timed out after {FILTER_TIMEOUT_SECONDS}s"
 
     # A truncated run is killed mid-stream (returncode is the kill signal), but we
@@ -180,8 +180,14 @@ async def _read_bounded(proc: asyncio.subprocess.Process) -> tuple[bytes, bytes,
     Reading stdout fully before stderr would deadlock: a child that fills the
     stderr pipe (64 KiB on Linux) blocks on its stderr write and never closes
     stdout, so the stdout read never sees EOF and the call wastes the full
-    timeout. Draining both in parallel — and continuing to drain (discard) stderr
-    past the kept cap — ensures the child can never back-pressure.
+    timeout. Draining both in parallel — and continuing to drain (discard) BOTH
+    pipes past the kept cap — ensures the child can never back-pressure.
+
+    Draining past the cap is what makes the overrun kill safe. asyncio pauses a
+    pipe transport once its buffer passes the high-water mark and only completes
+    ``wait()`` once every pipe has seen EOF, so reaping the child from inside
+    this loop — while stdout sits paused and unread — hangs until the timeout.
+    Signal the child, keep reading to EOF, and let the caller reap it.
     """
     if proc.stdout is None:
         return b"", b"", False
@@ -198,12 +204,13 @@ async def _read_bounded(proc: asyncio.subprocess.Process) -> tuple[bytes, bytes,
             chunk = await proc.stdout.read(_READ_CHUNK)
             if not chunk:
                 break
+            if truncated:
+                continue  # past the cap: discard, but keep draining to EOF
             chunks.append(chunk)
             total += len(chunk)
             if total > _MAX_OUTPUT_BYTES:
                 truncated = True
-                await _terminate(proc)
-                break
+                _kill(proc)
         return b"".join(chunks)[:_MAX_OUTPUT_BYTES]
 
     async def drain_stderr() -> bytes:
@@ -223,8 +230,20 @@ async def _read_bounded(proc: asyncio.subprocess.Process) -> tuple[bytes, bytes,
     return out, err, truncated
 
 
-async def _terminate(proc: asyncio.subprocess.Process) -> None:
+def _kill(proc: asyncio.subprocess.Process) -> None:
+    """Signal the child only. Never awaits, so it is safe to call from a drain."""
     if proc.returncode is None:
         with contextlib.suppress(ProcessLookupError):
             proc.kill()
-            await proc.wait()
+
+
+async def _kill_and_reap(proc: asyncio.subprocess.Process) -> None:
+    """Kill the child and reap it, for callers that are no longer draining it.
+
+    ``communicate()`` rather than ``wait()``: asyncio completes ``wait()`` only
+    once every pipe transport has seen EOF, so a child whose stdout is still
+    buffered would never be reaped. The child is already dead, so what is left to
+    read is bounded by the pipe and the reader's buffer.
+    """
+    _kill(proc)
+    await proc.communicate()

--- a/apps/api/app/api/v1/endpoints/chat.py
+++ b/apps/api/app/api/v1/endpoints/chat.py
@@ -25,14 +25,17 @@ from app.db.redis import redis_cache
 from app.decorators import enforce_daily_cost_budget, tiered_rate_limit
 from app.models.chat_models import CancelStreamResponse, ConversationSource
 from app.models.message_models import MessageRequestWithHistory
+from app.models.stream_events import ErrorFrame
 from app.models.user_models import AuthenticatedUser
 from app.services.chat.stream import run_chat_stream_background
+from app.utils.agent_utils import format_sse_data
 from app.utils.background_tasks import spawn_background_task
 from shared.py.wide_events import ChatContext, get_trace_id, log, log_context
 
 _USER_ID_REQUIRED = "user_id is required"
 _DUPLICATE_TURN = "duplicate turn_id: this send was already accepted"
 _SSE_MEDIA_TYPE = "text/event-stream"
+_DELIVERY_FAILED = "The connection to the server was lost before this response finished."
 _CLIENT_TYPE_HEADER = "X-Client-Type"
 
 router = APIRouter()
@@ -115,6 +118,12 @@ async def _stream_from_redis(
                 error_type=type(e).__name__,
                 error=str(e),
             )
+            # Returning silently here ends a well-formed SSE stream with no
+            # [DONE] and no error, which the client cannot tell apart from a
+            # finished turn — it would render a truncated answer as complete.
+            # The message is deliberately generic: this is an infrastructure
+            # failure between us and the browser, not the model's error.
+            yield format_sse_data(ErrorFrame(error=_DELIVERY_FAILED).model_dump())
 
 
 @router.post("/chat-stream")

--- a/apps/api/app/api/v1/endpoints/chat.py
+++ b/apps/api/app/api/v1/endpoints/chat.py
@@ -118,11 +118,8 @@ async def _stream_from_redis(
                 error_type=type(e).__name__,
                 error=str(e),
             )
-            # Returning silently here ends a well-formed SSE stream with no
-            # [DONE] and no error, which the client cannot tell apart from a
-            # finished turn — it would render a truncated answer as complete.
-            # The message is deliberately generic: this is an infrastructure
-            # failure between us and the browser, not the model's error.
+            # Closing silently is indistinguishable from a finished turn, so the
+            # client would render a truncated answer as complete.
             yield format_sse_data(ErrorFrame(error=_DELIVERY_FAILED).model_dump())
 
 

--- a/apps/api/app/constants/chat.py
+++ b/apps/api/app/constants/chat.py
@@ -15,6 +15,17 @@ UPLOADED_FILE_INLINE_SUMMARY_MAX_CHARS = 4000
 # normal traffic never gets near this.
 MAX_MESSAGE_LENGTH = 50_000
 
+# Shown when a turn dies and the provider exception carries no message of its
+# own. Names the exception type so a support report still identifies the failure.
+GENERIC_TURN_ERROR = "Something went wrong while generating this response ({error_type})."
+
+# A recursion-limit stop is an expected degradation, not an infrastructure
+# failure — never show the raw "Recursion limit of N reached..." internals.
+RECURSION_LIMIT_MESSAGE = (
+    "I hit my step limit on this one before finishing. "
+    "Ask me to continue and I'll pick up where I left off."
+)
+
 # Matches bot-emitted artifact references in three shapes — ``./artifacts/x``,
 # ``/artifacts/x``, and plain ``artifacts/x`` — so each can be rewritten to an
 # absolute backend URL. The reference must sit at the start of the string or

--- a/apps/api/app/services/chat/stream.py
+++ b/apps/api/app/services/chat/stream.py
@@ -29,6 +29,7 @@ from app.agents.core.background.executor_capture import (
 )
 from app.constants.artifacts import ARTIFACT_FORWARDER_SUBSCRIBE_TIMEOUT
 from app.constants.cache import EXECUTOR_WAIT_TIMEOUT, VOICE_EXECUTOR_RESULT_TIMEOUT_S
+from app.constants.chat import GENERIC_TURN_ERROR, RECURSION_LIMIT_MESSAGE
 from app.constants.hil import HIL_ACK_APPROVED, HIL_ACK_DENIED, HIL_CLASSIFIER_HISTORY_TURNS
 from app.constants.log_tags import LogTag
 from app.core.stream_manager import stream_manager
@@ -63,10 +64,6 @@ from app.utils.agent_utils import format_sse_data, format_sse_response
 from app.utils.chat_utils import generate_and_update_description
 from app.utils.stream_utils import reconstruct_subagent_groups
 from shared.py.wide_events import ChatContext, get_trace_id, log, wide_task
-
-# Last resort when a provider exception carries no message of its own. Names the
-# exception type so a support report still identifies the failure.
-_GENERIC_TURN_ERROR = "Something went wrong while generating this response ({error_type})."
 
 
 async def run_chat_stream_background(
@@ -637,21 +634,12 @@ async def _handle_stream_error(
     breaks the subscriber loop, so the error chunk must go on the wire first.
     """
     log.error(f"{LogTag.CHAT} Background stream error for", stream_id=stream_id, error=error)
-    # A recursion-limit stop is an expected degradation, not an infrastructure
-    # failure - never show the raw "Recursion limit of N reached..." internals.
     if isinstance(error, GraphRecursionError):
-        user_error = (
-            "I hit my step limit on this one before finishing. "
-            "Ask me to continue and I'll pick up where I left off."
-        )
+        user_error = RECURSION_LIMIT_MESSAGE
     else:
-        # Provider SDKs can carry a blank message — the OpenRouter client builds
-        # its message from the error body and its __str__ returns it verbatim, so
-        # str(exc) is "" when the body's message is empty. A blank string is
-        # FALSY on the client: no error bubble renders and the empty-message
-        # filter drops the turn from the thread, so the failure vanishes
-        # completely. Never let one through; name the error type instead.
-        user_error = str(error).strip() or _GENERIC_TURN_ERROR.format(
+        # str(exc) is genuinely "" for some provider errors, and a blank string is
+        # falsy on the client: no error bubble renders and the turn is filtered out.
+        user_error = str(error).strip() or GENERIC_TURN_ERROR.format(
             error_type=type(error).__name__
         )
     await stream_manager.publish_chunk(

--- a/apps/api/app/services/chat/stream.py
+++ b/apps/api/app/services/chat/stream.py
@@ -64,6 +64,10 @@ from app.utils.chat_utils import generate_and_update_description
 from app.utils.stream_utils import reconstruct_subagent_groups
 from shared.py.wide_events import ChatContext, get_trace_id, log, wide_task
 
+# Last resort when a provider exception carries no message of its own. Names the
+# exception type so a support report still identifies the failure.
+_GENERIC_TURN_ERROR = "Something went wrong while generating this response ({error_type})."
+
 
 async def run_chat_stream_background(
     stream_id: str,
@@ -641,7 +645,15 @@ async def _handle_stream_error(
             "Ask me to continue and I'll pick up where I left off."
         )
     else:
-        user_error = str(error)
+        # Provider SDKs can carry a blank message — the OpenRouter client builds
+        # its message from the error body and its __str__ returns it verbatim, so
+        # str(exc) is "" when the body's message is empty. A blank string is
+        # FALSY on the client: no error bubble renders and the empty-message
+        # filter drops the turn from the thread, so the failure vanishes
+        # completely. Never let one through; name the error type instead.
+        user_error = str(error).strip() or _GENERIC_TURN_ERROR.format(
+            error_type=type(error).__name__
+        )
     await stream_manager.publish_chunk(
         stream_id, f"data: {json.dumps(ErrorFrame(error=user_error).model_dump())}\n\n"
     )

--- a/apps/api/tests/unit/agents/test_llm_retry_budget.py
+++ b/apps/api/tests/unit/agents/test_llm_retry_budget.py
@@ -1,0 +1,84 @@
+"""The app owns the LLM retry policy — the provider SDK must not retry too.
+
+Found by driving one failing turn against a provider returning 500: it produced
+**40** upstream requests and took four minutes to surface an error.
+
+``langchain-openrouter`` defaults ``max_retries=2``, which hands the OpenRouter
+SDK a backoff window of ``max_retries * 150_000`` ms — 300 seconds of internal
+retrying *inside a single* ``ainvoke``. That nests under ``with_llm_retry``
+(3 attempts) and then repeats for the fallback model, so the real budget was
+never 3 attempts; the 120 s ``asyncio.timeout`` in ``ainvoke_llm`` was the only
+thing stopping it, and it fired twice.
+
+``with_llm_retry`` documents itself as "the single, canonical LLM retry". These
+pin that claim: exactly one layer retries, so the attempt count and the timeout
+mean what they say.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.agents.llm.client import (
+    _build_default_llm,
+    _sim_llm,
+    init_openrouter_llm,
+)
+from app.agents.llm.types import LLMProviderKey
+from app.constants.llm import LLM_RETRY_MAX_ATTEMPTS
+from app.core.lazy_loader import providers
+
+
+@pytest.fixture(autouse=True)
+def _openrouter_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The hermetic conftest blanks credentials; these factories need a key."""
+    from app.config.settings import settings
+
+    monkeypatch.setattr(settings, "OPENROUTER_API_KEY", "test-key", raising=False)
+    monkeypatch.setattr(settings, "DEV_LLM_API_KEY", "test-key", raising=False)
+    monkeypatch.setattr(settings, "DEV_LLM_BASE_URL", "http://localhost:1", raising=False)
+    monkeypatch.setattr(settings, "DEV_LLM_MODEL", "test/model", raising=False)
+    _build_default_llm.cache_clear()
+    _sim_llm.cache_clear()
+
+
+@pytest.mark.unit
+class TestLLMRetryBudget:
+    def test_default_model_client_delegates_retry_to_the_app(self) -> None:
+        assert _retries(_build_default_llm(0.0)) is False
+
+    def test_sim_stub_client_delegates_retry_to_the_app(self) -> None:
+        assert _retries(_sim_llm()) is False
+
+    def test_primary_openrouter_client_delegates_retry_to_the_app(self) -> None:
+        init_openrouter_llm()
+        assert _retries(_resolve(LLMProviderKey.OPENROUTER)) is False
+
+    # The custom dev endpoint (init_custom_llm) carries the same setting, but its
+    # @lazy_provider registration is gated on DEV_LLM_* keys read at import time,
+    # which the hermetic conftest blanks — so it cannot be resolved here. Under
+    # GAIA_SIM_MODE it returns _sim_llm(), which the case above covers.
+
+    def test_the_app_still_retries(self) -> None:
+        """Disabling SDK retry must not leave the system with no retry at all."""
+        assert LLM_RETRY_MAX_ATTEMPTS > 1
+
+
+def _resolve(key: LLMProviderKey) -> Any:
+    """The concrete chat model a registered provider resolves to, unwrapping the
+    ``configurable_fields`` runnable the factories return."""
+    instance = providers.get(key)
+    return getattr(instance, "default", instance)
+
+
+def _retries(llm: Any) -> bool:
+    """Whether the SDK client will run its own retry loop.
+
+    Asserted on the config the SDK actually reads at request time, not on
+    ``max_retries``: that kwarg cannot express "off" — setting it to 0 only stops
+    langchain passing a config, and the SDK then applies its own one-hour default.
+    """
+    config = llm.client.sdk_configuration.retry_config
+    return getattr(config, "strategy", None) == "backoff"

--- a/apps/api/tests/unit/agents/test_llm_retry_budget.py
+++ b/apps/api/tests/unit/agents/test_llm_retry_budget.py
@@ -17,6 +17,7 @@ mean what they say.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -24,11 +25,10 @@ import pytest
 from app.agents.llm.client import (
     _build_default_llm,
     _sim_llm,
+    init_custom_llm,
     init_openrouter_llm,
 )
-from app.agents.llm.types import LLMProviderKey
 from app.constants.llm import LLM_RETRY_MAX_ATTEMPTS
-from app.core.lazy_loader import providers
 
 
 @pytest.fixture(autouse=True)
@@ -53,24 +53,26 @@ class TestLLMRetryBudget:
         assert _retries(_sim_llm()) is False
 
     def test_primary_openrouter_client_delegates_retry_to_the_app(self) -> None:
-        init_openrouter_llm()
-        assert _retries(_resolve(LLMProviderKey.OPENROUTER)) is False
+        assert _retries(_construct(init_openrouter_llm)) is False
 
-    # The custom dev endpoint (init_custom_llm) carries the same setting, but its
-    # @lazy_provider registration is gated on DEV_LLM_* keys read at import time,
-    # which the hermetic conftest blanks — so it cannot be resolved here. Under
-    # GAIA_SIM_MODE it returns _sim_llm(), which the case above covers.
+    def test_custom_dev_client_delegates_retry_to_the_app(self) -> None:
+        assert _retries(_construct(init_custom_llm)) is False
 
     def test_the_app_still_retries(self) -> None:
         """Disabling SDK retry must not leave the system with no retry at all."""
         assert LLM_RETRY_MAX_ATTEMPTS > 1
 
 
-def _resolve(key: LLMProviderKey) -> Any:
-    """The concrete chat model a registered provider resolves to, unwrapping the
-    ``configurable_fields`` runnable the factories return."""
-    instance = providers.get(key)
-    return getattr(instance, "default", instance)
+def _construct(factory: Callable[[], Any]) -> Any:
+    """Run a ``@lazy_provider`` factory's real body and unwrap the chat model.
+
+    Via ``loader_func`` rather than resolving through the registry: registration
+    is gated on credentials read at IMPORT time, which the hermetic fence blanks,
+    so a registry lookup returns None in CI while passing for anyone whose local
+    ``.env`` happened to hold a key.
+    """
+    llm = factory().loader_func()
+    return getattr(llm, "default", llm)
 
 
 def _retries(llm: Any) -> bool:

--- a/apps/api/tests/unit/api/test_chat_stream_delivery_errors.py
+++ b/apps/api/tests/unit/api/test_chat_stream_delivery_errors.py
@@ -1,0 +1,120 @@
+"""The SSE delivery generator must never close silently on a failure.
+
+``_stream_from_redis`` is the last hop between the background turn and the
+browser. It used to catch a forwarding failure, log it, and simply return — the
+client saw a well-formed stream end with no ``[DONE]`` and no error frame, which
+the web client could not distinguish from a finished turn. The user got a
+half-written answer that looked complete, or an empty bubble and no explanation.
+
+A client disconnect is the one case that is NOT an error: the background task
+keeps running and persists the turn, so it must stay silent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import fakeredis.aioredis
+import pytest
+
+from app.api.v1.endpoints.chat import _stream_from_redis
+from app.db.redis import redis_cache
+
+STREAM_ID = "stream-delivery-failure"
+
+
+@pytest.fixture(autouse=True)
+async def fake_redis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_cache, "redis", client)
+    yield client
+    await client.aclose()
+
+
+def _request(disconnected: bool = False) -> Any:
+    request = AsyncMock()
+    request.is_disconnected = AsyncMock(return_value=disconnected)
+    return request
+
+
+def _error_payloads(frames: list[str]) -> list[str]:
+    """The ``error`` field of every frame that carries one."""
+    errors: list[str] = []
+    for frame in frames:
+        body = frame.removeprefix("data: ").strip()
+        if not body.startswith("{"):
+            continue
+        parsed = json.loads(body)
+        if "error" in parsed:
+            errors.append(parsed["error"])
+    return errors
+
+
+@pytest.mark.unit
+class TestStreamDeliveryErrors:
+    async def test_forwarding_failure_emits_an_error_frame(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mid-delivery exception must reach the client as an error frame."""
+
+        async def exploding_subscribe(*_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            yield 'data: {"response":"partial"}\n\n'
+            raise RuntimeError("redis connection reset")
+
+        monkeypatch.setattr(
+            "app.api.v1.endpoints.chat.stream_manager.subscribe_stream",
+            exploding_subscribe,
+        )
+
+        frames = [chunk async for chunk in _stream_from_redis(STREAM_ID, _request())]
+
+        assert _error_payloads(frames), (
+            "delivery failure closed the stream with no error frame; the client "
+            f"cannot tell this from a completed turn. frames={frames}"
+        )
+
+    async def test_client_disconnect_stays_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A disconnect is not a failure — the background task still persists."""
+
+        async def subscribe(*_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            yield 'data: {"response":"partial"}\n\n'
+            yield 'data: {"response":"more"}\n\n'
+
+        monkeypatch.setattr("app.api.v1.endpoints.chat.stream_manager.subscribe_stream", subscribe)
+
+        frames = [
+            chunk async for chunk in _stream_from_redis(STREAM_ID, _request(disconnected=True))
+        ]
+
+        assert _error_payloads(frames) == []
+
+    async def test_cancellation_does_not_emit_an_error_frame(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Client-cancelled delivery re-raises; it is not a turn failure."""
+
+        async def cancelling_subscribe(*_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            yield 'data: {"response":"partial"}\n\n'
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(
+            "app.api.v1.endpoints.chat.stream_manager.subscribe_stream",
+            cancelling_subscribe,
+        )
+
+        frames: list[str] = []
+
+        async def drain() -> None:
+            async for chunk in _stream_from_redis(STREAM_ID, _request()):
+                frames.append(chunk)
+
+        with pytest.raises(asyncio.CancelledError):
+            await drain()
+
+        assert _error_payloads(frames) == []

--- a/apps/api/tests/unit/config/test_settings_guards.py
+++ b/apps/api/tests/unit/config/test_settings_guards.py
@@ -5,6 +5,8 @@ The dev-only overrides (`DEV_AUTH_BYPASS_EMAIL`, `OPENROUTER_BASE_URL`) must mak
 must forward the base-URL override only in development.
 """
 
+from types import SimpleNamespace
+
 from pydantic import ValidationError
 import pytest
 
@@ -19,6 +21,25 @@ def _reset_settings_cache():
 
 
 DEV_OVERRIDE_VARS = ("DEV_AUTH_BYPASS_EMAIL", "OPENROUTER_BASE_URL", "GAIA_SIM_MODE")
+
+
+def _fake_chat_openrouter(captured: dict[str, object]) -> type:
+    """A ChatOpenRouter double that records its construction kwargs.
+
+    It carries a ``client.sdk_configuration`` because the real class does and
+    ``without_sdk_retry`` writes the SDK's retry config there — a double missing
+    it would pass while the production path raises.
+    """
+
+    class _FakeChatOpenRouter:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+            self.client = SimpleNamespace(sdk_configuration=SimpleNamespace(retry_config=None))
+
+        def configurable_fields(self, **_: object) -> "_FakeChatOpenRouter":
+            return self
+
+    return _FakeChatOpenRouter
 
 
 @pytest.mark.parametrize(
@@ -60,14 +81,7 @@ def test_init_openrouter_omits_base_url_outside_sim_dev(monkeypatch):
 
     captured: dict[str, object] = {}
 
-    class _FakeChatOpenRouter:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
-        def configurable_fields(self, **_):
-            return self
-
-    monkeypatch.setattr(client, "ChatOpenRouter", _FakeChatOpenRouter)
+    monkeypatch.setattr(client, "ChatOpenRouter", _fake_chat_openrouter(captured))
     monkeypatch.setattr(client.settings, "ENV", "development")
     monkeypatch.setattr(client.settings, "GAIA_SIM_MODE", False)
     monkeypatch.setattr(client.settings, "OPENROUTER_BASE_URL", "http://localhost:9797")
@@ -86,14 +100,7 @@ def test_init_openrouter_omits_base_url_in_production(monkeypatch):
 
     captured: dict[str, object] = {}
 
-    class _FakeChatOpenRouter:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
-        def configurable_fields(self, **_):
-            return self
-
-    monkeypatch.setattr(client, "ChatOpenRouter", _FakeChatOpenRouter)
+    monkeypatch.setattr(client, "ChatOpenRouter", _fake_chat_openrouter(captured))
     monkeypatch.setattr(client.settings, "ENV", "production")
     monkeypatch.setattr(client.settings, "GAIA_SIM_MODE", False)
     # Even if the override leaks into a production settings object, it is ignored.

--- a/apps/api/tests/unit/services/chat/test_stream_error_message.py
+++ b/apps/api/tests/unit/services/chat/test_stream_error_message.py
@@ -1,0 +1,95 @@
+"""A turn failure must always reach the client as a non-empty message.
+
+Found by driving a real failing turn: the OpenRouter SDK builds its exception
+message as ``str(data.error.message) or fallback`` and its ``__str__`` returns
+that message verbatim, so ``str(exc)`` is genuinely ``""`` when the provider
+sends an error body with an empty message. The stream then published
+``{"error": ""}``.
+
+An empty string is falsy on the client, which is worse than no error handling at
+all: ``hasError`` is false so no failed-response bubble renders, and
+``isBotMessageEmpty`` treats the turn as contentless, so
+``filterEmptyMessagePairs`` drops the bot message from the thread entirely. The
+user sees their own message, no answer, and no explanation — exactly the
+"sometimes the error just doesn't appear" report.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import fakeredis.aioredis
+from langgraph.errors import GraphRecursionError
+import pytest
+
+from app.db.redis import redis_cache
+from app.services.chat.stream import _handle_stream_error
+
+STREAM_ID = "stream-error-message"
+
+
+@pytest.fixture(autouse=True)
+async def fake_redis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[fakeredis.aioredis.FakeRedis]:
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_cache, "redis", client)
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def published(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture what the client would receive, in order."""
+    chunks: list[str] = []
+
+    async def capture(_stream_id: str, chunk: str) -> None:
+        chunks.append(chunk)
+
+    monkeypatch.setattr(
+        "app.services.chat.stream.stream_manager.publish_chunk", AsyncMock(side_effect=capture)
+    )
+    monkeypatch.setattr(
+        "app.services.chat.stream.stream_manager.set_error", AsyncMock(return_value=None)
+    )
+    return chunks
+
+
+class _EmptyMessageError(Exception):
+    """Stands in for the SDK errors whose ``__str__`` is empty."""
+
+    def __str__(self) -> str:
+        return ""
+
+
+@pytest.mark.unit
+class TestStreamErrorMessage:
+    @pytest.mark.parametrize(
+        "error",
+        [_EmptyMessageError(), Exception(""), Exception("   ")],
+        ids=["empty-str-dunder", "empty-args", "whitespace-only"],
+    )
+    async def test_blank_provider_error_never_reaches_the_client(
+        self, error: Exception, published: list[str]
+    ) -> None:
+        user_error = await _handle_stream_error(STREAM_ID, error)
+
+        assert user_error.strip(), (
+            "a blank error is falsy on the client: no error bubble renders and the "
+            "bot message is filtered out of the thread entirely"
+        )
+        assert published, "the failure was never published to the client"
+        assert '"error": ""' not in published[0]
+
+    async def test_a_real_provider_message_is_preserved(self, published: list[str]) -> None:
+        user_error = await _handle_stream_error(
+            STREAM_ID, Exception("Provider returned 503 Service Unavailable")
+        )
+
+        assert user_error == "Provider returned 503 Service Unavailable"
+
+    async def test_recursion_limit_keeps_its_friendly_copy(self, published: list[str]) -> None:
+        user_error = await _handle_stream_error(STREAM_ID, GraphRecursionError("Recursion limit"))
+
+        assert "step limit" in user_error

--- a/apps/api/tests/unit/tools/coding/test_grep_filter_tools.py
+++ b/apps/api/tests/unit/tools/coding/test_grep_filter_tools.py
@@ -118,6 +118,49 @@ async def test_security_output_cap_truncates(tmp_path: Path) -> None:
     assert len(out) <= MAX_FILTER_OUTPUT_CHARS + 200
 
 
+@pytest.mark.regression
+async def test_output_cap_kill_does_not_hang_on_a_paused_stdout_pipe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: the overrun kill used to reap the child from inside the drain.
+
+    asyncio pauses a pipe transport once its buffer passes the high-water mark and
+    completes ``wait()`` only when every pipe has seen EOF — so reaping there, with
+    stdout paused and nobody reading it, hung until the wall-clock timeout. It
+    reproduced roughly half the time on CI, depending on how full the buffer was
+    when the cap tripped. Reading a byte at a time pins the buffer full so the
+    condition is deterministic rather than a coin flip.
+    """
+    monkeypatch.setattr(_filter, "FILTER_TIMEOUT_SECONDS", 3)
+    monkeypatch.setattr(_filter, "_READ_CHUNK", 1)
+    monkeypatch.setattr(_filter, "_MAX_OUTPUT_BYTES", 4)
+
+    out = await _py("import sys;sys.stdout.write('Z'*5_000_000)", tmp_path)
+
+    assert "truncated" in out
+
+
+@pytest.mark.regression
+async def test_timeout_reaps_a_child_whose_stdout_is_still_buffered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The timeout path had the same defect, and nothing bounds it from above.
+
+    A slow reader leaves stdout paused when the wall clock runs out; reaping there
+    waited on a pipe no one was draining, so the call hung forever rather than
+    returning the timeout message.
+    """
+    monkeypatch.setattr(_filter, "FILTER_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(_filter, "_READ_CHUNK", 1)  # fall behind the child
+    monkeypatch.setattr(_filter, "_MAX_OUTPUT_BYTES", 100_000_000)  # never cap
+
+    out = await asyncio.wait_for(
+        _py("import sys;sys.stdout.write('Z'*5_000_000)", tmp_path), timeout=20
+    )
+
+    assert "timed out" in out
+
+
 async def test_security_child_resource_limits_are_applied(tmp_path: Path) -> None:
     code = (
         "import resource;"

--- a/apps/web/src/__tests__/chat-executor-stream-failure.test.ts
+++ b/apps/web/src/__tests__/chat-executor-stream-failure.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression test for a background executor run that dies mid-stream.
+ *
+ * A failed run publishes an error frame and then closes. The close is byte-for-byte
+ * a clean one, so the handler finalized the placeholder with no error — status
+ * `sent` — and a dead run rendered as a finished answer with no Retry.
+ *
+ * The suite missed it because nothing exercised the executor SSE path at all:
+ * `chat-turn-failure.test.ts` covers the live chat turn's equivalent seam
+ * (`resolveTurnOutcome`), and the executor path reaches the same outcome through
+ * completely separate code.
+ */
+import type { EventSourceMessage } from "@microsoft/fetch-event-source";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db/chatDb", () => ({
+  db: {
+    putMessage: vi.fn().mockResolvedValue(undefined),
+    getAllConversations: vi.fn().mockResolvedValue([]),
+    getAllMessages: vi.fn().mockResolvedValue([]),
+  },
+  dbEventEmitter: { on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock("@/lib/websocket/WebSocketManager", () => ({
+  wsManager: { on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock("@/features/chat/api/chatApi", () => ({
+  chatApi: { subscribeToExecutorStream: vi.fn() },
+}));
+
+import { chatApi } from "@/features/chat/api/chatApi";
+import { createExecutorStreamHandler } from "@/features/chat/hooks/useExecutorStream";
+import { useChatStore } from "@/stores/chatStore";
+
+const CONVERSATION_ID = "conv-exec-1";
+const TASK_ID = "task-exec-1";
+const STREAM_ID = "stream-exec-1";
+
+const frame = (payload: unknown): EventSourceMessage => ({
+  id: "",
+  event: "",
+  retry: undefined,
+  data: JSON.stringify(payload),
+});
+
+/** Drive the handler against a scripted stream, then read back the placeholder. */
+const runStream = async (
+  script: (onMessage: (event: EventSourceMessage) => void) => void,
+  sawDone: boolean,
+) => {
+  vi.mocked(chatApi.subscribeToExecutorStream).mockImplementation(
+    async (_streamId, onMessage, onClose) => {
+      script(onMessage);
+      onClose(sawDone);
+    },
+  );
+
+  await createExecutorStreamHandler(
+    new Set(),
+    new Set(),
+  )({
+    type: "executor.stream_started",
+    stream_id: STREAM_ID,
+    conversation_id: CONVERSATION_ID,
+    task_id: TASK_ID,
+  });
+
+  return useChatStore
+    .getState()
+    .messagesByConversation[CONVERSATION_ID]?.find((m) => m.id === TASK_ID);
+};
+
+describe("executor stream failure", () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      activeConversationId: CONVERSATION_ID,
+      messagesByConversation: {},
+    });
+  });
+
+  it("finalizes a run that published an error frame as failed, keeping its partial output", async () => {
+    const message = await runStream((onMessage) => {
+      onMessage(frame({ response: "half an answer" }));
+      onMessage(frame({ error: "The executor crashed." }));
+    }, false);
+
+    expect(message?.status).toBe("failed");
+    expect(message?.error).toBe("The executor crashed.");
+    expect(message?.content).toBe("half an answer");
+  });
+
+  it("still finalizes a clean run as sent", async () => {
+    const message = await runStream((onMessage) => {
+      onMessage(frame({ response: "all done" }));
+    }, true);
+
+    expect(message?.status).toBe("sent");
+    expect(message?.error).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/chat-optimistic-failure.test.ts
+++ b/apps/web/src/__tests__/chat-optimistic-failure.test.ts
@@ -11,9 +11,21 @@
  * left a completely empty thread. In an existing conversation the same failure
  * correctly showed "Not delivered" + Retry, because there the user message is
  * persisted and gets flipped to `failed` instead.
+ *
+ * The chain these pin is store flag -> conversation mapping -> bubble props. The
+ * JSX itself is NOT covered: apps/web has no DOM test environment, so "the label
+ * and Retry button are on screen" rests on the live-stack run above, not on a
+ * rendered assertion.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mapOptimisticMessageToConversationMessage,
+  mapStoredMessageToConversationMessage,
+} from "@/features/chat/hooks/useConversation";
+import { getMessageProps } from "@/features/chat/utils/messagePropsUtils";
+import type { IMessage } from "@/lib/db/chatDb";
 import { type OptimisticMessage, useChatStore } from "@/stores/chatStore";
+import type { MessageType } from "@/types/features/convoTypes";
 
 const optimistic = (): OptimisticMessage => ({
   id: "optimistic-1",
@@ -53,5 +65,67 @@ describe("optimistic message failure", () => {
     store.clearOptimisticMessage();
 
     expect(useChatStore.getState().optimisticMessage).toBeNull();
+  });
+});
+
+describe("failed message mapping", () => {
+  it("carries the optimistic failure into the conversation message", () => {
+    const mapped = mapOptimisticMessageToConversationMessage({
+      ...optimistic(),
+      failed: true,
+    });
+
+    expect(mapped.failed).toBe(true);
+    expect(mapped.response).toBe("the message the user typed");
+  });
+
+  it("leaves a healthy optimistic message unflagged", () => {
+    expect(
+      mapOptimisticMessageToConversationMessage(optimistic()).failed,
+    ).toBeUndefined();
+  });
+
+  it("derives failed from a stored message's status", () => {
+    const stored = (status: IMessage["status"]): IMessage => ({
+      id: "user-1",
+      conversationId: "conv-1",
+      content: "the message the user typed",
+      role: "user",
+      status,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    expect(mapStoredMessageToConversationMessage(stored("failed")).failed).toBe(
+      true,
+    );
+    expect(mapStoredMessageToConversationMessage(stored("sent")).failed).toBe(
+      false,
+    );
+  });
+});
+
+describe("failed user bubble props", () => {
+  // The "Not delivered" label renders on `failed`, and Retry on `onRetry` — the
+  // two props the bubble needs before the failure is actionable on screen.
+  it("hands the bubble the failed flag and a bound retry callback", () => {
+    const message: MessageType = {
+      type: "user",
+      response: "the message the user typed",
+      message_id: "user-1",
+      failed: true,
+    };
+    const onRetry = vi.fn();
+
+    const props = getMessageProps(message, "user", {
+      setImageData: vi.fn(),
+      setOpenGeneratedImage: vi.fn(),
+      setOpenMemoryModal: vi.fn(),
+      onRetry,
+    });
+
+    expect(props.failed).toBe(true);
+    props.onRetry?.();
+    expect(onRetry).toHaveBeenCalledWith("user-1");
   });
 });

--- a/apps/web/src/__tests__/chat-optimistic-failure.test.ts
+++ b/apps/web/src/__tests__/chat-optimistic-failure.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A send that dies before the backend assigns any ids must still leave evidence.
+ *
+ * For a brand-new conversation the optimistic message is the ONLY record of what
+ * the user typed — nothing is in IndexedDB and no conversation exists yet. The
+ * failure path used to call `clearOptimisticMessage()` unconditionally, so an
+ * API that was down, rate-limiting, or rejecting auth erased the user's message
+ * from the thread entirely, leaving a toast that faded in a few seconds.
+ *
+ * Verified against a live stack: with the API stopped, a new-conversation send
+ * left a completely empty thread. In an existing conversation the same failure
+ * correctly showed "Not delivered" + Retry, because there the user message is
+ * persisted and gets flipped to `failed` instead.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { type OptimisticMessage, useChatStore } from "@/stores/chatStore";
+
+const optimistic = (): OptimisticMessage => ({
+  id: "optimistic-1",
+  conversationId: null,
+  content: "the message the user typed",
+  role: "user",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+describe("optimistic message failure", () => {
+  beforeEach(() => {
+    useChatStore.setState({ optimisticMessage: null });
+  });
+
+  it("keeps the message and marks it failed", () => {
+    const store = useChatStore.getState();
+    store.setOptimisticMessage(optimistic());
+
+    store.markOptimisticMessageFailed();
+
+    const current = useChatStore.getState().optimisticMessage;
+    expect(current).not.toBeNull();
+    expect(current?.content).toBe("the message the user typed");
+    expect(current?.failed).toBe(true);
+  });
+
+  it("is a no-op when there is no optimistic message", () => {
+    useChatStore.getState().markOptimisticMessageFailed();
+
+    expect(useChatStore.getState().optimisticMessage).toBeNull();
+  });
+
+  it("clearOptimisticMessage still removes it outright", () => {
+    const store = useChatStore.getState();
+    store.setOptimisticMessage(optimistic());
+
+    store.clearOptimisticMessage();
+
+    expect(useChatStore.getState().optimisticMessage).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/chat-turn-failure.test.ts
+++ b/apps/web/src/__tests__/chat-turn-failure.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression tests for the chat failure surface.
+ *
+ * The bug: a turn that died client-side was persisted with `status: "failed"`
+ * but no `error` string. Nothing reads `status`, and the failed-response bubble
+ * keys off `error` — so the message rendered as empty, `filterEmptyMessagePairs`
+ * dropped it from the thread entirely, and the only trace of the failure was a
+ * transient toast. A stream that closed without its completion signal was worse:
+ * it was persisted as `"sent"`, indistinguishable from a finished answer.
+ *
+ * These pin the three seams that chain together to put a failure on screen:
+ * the record carries the error, the outcome rule classifies a truncated stream
+ * as failed, and the empty-message filter keeps an errored turn in the thread.
+ */
+import { createTurnAccumulator, type TurnAccumulator } from "@shared/chat";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildTurnMessageRecord,
+  INTERRUPTED_ERROR,
+  resolveTurnOutcome,
+  type TurnMessageMeta,
+} from "@/features/chat/stream/messageRecord";
+import { StallWatchdog } from "@/features/chat/stream/stallWatchdog";
+import {
+  filterEmptyMessagePairs,
+  isBotMessageEmpty,
+} from "@/features/chat/utils/messageContentUtils";
+import type { ChatBubbleBotProps } from "@/types/features/chatBubbleTypes";
+import type { MessageType } from "@/types/features/convoTypes";
+
+const meta = (): TurnMessageMeta => ({
+  conversationId: "conv-1",
+  botMessageId: "bot-1",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  options: {
+    fileData: [],
+    selectedTool: null,
+    toolCategory: null,
+    selectedWorkflow: null,
+    selectedCalendarEvent: null,
+    replyToMessage: null,
+    optimisticUserId: "user-1",
+    conversationId: "conv-1",
+    isOnboardingDemo: false,
+  },
+});
+
+const accWithText = (text: string): TurnAccumulator => ({
+  ...createTurnAccumulator(),
+  responseText: text,
+});
+
+describe("buildTurnMessageRecord", () => {
+  it("carries the failure reason onto a failed record", () => {
+    const record = buildTurnMessageRecord(
+      meta(),
+      createTurnAccumulator(),
+      "failed",
+      "Provider overloaded",
+    );
+
+    expect(record.status).toBe("failed");
+    expect(record.error).toBe("Provider overloaded");
+  });
+
+  it("leaves error null on a successful record", () => {
+    const record = buildTurnMessageRecord(
+      meta(),
+      accWithText("all good"),
+      "sent",
+    );
+
+    expect(record.status).toBe("sent");
+    expect(record.error).toBeNull();
+  });
+
+  it("keeps partial streamed text alongside the error on a truncated turn", () => {
+    const record = buildTurnMessageRecord(
+      meta(),
+      accWithText("half an ans"),
+      "failed",
+      INTERRUPTED_ERROR,
+    );
+
+    expect(record.content).toBe("half an ans");
+    expect(record.error).toBe(INTERRUPTED_ERROR);
+  });
+});
+
+describe("resolveTurnOutcome", () => {
+  it("marks a stream that never signalled completion as failed", () => {
+    expect(resolveTurnOutcome(false)).toEqual({
+      status: "failed",
+      error: INTERRUPTED_ERROR,
+    });
+  });
+
+  it("marks a stream that signalled completion as sent", () => {
+    expect(resolveTurnOutcome(true)).toEqual({ status: "sent", error: null });
+  });
+});
+
+describe("isBotMessageEmpty", () => {
+  const props = (over: Partial<ChatBubbleBotProps>): ChatBubbleBotProps =>
+    ({ text: "", message_id: "bot-1", ...over }) as ChatBubbleBotProps;
+
+  it("treats an errored turn with no text as non-empty so it still renders", () => {
+    expect(isBotMessageEmpty(props({ error: "boom" }))).toBe(false);
+  });
+
+  it("still treats a contentless, errorless turn as empty", () => {
+    expect(isBotMessageEmpty(props({}))).toBe(true);
+  });
+});
+
+describe("filterEmptyMessagePairs", () => {
+  it("keeps a failed bot turn in the thread instead of dropping the pair", () => {
+    const messages: MessageType[] = [
+      { type: "user", response: "hi", message_id: "u-1" },
+      { type: "bot", response: "", message_id: "b-1", error: "Provider down" },
+    ];
+
+    const kept = filterEmptyMessagePairs(messages);
+
+    expect(kept.map((m) => m.message_id)).toEqual(["u-1", "b-1"]);
+  });
+
+  it("still drops a genuinely empty bot turn, keeping its user message", () => {
+    const messages: MessageType[] = [
+      { type: "user", response: "hi", message_id: "u-1" },
+      { type: "bot", response: "", message_id: "b-1" },
+    ];
+
+    const kept = filterEmptyMessagePairs(messages);
+
+    expect(kept.map((m) => m.message_id)).toEqual(["u-1"]);
+  });
+});
+
+describe("StallWatchdog", () => {
+  it("fires when no frame arrives within the idle window", () => {
+    vi.useFakeTimers();
+    const onStall = vi.fn();
+    const watchdog = new StallWatchdog(1000, onStall);
+
+    watchdog.arm();
+    vi.advanceTimersByTime(999);
+    expect(onStall).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onStall).toHaveBeenCalledTimes(1);
+
+    watchdog.disarm();
+    vi.useRealTimers();
+  });
+
+  it("does not fire while frames keep arriving", () => {
+    vi.useFakeTimers();
+    const onStall = vi.fn();
+    const watchdog = new StallWatchdog(1000, onStall);
+
+    watchdog.arm();
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(900);
+      watchdog.kick();
+    }
+    vi.advanceTimersByTime(900);
+    expect(onStall).not.toHaveBeenCalled();
+
+    watchdog.disarm();
+    vi.useRealTimers();
+  });
+
+  it("stops firing once disarmed", () => {
+    vi.useFakeTimers();
+    const onStall = vi.fn();
+    const watchdog = new StallWatchdog(1000, onStall);
+
+    watchdog.arm();
+    watchdog.disarm();
+    vi.advanceTimersByTime(5000);
+
+    expect(onStall).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("fires at most once per armed window", () => {
+    vi.useFakeTimers();
+    const onStall = vi.fn();
+    const watchdog = new StallWatchdog(1000, onStall);
+
+    watchdog.arm();
+    vi.advanceTimersByTime(10_000);
+
+    expect(onStall).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/features/chat/api/chatApi.ts
+++ b/apps/web/src/features/chat/api/chatApi.ts
@@ -59,7 +59,9 @@ export interface ChatStreamRequest {
   onMessage: (
     event: EventSourceMessage,
   ) => undefined | string | Promise<undefined | string>;
-  onClose: () => void;
+  /** `sawDone` is false when the connection ended without `[DONE]` — a
+   *  truncated turn, not a finished one. */
+  onClose: (sawDone: boolean) => void;
   onError: (err: Error) => void;
   controller: AbortController;
   fileData: FileData[];
@@ -411,7 +413,7 @@ export const chatApi = {
 
           if (event.data === "[DONE]") {
             doneReceived = true;
-            onClose();
+            onClose(true);
             return;
           }
 
@@ -437,7 +439,7 @@ export const chatApi = {
           // Only call onClose if [DONE] didn't already trigger it.
           // Connection drops without [DONE] (e.g. network failure) still need cleanup.
           if (!doneReceived) {
-            onClose();
+            onClose(false);
           }
         },
         onerror: (err) => {
@@ -460,7 +462,7 @@ export const chatApi = {
   subscribeToExecutorStream: async (
     streamId: string,
     onMessage: (event: EventSourceMessage) => void,
-    onClose: () => void,
+    onClose: (sawDone: boolean) => void,
     onError: (err: Error) => void,
     signal: AbortSignal,
     lastEventId?: string,
@@ -483,7 +485,7 @@ export const chatApi = {
         onmessage(event) {
           if (event.data === "[DONE]") {
             doneReceived = true;
-            onClose();
+            onClose(true);
             return;
           }
           onMessage(event);
@@ -491,7 +493,7 @@ export const chatApi = {
         onclose() {
           streamLog("sse", "connection-closed");
           if (!doneReceived) {
-            onClose();
+            onClose(false);
           }
         },
         onerror(err) {

--- a/apps/web/src/features/chat/components/bubbles/bot/TextBubble/index.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/TextBubble/index.tsx
@@ -1,5 +1,6 @@
+import { Button } from "@heroui/button";
 import { Chip } from "@heroui/chip";
-import { Alert01Icon } from "@icons";
+import { Alert01Icon, RedoIcon } from "@icons";
 import {
   APPROVAL_REQUEST_TOOL_NAME,
   type ApprovalRequestData,
@@ -83,8 +84,55 @@ function ReplyQuote({
   );
 }
 
-/** Quiet failed-response bubble shown when a bot turn died with no text. */
-function FailedResponse({ error }: Readonly<{ error: string }>) {
+/**
+ * The failure surface for a bot turn, in two shapes:
+ *  - `partial` — some text streamed before the turn died, so a bubble already
+ *    rendered above; this is a compact strip under it saying it was cut short.
+ *  - full bubble — nothing streamed, so this IS the message.
+ *
+ * Retry lives here rather than only in the hover actions row: that row is
+ * invisible until hover and suppressed on the last bubble while the
+ * conversation is busy, which is exactly when a failure appears.
+ */
+function FailedResponse({
+  error,
+  partial,
+  onRetry,
+  isRetrying,
+}: Readonly<{
+  error: string;
+  partial: boolean;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}>) {
+  const retryButton = onRetry && (
+    <Button
+      className="h-7 min-w-0 shrink-0 px-2 text-xs"
+      isDisabled={isRetrying}
+      onPress={onRetry}
+      radius="full"
+      size="sm"
+      startContent={
+        <div className={isRetrying ? "animate-spin" : ""}>
+          <RedoIcon height={13} width={13} />
+        </div>
+      }
+      variant="flat"
+    >
+      Retry
+    </Button>
+  );
+
+  if (partial) {
+    return (
+      <div className="mt-1 flex items-center gap-2 text-zinc-400">
+        <Alert01Icon className="shrink-0" height={15} width={15} />
+        <span className="text-xs">Response was cut short</span>
+        {retryButton}
+      </div>
+    );
+  }
+
   return (
     <div className="imessage-bubble imessage-from-them imessage-grouped-last">
       <div className="flex items-start gap-2">
@@ -93,9 +141,12 @@ function FailedResponse({ error }: Readonly<{ error: string }>) {
           height={17}
           width={17}
         />
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm text-zinc-200">This response failed</span>
-          <span className="line-clamp-2 text-xs text-zinc-400">{error}</span>
+        <div className="flex flex-col items-start gap-1.5">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm text-zinc-200">This response failed</span>
+            <span className="line-clamp-2 text-xs text-zinc-400">{error}</span>
+          </div>
+          {retryButton}
         </div>
       </div>
     </div>
@@ -309,6 +360,8 @@ export default function TextBubble({
   loading,
   replyToMessage,
   error,
+  onRetry,
+  isRetrying,
 }: Readonly<ChatBubbleBotProps>) {
   const baseId = useId();
 
@@ -481,12 +534,21 @@ export default function TextBubble({
           );
         })()}
 
-      {/* Failed turn with no response text — render a quiet error bubble so
-          reloads don't show an empty bubble. Mirror ChatBubbleBot's hasError
-          gating: a turn that should show as a text bubble is never an error. */}
-      {!!error &&
-        !shouldShowTextBubble(text, isConvoSystemGenerated, systemPurpose) &&
-        !parsedContent.cleanText.trim() && <FailedResponse error={error} />}
+      {/* Every errored turn surfaces its failure and a retry. With no text this
+          IS the message (a quiet error bubble, so reloads don't show an empty
+          one); with partial text it's a strip under the bubble that already
+          rendered, marking the answer as truncated rather than finished. */}
+      {!!error && (
+        <FailedResponse
+          error={error}
+          isRetrying={isRetrying}
+          onRetry={onRetry}
+          partial={
+            shouldShowTextBubble(text, isConvoSystemGenerated, systemPurpose) ||
+            !!parsedContent.cleanText.trim()
+          }
+        />
+      )}
     </ApprovalResolveProvider>
   );
 }

--- a/apps/web/src/features/chat/components/bubbles/user/ChatBubbleUser.tsx
+++ b/apps/web/src/features/chat/components/bubbles/user/ChatBubbleUser.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@heroui/button";
+import { RedoIcon } from "@icons";
 import Image from "next/image";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -113,6 +115,7 @@ export default function ChatBubbleUser({
   selectedCalendarEvent,
   replyToMessage,
   queued,
+  failed,
   disableActions = false,
   onRetry,
   isRetrying,
@@ -211,8 +214,37 @@ export default function ChatBubbleUser({
           </div>
         )}
 
+        {/* Undelivered: a persistent label + retry, not the hover-only actions
+            row — a send that never landed must be visible without hovering. */}
+        {!disableActions && !queued && failed && (
+          <div
+            className={`flex items-center gap-2 ${hideAvatar ? "pr-1" : "pr-13"} pb-1`}
+          >
+            <span className="text-xs text-zinc-400 select-none">
+              Not delivered
+            </span>
+            {onRetry && (
+              <Button
+                className="h-7 min-w-0 px-2 text-xs"
+                isDisabled={isRetrying}
+                onPress={onRetry}
+                radius="full"
+                size="sm"
+                startContent={
+                  <div className={isRetrying ? "animate-spin" : ""}>
+                    <RedoIcon height={13} width={13} />
+                  </div>
+                }
+                variant="flat"
+              >
+                Retry
+              </Button>
+            )}
+          </div>
+        )}
+
         {/* Actions row below bubble, aligned under content (not avatar) */}
-        {!disableActions && !queued && (
+        {!disableActions && !queued && !failed && (
           <div
             className={`flex flex-col items-end gap-1 ${hideAvatar ? "pr-1" : "pr-13"} pb-1 opacity-0 transition-all group-hover:opacity-100`}
           >

--- a/apps/web/src/features/chat/hooks/useConversation.ts
+++ b/apps/web/src/features/chat/hooks/useConversation.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import type { IMessage } from "@/lib/db/chatDb";
+import type { OptimisticMessage } from "@/stores/chatStore";
 import { useChatStore } from "@/stores/chatStore";
 import type { MessageType } from "@/types/features/convoTypes";
 
@@ -12,7 +13,7 @@ import type { MessageType } from "@/types/features/convoTypes";
 // bubble on every token.
 const conversionCache = new WeakMap<IMessage, MessageType>();
 
-const mapStoredMessageToConversationMessage = (
+export const mapStoredMessageToConversationMessage = (
   message: IMessage,
 ): MessageType => {
   const cached = conversionCache.get(message);
@@ -47,6 +48,30 @@ const mapStoredMessageToConversationMessage = (
   return mapped;
 };
 
+/**
+ * The optimistic message is a separate shape from a stored one — it has no
+ * status field, so `failed` is carried explicitly rather than derived. It only
+ * exists before the backend assigns ids, and it is the only record of a send
+ * that died there.
+ */
+export const mapOptimisticMessageToConversationMessage = (
+  message: OptimisticMessage,
+): MessageType => ({
+  type: message.role === "user" ? ("user" as const) : ("bot" as const),
+  response: message.content,
+  message_id: message.id,
+  date: message.createdAt?.toISOString(),
+  fileIds: message.fileIds,
+  fileData: message.fileData,
+  selectedTool: message.toolName ?? undefined,
+  toolCategory: message.toolCategory ?? undefined,
+  selectedWorkflow: message.selectedWorkflow ?? undefined,
+  selectedCalendarEvent: message.selectedCalendarEvent ?? undefined,
+  replyToMessage: message.replyToMessage ?? undefined,
+  loading: false,
+  failed: message.failed,
+});
+
 export const useConversation = () => {
   const activeConversationId = useChatStore(
     (state) => state.activeConversationId,
@@ -73,27 +98,10 @@ export const useConversation = () => {
       !activeConversationId &&
       optimisticMessage.conversationId === null
     ) {
-      const optimisticMsg: MessageType = {
-        type:
-          optimisticMessage.role === "user"
-            ? ("user" as const)
-            : ("bot" as const),
-        response: optimisticMessage.content,
-        message_id: optimisticMessage.id,
-        date: optimisticMessage.createdAt?.toISOString(),
-        fileIds: optimisticMessage.fileIds,
-        fileData: optimisticMessage.fileData,
-        selectedTool: optimisticMessage.toolName ?? undefined,
-        toolCategory: optimisticMessage.toolCategory ?? undefined,
-        selectedWorkflow: optimisticMessage.selectedWorkflow ?? undefined,
-        selectedCalendarEvent:
-          optimisticMessage.selectedCalendarEvent ?? undefined,
-        replyToMessage: optimisticMessage.replyToMessage ?? undefined,
-        loading: false,
-        failed: optimisticMessage.failed,
-      };
-
-      return [...messages, optimisticMsg];
+      return [
+        ...messages,
+        mapOptimisticMessageToConversationMessage(optimisticMessage),
+      ];
     }
 
     return messages;

--- a/apps/web/src/features/chat/hooks/useConversation.ts
+++ b/apps/web/src/features/chat/hooks/useConversation.ts
@@ -90,6 +90,7 @@ export const useConversation = () => {
           optimisticMessage.selectedCalendarEvent ?? undefined,
         replyToMessage: optimisticMessage.replyToMessage ?? undefined,
         loading: false,
+        failed: optimisticMessage.failed,
       };
 
       return [...messages, optimisticMsg];

--- a/apps/web/src/features/chat/hooks/useConversation.ts
+++ b/apps/web/src/features/chat/hooks/useConversation.ts
@@ -31,6 +31,7 @@ const mapStoredMessageToConversationMessage = (
     selectedCalendarEvent: message.selectedCalendarEvent ?? undefined,
     loading: message.status === "sending",
     queued: message.status === "queued",
+    failed: message.status === "failed",
     tool_data: message.tool_data ?? undefined,
     follow_up_actions: message.follow_up_actions ?? undefined,
     image_data: message.image_data ?? undefined,

--- a/apps/web/src/features/chat/hooks/useExecutorStream.ts
+++ b/apps/web/src/features/chat/hooks/useExecutorStream.ts
@@ -4,7 +4,7 @@ import {
   parseChatStreamEvent,
   type TurnAccumulator,
 } from "@shared/chat";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { ToolDataEntry } from "@/config/registries/toolRegistry";
 import { chatApi } from "@/features/chat/api/chatApi";
 import { relayDesktopToolRequest } from "@/features/chat/utils/desktopToolBridge";
@@ -47,27 +47,17 @@ const applyAccumulatorToMessage = (
 });
 
 /**
- * Subscribe to `executor.stream_started` WebSocket events.
+ * Handle one `executor.stream_started` event: open the SSE connection and fold
+ * it into a placeholder message. Takes its two live sets as arguments so the
+ * whole run is exercisable without a React renderer.
  *
- * When a queued executor task starts, the backend emits this event with a
- * fresh stream_id. This hook creates a temporary placeholder message in the
- * Zustand store and opens a new SSE connection to `GET /stream/{stream_id}`,
- * folding live events into the placeholder through the SAME shared accumulator
- * the live chat turn uses — reasoning, subagents, todo progress, and text all
- * render identically on both paths. The placeholder is removed when
- * `useBgMessageWebSocket` receives the final `conversation.new_message`.
- *
- * Only active for the currently-viewed conversation — if the user is elsewhere,
- * the final message arrives via the normal WS notification path.
+ * `controllers` holds in-flight subscriptions so the hook can abort them on
+ * unmount; `activeStreams` dedupes by stream_id — a re-emitted stream_started
+ * would otherwise open a second reader that appends duplicate tool cards.
  */
-export function useExecutorStream() {
-  // Abort in-flight SSE subscriptions on unmount, and dedupe concurrent
-  // subscriptions for the same stream_id — a re-emitted stream_started would
-  // otherwise open a second reader that appends duplicate tool cards.
-  const controllersRef = useRef<Set<AbortController>>(new Set());
-  const activeStreamsRef = useRef<Set<string>>(new Set());
-
-  const handleExecutorStreamStarted = useCallback(async (raw: unknown) => {
+export const createExecutorStreamHandler =
+  (controllers: Set<AbortController>, activeStreams: Set<string>) =>
+  async (raw: unknown): Promise<void> => {
     const event = raw as ExecutorStreamStartedEvent;
     const { stream_id, conversation_id, task_id } = event;
 
@@ -81,11 +71,11 @@ export function useExecutorStream() {
       return;
     }
 
-    if (activeStreamsRef.current.has(stream_id)) {
+    if (activeStreams.has(stream_id)) {
       // Already streaming this run — ignore a duplicate stream_started.
       return;
     }
-    activeStreamsRef.current.add(stream_id);
+    activeStreams.add(stream_id);
     streamLog("lifecycle", "executor-stream:start", {
       conversationId: conversation_id,
       detail: { stream_id, task_id },
@@ -114,7 +104,7 @@ export function useExecutorStream() {
     await db.putMessage(placeholder);
 
     const controller = new AbortController();
-    controllersRef.current.add(controller);
+    controllers.add(controller);
 
     let acc = createTurnAccumulator();
 
@@ -174,6 +164,11 @@ export function useExecutorStream() {
       });
     };
 
+    // A run that dies publishes an error frame and then closes — the close looks
+    // exactly like a clean one, so without holding the reason here the failed run
+    // finalizes as `sent` and renders as a finished answer.
+    let terminalError: string | undefined;
+
     try {
       await chatApi.subscribeToExecutorStream(
         stream_id,
@@ -183,6 +178,10 @@ export function useExecutorStream() {
             streamLog("sse", `executor-event:${parsed.type}`, {
               conversationId: conversation_id,
             });
+            if (parsed.type === "error") {
+              terminalError = parsed.error;
+              continue;
+            }
             if (parsed.type === "desktop_tool_request") {
               // Queued executor runs ride this stream too — relay desktop
               // actions exactly like the live chat stream does.
@@ -201,9 +200,10 @@ export function useExecutorStream() {
           flushToStore();
         },
         () => {
-          // Stream closed cleanly — finalize so the loading indicator clears.
-          // The final conversation.new_message WS event replaces this shortly.
-          finalizePlaceholder();
+          // Stream closed — finalize so the loading indicator clears. A run that
+          // errored gets its own reason; a clean one is replaced shortly by the
+          // final conversation.new_message WS event.
+          finalizePlaceholder(terminalError);
         },
         (err) => {
           console.error("[useExecutorStream] SSE error:", err);
@@ -220,12 +220,39 @@ export function useExecutorStream() {
         "[useExecutorStream] Executor stream ended with error:",
         err,
       );
-      finalizePlaceholder(EXECUTOR_STREAM_FAILED);
+      finalizePlaceholder(terminalError ?? EXECUTOR_STREAM_FAILED);
     } finally {
-      controllersRef.current.delete(controller);
-      activeStreamsRef.current.delete(stream_id);
+      controllers.delete(controller);
+      activeStreams.delete(stream_id);
     }
-  }, []);
+  };
+
+/**
+ * Subscribe to `executor.stream_started` WebSocket events.
+ *
+ * When a queued executor task starts, the backend emits this event with a
+ * fresh stream_id. This hook creates a temporary placeholder message in the
+ * Zustand store and opens a new SSE connection to `GET /stream/{stream_id}`,
+ * folding live events into the placeholder through the SAME shared accumulator
+ * the live chat turn uses — reasoning, subagents, todo progress, and text all
+ * render identically on both paths. The placeholder is removed when
+ * `useBgMessageWebSocket` receives the final `conversation.new_message`.
+ *
+ * Only active for the currently-viewed conversation — if the user is elsewhere,
+ * the final message arrives via the normal WS notification path.
+ */
+export function useExecutorStream() {
+  const controllersRef = useRef<Set<AbortController>>(new Set());
+  const activeStreamsRef = useRef<Set<string>>(new Set());
+
+  const handleExecutorStreamStarted = useMemo(
+    () =>
+      createExecutorStreamHandler(
+        controllersRef.current,
+        activeStreamsRef.current,
+      ),
+    [],
+  );
 
   useEffect(() => {
     const controllers = controllersRef.current;

--- a/apps/web/src/features/chat/hooks/useExecutorStream.ts
+++ b/apps/web/src/features/chat/hooks/useExecutorStream.ts
@@ -20,6 +20,10 @@ import type { ImageData, MemoryData } from "@/types/features/toolDataTypes";
 // run emitting many tool events doesn't trigger one full-message write per chunk.
 const DB_WRITE_THROTTLE_MS = 500;
 
+// Shown when a background executor's stream dies before it delivered a result.
+const EXECUTOR_STREAM_FAILED =
+  "This background task stopped before it finished.";
+
 interface ExecutorStreamStartedEvent {
   type: "executor.stream_started";
   stream_id: string;
@@ -146,7 +150,7 @@ export function useExecutorStream() {
     // Mark the placeholder sent so the loading indicator clears. Runs on every
     // terminal outcome — normal close AND error/abort — otherwise an SSE error
     // leaves the placeholder status:'sending' and the card spins forever.
-    const finalizePlaceholder = () => {
+    const finalizePlaceholder = (error?: string) => {
       if (writeTimer !== null) {
         clearTimeout(writeTimer);
         writeTimer = null;
@@ -158,7 +162,8 @@ export function useExecutorStream() {
       if (current) {
         const finalized: IMessage = {
           ...applyAccumulatorToMessage(current, acc),
-          status: "sent",
+          status: error ? "failed" : "sent",
+          error: error ?? null,
         };
         state.updateMessageInPlace(finalized);
         void db.putMessage(finalized);
@@ -208,12 +213,14 @@ export function useExecutorStream() {
       );
     } catch (err) {
       // subscribeToExecutorStream re-throws on SSE error/abort. Finalize here so
-      // the error path clears the spinner too (not only the clean-close path).
+      // the error path clears the spinner too (not only the clean-close path) —
+      // and carry the reason, or a dead background run persists as a finished
+      // one and renders as a complete answer.
       console.error(
         "[useExecutorStream] Executor stream ended with error:",
         err,
       );
-      finalizePlaceholder();
+      finalizePlaceholder(EXECUTOR_STREAM_FAILED);
     } finally {
       controllersRef.current.delete(controller);
       activeStreamsRef.current.delete(stream_id);

--- a/apps/web/src/features/chat/stream/messageRecord.ts
+++ b/apps/web/src/features/chat/stream/messageRecord.ts
@@ -18,10 +18,28 @@ export interface TurnMessageMeta {
   options: TurnOptions;
 }
 
+/** Shown when a stream ended without ever signalling completion. */
+export const INTERRUPTED_ERROR =
+  "The response was interrupted before it finished.";
+
+/**
+ * Terminal status for a turn whose stream ended, from whether it signalled
+ * completion ([DONE] or main_response_complete). A connection that simply
+ * stopped — dropped socket, proxy timeout, backend crash — is a truncated turn,
+ * not a finished one, and must not be persisted as `sent`.
+ */
+export const resolveTurnOutcome = (
+  sawCompletion: boolean,
+): { status: IMessage["status"]; error: string | null } =>
+  sawCompletion
+    ? { status: "sent", error: null }
+    : { status: "failed", error: INTERRUPTED_ERROR };
+
 export const buildTurnMessageRecord = (
   meta: TurnMessageMeta,
   acc: TurnAccumulator,
   status: IMessage["status"],
+  error: string | null = null,
 ): IMessage => ({
   id: meta.botMessageId,
   conversationId: meta.conversationId,
@@ -45,6 +63,7 @@ export const buildTurnMessageRecord = (
   todo_progress: (acc.todoProgress as TodoProgressData | null) ?? null,
   pinned: false,
   isConvoSystemGenerated: false,
+  error,
   replyToMessageId: meta.options.replyToMessage?.id ?? null,
   replyToMessageData: meta.options.replyToMessage,
 });

--- a/apps/web/src/features/chat/stream/stallWatchdog.ts
+++ b/apps/web/src/features/chat/stream/stallWatchdog.ts
@@ -1,0 +1,38 @@
+/**
+ * Idle timer for a live SSE turn.
+ *
+ * The backend follows its event log forever, emitting a keepalive whenever the
+ * log is quiet, so a background task that dies without publishing leaves the
+ * connection open and silent. Nothing else in the client bounds that: without a
+ * watchdog the spinner runs until the tab closes. Every inbound frame —
+ * keepalives included — kicks the timer; the window elapsing means the stream
+ * went silent even by its own liveness signal.
+ */
+export class StallWatchdog {
+  private handle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly idleMs: number,
+    private readonly onStall: () => void,
+  ) {}
+
+  arm(): void {
+    this.disarm();
+    this.handle = setTimeout(() => {
+      this.handle = null;
+      this.onStall();
+    }, this.idleMs);
+  }
+
+  /** A frame arrived — restart the window. No-op once disarmed or fired. */
+  kick(): void {
+    if (this.handle === null) return;
+    this.arm();
+  }
+
+  disarm(): void {
+    if (this.handle === null) return;
+    clearTimeout(this.handle);
+    this.handle = null;
+  }
+}

--- a/apps/web/src/features/chat/stream/turnSession.ts
+++ b/apps/web/src/features/chat/stream/turnSession.ts
@@ -885,7 +885,16 @@ export class TurnSession {
     }
 
     this.markUserMessageFailed();
-    useChatStore.getState().clearOptimisticMessage();
+    // A turn that never learned its conversation id persisted nothing, anywhere:
+    // the optimistic bubble is the only record of what the user sent, so clearing
+    // it erases the message from the thread and leaves just a fading toast. Mark
+    // it undelivered instead. Once ids exist the real rows are in IndexedDB and
+    // the optimistic copy is a duplicate that must go.
+    if (this.conversationId) {
+      useChatStore.getState().clearOptimisticMessage();
+    } else {
+      useChatStore.getState().markOptimisticMessageFailed();
+    }
     this.end();
   }
 
@@ -909,6 +918,7 @@ export class TurnSession {
       return;
     }
     this.markUserMessageFailed();
+    useChatStore.getState().markOptimisticMessageFailed();
     this.end();
   }
 

--- a/apps/web/src/features/chat/stream/turnSession.ts
+++ b/apps/web/src/features/chat/stream/turnSession.ts
@@ -28,8 +28,10 @@ import { hasExecutorDelegation } from "./executorDelegation";
 import {
   buildTurnMessageRecord,
   buildUserMessageRecord,
+  resolveTurnOutcome,
   type TurnMessageMeta,
 } from "./messageRecord";
+import { StallWatchdog } from "./stallWatchdog";
 import type { SendArgs } from "./types";
 import { isViewingConversation, markConversationUnread } from "./unread";
 
@@ -50,6 +52,13 @@ const APPROVAL_STRANDED_TIMEOUT_MS = 8 * 60 * 60 * 1000;
 // cache of tape-derived state only: the event-log replay overwrites it on
 // resume, so staleness (≤ one interval) never affects correctness.
 const STREAM_PERSIST_INTERVAL_MS = 500;
+
+// How long a live stream may go completely silent before the turn is declared
+// dead. The backend emits a keepalive whenever its event log is idle (see
+// StreamManager.subscribe_stream), so silence this long means the connection or
+// the background task is gone, not that the model is thinking. Comfortably
+// above the server's keepalive cadence so a slow tool call can never trip it.
+const STREAM_STALL_TIMEOUT_MS = 90_000;
 
 export interface TurnSessionCallbacks {
   /** Session finished (any terminal path). Manager dispatches the queue. */
@@ -87,6 +96,13 @@ export class TurnSession {
   private readonly pendingApprovalIds = new Set<string>();
   private aborted = false;
   private readonly isNewConversation: boolean;
+  /** The comms agent delivered its answer. A connection that drops after this
+   *  lost only the executor tail, so the turn is complete, not truncated. */
+  private sawMainResponseComplete = false;
+  private readonly stallWatchdog = new StallWatchdog(
+    STREAM_STALL_TIMEOUT_MS,
+    () => this.handleStall(),
+  );
 
   constructor(key: string, args: SendArgs, callbacks: TurnSessionCallbacks) {
     this.key = key;
@@ -128,6 +144,7 @@ export class TurnSession {
       is_new_conversation: this.isNewConversation,
     });
 
+    this.stallWatchdog.arm();
     try {
       if (this.args.options.resumeStreamId) {
         await this.attachToStream(this.args.options.resumeStreamId);
@@ -142,7 +159,7 @@ export class TurnSession {
         // same send is rejected server-side instead of duplicating the turn.
         turnId: this.args.options.optimisticUserId,
         onMessage: (event) => this.handleSSEMessage(event),
-        onClose: () => void this.close(),
+        onClose: (sawDone) => void this.close(sawDone),
         onError: (err) => this.fail(err),
         controller: this.controller,
         fileData: this.args.options.fileData,
@@ -181,10 +198,25 @@ export class TurnSession {
           }
         });
       },
-      () => void this.close(),
+      (sawDone) => void this.close(sawDone),
       (err) => this.fail(err),
       this.controller.signal,
     );
+  }
+
+  /** The stream went silent past even the server's keepalive cadence. */
+  private handleStall(): void {
+    streamLogError("sse", "stream-stalled", {
+      turnKey: this.key,
+      conversationId: this.conversationId,
+      detail: { idleMs: STREAM_STALL_TIMEOUT_MS },
+    });
+    // Fail BEFORE aborting: aborting first lets the transport's AbortError
+    // reach fail() and claim the turn, which suppresses the user-facing toast.
+    this.fail(
+      new Error("The connection went quiet, so this response was stopped."),
+    );
+    this.controller.abort();
   }
 
   /** User pressed Stop: persist what streamed so far, then cancel everywhere. */
@@ -197,6 +229,7 @@ export class TurnSession {
       conversationId: this.conversationId,
     });
 
+    this.stallWatchdog.disarm();
     useStreamStore.getState().beginPendingSave();
     try {
       this.cancelFlush();
@@ -230,6 +263,8 @@ export class TurnSession {
     event: EventSourceMessage,
   ): Promise<string | undefined> {
     if (this.aborted) return "Stream was aborted";
+    // Any frame — keepalives included — proves the connection is still alive.
+    this.stallWatchdog.kick();
     if (!event.data) return undefined; // SSE comments dispatch empty events
 
     try {
@@ -273,7 +308,8 @@ export class TurnSession {
         return "Malformed stream frame";
 
       case "error":
-        toast.error(event.error);
+        // No toast here — fail() owns the user-facing message for every
+        // failure path, and toasting both places double-reports one error.
         return event.error;
 
       case "model_fallback":
@@ -554,6 +590,7 @@ export class TurnSession {
   // ── Loading / composer UI ──────────────────────────────────────────────────
 
   private handleMainResponseComplete(): void {
+    this.sawMainResponseComplete = true;
     const store = useStreamStore.getState();
     // The comms agent acked — unlock the composer so the user can queue.
     store.updateSession(this.sessionKey, { composerLocked: false });
@@ -629,6 +666,7 @@ export class TurnSession {
 
   private buildRecord(
     status: IMessage["status"],
+    error: string | null = null,
   ): ReturnType<typeof buildTurnMessageRecord> | null {
     if (!this.conversationId || !this.botMessageId) return null;
     const meta: TurnMessageMeta = {
@@ -637,7 +675,7 @@ export class TurnSession {
       createdAt: this.botCreatedAt ?? new Date(),
       options: this.args.options,
     };
-    return buildTurnMessageRecord(meta, this.acc, status);
+    return buildTurnMessageRecord(meta, this.acc, status, error);
   }
 
   /** Batch accumulator flushes to one store write per animation frame. */
@@ -680,10 +718,11 @@ export class TurnSession {
 
   // ── Terminal paths ─────────────────────────────────────────────────────────
 
-  private async close(): Promise<void> {
+  private async close(sawDone: boolean): Promise<void> {
     if (this.closeHandled) return;
     this.closeHandled = true;
     this.cancelFlush();
+    this.stallWatchdog.disarm();
     streamLog("lifecycle", "turn:close", {
       turnKey: this.key,
       conversationId: this.conversationId,
@@ -695,7 +734,20 @@ export class TurnSession {
         return;
       }
 
-      const record = this.buildRecord("sent");
+      // A connection that ended without [DONE] and without the comms answer is
+      // a truncated turn — persisting it as "sent" makes a dead stream
+      // indistinguishable from a finished one.
+      const outcome = resolveTurnOutcome(
+        sawDone || this.sawMainResponseComplete,
+      );
+      if (outcome.status === "failed") {
+        streamLogError("lifecycle", "turn:truncated", {
+          turnKey: this.key,
+          conversationId: this.conversationId,
+        });
+      }
+
+      const record = this.buildRecord(outcome.status, outcome.error);
       if (record) {
         useChatStore.getState().addOrUpdateMessage(record);
         try {
@@ -720,7 +772,15 @@ export class TurnSession {
         markConversationUnread(this.conversationId);
       }
 
-      if (hasExecutorDelegation(this.acc.toolData)) {
+      // Only a turn that actually completed can be waiting on an executor tail.
+      // The normal delegation flow acks (main_response_complete) long before the
+      // executor streams, so a truncated turn here died before the hand-off was
+      // confirmed — park it as failed and retryable rather than spinning on a
+      // result that may never come.
+      if (
+        outcome.status === "sent" &&
+        hasExecutorDelegation(this.acc.toolData)
+      ) {
         this.enterAwaitingExecutor();
         return;
       }
@@ -776,6 +836,7 @@ export class TurnSession {
     if (this.closeHandled) return;
     this.closeHandled = true;
     this.cancelFlush();
+    this.stallWatchdog.disarm();
     streamLogError("lifecycle", "turn:error", {
       turnKey: this.key,
       conversationId: this.conversationId,
@@ -793,13 +854,14 @@ export class TurnSession {
       return;
     }
 
+    const reason =
+      error.message || "An error occurred while processing your message";
+
     if (error.name !== "AbortError") {
       // A usage-wall rejection already showed the rate-limit upsell toast at
       // the stream layer — a second generic toast would bury it.
       if (!(error instanceof RateLimitError)) {
-        toast.error(
-          error.message || "An error occurred while processing your message",
-        );
+        toast.error(reason);
       }
       // Give the user their prompt back to retry.
       useComposerStore.getState().setInputText(this.inputText);
@@ -807,8 +869,10 @@ export class TurnSession {
 
     // Content already flushed with status "sending" must still land in a
     // terminal state — mirror abort()'s finalization, with "failed" status.
+    // The reason rides ON the record: the toast is transient, so without it a
+    // reload shows an empty bubble and the failure disappears entirely.
     if (this.conversationId && this.botMessageId) {
-      const record = this.buildRecord("failed");
+      const record = this.buildRecord("failed", reason);
       if (record) {
         useChatStore.getState().addOrUpdateMessage(record);
         db.putMessage(record).catch((persistError) => {

--- a/apps/web/src/stores/chatStore.ts
+++ b/apps/web/src/stores/chatStore.ts
@@ -26,6 +26,9 @@ export interface OptimisticMessage {
   selectedCalendarEvent?: SelectedCalendarEventData | null;
   replyToMessage?: ReplyToMessageData | null;
   metadata?: Record<string, unknown>;
+  // The send never reached the backend. For a new conversation this bubble is
+  // the only record of the message, so it is marked rather than cleared.
+  failed?: boolean;
 }
 
 interface ChatState {
@@ -66,6 +69,8 @@ interface ChatState {
   // Optimistic message management for new conversations (single message only)
   setOptimisticMessage: (message: OptimisticMessage | null) => void;
   clearOptimisticMessage: () => void;
+  /** Flag the optimistic message as undelivered, keeping it on screen. */
+  markOptimisticMessageFailed: () => void;
 }
 
 export const useChatStore = create<ChatState>((set) => ({
@@ -238,6 +243,13 @@ export const useChatStore = create<ChatState>((set) => ({
 
   // Clear the optimistic message (set to null)
   clearOptimisticMessage: () => set({ optimisticMessage: null }),
+
+  markOptimisticMessageFailed: () =>
+    set((state) => ({
+      optimisticMessage: state.optimisticMessage
+        ? { ...state.optimisticMessage, failed: true }
+        : null,
+    })),
 }));
 
 // Hydrate immediately on module load (before any React renders)

--- a/apps/web/src/types/features/baseMessageTypes.ts
+++ b/apps/web/src/types/features/baseMessageTypes.ts
@@ -28,6 +28,10 @@ export interface UserMessageData extends BaseMessageData {
   // True while the message is held in the send queue (greyed-out bubble).
   queued?: boolean;
 
+  // The send never reached the backend (dropped connection, reload mid-flight).
+  // Drives a persistent "Not delivered" label + retry on the user bubble.
+  failed?: boolean;
+
   // True while the message is still streaming in — the voice transcript grows
   // word-by-word as the user speaks. Drives the user bubble's blur-in animation.
   loading?: boolean;
@@ -64,6 +68,7 @@ export interface ConversationMessage extends Partial<BaseMessageData> {
   response: string; // The main content field for conversations
   loading?: boolean;
   queued?: boolean; // Held in the send queue (greyed-out user bubble)
+  failed?: boolean; // Send never reached the backend
   disclaimer?: string;
 }
 


### PR DESCRIPTION
A failed LLM turn could disappear from the thread entirely — two independent causes, both found by driving a real failing turn rather than reading the code: the client persisted the dead turn with `status: "failed"` but no `error` string (the failed-response bubble keys off `error`, and nothing reads `status`, so the message rendered empty and `filterEmptyMessagePairs` then dropped it), and the OpenRouter SDK returns its exception message verbatim from `__str__`, which is genuinely `""` for some error bodies — a falsy value that reproduced the same symptom from the server side.

Retry was also nested without anyone noticing: `langchain-openrouter` defaults `max_retries=2`, which the SDK turns into a 300-second backoff window inside a *single* `ainvoke`, sitting under our own 3 attempts and repeating for the fallback model. One failing turn measured **40 upstream requests over 4 minutes**, bounded only by the 120 s timeout firing twice; `max_retries=0` is not the fix and makes it worse (the SDK then falls back to a one-hour default), so retry is disabled via the config the SDK actually reads. Same failing turn, measured live: **40 calls / 4m00s / empty error → 3 calls / 4.6s / real error**.

This PR also stops a stream that ends without `[DONE]` or `main_response_complete` being saved as `"sent"` (a dropped connection no longer looks like a finished answer), puts a visible **Retry** on the failure itself — the hover actions row is hidden exactly when a turn fails — on both the bot bubble and an undelivered user send, adds a 90 s stall watchdog (the server keepalives every 15 s, and nothing previously bounded a silent stream), emits an error frame when SSE delivery fails instead of closing silently, and removes a duplicate error toast.

Every fix ships a failing-then-passing test and the retry-budget suite was mutation-checked; verified end to end against a live stack — the error bubble and Retry render, Retry re-sends without a 409, and both survive a reload.

**Not covered:** the bubble has no automated render test (`apps/web` has no jsdom/testing-library, so it is proven by screenshots only), the stall watchdog is unit-tested with fake timers but was never held silent for a real 90 s, and the live runs used the local scripted LLM stub rather than real OpenRouter error bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)