### PR TITLE
fix(ci): mutate each module against every test file that covers it, not one

### DIFF
--- a/apps/api/tests/unit/scripts/test_mutation_matrix.py
+++ b/apps/api/tests/unit/scripts/test_mutation_matrix.py
@@ -191,3 +191,81 @@ def test_is_comment_only_change_false_for_a_file_the_base_never_had(
     monkeypatch.chdir(tmp_path)
 
     assert mm._is_comment_only_change("mod.py", base_sha) is False
+
+
+# ---------------------------------------------------------------------------
+# with_unit_mirror — the gate mutates a module against EVERY referencing test
+# file, not one.
+#
+# Picking one was the defect: a module whose tests span several files was
+# measured against whichever the mirror-check or the sort happened to choose,
+# and every mutant only the discarded files covered was reported as "no
+# covering test" — informational, failing nothing. A module could pass the
+# gate having killed nothing at all.
+# ---------------------------------------------------------------------------
+
+
+def test_every_referencing_file_is_kept_not_just_the_first(tmp_path: Path) -> None:
+    hits = [
+        "apps/api/tests/unit/agents/test_handoff_brief.py",
+        "apps/api/tests/unit/tools/test_executor_tool.py",
+    ]
+
+    assert mm.with_unit_mirror("agents/tools/executor_tool", hits, tmp_path) == [
+        "tests/unit/agents/test_handoff_brief.py",
+        "tests/unit/tools/test_executor_tool.py",
+    ]
+
+
+def test_the_unit_mirror_leads_the_set_rather_than_replacing_it(tmp_path: Path) -> None:
+    # The mirror used to short-circuit the scan entirely — it never even
+    # computed the other hits. It is a member now, not an exit.
+    _write(tmp_path, "tests/unit/services/test_cost_budget.py", "")
+    hits = ["apps/api/tests/unit/middleware/test_accounting.py"]
+
+    assert mm.with_unit_mirror("services/cost_budget", hits, tmp_path) == [
+        "tests/unit/services/test_cost_budget.py",
+        "tests/unit/middleware/test_accounting.py",
+    ]
+
+
+def test_the_mirror_is_not_duplicated_when_it_also_references_the_module(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "tests/unit/services/test_cost_budget.py", "")
+    hits = [
+        "apps/api/tests/unit/services/test_cost_budget.py",
+        "apps/api/tests/unit/middleware/test_accounting.py",
+    ]
+
+    assert mm.with_unit_mirror("services/cost_budget", hits, tmp_path) == [
+        "tests/unit/services/test_cost_budget.py",
+        "tests/unit/middleware/test_accounting.py",
+    ]
+
+
+def test_a_module_with_no_referencing_file_and_no_mirror_selects_nothing(
+    tmp_path: Path,
+) -> None:
+    # Empty is what makes main() report "no test file anywhere" — the one
+    # case that must still fail the lane loudly.
+    assert mm.with_unit_mirror("services/orphan", [], tmp_path) == []
+
+
+def test_a_mirror_alone_is_enough_when_nothing_references_the_module(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "tests/unit/services/test_orphan.py", "")
+
+    assert mm.with_unit_mirror("services/orphan", [], tmp_path) == [
+        "tests/unit/services/test_orphan.py"
+    ]
+
+
+def test_entries_carry_the_whole_list_under_a_plural_key() -> None:
+    # Renamed from "testfile": a consumer still reading the old key now fails
+    # with a KeyError instead of silently iterating a string's characters.
+    entry = mm._entry("app/services/cost_budget.py", ["tests/unit/a.py", "tests/unit/b.py"], "")
+
+    assert entry["testfiles"] == ["tests/unit/a.py", "tests/unit/b.py"]
+    assert "testfile" not in entry

--- a/scripts/ci/mutation-matrix.py
+++ b/scripts/ci/mutation-matrix.py
@@ -9,13 +9,15 @@ when any test file imports it, imports from it, or names it in a string
 literal (patch target).
 
 Input:  changed app module paths on stdin (one per line, repo-root-relative).
-Output: {"modules": [{"module": ..., "testfile": ...}, ...]}
+Output: [{"module": ..., "testfiles": [...], "changed_lines": [...]}, ...]
+        Every test file referencing the module, not one — see with_unit_mirror.
 Exit 1 with a ::error message when a changed module has no test file.
 """
 
 from __future__ import annotations
 
 import ast
+from collections.abc import Sequence
 import io
 import json
 import os
@@ -230,6 +232,28 @@ def _test_files_for(module_rel: str, tests_dir: Path = TESTS_DIR) -> list[str]:
     return hits
 
 
+def with_unit_mirror(
+    module_rel: str, hits: Sequence[str], repo_root: Path = TESTS_DIR.parent
+) -> list[str]:
+    """Every test file for a module, its unit mirror first — the gate's full set.
+
+    The mirror used to short-circuit the scan instead of joining it: a module
+    that had one was measured against ONLY that file, and a module without one
+    against whichever hit sorted first. Either way the rest were discarded, so
+    mutants covered only by a discarded file were reported as "no covering
+    test" — informational, failing nothing. ``app/agents/tools/executor_tool.py``
+    is the extreme case: measured against the file the sort picked, all 65 of
+    its mutants land in that bucket and the gate reports OK having killed
+    nothing; measured against every referencing file, 24 real survivors appear
+    on lines the PR changed.
+    """
+    mirror = f"tests/unit/{Path(module_rel).parent}/test_{Path(module_rel).stem}.py"
+    ordered = [hit.removeprefix("apps/api/") for hit in hits]
+    if (repo_root / mirror).exists():
+        ordered = [mirror, *(hit for hit in ordered if hit != mirror)]
+    return ordered
+
+
 def main() -> int:
     changed = [line.strip() for line in sys.stdin if line.strip()]
     merge_base = _merge_base()
@@ -259,14 +283,11 @@ def main() -> int:
             continue
         rel_py = rel.removeprefix("app/")
         rel_py = rel_py.removesuffix(".py")
+        testfiles = with_unit_mirror(rel_py, _test_files_for(rel_py))
+        if testfiles:
+            matrix.append(_entry(rel, testfiles, merge_base))
+            continue
         unit_mirror = f"tests/unit/{Path(rel_py).parent}/test_{Path(rel_py).stem}.py"
-        if (TESTS_DIR.parent / unit_mirror).exists():
-            matrix.append(_entry(rel, unit_mirror, merge_base))
-            continue
-        hits = _test_files_for(rel_py)
-        if hits:
-            matrix.append(_entry(rel, hits[0].removeprefix("apps/api/"), merge_base))
-            continue
         failures.append(
             f"changed module {rel} has no test file anywhere (looked for {unit_mirror} "
             "and AST importers/patch targets). Changed code must ship tests."
@@ -279,7 +300,7 @@ def main() -> int:
     return 0
 
 
-def _entry(module_rel: str, testfile: str, merge_base: str) -> dict[str, object]:
+def _entry(module_rel: str, testfiles: list[str], merge_base: str) -> dict[str, object]:
     """Module matrix entry with the PR's changed line ranges for this file.
 
     The gate is diff-driven: a survivor only fails the lane when its mutation
@@ -288,7 +309,7 @@ def _entry(module_rel: str, testfile: str, merge_base: str) -> dict[str, object]
     coverage.
     """
     ranges = _changed_line_ranges(f"apps/api/{module_rel}", merge_base)
-    return {"module": module_rel, "testfile": testfile, "changed_lines": ranges}
+    return {"module": module_rel, "testfiles": testfiles, "changed_lines": ranges}
 
 
 def _changed_line_ranges(path: str, merge_base: str) -> list[list[int]]:

--- a/scripts/test/mutation-sweep.sh
+++ b/scripts/test/mutation-sweep.sh
@@ -40,6 +40,7 @@ echo "sweep: $TOTAL modules, $PARALLEL parallel"
 #    with no test anywhere are recorded as a finding (NO_TEST), not a failure.
 python3 - "$OUT_DIR/modules.txt" "$OUT_DIR/entries.txt" "$OUT_DIR/no-test.txt" << 'EOF'
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -103,19 +104,19 @@ def _tests_for(rel_py: str, seen: set[str] | None = None) -> list[str]:
 for module in Path(modules_file).read_text().splitlines():
     rel = module.removeprefix("apps/api/")
     rel_py = rel.removeprefix("app/").removesuffix(".py")
-    unit_mirror = f"tests/unit/{Path(rel_py).parent}/test_{Path(rel_py).stem}.py"
-    if (tests_dir / unit_mirror).exists():
-        entries.append((rel, unit_mirror))
-        continue
-    hits = _tests_for(rel_py)
-    if hits:
-        entries.append((rel, hits[0].removeprefix("apps/api/")))
+    # Same selection policy as the CI matrix, from the same function — this
+    # used to be a second copy of it, and its mirror check was dead besides
+    # (it joined "tests/unit/..." onto tests_dir, giving "tests/tests/unit/...").
+    # Run from apps/api, so the repo-relative paths are already correct here.
+    testfiles = mm.with_unit_mirror(rel_py, _tests_for(rel_py), Path("."))
+    if testfiles:
+        entries.append((rel, testfiles))
         continue
     no_test.append(rel)
 
 with open(entries_file, "w") as f:
-    for module, testfile in entries:
-        f.write(f"{module} {testfile}\n")
+    for module, testfiles in entries:
+        f.write(f"{module} {json.dumps(testfiles, separators=(',', ':'))}\n")
 with open(no_test_file, "w") as f:
     for module in no_test:
         f.write(f"{module}\n")
@@ -135,10 +136,10 @@ trap 'kill "$SAMPLER_PID" 2>/dev/null || true' EXIT
 # 4. Run the sweep with bounded parallelism; every verdict lands in its own
 #    log so the summary below can classify precisely.
 COUNT=0
-while read -r module testfile; do
+while read -r module testfiles; do
   COUNT=$((COUNT + 1))
   SLUG="$(echo "$module" | tr '/' '_')"
-  bash "$REPO_ROOT/scripts/test/mutation.sh" "$module" "$testfile" > "$OUT_DIR/$SLUG.log" 2>&1 &
+  bash "$REPO_ROOT/scripts/test/mutation.sh" "$module" "$testfiles" > "$OUT_DIR/$SLUG.log" 2>&1 &
   if [ "$(jobs -r -p | wc -l)" -ge "$PARALLEL" ]; then
     wait -n || true
   fi
@@ -154,7 +155,7 @@ SKIP=0
 FAIL=0
 NO_TEST="$(wc -l < "$OUT_DIR/no-test.txt" | tr -d ' ')"
 : > "$OUT_DIR/survivors.txt"
-while read -r module testfile; do
+while read -r module testfiles; do
   SLUG="$(echo "$module" | tr '/' '_')"
   LOG="$OUT_DIR/$SLUG.log"
   if grep -q "Mutation: OK" "$LOG"; then


### PR DESCRIPTION
`scripts/ci/mutation-matrix.py` picked **one** test file per module. 34 of the 52 modules on the branch that surfaced this have more than one, so the rest were discarded — and every mutant only a discarded file covered was reported as `no covering test`: informational, failing nothing.

Two code paths, both dropping files:

```python
if (TESTS_DIR.parent / unit_mirror).exists():
    matrix.append(_entry(rel, unit_mirror, merge_base))   # never computes the hit list at all
    continue
hits = _test_files_for(rel_py)
if hits:
    matrix.append(_entry(rel, hits[0].removeprefix("apps/api/"), merge_base))   # takes the first
```

## A module can pass this gate having proved nothing

`app/agents/tools/executor_tool.py`, measured against the file the current selection picks. Raw run output:

```
## app/agents/tools/executor_tool.py [GATE] rc=0
  tally             : 65 mutants — 65 no tests
  *** nothing killed AND nothing survived — no verdict was reached
  survived  ON-diff :    0
  survived  off-diff:    0
  no-tests  ON-diff :   24   <- UNTESTED CHANGED CODE
  no-tests  off-diff:   41
  untested changed lines: [190, 284, 285, 286, 287, 288, 289, 290, 291]
```

**Every one of its 65 mutants lands in `no tests`. Nothing killed, nothing survived, and the lane exits 0 printing `Mutation: OK`.** Add its own `tests/unit/tools/test_executor_tool.py` — which the lane never runs — and **24 real survivors appear on changed lines 190 and 284-291**.

The common case, from the same defect. `app/agents/tools/core/retrieval.py`:

```
  mirror tests/unit/agents/tools/core/test_retrieval.py exists=False
  hits(3): tests/unit/agents/test_tool_infra_runtime.py     <- hits[0], the only one that runs
           tests/unit/tools/test_retrieval.py               <- 41 tests, discarded
           tests/integration/agents/test_retrieve_tools_mcp.py  <- discarded
```

The mirror is absent, `agents/` sorts before `tools/`, and a 41-test file written for the module is discarded. Measured one file each: **3 survivors vs 140.**

A third shape: `app/override/langgraph_bigtool/create_agent.py` is measured against `test_agent_routing.py`, which contains **zero references** to `nudge_continue`, `MAX_COMPLETION_NUDGES` or `COMPLETION_NUDGE` — the feature whose lines the PR changed.

## This makes the gate stricter. That is the point.

Across those 52 modules, judged by the gate's own exit code:

| | today | with this fix |
|---|---|---|
| modules **failing** | 11 | **14** |
| changed-line mutants with **no covering test** | **125** | 4 |

The three extra failures are not new bugs — they are modules the gate currently passes without having tested them. On the same 21 red modules at one commit and one classifier, survivors go **219 → 226**; individual modules move both ways (`create_agent.py` −7, `cost_budget.py` **0 → 11**, green today only because the lane runs it against `test_accounting.py`, which never touches `record_model_call_usage`).

**Nothing measured before this lands is comparable to anything measured after** — the mutant count and the `no tests` bucket both shift, because the stats phase maps more tests onto more mutants.

## Method, and one limitation worth knowing

Survivors were resolved per mutant — each one walked back to its real source line through the module's AST — rather than inferred from a count. The resolver used for the on/off-diff split does **not** apply the gate's `LOGGING` and `EQUIV` exclusions, so its raw counts run *above* the gate's verdict. **Every figure in this description is therefore taken from the gate's own exit code, not from those counts.**

The union figures come from `tests/unit/**` only; e2e, integration and real-tier files were excluded from the measurement because some skip without `USE_REAL_SERVICES`, which keeps every survivor count an upper bound.

## What changed

- `with_unit_mirror()` — one shared helper: every referencing file, unit mirror first. The mirror joins the set instead of short-circuiting it.
- `testfile` → `testfiles`. Renamed deliberately: a consumer still reading the old key gets a `KeyError` instead of silently iterating a string's characters.
- `mutation-sweep.sh` carried a second copy of the same policy and now calls the helper. Its mirror branch was dead regardless — it joined `tests/unit/...` onto a `tests/` root, giving `tests/tests/unit/...`, which never exists.
- **No cap on the list.** A silent cap would recreate this bug with a bigger N. Across 78 measured runs cost tracked the size of the changed-line ranges, not the file count — `subagent_runner.py` has 8 referencing files and completed in 18s.

## Consequence worth reviewing

Some modules now pull in `tests/integration/**` files (e.g. `retrieval.py` gains `test_retrieve_tools_mcp.py`). The mutation lane runs with no service containers and no `USE_REAL_SERVICES`, so `tests/integration/real/` and `tests/contracts/` files skip at collection there — harmless, but they are in the list rather than filtered out, because filtering by tier is a cap by another name.

## Tests

Six new cases in `apps/api/tests/unit/scripts/test_mutation_matrix.py`, **all six verified red against master's version first** (`with_unit_mirror` missing; `_entry` still emitting the singular key), green after. Full file: 18 passed.

## Sequencing

**Do not merge before #1010's `mutation.sh` change** (arg 2 accepting a JSON array, both forms supported). That one is backward-compatible and can land first safely; this one on its own emits a list the current runner would treat as a single path, failing every module with "test file not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
