### PR TITLE
chore(license): relicense from PolyForm Strict 1.0.0 to PolyForm Noncommercial 1.0.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-# PolyForm Strict License 1.0.0
+# PolyForm Noncommercial License 1.0.0
 
-<https://polyformproject.org/licenses/strict/1.0.0>
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
 ## Acceptance
 
@@ -13,8 +13,33 @@ your licenses.
 The licensor grants you a copyright license for the software
 to do everything you might do with the software that would
 otherwise infringe the licensor's copyright in it for any
-permitted purpose, other than distributing the software or
-making changes or new works based on the software.
+permitted purpose.  However, you may only distribute the
+software according to [Distribution License](#distribution-license)
+and make changes or new works based on the software according
+to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to
+distribute copies of the software.  Your license to distribute
+covers distributing the software with changes and new works
+permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
 
 ## Patent License
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ On **self-hosted**, yes — provider keys (model providers, integration services
 <details>
 <summary><b>What does self-hosting cost to run?</b></summary>
 
-The GAIA code is free under Polyform Strict (noncommercial use). Real costs are: model API usage (scales with how much you use it), any paid-tier integration services you opt into, and hosting — a single modestly-sized VM handles a small team. See the <a href="https://docs.heygaia.io/self-hosting/overview">self-hosting guide</a> for detailed numbers.
+The GAIA code is free under PolyForm Noncommercial (noncommercial use). Real costs are: model API usage (scales with how much you use it), any paid-tier integration services you opt into, and hosting — a single modestly-sized VM handles a small team. See the <a href="https://docs.heygaia.io/self-hosting/overview">self-hosting guide</a> for detailed numbers.
 
 </details>
 
@@ -349,7 +349,7 @@ GAIA is built on the shoulders of giants — the language models, frameworks, an
 
 ## License
 
-This project is licensed under the [Polyform Strict License 1.0.0](https://polyformproject.org/licenses/strict/1.0.0/).
+This project is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/).
 
 > [!WARNING]
 > This license allows noncommercial use only.

--- a/apps/web/src/app/[locale]/(landing)/terms/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/terms/page.tsx
@@ -46,7 +46,7 @@ const TermsOfService = () => {
           <h1 className="mb-4 text-3xl font-bold">
             Terms of Service Agreement
           </h1>
-          <p className="mb-4 text-sm">Effective Date: August 7, 2026</p>
+          <p className="mb-4 text-sm">Effective Date: August 14, 2026</p>
           <p className="mb-4">
             This Terms of Service Agreement (this "Agreement") is entered into
             by and between The Experience Company, Inc., a Delaware corporation
@@ -338,9 +338,11 @@ const TermsOfService = () => {
               </li>
               <li>
                 <strong>Self-hosted deployments:</strong> Your use of the GAIA
-                source code is governed solely by the PolyForm Strict License
-                1.0.0 accompanying that code, which permits noncommercial
-                purposes only and does not permit distribution or modification.
+                source code is governed solely by the PolyForm Noncommercial
+                License 1.0.0 accompanying that code, which permits
+                noncommercial purposes only, including distributing the source
+                code and making changes or new works based on it for those
+                purposes, subject to the notice requirements of that license.
                 This Agreement does not grant any additional rights in the
                 source code, and the PolyForm license does not grant any right
                 to use the hosted Service.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -64,7 +64,7 @@ That last one becomes a [workflow](/workflows), an automation that runs on its o
 
 ## Open source
 
-GAIA is fully open source and self-hostable. Your conversations and context can live on your own servers, and you can modify anything to fit how you work. It's licensed under the [Polyform Strict License 1.0.0](https://polyformproject.org/licenses/strict/1.0.0/), which permits noncommercial, personal, and research use.
+GAIA is fully open source and self-hostable. Your conversations and context can live on your own servers, and you can modify anything to fit how you work. It's licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/), which permits noncommercial, personal, and research use.
 
 <CardGroup cols={2}>
   <Card title="Self-host GAIA" icon="server" href="/self-hosting/overview">

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -64,7 +64,7 @@ That last one becomes a [workflow](/workflows), an automation that runs on its o
 
 ## Open source
 
-GAIA is fully open source and self-hostable. Your conversations and context can live on your own servers, and you can modify anything to fit how you work. It's licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/), which permits noncommercial, personal, and research use.
+GAIA is source-available and self-hostable. Your conversations and context can live on your own servers, and you're free to read the code, modify it, and share your changes — for noncommercial purposes. It's licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/), which covers personal, research, and other noncommercial use; if you pass the code on, include the license terms or a link to them.
 
 <CardGroup cols={2}>
   <Card title="Self-host GAIA" icon="server" href="/self-hosting/overview">


### PR DESCRIPTION
Switches GAIA from **PolyForm Strict 1.0.0** to **[PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/)**.

## Why

Strict grants a *use-only* license — it explicitly forbids **distributing** the software and **making changes or new works** based on it. That contradicted how the project actually presents itself: the README invites contributions ("bug fixes, features, docs, and tests"), `docs/introduction.mdx` says "you can modify anything to fit how you work", and several docs pages already tell users they may modify the code.

## What changes for users

| | Strict (before) | Noncommercial (after) |
|---|---|---|
| Noncommercial use | Allowed | Allowed |
| **Distribute the source** | **Forbidden** | **Allowed** (noncommercial purposes) |
| **Modify / build derivative works** | **Forbidden** | **Allowed** (noncommercial purposes) |
| Commercial use | Forbidden | Forbidden |
| Notices | — | Downstream copies must carry the terms or their URL |

Commercial use remains prohibited. The new **Notices** section adds one obligation: anyone you pass a copy to must also get these terms or the URL for them.

## Changes

- **`LICENSE.md`** — replaced with the official upstream text, verbatim. Everything from `## Patent License` onward is byte-identical between the two variants, so the diff is limited to the header, the rewritten Copyright License paragraph, and the three new sections (`Distribution License`, `Notices`, `Changes and New Works License`).
- **`README.md`**, **`docs/introduction.mdx`** — license name and URL. The `> [!WARNING] This license allows noncommercial use only` callout stays; it is still the key constraint.
- **Terms of Service** (`apps/web/.../terms/page.tsx`) — the self-hosting clause said the license "does not permit distribution or modification", which stops being true. Rewritten to name the new license and describe what it now permits, keeping both existing carve-outs intact (this Agreement grants no additional rights in the source; the PolyForm license grants no right to use the hosted Service). Effective date bumped to Aug 14, 2026 since the terms users agree to have materially changed.

## Not changed

- Six `docs/knowledge/**` pages already (incorrectly) said "PolyForm Noncommercial" — they become **accurate** with this change and needed no edit. Two of them claimed modification was permitted, which is now true.
- `docs/release-notes*.mdx` "Moved from PolyForm Shield to PolyForm Strict" — historical record, left as-is.

## Verification

- License text diffed whitespace-normalized against upstream `PolyForm-Noncommercial-1.0.0.md` (polyform-licenses tag `1.0.0`) — **exact match**, no clause paraphrased or dropped. The same check confirmed the previous `LICENSE.md` was upstream Strict.
- `nx type-check web` and `nx lint web` pass.
- Booted `nx dev web` and loaded `/terms` — confirmed on the rendered page: new effective date, rewritten clause, and zero remaining "PolyForm Strict" mentions.

## Flagged separately (not in this PR)

`packages/cli/package.json` declares `"license": "MIT"` and `apps/desktop/package.json` declares `"license": "UNLICENSED"`. Both diverge from the repo license. The CLI being MIT is plausibly intentional (separately published npm package); `UNLICENSED` on desktop looks like an unreviewed scaffold default. Neither is a Strict→Noncommercial concern — say the word if you want either corrected.