### PR TITLE
feat(bots): iMessage platform via Photon/Spectrum with Pro gating

### DIFF
--- a/apps/api/app/api/v1/endpoints/platform_links.py
+++ b/apps/api/app/api/v1/endpoints/platform_links.py
@@ -1,7 +1,8 @@
 from collections.abc import Mapping
+import re
 from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.config.settings import settings
@@ -17,11 +18,18 @@ from app.models.platform_models import (
 from app.models.user_models import AuthenticatedUser
 from app.services.oauth.oauth_state_service import create_oauth_state
 from app.services.outbound_delivery import notify_account_linked
-from app.services.platform_link_service import Platform, PlatformLinkService
+from app.services.photon.photon_client import redirect_deep_link, register_shared_user
+from app.services.platform_link_service import (
+    Platform,
+    PlatformLinkService,
+    require_platform_plan,
+)
 from app.utils.errors import create_error
 from shared.py.wide_events import log
 
 router = APIRouter()
+
+E164_PHONE_PATTERN = re.compile(r"^\+[1-9]\d{6,14}$")
 
 
 def _require_user_id(current_user: Mapping[str, object]) -> str:
@@ -75,6 +83,8 @@ async def link_platform(
     # worth seeing — still names the session that presented it.
     user_id = _require_user_id(current_user)
     log.set(user={"id": user_id}, operation="link_platform", platform=platform)
+
+    await require_platform_plan(user_id, platform)
 
     # Look up and consume the token from Redis
     redis_client = redis_cache.client
@@ -209,6 +219,7 @@ async def disconnect_platform(
 @router.get("/{platform}/connect")
 async def initiate_platform_connect(
     platform: str,
+    phone: str | None = Query(default=None, description="E.164 number, iMessage only"),
     current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> InitiatePlatformConnectResponse:
     """Initiate platform connection via OAuth or manual instructions.
@@ -225,6 +236,8 @@ async def initiate_platform_connect(
 
     user_id = _require_user_id(current_user)
     log.set(user={"id": user_id}, operation="initiate_platform_connect", platform=platform)
+
+    await require_platform_plan(user_id, platform)
 
     # Discord OAuth flow
     if platform == "discord" and settings.DISCORD_OAUTH_CLIENT_ID:
@@ -287,6 +300,28 @@ async def initiate_platform_connect(
             auth_type="manual",
             instructions="Open WhatsApp and send /auth to the GAIA WhatsApp number to link your account.",
             action_link=f"https://wa.me/{phone_number}" if phone_number else None,
+        )
+
+    # iMessage manual flow: Photon's shared pool only delivers to registered
+    # numbers, so the user's phone must be allowlisted before they can text.
+    if platform == "imessage":
+        if not phone or not E164_PHONE_PATTERN.fullmatch(phone):
+            raise HTTPException(
+                status_code=422,
+                detail="A phone number in E.164 format (e.g. +15551234567) is required for iMessage.",
+            )
+        photon_user = await register_shared_user(phone)
+        log.audit(
+            "imessage number registered for linking",
+            actor=user_id,
+            provider=platform,
+        )
+        log.set(outcome="success", auth_type="manual")
+        return InitiatePlatformConnectResponse(
+            auth_url=None,
+            auth_type="manual",
+            instructions="Open the link on your iPhone or Mac, then text /auth to your GAIA iMessage number to link your account.",
+            action_link=redirect_deep_link(photon_user.id),
         )
 
     raise HTTPException(status_code=501, detail=f"{platform} OAuth not configured")

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -438,6 +438,8 @@ class ProductionSettings(CommonSettings):
     WHATSAPP_PHONE_NUMBER: str | None = (
         None  # E.164 without +, e.g. "15551234567" — used for wa.me links
     )
+    SPECTRUM_PROJECT_ID: str | None = None
+    SPECTRUM_PROJECT_SECRET: str | None = None
 
     # ----------------------------------------------
     # Bot OAuth Configuration (Optional)
@@ -655,6 +657,8 @@ class DevelopmentSettings(CommonSettings):
     WHATSAPP_PHONE_NUMBER: str | None = (
         None  # E.164 without +, e.g. "15551234567" — used for wa.me links
     )
+    SPECTRUM_PROJECT_ID: str | None = None
+    SPECTRUM_PROJECT_SECRET: str | None = None
 
     # ----------------------------------------------
     # Bot OAuth Configuration (Optional)

--- a/apps/api/app/constants/notifications.py
+++ b/apps/api/app/constants/notifications.py
@@ -16,6 +16,7 @@ CHANNEL_TYPE_TELEGRAM = "telegram"
 CHANNEL_TYPE_DISCORD = "discord"
 CHANNEL_TYPE_WHATSAPP = "whatsapp"
 CHANNEL_TYPE_SLACK = "slack"
+CHANNEL_TYPE_IMESSAGE = "imessage"
 CHANNEL_TYPE_EMAIL = "email"
 
 # External channel types that are auto-injected based on platform links
@@ -24,16 +25,18 @@ EXTERNAL_NOTIFICATION_CHANNELS = (
     CHANNEL_TYPE_DISCORD,
     CHANNEL_TYPE_WHATSAPP,
     CHANNEL_TYPE_SLACK,
+    CHANNEL_TYPE_IMESSAGE,
 )
 
 # All channel types that are auto-injected when no channels are explicitly specified.
-# inapp is always available; telegram/discord/whatsapp/slack respect user preferences.
+# inapp is always available; the external platforms respect user preferences.
 ALL_AUTO_INJECTED_CHANNELS = (
     CHANNEL_TYPE_INAPP,
     CHANNEL_TYPE_TELEGRAM,
     CHANNEL_TYPE_DISCORD,
     CHANNEL_TYPE_WHATSAPP,
     CHANNEL_TYPE_SLACK,
+    CHANNEL_TYPE_IMESSAGE,
 )
 
 # Default enabled state for external channels
@@ -42,6 +45,7 @@ DEFAULT_CHANNEL_PREFERENCES: dict[str, bool] = {
     CHANNEL_TYPE_DISCORD: True,
     CHANNEL_TYPE_WHATSAPP: True,
     CHANNEL_TYPE_SLACK: True,
+    CHANNEL_TYPE_IMESSAGE: True,
     CHANNEL_TYPE_EMAIL: True,
 }
 

--- a/apps/api/app/models/chat_models.py
+++ b/apps/api/app/models/chat_models.py
@@ -138,6 +138,7 @@ class ConversationSource(str, Enum):
     DISCORD = "discord"
     SLACK = "slack"
     WHATSAPP = "whatsapp"
+    IMESSAGE = "imessage"
     WORKFLOW_SYSTEM = "workflow_system"
     BACKGROUND = "background"
 
@@ -196,6 +197,7 @@ BOT_CONVERSATION_SOURCES: frozenset[ConversationSource] = frozenset(
         ConversationSource.TELEGRAM,
         ConversationSource.DISCORD,
         ConversationSource.SLACK,
+        ConversationSource.IMESSAGE,
     }
 )
 

--- a/apps/api/app/services/photon/photon_client.py
+++ b/apps/api/app/services/photon/photon_client.py
@@ -1,0 +1,63 @@
+"""Photon (Spectrum) management API client.
+
+Used for iMessage account linking on Photon's shared-number pool: a recipient
+must be registered as a project user before Photon will deliver to them, and
+registration assigns them their pool number. Runtime messaging is NOT done
+here — the iMessage bot process owns that via the spectrum-ts SDK.
+"""
+
+import httpx
+from pydantic import BaseModel
+
+from app.config.settings import settings
+from app.utils.errors import create_error
+
+SPECTRUM_API_BASE = "https://spectrum.photon.codes"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+
+
+class PhotonUser(BaseModel):
+    id: str
+    phoneNumber: str
+
+
+def _auth() -> tuple[str, str]:
+    if not settings.SPECTRUM_PROJECT_ID or not settings.SPECTRUM_PROJECT_SECRET:
+        raise create_error(
+            message="iMessage is not configured",
+            why="SPECTRUM_PROJECT_ID / SPECTRUM_PROJECT_SECRET are not set",
+            fix="set the Photon project credentials in the API environment",
+            status_code=501,
+        )
+    return (settings.SPECTRUM_PROJECT_ID, settings.SPECTRUM_PROJECT_SECRET)
+
+
+async def register_shared_user(phone_number: str) -> PhotonUser:
+    """Register (or return the existing) project user for a phone number."""
+    auth = _auth()
+    users_url = f"{SPECTRUM_API_BASE}/projects/{auth[0]}/users/"
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS, auth=auth) as client:
+        resp = await client.post(users_url, json={"type": "shared", "phoneNumber": phone_number})
+        if resp.status_code < 400:
+            return PhotonUser.model_validate(resp.json()["data"])
+
+        # Registration is not idempotent on Photon's side — an already-registered
+        # phone fails, so fall back to finding the existing user record.
+        listing = await client.get(users_url)
+        listing.raise_for_status()
+        for raw in listing.json()["data"]:
+            user = PhotonUser.model_validate(raw)
+            if user.phoneNumber == phone_number:
+                return user
+
+    raise create_error(
+        message="Could not register your number for iMessage",
+        why=f"Photon user registration failed with HTTP {resp.status_code}",
+        fix="verify the Photon project credentials and plan user limit, then retry",
+        status_code=502,
+    )
+
+
+def redirect_deep_link(photon_user_id: str) -> str:
+    """Public Photon URL that 302s to the sms: deep link for the user's assigned number."""
+    return f"{SPECTRUM_API_BASE}/users/{photon_user_id}/redirect"

--- a/apps/api/app/services/platform_link_service.py
+++ b/apps/api/app/services/platform_link_service.py
@@ -13,13 +13,16 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
+from app.api.v1.middleware.tiered_rate_limiter import RateLimitExceededException
 from app.db.repositories.users import user_repository
+from app.models.payment_models import PlanType
 from app.models.platform_models import (
     DisconnectPlatformResponse,
     PlatformLinkEntry,
     PlatformLinkResult,
 )
 from app.models.user_models import PlatformLinkRecord, user_to_legacy_dict
+from app.services.payments.payment_service import payment_service
 
 
 class Platform(str, Enum):
@@ -29,6 +32,7 @@ class Platform(str, Enum):
     SLACK = "slack"
     TELEGRAM = "telegram"
     WHATSAPP = "whatsapp"
+    IMESSAGE = "imessage"
 
     @classmethod
     def is_valid(cls, platform: str) -> bool:
@@ -43,6 +47,22 @@ class Platform(str, Enum):
     def values(cls) -> list[str]:
         """Get list of all platform values."""
         return [p.value for p in cls]
+
+
+PREMIUM_PLATFORMS: frozenset[str] = frozenset({Platform.IMESSAGE.value})
+
+
+async def require_platform_plan(user_id: str, platform: str) -> None:
+    """Raise the standard 429 upsell when a free user tries to link a paid-only platform."""
+    if platform not in PREMIUM_PLATFORMS:
+        return
+    plan = await payment_service.get_cached_plan_type(user_id)
+    if plan == PlanType.FREE:
+        raise RateLimitExceededException(
+            feature=f"{platform}_linking",
+            plan_required=PlanType.PRO.value,
+            current_plan=plan.value,
+        )
 
 
 class PlatformLinkService:

--- a/apps/api/app/utils/notification/channels/__init__.py
+++ b/apps/api/app/utils/notification/channels/__init__.py
@@ -1,6 +1,7 @@
 from app.utils.notification.channels.base import ChannelAdapter, TContent
 from app.utils.notification.channels.discord import DiscordChannelAdapter
 from app.utils.notification.channels.external import ExternalPlatformAdapter
+from app.utils.notification.channels.imessage import ImessageChannelAdapter
 from app.utils.notification.channels.inapp import InAppChannelAdapter
 from app.utils.notification.channels.slack import SlackChannelAdapter
 from app.utils.notification.channels.telegram import TelegramChannelAdapter
@@ -10,6 +11,7 @@ __all__ = [
     "ChannelAdapter",
     "DiscordChannelAdapter",
     "ExternalPlatformAdapter",
+    "ImessageChannelAdapter",
     "InAppChannelAdapter",
     "SlackChannelAdapter",
     "TContent",

--- a/apps/api/app/utils/notification/channels/imessage.py
+++ b/apps/api/app/utils/notification/channels/imessage.py
@@ -1,0 +1,16 @@
+"""iMessage notification channel adapter.
+
+Publishes the message to the iMessage outbound queue; the iMessage bot process
+consumes it and sends via the Photon Spectrum SDK.
+"""
+
+from app.models.chat_models import ConversationSource
+from app.utils.notification.channels.external import ExternalPlatformAdapter
+
+
+class ImessageChannelAdapter(ExternalPlatformAdapter):
+    """Publishes notifications to the user's linked iMessage account's queue."""
+
+    @property
+    def platform(self) -> ConversationSource:
+        return ConversationSource.IMESSAGE

--- a/apps/api/app/utils/notification/orchestrator.py
+++ b/apps/api/app/utils/notification/orchestrator.py
@@ -35,6 +35,7 @@ from app.utils.notification.channel_preferences import fetch_channel_preferences
 from app.utils.notification.channels import (
     ChannelAdapter,
     DiscordChannelAdapter,
+    ImessageChannelAdapter,
     InAppChannelAdapter,
     SlackChannelAdapter,
     TContent,
@@ -71,6 +72,7 @@ class NotificationOrchestrator:
         self.register_channel_adapter(DiscordChannelAdapter())
         self.register_channel_adapter(WhatsAppChannelAdapter())
         self.register_channel_adapter(SlackChannelAdapter())
+        self.register_channel_adapter(ImessageChannelAdapter())
 
         # Action handlers
         self.register_action_handler(ApiCallActionHandler())

--- a/apps/api/tests/unit/api/test_platform_links_endpoint.py
+++ b/apps/api/tests/unit/api/test_platform_links_endpoint.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, patch
 from httpx import AsyncClient
 import pytest
 
-from app.models.platform_models import PlatformLinkResult
+from app.models.payment_models import PlanType
+from app.models.platform_models import DisconnectPlatformResponse, PlatformLinkResult
+from app.services.photon.photon_client import PhotonUser
 
 BASE = "/api/v1/platform-links"
 
@@ -342,3 +344,114 @@ class TestInitiatePlatformConnect:
     async def test_unauthenticated(self, unauthed_client: AsyncClient) -> None:
         resp = await unauthed_client.get(f"{BASE}/discord/connect")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# iMessage premium gate
+# ---------------------------------------------------------------------------
+
+PLAN_PATCH = "app.services.platform_link_service.payment_service.get_cached_plan_type"
+
+
+class TestImessagePremiumGate:
+    @pytest.mark.asyncio
+    async def test_free_user_link_returns_429_upsell(self, client: AsyncClient) -> None:
+        with patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.FREE):
+            resp = await client.post(f"{BASE}/imessage", json={"token": "tok123"})
+
+        assert resp.status_code == 429
+        detail = resp.json()["detail"]
+        assert detail["plan_required"] == "pro"
+        assert detail["current_plan"] == "free"
+
+    @pytest.mark.asyncio
+    async def test_free_user_connect_returns_429_upsell(self, client: AsyncClient) -> None:
+        with patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.FREE):
+            resp = await client.get(f"{BASE}/imessage/connect")
+
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["plan_required"] == "pro"
+
+    @pytest.mark.asyncio
+    async def test_pro_user_link_passes_gate(self, client: AsyncClient) -> None:
+        mock_redis = AsyncMock()
+        mock_redis.hgetall = AsyncMock(return_value={})
+
+        with (
+            patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO),
+            patch("app.api.v1.endpoints.platform_links.redis_cache") as mock_cache,
+        ):
+            mock_cache.client = mock_redis
+            resp = await client.post(f"{BASE}/imessage", json={"token": "tok123"})
+
+        # Gate passed; the request proceeds to token redemption and fails there.
+        assert resp.status_code == 400
+        assert "expired" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_free_user_can_still_disconnect(self, client: AsyncClient) -> None:
+        entry = {
+            "platform": "imessage",
+            "platformUserId": "+15551234567",
+            "username": None,
+            "displayName": None,
+            "connectedAt": "2026-01-01T00:00:00Z",
+        }
+        with (
+            patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.FREE),
+            patch(
+                "app.api.v1.endpoints.platform_links.PlatformLinkService.get_linked_platforms",
+                new_callable=AsyncMock,
+                return_value={"imessage": entry},
+            ),
+            patch(
+                "app.api.v1.endpoints.platform_links.PlatformLinkService.unlink_account",
+                new_callable=AsyncMock,
+                return_value=DisconnectPlatformResponse(status="disconnected", platform="imessage"),
+            ),
+            patch("app.api.v1.endpoints.platform_links.redis_cache") as mock_cache,
+        ):
+            mock_cache.client = AsyncMock()
+            resp = await client.delete(f"{BASE}/imessage")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "disconnected"
+
+    @pytest.mark.asyncio
+    async def test_pro_user_connect_missing_phone_422(self, client: AsyncClient) -> None:
+        with patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO):
+            resp = await client.get(f"{BASE}/imessage/connect")
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_pro_user_connect_returns_photon_deep_link(self, client: AsyncClient) -> None:
+        photon_user = PhotonUser(id="pu_123", phoneNumber="+15551234567")
+        with (
+            patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO),
+            patch(
+                "app.api.v1.endpoints.platform_links.register_shared_user",
+                new_callable=AsyncMock,
+                return_value=photon_user,
+            ) as mock_register,
+        ):
+            resp = await client.get(f"{BASE}/imessage/connect", params={"phone": "+15551234567"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["auth_type"] == "manual"
+        assert body["action_link"] == "https://spectrum.photon.codes/users/pu_123/redirect"
+        mock_register.assert_awaited_once_with("+15551234567")
+
+    @pytest.mark.asyncio
+    async def test_free_user_other_platforms_unaffected(self, client: AsyncClient) -> None:
+        with (
+            patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.FREE),
+            patch("app.api.v1.endpoints.platform_links.settings") as mock_settings,
+        ):
+            mock_settings.DISCORD_OAUTH_CLIENT_ID = None
+            mock_settings.SLACK_OAUTH_CLIENT_ID = None
+            mock_settings.TELEGRAM_BOT_USERNAME = "gaia_bot"
+            resp = await client.get(f"{BASE}/telegram/connect")
+
+        assert resp.status_code == 200

--- a/apps/api/tests/unit/utils/test_notification_storage.py
+++ b/apps/api/tests/unit/utils/test_notification_storage.py
@@ -110,6 +110,7 @@ class TestNormalizeChannelPreferences:
             "discord": True,
             "whatsapp": True,
             "slack": True,
+            "imessage": True,
             "email": True,
         }
 
@@ -121,6 +122,7 @@ class TestNormalizeChannelPreferences:
             "discord": True,
             "whatsapp": True,
             "slack": True,
+            "imessage": True,
             "email": True,
         }
 
@@ -182,6 +184,7 @@ class TestFetchChannelPreferences:
             "discord": True,
             "whatsapp": True,
             "slack": True,
+            "imessage": True,
             "email": True,
         }
 
@@ -199,6 +202,7 @@ class TestFetchChannelPreferences:
             "discord": True,
             "whatsapp": True,
             "slack": True,
+            "imessage": True,
             "email": True,
         }
 
@@ -217,5 +221,6 @@ class TestFetchChannelPreferences:
             "discord": True,
             "whatsapp": True,
             "slack": True,
+            "imessage": True,
             "email": True,
         }

--- a/apps/bots/__tests__/shared/utils/formatters.test.ts
+++ b/apps/bots/__tests__/shared/utils/formatters.test.ts
@@ -2,6 +2,7 @@ import type { Conversation, Todo, Workflow } from "@gaia/shared";
 import {
   buildAuthLinkMessage,
   convertToDiscordMarkdown,
+  convertToImessageText,
   convertToSlackMrkdwn,
   convertToTelegramHtml,
   convertToWhatsAppMarkdown,
@@ -431,6 +432,53 @@ describe("convertToWhatsAppMarkdown", () => {
 
   it("converts field values with **Name:** pattern to *Name:*", () => {
     expect(convertToWhatsAppMarkdown("**Name:** Aryan")).toBe("*Name:* Aryan");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertToImessageText
+// ---------------------------------------------------------------------------
+describe("convertToImessageText", () => {
+  it("strips **bold** markers", () => {
+    expect(convertToImessageText("Hello **world**")).toBe("Hello world");
+  });
+
+  it("strips ***bold italic*** markers", () => {
+    expect(convertToImessageText("***text***")).toBe("text");
+  });
+
+  it("converts [label](url) to label (url)", () => {
+    expect(convertToImessageText("[Click here](https://example.com)")).toBe(
+      "Click here (https://example.com)",
+    );
+  });
+
+  it("strips heading prefixes", () => {
+    expect(convertToImessageText("# My Heading")).toBe("My Heading");
+    expect(convertToImessageText("## Sub Heading")).toBe("Sub Heading");
+  });
+
+  it("strips inline code backticks", () => {
+    expect(convertToImessageText("run `pnpm install` now")).toBe(
+      "run pnpm install now",
+    );
+  });
+
+  it("converts - bullets to •", () => {
+    expect(convertToImessageText("- one\n- two")).toBe("• one\n• two");
+  });
+
+  it("strips > quote prefix", () => {
+    expect(convertToImessageText("> quoted text")).toBe("quoted text");
+  });
+
+  it("removes --- horizontal rule", () => {
+    expect(convertToImessageText("above\n---\nbelow")).toBe("above\n\nbelow");
+  });
+
+  it("preserves fenced code blocks unchanged", () => {
+    const input = "```\nconst x = 1; // **not bold**\n```";
+    expect(convertToImessageText(input)).toBe(input);
   });
 });
 

--- a/apps/bots/harness/src/emulation.ts
+++ b/apps/bots/harness/src/emulation.ts
@@ -51,6 +51,7 @@ const SUPPORTS_EDIT: Record<PlatformName, boolean> = {
   slack: true,
   telegram: true,
   whatsapp: false,
+  imessage: false,
 };
 
 /**

--- a/libs/shared/ts/src/bots/consumer/topology.ts
+++ b/libs/shared/ts/src/bots/consumer/topology.ts
@@ -28,6 +28,7 @@ export const OUTBOUND_QUEUES: Record<PlatformName, string> = {
   slack: `${OUTBOUND_QUEUE_PREFIX}slack`,
   telegram: `${OUTBOUND_QUEUE_PREFIX}telegram`,
   discord: `${OUTBOUND_QUEUE_PREFIX}discord`,
+  imessage: `${OUTBOUND_QUEUE_PREFIX}imessage`,
 };
 
 /** Dead-letter queue name for a work queue. */

--- a/libs/shared/ts/src/bots/index.ts
+++ b/libs/shared/ts/src/bots/index.ts
@@ -109,6 +109,7 @@ export {
   COMMAND_HELP,
   chunkResponse,
   convertToDiscordMarkdown,
+  convertToImessageText,
   convertToSlackMrkdwn,
   convertToTelegramHtml,
   convertToWhatsAppMarkdown,

--- a/libs/shared/ts/src/bots/types/index.ts
+++ b/libs/shared/ts/src/bots/types/index.ts
@@ -37,7 +37,7 @@ export interface ChatRequest {
   /** The message content to send. */
   message: string;
   /** The platform the message originated from. */
-  platform: "discord" | "slack" | "telegram" | "whatsapp";
+  platform: PlatformName;
   /** The user ID of the sender on the platform. */
   platformUserId: string;
   /** Optional channel ID where the conversation is happening. */
@@ -157,7 +157,7 @@ export interface BotConversationListResponse {
 }
 
 export interface BotUserContext {
-  platform: "discord" | "slack" | "telegram" | "whatsapp";
+  platform: PlatformName;
   platformUserId: string;
 }
 
@@ -206,7 +206,12 @@ export type SettingsResponse =
 // ---------------------------------------------------------------------------
 
 /** Supported platform names for bot integrations. */
-export type PlatformName = "discord" | "slack" | "telegram" | "whatsapp";
+export type PlatformName =
+  | "discord"
+  | "slack"
+  | "telegram"
+  | "whatsapp"
+  | "imessage";
 
 /**
  * A message that has been sent to a platform channel.

--- a/libs/shared/ts/src/bots/utils/formatters.ts
+++ b/libs/shared/ts/src/bots/utils/formatters.ts
@@ -401,6 +401,26 @@ export function convertToWhatsAppMarkdown(text: string): string {
 }
 
 /**
+ * iMessage renders no markup at all, so every markdown construct degrades to
+ * plain text: emphasis markers are stripped, links become `label (url)`,
+ * headings/quotes lose their prefixes. Fenced code blocks are preserved
+ * verbatim (content matters more than the stray backticks).
+ */
+export function convertToImessageText(text: string): string {
+  return applyOutsideCodeBlocks(text, (segment) =>
+    segment
+      .replaceAll(/^#{1,6}\s+(.+)$/gm, "$1")
+      .replaceAll(/^[-_*]{3,}$/gm, "")
+      .replaceAll(/\*\*\*([^*\n]+)\*\*\*/g, "$1")
+      .replaceAll(/\*\*([^*\n]+)\*\*/g, "$1")
+      .replaceAll(/`([^`\n]+)`/g, "$1")
+      .replaceAll(/\[([^\]]{1,500})\]\(([^)]{1,2048})\)/g, "$1 ($2)")
+      .replaceAll(/^(\s*)[*\-+]\s+/gm, "$1• ")
+      .replaceAll(/^>\s*/gm, ""),
+  );
+}
+
+/**
  * Discord renders CommonMark natively (bold, italic, headings, lists, code,
  * quotes), so the only transform it needs is masked links: Discord shows
  * `[label](url)` literally in regular message content — masked links render
@@ -429,6 +449,7 @@ export const PLATFORM_MARKDOWN: Record<PlatformName, (text: string) => string> =
     slack: convertToSlackMrkdwn,
     telegram: convertToTelegramHtml,
     whatsapp: convertToWhatsAppMarkdown,
+    imessage: convertToImessageText,
   };
 
 /**

--- a/libs/shared/ts/src/bots/utils/index.ts
+++ b/libs/shared/ts/src/bots/utils/index.ts
@@ -36,6 +36,7 @@ export {
   buildAuthLinkMessage,
   COMMAND_HELP,
   convertToDiscordMarkdown,
+  convertToImessageText,
   convertToSlackMrkdwn,
   convertToTelegramHtml,
   convertToWhatsAppMarkdown,

--- a/libs/shared/ts/src/bots/utils/media.ts
+++ b/libs/shared/ts/src/bots/utils/media.ts
@@ -42,6 +42,7 @@ export const OUTBOUND_FILE_LIMITS: Record<PlatformName, number> = {
   slack: 50 * MB,
   telegram: 50 * MB, // bot API sendDocument limit
   whatsapp: 100 * MB, // WhatsApp document limit
+  imessage: 50 * MB, // Photon caps are undocumented; conservative floor
 };
 
 /** Normalised media kind, identical across platforms. */

--- a/libs/shared/ts/src/bots/utils/streaming.ts
+++ b/libs/shared/ts/src/bots/utils/streaming.ts
@@ -26,7 +26,7 @@ import {
   NEW_MESSAGE_BREAK_TOKEN_LENGTH,
 } from "../../utils/messageBreakUtils";
 import type { GaiaClient } from "../api";
-import type { ChatRequest } from "../types";
+import type { ChatRequest, PlatformName } from "../types";
 import { formatBotError, PLATFORM_MARKDOWN } from "./formatters";
 
 import {
@@ -60,16 +60,13 @@ function formatApprovalPrompt(data: ApprovalRequestData): string {
 export interface StreamingOptions {
   editIntervalMs: number;
   streaming: boolean;
-  platform: "discord" | "slack" | "telegram" | "whatsapp";
+  platform: PlatformName;
 }
 
 export type MessageEditor = (text: string) => Promise<void>;
 export type NewMessageSender = (text: string) => Promise<MessageEditor>;
 
-export const STREAMING_DEFAULTS: Record<
-  "discord" | "slack" | "telegram" | "whatsapp",
-  StreamingOptions
-> = {
+export const STREAMING_DEFAULTS: Record<PlatformName, StreamingOptions> = {
   discord: {
     editIntervalMs: 1200,
     streaming: false,
@@ -89,6 +86,11 @@ export const STREAMING_DEFAULTS: Record<
     editIntervalMs: 2000,
     streaming: false,
     platform: "whatsapp",
+  },
+  imessage: {
+    editIntervalMs: 2000,
+    streaming: false,
+    platform: "imessage",
   },
 };
 

--- a/libs/shared/ts/src/bots/utils/text.ts
+++ b/libs/shared/ts/src/bots/utils/text.ts
@@ -7,6 +7,8 @@
  * a barrel <-> module import cycle.
  */
 
+import type { PlatformName } from "../types";
+
 /**
  * Parses whitespace-separated text into a subcommand and remaining args.
  * Used by Slack and Telegram command handlers where input is plain text.
@@ -51,11 +53,12 @@ export function extractSubcommandArgs(
  * that — we cap at 3000 (not the 4000 block limit) for readable bubbles, the
  * same headroom the per-channel Slack sender used before delivery moved here.
  */
-export const PLATFORM_LIMITS: Record<string, number> = {
+export const PLATFORM_LIMITS: Record<PlatformName, number> = {
   discord: 2000,
   slack: 3000,
   telegram: 4096,
   whatsapp: 4096,
+  imessage: 4096,
 };
 
 /**
@@ -63,13 +66,13 @@ export const PLATFORM_LIMITS: Record<string, number> = {
  * Truncates at word boundaries and optionally appends a web app link.
  *
  * @param text - The message text to truncate.
- * @param platform - The target platform (discord, slack, telegram, whatsapp).
+ * @param platform - The target platform.
  * @param conversationUrl - Optional URL to the full conversation on the web app.
  * @returns The truncated message.
  */
 export function truncateResponse(
   text: string,
-  platform: "discord" | "slack" | "telegram" | "whatsapp",
+  platform: PlatformName,
   conversationUrl?: string,
 ): string {
   const limit = PLATFORM_LIMITS[platform];
@@ -460,7 +463,7 @@ const MAX_RENDER_SHRINK_ITERS = 6;
  * the 4096-char API limit and the send is rejected.
  *
  * @param text - The full message text.
- * @param platform - The target platform (discord, slack, telegram, whatsapp).
+ * @param platform - The target platform.
  * @param render - Optional platform renderer; when given, chunk sizes are
  *   measured against the rendered output rather than the raw markdown.
  * @returns An array of chunks (raw markdown, in order); each is ≤ the platform
@@ -468,7 +471,7 @@ const MAX_RENDER_SHRINK_ITERS = 6;
  */
 export function chunkResponse(
   text: string,
-  platform: "discord" | "slack" | "telegram" | "whatsapp",
+  platform: PlatformName,
   render?: (chunk: string) => string,
 ): string[] {
   const limit = PLATFORM_LIMITS[platform];

--- a/libs/shared/ts/src/index.ts
+++ b/libs/shared/ts/src/index.ts
@@ -136,6 +136,7 @@ export {
   chunkResponse,
   conversationsCommand,
   convertToDiscordMarkdown,
+  convertToImessageText,
   convertToSlackMrkdwn,
   convertToTelegramHtml,
   convertToWhatsAppMarkdown,


### PR DESCRIPTION
Adds iMessage as a fifth bot platform using Photon's Spectrum (shared-pool iMessage API), gated to Pro subscribers.

**Done so far**
- Shared bot framework: `imessage` registered in `PlatformName` + every exhaustive platform record; plain-text markdown converter (+ tests)
- Backend: `ConversationSource.IMESSAGE`, platform link `Platform.IMESSAGE`, notification channel adapter, outbound queue (auto-derived)
- Premium gate: link/connect endpoints raise the standard 429 upsell (`plan_required: pro`) for free users — first plan-gated platform; disconnect never gated (+ red-first tests)
- Photon management client: shared-pool user registration + `sms:` deep link on connect

**Remaining (WIP)**
- `apps/bots/imessage` adapter package (Spectrum SDK outbound, HMAC webhook inbound)
- Web settings connect card with phone input + Pro chip
- Infra wiring (compose, nx release group, mise tasks), env examples, docs tables
- Live E2E against the real Photon line

Note: `nx lint api` has 94 pre-existing errors on master in files untouched here; all files in this diff pass ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187qnDP7yft1cRTQEQWjgvY