### PR TITLE
fix(ci): register bot projects as docker releases so they get immutable tags

### DIFF
--- a/apps/bots/discord/project.json
+++ b/apps/bots/discord/project.json
@@ -75,7 +75,13 @@
         "cwd": "."
       },
       "cache": true,
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production"],
+      "metadata": {
+        "technologies": ["docker"]
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/docker:release-publish"
     }
   }
 }

--- a/apps/bots/slack/project.json
+++ b/apps/bots/slack/project.json
@@ -68,7 +68,13 @@
         "cwd": "."
       },
       "cache": true,
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production"],
+      "metadata": {
+        "technologies": ["docker"]
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/docker:release-publish"
     }
   }
 }

--- a/apps/bots/telegram/project.json
+++ b/apps/bots/telegram/project.json
@@ -68,7 +68,13 @@
         "cwd": "."
       },
       "cache": true,
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production"],
+      "metadata": {
+        "technologies": ["docker"]
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/docker:release-publish"
     }
   }
 }

--- a/apps/bots/whatsapp/project.json
+++ b/apps/bots/whatsapp/project.json
@@ -61,7 +61,13 @@
         "cwd": "."
       },
       "cache": true,
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production"],
+      "metadata": {
+        "technologies": ["docker"]
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/docker:release-publish"
     }
   }
 }


### PR DESCRIPTION
## Problem

The 2026-08-14 master push (#1000/#1001) published the api image fine but **blocked its own deploy**: the `docker-release` lane failed with

```
resolve-image-tags: bots released but ghcr.io/theexperiencecompany/gaia-bot-discord
has no local production tag matching ^[0-9]{4}\.[0-9]{2}\.[0-9a-f]{6,12}$
```

## Root cause

nx's docker release machinery (`processDockerProjects`) only versions projects carrying `metadata.technologies: ['docker']` on a target. That metadata is inferred by `@nx/docker`'s plugin from Dockerfile location — and the four bots share `apps/bots/Dockerfile`, which belongs to no bot project. So no bot was ever registered as a docker project: nx never minted a production tag (`YYMM.DD.<sha>`) for a bot image and never published one (`Skipped publishing packages.` in every bots release), on any commit history.

Invisible until a master push pulls the bots into an affected build — which **any change to `libs/shared/ts` does** — then `resolve-image-tags.sh` correctly refuses to deploy untagged images and the whole deploy is blocked, including the unrelated api image.

api/voice-agent never hit this because they own their Dockerfiles, so inference works (`nx show project api` → `docker:run: ['docker']`; `bot-discord` → nothing).

## Fix

Declare per bot what the shared Dockerfile prevents nx from inferring:

- `metadata.technologies: ["docker"]` on the existing `docker:build` target — the exact predicate `processDockerProjects` filters on
- `nx-release-publish: @nx/docker:release-publish` — the publish target inference would also have created

Bots now version, tag, and publish through the same mechanism as api/voice-agent. No workflow/script changes.

## Verification

- `nx show project bot-*` now reports the docker technology + publish target for all four bots (before: none)
- Live CI test: `build.yml` dispatched on this branch — bots lane must show `Image tagged with ghcr.io/theexperiencecompany/gaia-bot-*:develop-<sha>` and successful `nx-release-publish` for all four bots (develop scheme off-master; deploys hard-disabled off-master in `compute-deploy-plan.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)