### PR TITLE
fix(web): always render a workflow's chosen icon on cards

### DIFF
--- a/apps/web/src/features/workflows/components/shared/WorkflowIcons.tsx
+++ b/apps/web/src/features/workflows/components/shared/WorkflowIcons.tsx
@@ -9,7 +9,7 @@ import {
 
 interface WorkflowIconsProps {
   steps: Array<{ category: string }>;
-  /** User-chosen icon slug — rendered instead when the steps carry no category icons */
+  /** User-chosen icon slug — rendered in place of the step-category icons when set */
   icon?: string | null;
   /** Hex color for the user-chosen icon */
   iconColor?: string | null;
@@ -34,18 +34,17 @@ export default function WorkflowIcons({
   spacing = "-space-x-1.5 ",
   showBackground = true,
 }: WorkflowIconsProps) {
-  const { getIntegrationIconUrl, getIntegrationName } = useIntegrationLookup();
+  const { getIntegrationIconUrl } = useIntegrationLookup();
   // De-duplicate categories, preserving first-seen order.
   const categories = [...new Set(steps.map((step) => step.category))];
   const displayIcons = categories.slice(0, maxIcons);
 
-  // A workflow whose steps use no integrations (only internal categories like
-  // "reminder"/"general") falls back to its user-chosen icon.
-  const usesIntegrations = categories.some(
-    (category) => !!getIntegrationName(category),
-  );
-  const customIcon =
-    icon && !usesIntegrations ? WORKFLOW_ICON_MAP.get(icon) : undefined;
+  // An explicitly chosen icon always wins over step-category icons. Gating it
+  // on "no integrations" made rendering depend on the auth-gated integrations
+  // catalog: icons flipped to tool icons (or blank, for internal categories)
+  // the moment /integrations/me resolved, and public pages behaved differently
+  // from the slug page, which renders the icon unconditionally.
+  const customIcon = icon ? WORKFLOW_ICON_MAP.get(icon) : undefined;
   if (customIcon) {
     const CustomIcon = customIcon.Icon;
     const iconElement = (


### PR DESCRIPTION
## Problem

On /use-cases (and anywhere `UnifiedWorkflowCard` renders), workflow icons are finicky: many featured cards show tool icons or nothing instead of the workflow's chosen icon, while the /use-cases/[slug] page always shows it correctly. Behavior also differs logged-in vs logged-out, and icons can visibly swap after page load.

## Root cause

`WorkflowIcons` gated the custom icon on "steps use no integrations", resolved through `useIntegrationLookup` → `useIntegrations`, which only fetches when authenticated:

- **first paint**: catalog empty → custom icon renders
- **`/integrations/me` resolves**: `gmail`/`googlecalendar`/etc. start matching → custom icon vanishes mid-view, replaced by tool icons — or by **nothing**, because internal categories (`todos`, `search`, `gaia`, …) return `null` from `getToolCategoryIcon`
- **logged out**: catalog never loads → different behavior again
- **slug page**: renders `workflow.icon` unconditionally → correct, and inconsistent with the cards

## Fix

An explicitly chosen icon always wins. Workflows without one keep the step-category tool icons exactly as before. Deterministic, auth-independent, consistent with the slug page. Dead `usesIntegrations` gate and `getIntegrationName` usage removed.

## Verification

- Biome + `tsc --noEmit` clean
- All 30 seeded icon slugs verified present in `WORKFLOW_ICON_MAP` (catalog lookup was ruled out as a cause first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)