### PR TITLE
docs(pr): add a PR template and a writing-pull-requests skill

### DIFF
--- a/.claude/skills/ship-feature/references/screenshots-and-pr.md
+++ b/.claude/skills/ship-feature/references/screenshots-and-pr.md
@@ -21,50 +21,24 @@ the code cannot reach.
 
 ## Publishing
 
-The repo is public, so SHA-pinned raw URLs render in PR bodies. Screenshots
-travel on a dedicated branch so they never touch the PR diff:
-
-1. Create branch `screenshots/<feature-branch-name>` from `master` (GitHub
-   MCP `create_branch`). Nothing triggers CI on `screenshots/*`.
-2. Upload each PNG with `create_or_update_file` (base64 content) under
-   `<feature-branch-name>/`.
-3. Embed via the **commit SHA** from the upload response — immutable, and
-   unambiguous even with slashes in the branch name:
-   `https://raw.githubusercontent.com/theexperiencecompany/gaia/<sha>/<path>.png`
-4. Leave the branch in place after merge — the SHA-pinned URLs stay valid
-   only while the commit is reachable.
+Upload to the shared `pr-assets` branch and embed by raw URL — the mechanics,
+including the render-failure diagnosis, live in the **`pr-image-embedding`
+skill**. Do not invent a per-PR assets branch.
 
 ## The PR
 
-Title: `<type>(<optional scope>): <description>` — a CI check validates the
-type against the allowed list in `pr-naming-conventions.yml` (read the list
-there; it drifts). Base: `master`. If a repo PR template exists, fill it in
-— but the `## Before / After`, `## Verification`, and `## Not verified`
-sections below are mandatory evidence and always appear, template or not.
-With no template, use this body structure:
+Title, body, and section-by-section guidance are owned by the
+**`writing-pull-requests` skill** and the repo template it fills,
+`.github/pull_request_template.md`. Follow it — base `master`, Conventional
+Commit title, never merge.
 
-```markdown
-## What & why
-<the feature, the user problem, key decisions and any scope choices made>
+Two of that template's sections are non-negotiable for a ship-feature run,
+because this pipeline exists to produce the evidence behind them:
 
-## How it works
-<data flow end to end, files/layers touched>
-
-## Before / After
-| Surface | Before | After |
-|---|---|---|
-| <name> | <img src="...before.png" width="420"> | <img src="...after.png" width="420"> |
-
-## Verification
-- <each acceptance criterion, with how it was verified against the running app>
-- Journey driven end to end via agent-browser as the dev user: <summary>
-- Console and network clean on all driven pages: <yes / details>
-- Local gates green: lint / type-check / build / tests / code-quality lanes
-- <run mode used: --sim or --agent, and why>
-
-## Not verified
-<anything you could not exercise, stated plainly; "nothing" if nothing>
-```
+- **Screenshots** — the before/after table from the capture protocol above.
+- **How to verify** + **Not verified** — each acceptance criterion with how it
+  was exercised against the running app, the run mode used (`--sim` or
+  `--agent`) and why, and an honest list of what you could not drive.
 
 After opening the PR, subscribe to its activity and enter the drive-to-green
 loop (ci-and-review.md).

--- a/.claude/skills/writing-pull-requests/SKILL.md
+++ b/.claude/skills/writing-pull-requests/SKILL.md
@@ -1,179 +1,126 @@
 ---
 name: writing-pull-requests
 description: >
-  Write a GAIA pull request description that a first-time reader can actually
-  use — the template in .github/pull_request_template.md, what belongs in each
-  section, and the failure modes (session narration, commit lists, "CI is
-  green", missing screenshots, missing deploy steps, a fix with no root cause)
-  that make our PRs unreadable. Use whenever opening a PR, rewriting a PR body,
-  reviewing whether a description is good enough, or asked to "write the PR",
-  "open a PR", "update the PR description", or "clean up this PR body".
+  Write a GAIA pull request description someone can read cold — how to fill the
+  template in .github/pull_request_template.md, and the habits (session
+  narration, commit lists, "CI is green", missing screenshots, missing deploy
+  steps, a fix with no real root cause) that make our PRs unreadable. Use when
+  opening a PR, rewriting a PR body, or judging whether a description is good
+  enough.
 ---
 
 # Writing Pull Requests
 
-## The reader you are writing for
+## Who you are writing for
 
-One person: an engineer who has never seen this branch, was not in the session
-that produced it, and is reading the PR cold — during review, or a year later
-while bisecting a regression into it. They have the diff and the commit log
-already. What they do not have is **why this exists, what it does for a user,
-how to see it working, and what breaks if it is wrong.** That is the entire job
-of the body.
+An engineer who has never seen this branch, was not in the session that produced
+it, and is reading it cold — in review, or a year later while bisecting a
+regression into it. They already have the diff and the commit log. What they
+don't have is why this exists, what it does for a user, how to see it working,
+and what breaks if it's wrong. That's the whole job of the body.
 
-Two tests to apply to every line before you keep it:
+Two tests for every line:
 
-- **Will this still be true and useful after merge?** "CI is green", "all 11,379
-  tests pass", "94 pre-existing lint errors on master", "merge after #858",
-  "rebased onto develop" — all false or meaningless within a week. Cut them.
-- **Does this exist only because of the session that produced it?** "The user
-  then pointed out…", "first I tried X, then switched to Y", "18 commits of
-  small fixes", a `claude.ai/code/session_…` link, "please confirm this commit
-  is yours". None of it survives contact with a stranger. Cut it. And never
-  attribute the work to a tool — no "generated with Claude Code" footer, no
-  "written by Claude", no co-author trailer, in the body or the commits. Open questions get resolved before review or posted as a PR comment —
-  never parked in the description.
+- **Will this still be true after merge?** "CI is green", "all tests pass", "94
+  pre-existing lint errors on master", "merge this after the other PR" — false or
+  pointless within a week.
+- **Does it only exist because of the session that wrote it?** "Then I tried X
+  instead", "18 commits of small fixes", session links, "please confirm this
+  commit is yours". Never attribute the work to a tool either — no "generated
+  with" footer, no co-author trailer, in the body or the commits. Open questions
+  get resolved before review or posted as a comment, not parked in the body.
 
 ## How it should read
 
-Write it the way you would explain the change to a teammate standing at your
-desk: plain sentences, in order, with the reasoning connecting them. That is the
-target on both sides of a common failure — the wall of dense prose nobody
-finishes, and the stack of clipped fragments that technically lists everything
-and explains nothing.
+Explain it the way you would to a teammate at your desk: plain sentences, in
+order, with the reasoning connecting them. Two ways that goes wrong — the wall of
+prose nobody finishes, and clipped fragments that list everything and explain
+nothing. "Saved logins, lifecycle rule, recap nav" says nothing; "logins are
+saved per user and encrypted at rest, so a repeat task on the same site skips the
+sign-in" says what happened and why it matters.
 
-- **Prefer real sentences over telegraphic bullets.** "Saved logins, R2 lifecycle,
-  recap nav" tells a reader nothing. "Logins are saved per user and encrypted at
-  rest, so a repeat task on the same site skips the sign-in" tells them what
-  happened and why they should care. Bullets are for grouping parallel items, not
-  for compressing a thought until it stops being one.
-- **Length follows content, not habit.** A one-line fix gets a short paragraph. A
-  feature touching five surfaces gets a page. Neither gets padding, and neither
-  gets a lab notebook — if you find yourself writing round-by-round investigation
-  notes or a fourth result matrix, that belongs in a linked issue.
-- **Cut the jargon, or explain it once.** Internal names (`ModelLane`,
-  `DeltaChannel`, "the T3 batch"), acronyms, and infrastructure shorthand are
-  invisible walls to anyone outside the thread that invented them. Use the
-  product's own words where they exist, and gloss the term the first time you
-  genuinely need it.
-- **Say things the plain way.** "This was failing for every user on mobile" beats
-  "a regression in the mobile render path manifested". No marketing tone, no
-  self-congratulation, no hedging a fact you actually verified.
+Length follows content. A one-line fix gets a paragraph; a feature across five
+surfaces gets a page. Neither gets padding, and neither gets a lab notebook —
+round-by-round investigation notes belong in an issue. Skip internal shorthand or
+gloss it once; acronyms and service names are invisible walls to anyone outside
+the thread that invented them. And say things the plain way: "this was broken for
+every user on mobile", not "a regression manifested in the mobile render path".
 
 ## Process
 
-1. **Read the actual diff** (`git diff master...HEAD --stat`, then the substance)
-   — not your memory of writing it, and not the commit subjects.
-2. **Fill the repo template**, `.github/pull_request_template.md`. GitHub loads it
-   automatically in the web UI; from the CLI, start from the file:
-   `gh pr create --base master --title "…" --body-file <filled-copy>`.
-3. **Delete every section you cannot fill honestly.** An empty heading, or one
-   padded to look filled, is worse than no heading.
-4. **Title**: Conventional Commit, `type(scope): description`, validated in CI by
-   `.github/workflows/pr-naming-conventions.yml` — read the allowed types there.
-   Write it as the changelog line it will become.
-5. **Base is always `master`.** Never merge the PR yourself.
+1. Read the actual diff, not your memory of writing it and not the commit
+   subjects.
+2. Fill `.github/pull_request_template.md`. GitHub pre-fills it in the browser;
+   from the CLI, `gh pr create --base master --body-file <your-filled-copy>`.
+3. Delete every section you can't fill honestly. An empty or padded heading is
+   worse than no heading.
+4. Title: Conventional Commit, `type(scope): description` — CI validates the type
+   against `.github/workflows/pr-naming-conventions.yml`. Write it as the
+   changelog line it becomes.
+5. Base is always `master`. Never merge the PR yourself.
 
-## Section by section
+## The sections
 
-**Summary** — 2–4 sentences on the outcome, in the vocabulary of someone using
-the product. Mechanism comes later. Expand every internal name on first use:
-`ModelLane`, `HIL`, `DeltaChannel`, `root_request_id` mean nothing cold.
+**Summary** — 2–4 sentences on the outcome, in the words someone using the
+product would use. Mechanism comes later.
 
-**Why** — the concrete trigger, and it must be falsifiable. A good one names an
-incident, a measured number, or a broken invariant:
+**Why** — the concrete trigger: an incident, a measured number, a broken
+invariant, a user complaint. "Cleanup", "improves maintainability" and "better
+UX" are labels for a reason you haven't written down yet.
 
-> Proof from 2026-08-14: the master run's `trigger-web` job was skipped … yet
-> the frontend shipped anyway — the CI path contributed nothing. (#1013)
+**What changed** — grouped by surface (API / Web / Bots / Infra) so a reviewer
+can find their part. Summarize; don't inventory the diff.
 
-> **The core idea:** message counts are the wrong unit when one message can cost
-> 1000x another. (#855)
+**The bug** (fix PRs) — symptom, reproduction, root cause, fix, then the
+regression test and the gap that let it ship. The usual failure is a root cause
+narrated from a stack trace: "this typically happens when the user cancels
+mid-stream" is a hypothesis, and shipping it as fact means the next person debugs
+from a fiction. If you didn't reproduce it, write "inferred from the trace, not
+reproduced". Point at the code (`file.py:42`) or the commit that introduced it.
+Per CLAUDE.md's bug loop a fix ships with a test seen red first; if it doesn't,
+say so — silence reads as coverage that isn't there.
 
-"Cleanup", "improves maintainability", "better UX" are not reasons. They are
-labels for a reason you have not written down yet.
+**Screenshots** — required for anything user-visible, or the reviewer has to
+build the branch to see a modal. Real captures from the running app, same
+viewport on both sides, plus the empty and error states. Host them on the
+`pr-assets` branch (`pr-image-embedding` skill), never in the diff.
 
-**What changed** — grouped by surface (API / Web / Bots / Infra), bullets, so a
-reviewer can jump to what they own. Summarize; do not inventory. If a section
-restates the diff line by line, delete it.
+**How to verify** — instructions the reviewer can run ("start the API, send X,
+expect Y"), not a list of what you ran. Then say what you couldn't exercise.
+Naming the gap costs one line and is the fastest way to be trusted; claiming
+coverage you don't have is the fastest way to lose it.
 
-**The bug** (fix PRs) — four questions, answered in order, no exceptions:
-symptom → reproduce → root cause → fix, then the regression test and the gap that
-let it ship. This is the section our fix PRs most often fake. The common failure
-is a root cause narrated from a stack trace: "this typically occurs when the user
-cancels mid-stream" is a hypothesis, and shipping it as a cause means the next
-person debugs from a fiction. If you did not reproduce it, write **"inferred from
-the trace, not reproduced"** and let the reader calibrate. The bar to aim at:
+**Post-merge steps** — everything the diff can't do to itself: env vars and
+secrets, DNS or proxy config, migrations, index builds, one-off scripts, feature
+flags, dashboards, third-party settings. Ordered, executable, and clear about
+which effects are expected rather than failures. Then a rollback line: "revert
+this PR", plus whatever a revert won't undo — a deleted branch, a migrated
+collection, a rotated secret.
 
-> Every chat request in production was failing with `GraphUnavailableError` …
-> behind an opaque `KeyError`. Introduced in `fc937af60`. … **Why no test caught
-> it**: [the two exact fixture blind spots]. … reverting the fix → `None`
-> (BROKEN). (#1004)
-
-By the repo's bug loop (CLAUDE.md), a fix ships with a test seen **red** before
-the fix. If it does not, the PR says so out loud — #999 does this well ("No
-regression test for the stale-cache bug yet … calling it out rather than burying
-it"). Silence reads as coverage that does not exist.
-
-**Screenshots** — mandatory for anything user-visible. Real captures from the
-running app, identical viewport on both sides, plus empty/error states. Most of
-our UI PRs ship with none, and a reviewer then has to build the branch to see a
-modal. Host on the `pr-assets` branch per the `pr-image-embedding` skill — images
-in the diff are noise, and a per-PR assets branch is noise too.
-
-**How to verify** — written as instructions for the reviewer ("run `nx dev api`,
-send X, expect Y"), not as a trophy case of what you ran. Then **Not verified**,
-naming the surface you could not exercise. This is the highest-trust move
-available to you and it costs one line:
-
-> Reproduced? No. Proven by CI log timestamps + code path … a hermeticity fix
-> backed by stability evidence, not a deterministic regression test. (#966)
-
-**Post-merge steps** — everything the diff cannot do to itself: env vars and
-secrets, DNS/vhost/proxy config, migrations, index builds, one-off scripts,
-feature flags, dashboards, third-party console settings. Ordered and executable,
-in the shape #961 used:
-
-> 1. Verify the master push goes green end-to-end 2. Repoint every open
-> develop-based PR … 3. Delete `origin/develop` … 5. Expected: release-please may
-> open release PRs.
-
-Note which steps are expected side effects rather than failures. Then a
-**Rollback** line: "revert this PR", plus whatever a revert does not undo (a
-deleted branch, a migrated collection, a rotated secret).
-
-**Metrics** — optional, and only with a baseline and a method. Say whether the
-harness is committed. If the numbers came from a throwaway script, disclose it in
-those words rather than implying reproducibility:
-
-> The end-to-end figures quoted in this description are reported, not
-> reproducible from anything in this diff. (#997)
+**Metrics** — optional. Numbers need a baseline and a method, and you say whether
+the harness is committed. If they came from a throwaway script, write that
+plainly instead of implying anyone can reproduce them.
 
 **Risk** — the specific failure mode and its blast radius: who breaks, how
-visibly, how fast you would notice. "Low risk" is a rubber stamp.
+visibly, how fast you'd notice. "Low risk" is a rubber stamp.
 
-**Out of scope** — deliberate omissions, one line each. State the boundary; do
-not re-argue approaches you rejected. #1016's "**Out of scope (deliberate)**:
-mobile surfaces … group chats" is the right length.
+**Out of scope** — deliberate omissions, one line each. State the boundary; don't
+re-argue approaches you rejected.
 
-## Patterns worth reaching for
+## Two things worth adding when they fit
 
-- **A before/after table** for anything that changes behaviour, limits, or
-  permissions. It turns a 40-commit branch into something scannable, and it is
-  the single highest-value artifact in our best PRs (#850, #1009, #1020).
-- **One bolded core-idea sentence** carrying the whole rationale (#855).
-- **A gotcha callout** that saves the next engineer an afternoon — a real
-  constraint of the system, stated where they will hit it (#876).
-- **Naming the seam that makes the change safe**: "metering and enforcement live
-  in `LLMAccountingMiddleware` — the one seam every execution path passes
-  through, so no entry point can route around it" (#855). It answers "how do I
-  know this is complete?" before the reviewer asks.
+A **before/after table** for anything that changes behaviour, limits, or
+permissions — it turns a large branch into something scannable in seconds.
+
+And **the seam that makes the change safe**: "enforcement lives in the one
+middleware every execution path passes through, so no entry point can route
+around it". It answers "how do I know this is complete?" before the reviewer asks.
 
 ## Before you submit
 
-- A stranger can state, from the body alone: what this does, why, how to see it,
+- A stranger can say, from the body alone, what this does, why, how to see it,
   and what to do after merge.
-- Every claim is evidence, not vibes; everything unproven is labelled unproven.
-- No session artifacts, no commit lists, no ephemeral CI status, no open
-  questions parked in the body.
-- UI change → screenshots present. Infra/config change → post-merge steps
-  present. Fix → root cause and regression test present, or their absence stated.
+- Everything unproven is labelled unproven.
+- No session artifacts, no commit lists, no ephemeral CI status.
+- UI change → screenshots. Infra or config change → post-merge steps. Fix → root
+  cause and regression test, or an honest note that there isn't one.

--- a/.claude/skills/writing-pull-requests/SKILL.md
+++ b/.claude/skills/writing-pull-requests/SKILL.md
@@ -57,7 +57,8 @@ every user on mobile", not "a regression manifested in the mobile render path".
    here executes" are headings that cost the reader time and give nothing back.
    A rollback line earns its place only when a revert alone doesn't undo the
    change; a verify section only when there's something to run.
-4. Title: Conventional Commit, `type(scope): description` — CI validates the type
+4. Title: Conventional Commit, `type: description` or `type(scope): description`
+   — the scope is optional, so add one only when it says something. CI validates the type
    against `.github/workflows/pr-naming-conventions.yml`. Write it as the
    changelog line it becomes.
 5. Base is always `master`. Never merge the PR yourself.

--- a/.claude/skills/writing-pull-requests/SKILL.md
+++ b/.claude/skills/writing-pull-requests/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: writing-pull-requests
+description: >
+  Write a GAIA pull request description that a first-time reader can actually
+  use — the template in .github/pull_request_template.md, what belongs in each
+  section, and the failure modes (session narration, commit lists, "CI is
+  green", missing screenshots, missing deploy steps, a fix with no root cause)
+  that make our PRs unreadable. Use whenever opening a PR, rewriting a PR body,
+  reviewing whether a description is good enough, or asked to "write the PR",
+  "open a PR", "update the PR description", or "clean up this PR body".
+---
+
+# Writing Pull Requests
+
+## The reader you are writing for
+
+One person: an engineer who has never seen this branch, was not in the session
+that produced it, and is reading the PR cold — during review, or a year later
+while bisecting a regression into it. They have the diff and the commit log
+already. What they do not have is **why this exists, what it does for a user,
+how to see it working, and what breaks if it is wrong.** That is the entire job
+of the body.
+
+Two tests to apply to every line before you keep it:
+
+- **Will this still be true and useful after merge?** "CI is green", "all 11,379
+  tests pass", "94 pre-existing lint errors on master", "merge after #858",
+  "rebased onto develop" — all false or meaningless within a week. Cut them.
+- **Does this exist only because of the session that produced it?** "The user
+  then pointed out…", "first I tried X, then switched to Y", "18 commits of
+  small fixes", a `claude.ai/code/session_…` link, "please confirm this commit
+  is yours". None of it survives contact with a stranger. Cut it. And never
+  attribute the work to a tool — no "generated with Claude Code" footer, no
+  "written by Claude", no co-author trailer, in the body or the commits. Open questions get resolved before review or posted as a PR comment —
+  never parked in the description.
+
+## How it should read
+
+Write it the way you would explain the change to a teammate standing at your
+desk: plain sentences, in order, with the reasoning connecting them. That is the
+target on both sides of a common failure — the wall of dense prose nobody
+finishes, and the stack of clipped fragments that technically lists everything
+and explains nothing.
+
+- **Prefer real sentences over telegraphic bullets.** "Saved logins, R2 lifecycle,
+  recap nav" tells a reader nothing. "Logins are saved per user and encrypted at
+  rest, so a repeat task on the same site skips the sign-in" tells them what
+  happened and why they should care. Bullets are for grouping parallel items, not
+  for compressing a thought until it stops being one.
+- **Length follows content, not habit.** A one-line fix gets a short paragraph. A
+  feature touching five surfaces gets a page. Neither gets padding, and neither
+  gets a lab notebook — if you find yourself writing round-by-round investigation
+  notes or a fourth result matrix, that belongs in a linked issue.
+- **Cut the jargon, or explain it once.** Internal names (`ModelLane`,
+  `DeltaChannel`, "the T3 batch"), acronyms, and infrastructure shorthand are
+  invisible walls to anyone outside the thread that invented them. Use the
+  product's own words where they exist, and gloss the term the first time you
+  genuinely need it.
+- **Say things the plain way.** "This was failing for every user on mobile" beats
+  "a regression in the mobile render path manifested". No marketing tone, no
+  self-congratulation, no hedging a fact you actually verified.
+
+## Process
+
+1. **Read the actual diff** (`git diff master...HEAD --stat`, then the substance)
+   — not your memory of writing it, and not the commit subjects.
+2. **Fill the repo template**, `.github/pull_request_template.md`. GitHub loads it
+   automatically in the web UI; from the CLI, start from the file:
+   `gh pr create --base master --title "…" --body-file <filled-copy>`.
+3. **Delete every section you cannot fill honestly.** An empty heading, or one
+   padded to look filled, is worse than no heading.
+4. **Title**: Conventional Commit, `type(scope): description`, validated in CI by
+   `.github/workflows/pr-naming-conventions.yml` — read the allowed types there.
+   Write it as the changelog line it will become.
+5. **Base is always `master`.** Never merge the PR yourself.
+
+## Section by section
+
+**Summary** — 2–4 sentences on the outcome, in the vocabulary of someone using
+the product. Mechanism comes later. Expand every internal name on first use:
+`ModelLane`, `HIL`, `DeltaChannel`, `root_request_id` mean nothing cold.
+
+**Why** — the concrete trigger, and it must be falsifiable. A good one names an
+incident, a measured number, or a broken invariant:
+
+> Proof from 2026-08-14: the master run's `trigger-web` job was skipped … yet
+> the frontend shipped anyway — the CI path contributed nothing. (#1013)
+
+> **The core idea:** message counts are the wrong unit when one message can cost
+> 1000x another. (#855)
+
+"Cleanup", "improves maintainability", "better UX" are not reasons. They are
+labels for a reason you have not written down yet.
+
+**What changed** — grouped by surface (API / Web / Bots / Infra), bullets, so a
+reviewer can jump to what they own. Summarize; do not inventory. If a section
+restates the diff line by line, delete it.
+
+**The bug** (fix PRs) — four questions, answered in order, no exceptions:
+symptom → reproduce → root cause → fix, then the regression test and the gap that
+let it ship. This is the section our fix PRs most often fake. The common failure
+is a root cause narrated from a stack trace: "this typically occurs when the user
+cancels mid-stream" is a hypothesis, and shipping it as a cause means the next
+person debugs from a fiction. If you did not reproduce it, write **"inferred from
+the trace, not reproduced"** and let the reader calibrate. The bar to aim at:
+
+> Every chat request in production was failing with `GraphUnavailableError` …
+> behind an opaque `KeyError`. Introduced in `fc937af60`. … **Why no test caught
+> it**: [the two exact fixture blind spots]. … reverting the fix → `None`
+> (BROKEN). (#1004)
+
+By the repo's bug loop (CLAUDE.md), a fix ships with a test seen **red** before
+the fix. If it does not, the PR says so out loud — #999 does this well ("No
+regression test for the stale-cache bug yet … calling it out rather than burying
+it"). Silence reads as coverage that does not exist.
+
+**Screenshots** — mandatory for anything user-visible. Real captures from the
+running app, identical viewport on both sides, plus empty/error states. Most of
+our UI PRs ship with none, and a reviewer then has to build the branch to see a
+modal. Host on the `pr-assets` branch per the `pr-image-embedding` skill — images
+in the diff are noise, and a per-PR assets branch is noise too.
+
+**How to verify** — written as instructions for the reviewer ("run `nx dev api`,
+send X, expect Y"), not as a trophy case of what you ran. Then **Not verified**,
+naming the surface you could not exercise. This is the highest-trust move
+available to you and it costs one line:
+
+> Reproduced? No. Proven by CI log timestamps + code path … a hermeticity fix
+> backed by stability evidence, not a deterministic regression test. (#966)
+
+**Post-merge steps** — everything the diff cannot do to itself: env vars and
+secrets, DNS/vhost/proxy config, migrations, index builds, one-off scripts,
+feature flags, dashboards, third-party console settings. Ordered and executable,
+in the shape #961 used:
+
+> 1. Verify the master push goes green end-to-end 2. Repoint every open
+> develop-based PR … 3. Delete `origin/develop` … 5. Expected: release-please may
+> open release PRs.
+
+Note which steps are expected side effects rather than failures. Then a
+**Rollback** line: "revert this PR", plus whatever a revert does not undo (a
+deleted branch, a migrated collection, a rotated secret).
+
+**Metrics** — optional, and only with a baseline and a method. Say whether the
+harness is committed. If the numbers came from a throwaway script, disclose it in
+those words rather than implying reproducibility:
+
+> The end-to-end figures quoted in this description are reported, not
+> reproducible from anything in this diff. (#997)
+
+**Risk** — the specific failure mode and its blast radius: who breaks, how
+visibly, how fast you would notice. "Low risk" is a rubber stamp.
+
+**Out of scope** — deliberate omissions, one line each. State the boundary; do
+not re-argue approaches you rejected. #1016's "**Out of scope (deliberate)**:
+mobile surfaces … group chats" is the right length.
+
+## Patterns worth reaching for
+
+- **A before/after table** for anything that changes behaviour, limits, or
+  permissions. It turns a 40-commit branch into something scannable, and it is
+  the single highest-value artifact in our best PRs (#850, #1009, #1020).
+- **One bolded core-idea sentence** carrying the whole rationale (#855).
+- **A gotcha callout** that saves the next engineer an afternoon — a real
+  constraint of the system, stated where they will hit it (#876).
+- **Naming the seam that makes the change safe**: "metering and enforcement live
+  in `LLMAccountingMiddleware` — the one seam every execution path passes
+  through, so no entry point can route around it" (#855). It answers "how do I
+  know this is complete?" before the reviewer asks.
+
+## Before you submit
+
+- A stranger can state, from the body alone: what this does, why, how to see it,
+  and what to do after merge.
+- Every claim is evidence, not vibes; everything unproven is labelled unproven.
+- No session artifacts, no commit lists, no ephemeral CI status, no open
+  questions parked in the body.
+- UI change → screenshots present. Infra/config change → post-merge steps
+  present. Fix → root cause and regression test present, or their absence stated.

--- a/.claude/skills/writing-pull-requests/SKILL.md
+++ b/.claude/skills/writing-pull-requests/SKILL.md
@@ -52,8 +52,11 @@ every user on mobile", not "a regression manifested in the mobile render path".
    subjects.
 2. Fill `.github/pull_request_template.md`. GitHub pre-fills it in the browser;
    from the CLI, `gh pr create --base master --body-file <your-filled-copy>`.
-3. Delete every section you can't fill honestly. An empty or padded heading is
-   worse than no heading.
+3. Delete every section that doesn't apply — don't answer it with "none".
+   "Post-merge steps: none", "Rollback: revert this PR", "Not verified: nothing
+   here executes" are headings that cost the reader time and give nothing back.
+   A rollback line earns its place only when a revert alone doesn't undo the
+   change; a verify section only when there's something to run.
 4. Title: Conventional Commit, `type(scope): description` — CI validates the type
    against `.github/workflows/pr-naming-conventions.yml`. Write it as the
    changelog line it becomes.
@@ -65,11 +68,15 @@ every user on mobile", not "a regression manifested in the mobile render path".
 product would use. Mechanism comes later.
 
 **Why** — the concrete trigger: an incident, a measured number, a broken
-invariant, a user complaint. "Cleanup", "improves maintainability" and "better
-UX" are labels for a reason you haven't written down yet.
+invariant, a user complaint. A few sentences, not a wall — if it runs past a
+short paragraph you're arguing the case instead of stating it. "Cleanup",
+"improves maintainability" and "better UX" are labels for a reason you haven't
+written down yet.
 
 **What changed** — grouped by surface (API / Web / Bots / Infra) so a reviewer
-can find their part. Summarize; don't inventory the diff.
+can find their part. One or two lines per item: what it is now, and the one thing
+worth knowing about it. If a bullet needs a paragraph, the detail belongs in the
+diff or in Why.
 
 **The bug** (fix PRs) — symptom, reproduction, root cause, fix, then the
 regression test and the gap that let it ship. The usual failure is a root cause

--- a/.claude/skills/writing-pull-requests/SKILL.md
+++ b/.claude/skills/writing-pull-requests/SKILL.md
@@ -111,8 +111,10 @@ plainly instead of implying anyone can reproduce them.
 **Risk** — the specific failure mode and its blast radius: who breaks, how
 visibly, how fast you'd notice. "Low risk" is a rubber stamp.
 
-**Out of scope** — deliberate omissions, one line each. State the boundary; don't
-re-argue approaches you rejected.
+Don't add a section listing what you didn't do. A reader needs to know what the
+change is, not the shape of every change it isn't. The rare exception is a
+missing piece someone would otherwise assume is there — a surface the feature
+visibly skips — and that's one line inside Summary, not a heading.
 
 ## Two things worth adding when they fit
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ GAIA is an open source project, and we welcome contributions of all kinds:
 ## Pull Requests
 
 - Ensure code style, tests, and docs are up to date
-- Use the [PR template](https://docs.heygaia.io/developers/contributing#pr-description-template)
+- Fill in the PR template that loads automatically (`.github/pull_request_template.md`), deleting the sections that do not apply
 - No merge conflicts with `master` branch
 
 ## Code of Conduct

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -113,10 +113,6 @@ reported rather than reproducible from this diff, say exactly that. -->
 
 <!-- The specific failure mode and its blast radius — who breaks, how visibly. Not "low risk". -->
 
-## Out of scope
-
-<!-- Deliberate omissions, one line each. Do not re-argue rejected approaches. -->
-
 ## Related
 
 <!-- Closes #123 · Depends on #456 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,9 @@
 Write for someone who has never seen this branch, never saw the conversation that
 produced it, and is reading this PR for the first time — today, or a year from now.
 
-Delete every section that does not apply. An empty heading is worse than no heading.
+Delete every section that does not apply — do not answer it with "none". A heading
+that says "Post-merge steps: none" or "Not verified: nothing here executes" costs the
+reader time and gives nothing back.
 
 Write it like you would explain the change to a teammate: plain sentences, in order,
 with the reasoning connecting them. Not a wall of dense prose, and not clipped fragments
@@ -83,19 +85,20 @@ on both sides, plus the states that matter (empty, filled, error). Host them on 
 "I ran it and it passed". Cover the failure path too, not just the happy one. -->
 
 **Not verified:**
-<!-- What you could not exercise, stated plainly. "Nothing" if nothing. -->
+<!-- What you could not exercise, stated plainly. Drop the line if you exercised it all. -->
 
 ## Post-merge steps
 
 <!-- Everything that must happen outside this diff before it works in production: env vars and
 secrets, DNS/vhost/proxy config, migrations, index builds, one-off scripts, feature flags,
 dashboards, third-party settings. Ordered, executable, and specific about who runs it.
-Delete the section only if there is genuinely nothing. -->
+Nothing to do outside the diff? Delete the section — do not write "none". -->
 
 - [ ]
 
 **Rollback:**
-<!-- "Revert this PR" plus anything a revert does not undo. -->
+<!-- Only when a revert alone does not undo it: a deleted branch, a migrated collection,
+a rotated secret. Otherwise delete this line. -->
 
 ## Metrics
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,119 @@
+<!--
+Write for someone who has never seen this branch, never saw the conversation that
+produced it, and is reading this PR for the first time — today, or a year from now.
+
+Delete every section that does not apply. An empty heading is worse than no heading.
+
+Write it like you would explain the change to a teammate: plain sentences, in order,
+with the reasoning connecting them. Not a wall of dense prose, and not clipped fragments
+("saved logins, lifecycle rule, recap nav") that list everything and explain nothing.
+Skip the internal jargon, or explain the term the first time you need it.
+
+Do NOT include: commit-by-commit lists, tool-attribution footers or session links, "CI is green",
+"all tests pass", "lint is clean", pre-existing-lint caveats, stacked-PR merge order,
+approaches you tried and abandoned, or narration of the session ("then I was asked to…").
+The diff, the commit log, and the Checks tab already carry that, and it goes stale
+the moment this merges.
+-->
+
+## Summary
+
+<!-- 2–4 sentences. What this changes and what it means for a user or an operator.
+Lead with the outcome, not the mechanism. Expand any internal name the first time it appears. -->
+
+## Why
+
+<!-- The concrete trigger: the user problem, the incident, the measured number, the broken
+invariant. Not "cleanup" or "improves things". One sharp sentence beats a paragraph. -->
+
+## What changed
+
+<!-- Grouped by surface, bullets not prose. Enough for a reviewer to know which parts they
+own. Do not restate the diff file by file — it is one click away. -->
+
+### API
+
+### Web
+
+### Bots / Mobile
+
+### Infra
+
+---
+
+## The bug
+
+<!-- Delete this whole block on feature/refactor PRs. Every line here is mandatory on a fix. -->
+
+**Symptom** —
+<!-- What the user or operator actually saw. Quote the real error, not a paraphrase. -->
+
+**Reproduce** —
+<!-- Numbered steps that trigger it on master. If you never reproduced it, say so here. -->
+
+**Root cause** —
+<!-- The mechanism, with a `file.py:42` pointer or the commit that introduced it.
+If it is inferred from a trace rather than reproduced, label it "inferred, not reproduced". -->
+
+**The fix** —
+<!-- Why this is the root fix and not a workaround. -->
+
+**Regression test** —
+<!-- The test that now covers it, and confirmation it was seen failing before the fix.
+If there is none, say that plainly instead of leaving the line out. -->
+
+**Why the suite missed it** —
+<!-- The specific gap: no test on this path, assertion too weak, the broken part was mocked. -->
+
+---
+
+## Screenshots
+
+<!-- Required for any user-visible change. Real captures from the running app, same viewport
+on both sides, plus the states that matter (empty, filled, error). Host them on the
+`pr-assets` branch — never in the diff. See the `pr-image-embedding` skill. -->
+
+| Surface | Before | After |
+| --- | --- | --- |
+|  |  |  |
+
+## How to verify
+
+<!-- Imperative steps a reviewer can run themselves: "run X, do Y, expect Z" — not
+"I ran it and it passed". Cover the failure path too, not just the happy one. -->
+
+**Not verified:**
+<!-- What you could not exercise, stated plainly. "Nothing" if nothing. -->
+
+## Post-merge steps
+
+<!-- Everything that must happen outside this diff before it works in production: env vars and
+secrets, DNS/vhost/proxy config, migrations, index builds, one-off scripts, feature flags,
+dashboards, third-party settings. Ordered, executable, and specific about who runs it.
+Delete the section only if there is genuinely nothing. -->
+
+- [ ]
+
+**Rollback:**
+<!-- "Revert this PR" plus anything a revert does not undo. -->
+
+## Metrics
+
+<!-- OPTIONAL — delete unless you measured something. A number without a baseline and a method
+is not evidence. Say whether the harness is committed and reproducible; if the figures are
+reported rather than reproducible from this diff, say exactly that. -->
+
+| Metric | Before | After | How measured |
+| --- | --- | --- | --- |
+
+## Risk
+
+<!-- The specific failure mode and its blast radius — who breaks, how visibly. Not "low risk". -->
+
+## Out of scope
+
+<!-- Deliberate omissions, one line each. Do not re-argue rejected approaches. -->
+
+## Related
+
+<!-- Closes #123 · Depends on #456 -->


### PR DESCRIPTION
## Summary

Adds a pull request template that loads automatically on every new PR, and a
`writing-pull-requests` skill that says how to fill it in. The goal is narrow: a
PR body someone who has never seen the branch can read once and come away knowing
what changed, why, how to see it working, and what has to happen after merge.

## Why

Our PR descriptions are written for the person who just wrote the code, and they
go stale within a week. Across the last ~50 merged PRs the same things repeat:
narration of the session that produced the branch, commit-count trivia, stacked-PR
merge order, and "CI is green" three times in one body. Meanwhile UI-only PRs ship
without a screenshot, and most fix PRs give a root cause that was inferred from a
stack trace and never reproduced, with no regression test and no mention that
there isn't one.

## What changed

- **`.github/pull_request_template.md`** — loads automatically on new PRs. Summary,
  why, what changed, an optional bug block, screenshots, verification, post-merge
  steps, optional metrics, risk, out of scope. Guidance lives in HTML comments.
- **`.claude/skills/writing-pull-requests/`** — how to fill each section, what to
  cut, and the voice to write in.
- **`.claude/skills/ship-feature/references/screenshots-and-pr.md`** — dropped its
  rival PR format and its stale `screenshots/*` hosting steps; keeps the capture
  protocol and defers the rest.
- **`.github/CONTRIBUTING.md`** — points at the in-repo template.

## Risk

Documentation and agent instructions only. The realistic downside is a template
long enough that people skip sections instead of deleting them.
