### PR TITLE
fix(chroma): make the put-batch write semaphore process-wide, not per-call

### DIFF
--- a/apps/api/app/constants/chroma.py
+++ b/apps/api/app/constants/chroma.py
@@ -5,6 +5,14 @@ Tunables for the ChromaDB-backed LangGraph store.
 """
 
 # Caps concurrent ChromaDB HTTP connections during a put batch to avoid
-# exhausting OS file descriptors (ENFILE 24) when a large batch fans out
-# all sockets at once.
-MAX_CONCURRENT_CHROMA_WRITES = 10
+# exhausting the container's open-file limit (EMFILE 24 — confirmed via
+# /proc/1/limits on gaia-backend: RLIMIT_NOFILE soft=1024) when a large batch
+# fans out all sockets at once. Upstream callers (chroma_tools_store.py,
+# chroma_triggers_store.py) already chunk into batches of 50, so that's the
+# real worst case this throttles; the shared chromadb httpx pool tolerates up
+# to 100 connections / 40 keepalive, so it isn't the binding constraint.
+# Baseline fd usage in prod is ~72, leaving ~950 of headroom, so 20 clears
+# even a pile-up of several concurrent batches with a wide margin, while
+# still meaningfully throttling below the 50-item batch that caused the
+# original crash.
+MAX_CONCURRENT_CHROMA_WRITES = 20

--- a/apps/api/app/constants/chroma.py
+++ b/apps/api/app/constants/chroma.py
@@ -5,14 +5,7 @@ Tunables for the ChromaDB-backed LangGraph store.
 """
 
 # Caps concurrent ChromaDB HTTP connections during a put batch to avoid
-# exhausting the container's open-file limit (EMFILE 24 — confirmed via
-# /proc/1/limits on gaia-backend: RLIMIT_NOFILE soft=1024) when a large batch
-# fans out all sockets at once. Upstream callers (chroma_tools_store.py,
-# chroma_triggers_store.py) already chunk into batches of 50, so that's the
-# real worst case this throttles; the shared chromadb httpx pool tolerates up
-# to 100 connections / 40 keepalive, so it isn't the binding constraint.
-# Baseline fd usage in prod is ~72, leaving ~950 of headroom, so 20 clears
-# even a pile-up of several concurrent batches with a wide margin, while
-# still meaningfully throttling below the 50-item batch that caused the
-# original crash.
+# EMFILE 24 (per-process fd limit, not system-wide ENFILE). gaia-backend's
+# RLIMIT_NOFILE soft limit is 1024 with ~72 fds baseline usage, so 20 clears
+# it with wide margin while still throttling below the 50-item worst-case batch.
 MAX_CONCURRENT_CHROMA_WRITES = 20

--- a/apps/api/app/constants/chroma.py
+++ b/apps/api/app/constants/chroma.py
@@ -4,8 +4,10 @@ ChromaDB Constants.
 Tunables for the ChromaDB-backed LangGraph store.
 """
 
-# Caps concurrent ChromaDB HTTP connections during a put batch to avoid
-# EMFILE 24 (per-process fd limit, not system-wide ENFILE). gaia-backend's
-# RLIMIT_NOFILE soft limit is 1024 with ~72 fds baseline usage, so 20 clears
-# it with wide margin while still throttling below the 50-item worst-case batch.
+# Caps concurrent ChromaDB HTTP connections process-wide (shared across every
+# _apply_put_ops call, not just within one batch — see loop_bound_semaphore
+# usage in chroma_store.py) to avoid EMFILE 24 (per-process fd limit, not
+# system-wide ENFILE). gaia-backend's RLIMIT_NOFILE soft limit is 1024 with
+# ~72 fds baseline usage, so 20 clears it with wide margin even when startup
+# fans out indexing across every provider toolkit concurrently.
 MAX_CONCURRENT_CHROMA_WRITES = 20

--- a/apps/api/app/db/chroma/chroma_store.py
+++ b/apps/api/app/db/chroma/chroma_store.py
@@ -33,6 +33,7 @@ from langgraph.store.base import (
 from app.constants.chroma import MAX_CONCURRENT_CHROMA_WRITES
 from app.constants.log_tags import LogTag
 from app.db.chroma.noop_embedding import NoOpEmbeddingFunction
+from app.utils.concurrency import loop_bound_semaphore
 from shared.py.wide_events import VectorContext, log
 
 # A filter value (or the item value it's compared against) is an arbitrary
@@ -535,7 +536,11 @@ class ChromaStore(BaseStore):
         if not tasks:
             return
 
-        sem = asyncio.Semaphore(MAX_CONCURRENT_CHROMA_WRITES)
+        # Process-wide, not per-call: concurrent _apply_put_ops calls (e.g. the
+        # startup catalog warmup fanning out over every provider toolkit) share
+        # this one semaphore, so the fd cap holds across callers, not just
+        # within a single batch.
+        sem = loop_bound_semaphore("chroma_put_batch", MAX_CONCURRENT_CHROMA_WRITES)
 
         async def _guarded(coro: Coroutine[Any, Any, None]) -> None:
             async with sem:

--- a/apps/api/tests/integration/db/test_chroma_store.py
+++ b/apps/api/tests/integration/db/test_chroma_store.py
@@ -24,6 +24,7 @@ Key production modules under test
 
 from __future__ import annotations
 
+import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -32,6 +33,7 @@ import chromadb
 from langgraph.store.base import GetOp, PutOp, SearchOp
 import pytest
 
+from app.constants.chroma import MAX_CONCURRENT_CHROMA_WRITES
 from app.db.chroma.chroma_store import ChromaStore
 from app.db.chroma.chroma_tools_store import (
     _build_put_operations,
@@ -494,6 +496,58 @@ class TestChromaStoreSearch:
         # The failed item should be absent.
         bad_results = await chroma_store.abatch([GetOp(namespace=ns, key=fail_key)])
         assert bad_results[0] is None
+
+    @pytest.mark.regression
+    async def test_concurrent_apply_put_ops_share_one_semaphore(self, chroma_store):
+        """Two concurrent _apply_put_ops calls must share one process-wide
+        semaphore (loop_bound_semaphore), not each get their own local one —
+        otherwise the fd cap doubles for every concurrent caller (e.g. the
+        startup catalog warmup fanning out over every provider toolkit).
+        """
+        batch_size = MAX_CONCURRENT_CHROMA_WRITES
+        in_flight = 0
+        max_in_flight = 0
+        lock = asyncio.Lock()
+
+        original_upsert_item = type(chroma_store)._upsert_item
+
+        async def tracked_upsert(self_arg, doc_id, op, collection):
+            nonlocal in_flight, max_in_flight
+            async with lock:
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+            try:
+                await asyncio.sleep(0.02)
+                return await original_upsert_item(self_arg, doc_id, op, collection)
+            finally:
+                async with lock:
+                    in_flight -= 1
+
+        ops_a = [
+            PutOp(
+                namespace=("sem_a",),
+                key=f"tool_{i}",
+                value={"description": "x", "tool_hash": f"a{i}"},
+            )
+            for i in range(batch_size)
+        ]
+        ops_b = [
+            PutOp(
+                namespace=("sem_b",),
+                key=f"tool_{i}",
+                value={"description": "x", "tool_hash": f"b{i}"},
+            )
+            for i in range(batch_size)
+        ]
+
+        with patch.object(type(chroma_store), "_upsert_item", tracked_upsert):
+            await asyncio.gather(chroma_store.abatch(ops_a), chroma_store.abatch(ops_b))
+
+        assert max_in_flight <= MAX_CONCURRENT_CHROMA_WRITES, (
+            f"saw {max_in_flight} concurrent writes across two batches, expected at "
+            f"most {MAX_CONCURRENT_CHROMA_WRITES} — the semaphore isn't shared across "
+            "concurrent _apply_put_ops calls"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the ChromaDB put-batch concurrency throttle introduced in #920: the semaphore meant to cap concurrent ChromaDB writes was recreated inside every `_apply_put_ops` call, so it bounded concurrency within one batch but not across concurrent callers — the real-world worst case (startup indexing fanning out across every provider toolkit) could open up to 2x the intended number of sockets. Also raises the cap itself from 10 to 20, grounded in the container's actual open-file limit instead of an unverified guess.

## Why

#920 fixed a crash where `_apply_put_ops` opened unlimited concurrent sockets to ChromaDB (`Errno 24` on the API container) by wrapping writes in an `asyncio.Semaphore`. But that semaphore was a local variable created fresh on every call, so it only bounded one batch at a time.

In production, `populate_provider_catalog` (`registry.py:479`) fans out `asyncio.gather` over every composio-managed toolkit (23 today) at startup, each independently calling into `_apply_put_ops`. On a cold Redis cache, all 23 can cache-miss and hit ChromaDB concurrently, each with its own full budget instead of sharing one. The original fd math only considered a single batch: confirmed on the prod `gaia-backend` container via `/proc/1/limits`, `RLIMIT_NOFILE` soft=1024 with ~72 fds baseline usage — the real worst case (up to 23 concurrent callers, each with their own budget) sits far closer to that ceiling than a single-batch view suggested.

## What changed

### API

- `app/db/chroma/chroma_store.py`: the put-batch semaphore now comes from `loop_bound_semaphore` (`app/utils/concurrency.py`), the process-wide-semaphore helper already used by `query_json_tool.py` and `crawl4ai_utils.py`, so the cap holds across every concurrent caller sharing the event loop instead of resetting per call.
- `app/constants/chroma.py`: `MAX_CONCURRENT_CHROMA_WRITES` 10 → 20 (the original value had no stated derivation); comment now records the measured ceiling.

## The bug

**Symptom** — Not observed in production. Found while auditing the semaphore's actual scope against real call patterns, before it caused an incident.

**Reproduce** — Two concurrent `_apply_put_ops` calls, each with a batch the size of `MAX_CONCURRENT_CHROMA_WRITES`. See `test_concurrent_apply_put_ops_share_one_semaphore` in `tests/integration/db/test_chroma_store.py`.

**Root cause** — `sem = asyncio.Semaphore(MAX_CONCURRENT_CHROMA_WRITES)` was a local variable inside `_apply_put_ops`, so every call got its own independent budget instead of sharing one process-wide cap.

**The fix** — Replace the local semaphore with `loop_bound_semaphore("chroma_put_batch", MAX_CONCURRENT_CHROMA_WRITES)`, the codebase's existing helper for exactly this (a process-wide `asyncio.Semaphore`, correctly rebound across event loops for tests).

**Regression test** — `test_concurrent_apply_put_ops_share_one_semaphore`: confirmed red on the pre-fix code (saw 40 concurrent writes across two 20-item batches — double the cap), green after the fix (capped at 20).

**Why the suite missed it** — The original #920 tests only exercised a single `_apply_put_ops` call in isolation; nothing tested two concurrent calls together, so the per-call scoping bug had no path to surface.

## How to verify

- `cd apps/api && uv run pytest tests/integration/db/test_chroma_store.py -q` — 33 tests pass, including the new regression test.
- To re-verify the fd ceiling directly on prod: `docker exec $(docker ps --filter name=gaia-backend -q | head -1) sh -c 'cat /proc/1/limits | grep -i "open files"'`.

## Risk

The semaphore mechanism changes from local to shared, but the failure mode if the cap is ever still too high is the same one #920 already handles (EMFILE from too many concurrent sockets) — this only tightens that guarantee, it doesn't remove it. `loop_bound_semaphore` is already exercised elsewhere in the codebase, so this isn't new machinery.

## Related

Follows up on #920
