### PR TITLE
fix(web): stop the infinite RSC prefetch loop on prod landing pages

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -119,6 +119,14 @@ const nextConfig = {
     },
   },
   experimental: {
+    // prefetchInlining stays OFF until OpenNext serves Next's segment-prefetch
+    // protocol (as of @opennextjs/cloudflare 1.20.2 it does not — peer dep tops
+    // out at Next 16.2.11). With it on, build-time RSC payloads carry the
+    // InliningHintsStale bit; OpenNext serves that same payload for every
+    // /_tree prefetch, so the client marks the route cache entry immediately
+    // stale and refetches in an infinite ~5 req/s loop for every viewport-
+    // visible <Link> (observed on heygaia.io /signup, 2026-08-18).
+    prefetchInlining: false,
     // optimizeCss stays OFF. Two reasons, both verified: (1) it crashes the
     // Cloudflare/OpenNext bundle (unconditional cpSync of .next/static/css,
     // which Turbopack doesn't emit -> ENOENT); (2) tested on a webpack build it

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -120,8 +120,9 @@ const nextConfig = {
   },
   experimental: {
     // prefetchInlining stays OFF until OpenNext serves Next's segment-prefetch
-    // protocol (as of @opennextjs/cloudflare 1.20.2 it does not — peer dep tops
-    // out at Next 16.2.11). With it on, build-time RSC payloads carry the
+    // protocol. As of @opennextjs/cloudflare 1.20.2 it does not: /_tree
+    // requests get the full build-time RSC payload back, with no
+    // x-nextjs-postponed header. With inlining on, that payload carries the
     // InliningHintsStale bit; OpenNext serves that same payload for every
     // /_tree prefetch, so the client marks the route cache entry immediately
     // stale and refetches in an infinite ~5 req/s loop for every viewport-

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -84,7 +84,7 @@
     "@next/mdx": "^16.3.0",
     "@next/third-parties": "^16.3.0",
     "@number-flow/react": "^0.6.1",
-    "@opennextjs/cloudflare": "^1.20.1",
+    "@opennextjs/cloudflare": "^1.20.2",
     "@openuidev/react-headless": "^0.8.2",
     "@openuidev/react-lang": "^0.2.8",
     "@openuidev/react-ui": "^0.11.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,8 +708,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@opennextjs/cloudflare':
-        specifier: ^1.20.1
-        version: 1.20.1(encoding@0.1.13)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))(wrangler@4.110.0)
+        specifier: ^1.20.2
+        version: 1.20.2(encoding@0.1.13)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))(wrangler@4.110.0)
       '@openuidev/react-headless':
         specifier: ^0.8.2
         version: 0.8.2(react@19.1.0)(zustand@5.0.14(@types/react@19.2.17)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)))
@@ -5377,17 +5377,17 @@ packages:
   '@nx/workspace@22.7.7':
     resolution: {integrity: sha512-tDSOWUEjTyEjoUKGSFyUGrFaCpScoFa8lRR0jorM169a3dA4iqwgkppcltR/uwklLw/aNSSW6J92DAzSRuOLnA==}
 
-  '@opennextjs/aws@4.0.2':
-    resolution: {integrity: sha512-nXQPT8GZDV+NWMJV9mD/Ywxyo+tCZfFvrR6jpEOYNcxK/AqiEDlJzPybGOrHUDWAYdR1b6tmh+MoR3VbqIao3w==}
+  '@opennextjs/aws@4.1.0':
+    resolution: {integrity: sha512-GuKkdUbnJhLvtwTiJlytNtWIcSYN3+Dzi+OusUlRgf+Ur7dGoXdzBopd+VFiSdTBduPOvr9lPFDg6BYNjEV3wQ==}
     hasBin: true
     peerDependencies:
-      next: '>=15.5.18 <16 || >=16.2.6'
+      next: '>=15.5.21 <16 || >=16.2.11'
 
-  '@opennextjs/cloudflare@1.20.1':
-    resolution: {integrity: sha512-T7yRoEmIdDQada0itRQmQ3cb9o9tWVg1193MviPWRX7XJulOQ6adz45ZgrJuzEPiwi+kMGnj9kozlNBlRNQZcw==}
+  '@opennextjs/cloudflare@1.20.2':
+    resolution: {integrity: sha512-iFBjABnaDk3be27F5EpxyMLMGPbVnnArFx5I3Y8Rf6BSx5nBV8h0UuJiMKrx3+whDU5ahIy4d8sfbvWvMiF1Kg==}
     hasBin: true
     peerDependencies:
-      next: '>=15.5.18 <16 || >=16.2.6'
+      next: '>=15.5.21 <16 || >=16.2.11'
       rclone.js: ^0.6.6
       wrangler: ^4.86.0
     peerDependenciesMeta:
@@ -25185,7 +25185,7 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@opennextjs/aws@4.0.2(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))':
+  '@opennextjs/aws@4.1.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -25208,11 +25208,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.1(encoding@0.1.13)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))(wrangler@4.110.0)':
+  '@opennextjs/cloudflare@1.20.2(encoding@0.1.13)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))(wrangler@4.110.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.0.2(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))
+      '@opennextjs/aws': 4.1.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.101.0))
       ci-info: 4.4.0
       cloudflare: 4.5.0(encoding@0.1.13)
       comment-json: 4.6.2
@@ -40875,7 +40875,7 @@ snapshots:
   terser@5.16.9:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 


### PR DESCRIPTION
## Summary

Every visitor whose viewport shows a signup link on the heygaia.io landing page fires `GET /signup?_rsc=...` roughly five times per second, forever — an infinite client-side prefetch loop that hammers the Cloudflare Worker from every open tab. This PR disables Next's `experimental.prefetchInlining` so the loop cannot trigger, and bumps `@opennextjs/cloudflare` 1.20.1 → 1.20.2.

## Why

The loop was noticed as a flood of prod requests initially blamed on PostHog (its session recorder patches `window.fetch`, so DevTools attributes every request to `posthog-recorder`). Reproduced in a clean tab with PostHog fully opted out: 154 prefetch requests in 25 seconds from a single idle landing page.

---

## The bug

**Symptom** — the prod landing page repeats `GET /signup?_rsc=<hash>` (header `Next-Router-Segment-Prefetch: /_tree`) ~5×/s for as long as a `/signup` link is in the viewport. Every request invokes the Worker (the route is excluded from static-asset promotion).

**Reproduce** —
1. Open https://heygaia.io in Chrome with the Network panel open, before this fix is deployed.
2. Stay on the hero section (the Sign Up button must be in view).
3. Watch `GET /signup?_rsc=...` repeat indefinitely.

**Root cause** — Next 16.3's prefetch-inlining feature (`experimental.prefetchInlining`, default `true`) marks the *build-time* RSC payload with an `InliningHintsStale` bit, because that payload is generated before `collectPrefetchHints` runs (`next/dist/esm/server/app-render/create-flight-router-state-from-loader-tree.js:38`). The client's segment cache is designed so that a follow-up `/_tree` segment-prefetch response always strips the bit (`collect-segment-data.js:606` — "the client should never see InliningHintsStale in a /_tree response"). But OpenNext on Cloudflare does not implement the segment-prefetch protocol — it serves the cached build-time payload (`x-opennext-cache: HIT`, `s-maxage=31536000`, no `x-nextjs-postponed` header) for every `/_tree` request. The client therefore sees the stale bit on every response, sets `staleAt = -1` on the route cache entry (`segment-cache/cache.js:815`), finds it expired on the next scheduler pass, and refetches — at network round-trip speed, forever.

Only `/signup` (and the other `EXCLUDE`d auth/locale routes in `scripts/promote-static-landing.mjs`) can loop: the promoted landing routes are served as static assets, whose HTML response to an RSC request is rejected by the client with a quiet 10-second retry instead.

**The fix** — turn off `experimental.prefetchInlining`. With it off, the stale-hints bit is never emitted into the build output, so the client caches the prefetch normally (5-minute stale time) and the loop cannot occur. This is the root fix for the current platform: the feature's contract requires a serving layer that answers segment-prefetch requests, and no released OpenNext version does (verified against prod: `/_tree` requests return the full build-time payload with no `x-nextjs-postponed` header; OpenNext's `prefetch-hints.json` change, opennextjs/opennextjs-cloudflare#1160, only avoids a manifest crash). The flag should be revisited when OpenNext ships real segment-prefetch support.

**Regression test** — none. The loop only exists in the interaction between a production client bundle and the Cloudflare serving layer; nothing in the repo's test tiers boots that combination. Verification is the manual prod check below.

**Why the suite missed it** — same reason: no tier exercises the deployed OpenNext/Cloudflare serving path, and `next dev` never prefetches links at all, so local runs cannot surface it.

## How to verify

After this deploys:

1. Open https://heygaia.io in a fresh tab with the Network panel filtered to `_rsc`.
2. Keep the hero Sign Up button in view for 60 seconds.
3. Expect exactly one `GET /signup?_rsc=...` (plus one per other in-view link), and no repeats.

**Not verified:** the fix itself has only been exercised as config validation (`next.config.mjs` loads, `prefetchInlining: false` resolves) — the loop's absence can only be confirmed against a deployed Cloudflare build, per the steps above.

## Risk

Disabling `prefetchInlining` forgoes a Next 16.3 prefetch optimization sitewide. On this stack it was never functional — the serving layer cannot answer the protocol it depends on — so the practical risk is limited to the 1.20.1 → 1.20.2 patch bump (upstream middleware path-encoding fixes). If navigation regresses, revert this PR.

