### PR TITLE
fix(infra): mount /mnt/jfs from the gaia_jfs_v2 JuiceFS plugin volume

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -1224,23 +1224,15 @@ volumes:
   #     -o backup-meta=1h -o cache-size=4096 \
   #     -o max-uploads=20 -o prefetch=8 -o buffer-size=600 \
   #     gaia_jfs_v2
-  # One `-o key=value` per flag: the released plugin has no `mountFlags` key and
-  # forwards it verbatim as `--mountFlags=...`, which `juicefs mount` rejects.
-  # No -o cache-dir (that path is absent from the plugin rootfs → mount EOF), and
-  # no -o all-squash: it squashes the plugin's own `touch /mnt/jfs/.juicefs`
-  # readiness probe down to uid 1000, which cannot write the root-owned .juicefs
-  # left by an earlier mount — the plugin then reports `exec: already started`
-  # and fails Mount on top of a daemon that did mount, leaking it. It buys
-  # nothing here: the volume root is 0777 and the API already runs as uid 1000.
-  # Confirm a fresh volume before pointing services at it — `stat -c %i /mnt/jfs`
-  # must be 1; anything else is node-local disk, not JuiceFS.
+  # One -o per flag: the released plugin has no `mountFlags` key. No -o cache-dir
+  # (absent from the plugin rootfs → mount EOF) and no -o all-squash (squashes
+  # the plugin's own root `touch .juicefs` readiness probe to uid 1000, which
+  # then can't write it → `exec: already started` and a failed Mount over a live
+  # daemon). Verify with `stat -c %i /mnt/jfs` == 1 before repointing the mounts.
   #
   # metaurl is baked in here, NOT read from JUICEFS_META_URL_TEMPLATE. Changing
-  # the metadata engine in Infisical moves the API and sandboxes but leaves this
-  # mount on the old engine — create a *new* volume, verify it, then point the
-  # two `source:` lines above at it and redeploy. Don't `docker volume rm` the
-  # live one to reuse its name: the plugin's Remove only os.Remove()s the
-  # mountpoint (EBUSY while mounted), and it's the rollback anchor.
+  # the metadata engine in Infisical leaves this mount on the old one — create a
+  # new volume, verify it, repoint. Don't rm the live one to reuse its name.
   #
   # --backup-meta belongs here, not in scripts/docker-entrypoint.sh: the plugin
   # mounts /mnt/jfs first, so the entrypoint's own mount short-circuits on

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -83,9 +83,9 @@ services:
     volumes:
       # JuiceFS via the official juicedata/juicefs volume plugin (Swarm-native).
       # The plugin holds the FUSE privilege; this container stays unprivileged
-      # (no /dev/fuse, no SYS_ADMIN). Volume `gaia_jfs` is pre-created per node.
+      # (no /dev/fuse, no SYS_ADMIN). Volume `gaia_jfs_v2` is pre-created per node.
       - type: volume
-        source: gaia_jfs
+        source: gaia_jfs_v2
         target: /mnt/jfs
         volume:
           nocopy: true
@@ -163,9 +163,9 @@ services:
     volumes:
       # JuiceFS via the official juicedata/juicefs volume plugin (Swarm-native).
       # The plugin holds the FUSE privilege; this container stays unprivileged
-      # (no /dev/fuse, no SYS_ADMIN). Volume `gaia_jfs` is pre-created per node.
+      # (no /dev/fuse, no SYS_ADMIN). Volume `gaia_jfs_v2` is pre-created per node.
       - type: volume
-        source: gaia_jfs
+        source: gaia_jfs_v2
         target: /mnt/jfs
         volume:
           nocopy: true
@@ -631,7 +631,7 @@ services:
   # ---------------------------------------------------------------------------
   # Holds the whole directory tree, filenames and inode→chunk mapping. R2 stores
   # only anonymous blocks, so losing this loses the filesystem — hence
-  # noeviction, appendfsync always, and the hourly dump on the gaia_jfs volume.
+  # noeviction, appendfsync always, and the hourly dump on the gaia_jfs_v2 volume.
   # Internet-reachable because E2B sandboxes mount JuiceFS directly
   # (apps/api/scripts/mount_juicefs.sh); AUTH password + firewall allowlist on
   # 6380 are the access control.
@@ -1215,26 +1215,37 @@ volumes:
   prometheus_data:
   promtail_positions:
   # AOF survives a crash, not the loss of this node — that's what --backup-meta
-  # on gaia_jfs below covers.
+  # on gaia_jfs_v2 below covers.
   jfs_meta_data:
   # JuiceFS volume backed by the juicedata/juicefs plugin. Pre-create per node:
   #   docker volume create -d juicedata/juicefs -o name=gaia-0 \
   #     -o metaurl='rediss://:PASSWORD@jfs-meta.heygaia.io:6380/0' \
   #     -o access-key=... -o secret-key=... \
-  #     -o mountFlags="--backup-meta 1h --cache-size 4096 --max-uploads 20 --prefetch 8 --buffer-size 600" \
-  #     gaia_jfs
-  # (no -o mountFlags --cache-dir: that path doesn't exist in the plugin → mount EOF)
+  #     -o backup-meta=1h -o cache-size=4096 \
+  #     -o max-uploads=20 -o prefetch=8 -o buffer-size=600 \
+  #     gaia_jfs_v2
+  # One `-o key=value` per flag: the released plugin has no `mountFlags` key and
+  # forwards it verbatim as `--mountFlags=...`, which `juicefs mount` rejects.
+  # No -o cache-dir (that path is absent from the plugin rootfs → mount EOF), and
+  # no -o all-squash: it squashes the plugin's own `touch /mnt/jfs/.juicefs`
+  # readiness probe down to uid 1000, which cannot write the root-owned .juicefs
+  # left by an earlier mount — the plugin then reports `exec: already started`
+  # and fails Mount on top of a daemon that did mount, leaking it. It buys
+  # nothing here: the volume root is 0777 and the API already runs as uid 1000.
+  # Confirm a fresh volume before pointing services at it — `stat -c %i /mnt/jfs`
+  # must be 1; anything else is node-local disk, not JuiceFS.
   #
   # metaurl is baked in here, NOT read from JUICEFS_META_URL_TEMPLATE. Changing
   # the metadata engine in Infisical moves the API and sandboxes but leaves this
-  # mount on the old engine — the volume must be dropped and recreated per node:
-  #   docker service scale gaia-prod_gaia-backend=0 gaia-prod_arq_worker=0
-  #   docker volume rm gaia_jfs && docker volume create ... (as above)
+  # mount on the old engine — create a *new* volume, verify it, then point the
+  # two `source:` lines above at it and redeploy. Don't `docker volume rm` the
+  # live one to reuse its name: the plugin's Remove only os.Remove()s the
+  # mountpoint (EBUSY while mounted), and it's the rollback anchor.
   #
   # --backup-meta belongs here, not in scripts/docker-entrypoint.sh: the plugin
   # mounts /mnt/jfs first, so the entrypoint's own mount short-circuits on
   # `mountpoint -q` and its flags never apply in prod. Dumps land under `meta/`.
-  gaia_jfs:
+  gaia_jfs_v2:
     external: true
 
 networks:

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -157,8 +157,9 @@ if [ "$_jfs_can_mount" = "1" ] && command -v juicefs >/dev/null 2>&1; then
         # Host mount only — sandbox clients pass 0 (mount_juicefs.sh) since the
         # host is already the single GC owner.
         # Skipped entirely in Swarm prod: the volume plugin mounts $JFS_MOUNT_PATH
-        # first so `mountpoint -q` short-circuits. Prod's interval is in the
-        # gaia_jfs mountFlags. This path serves selfhost / dockered-dev.
+        # first so `mountpoint -q` short-circuits. Prod's interval is the
+        # `-o backup-meta=1h` option on the gaia_jfs_v2 volume. This path serves
+        # selfhost / dockered-dev.
         # No --writeback: writeback loses data on container kill, unacceptable for agent writes.
         # `|| true`: --background's readiness probe gives up after ~10s, but on a
         # remote meta (e.g. Neon / cloud Postgres) the daemon often needs longer


### PR DESCRIPTION
## Summary

Production's `/mnt/jfs` is not JuiceFS. It is an empty directory on the node's local disk, and has been since 2026-08-10, so every user workspace operation in `gaia-backend` and `arq_worker` fails with `Permission denied`. This points both services at `gaia_jfs_v2`, a real `juicedata/juicefs` plugin volume that has been created and verified on the prod node, and rewrites the volume comment block, which documented two `docker volume create` recipes that cannot work.

## Why

`/mnt/jfs` inside both running containers reports `/dev/sda1` ext4, `ino=276586`, `drwxr-xr-x 0:0` — node-local disk, not a JuiceFS mount. In the two hours of retained log there were 369 permission errors on the API and 44 on the worker, and `workspace_sync.done` reported `scanned: 356, synced: 0`. All 344 user workspaces are intact in R2 and the metadata engine; nothing could be written to the wrong place because `nocopy: true` made the failure loud rather than silently redirecting writes to node disk.

## What changed

### Infra

- `gaia-backend` and `arq_worker` mount `gaia_jfs_v2` instead of `gaia_jfs`; the volume declaration renames with them. `nocopy: true` stays — it is what turned this into a visible EACCES instead of silent local-disk writes.
- The volume comment block now documents the create command that actually works: one `-o key=value` per flag, no `-o mountFlags`, no `-o all-squash`, plus the `stat -c %i /mnt/jfs` check that distinguishes a real mount from a conjured local volume.
- The metadata-engine-change note no longer tells you to `docker volume rm` the live volume; it tells you to create a new one, verify it, and repoint the two `source:` lines.
- `scripts/docker-entrypoint.sh` comment: prod's `--backup-meta` interval comes from `-o backup-meta=1h` on the volume, not from a `mountFlags` string.

---

## The bug

**Symptom** — `[Errno 13] Permission denied: '/mnt/jfs/users'` on every workspace create, and `workspace_sync.done → scanned: 356, synced: 0, skipped: 0` on every sync pass.

**Reproduce** — On a node where `gaia_jfs` was never pre-created with the plugin driver, deploy the stack. Docker creates the named volume on demand with the default `local` driver, and:

1. `docker volume inspect gaia_jfs --format '{{.Driver}}'` → `local`
2. `docker exec <gaia-backend> stat -c '%i %A %u:%g' /mnt/jfs` → `276586 drwxr-xr-x 0:0`
3. Any workspace create → `EACCES`, because the container runs as uid 1000 against a root-owned `0755` directory.

**Root cause** — `gaia_jfs` is `external: true` and pre-created by hand per node. That manual step did not happen on this node, so Docker conjured a `local` volume with the same name. `nocopy: true` (`infra/docker/docker-compose.prod.yml:90`) suppressed the image-content copy, so the volume root kept `root:root 0755` instead of inheriting `appuser` from the image's pre-chowned `/mnt/jfs`.

Two earlier attempts to repair the volume on this node failed for a second, independent reason, and that is why the previous fix recipe is wrong. `-o all-squash=1000:1000` rewrites the *caller's* identity in every FUSE request (`pkg/fuse/context.go:71-75`) and disables the kernel permission check. That includes the plugin's own readiness probe, `touch /mnt/jfs/.juicefs`, which runs as root — squashed to uid 1000 it cannot write the `-rw-r--r-- root root` `.juicefs` left behind by an earlier mount. The plugin then retries the *same* `exec.Cmd`, so the real EACCES is replaced by `exec: already started`, `Mount` fails, and the already-mounted juicefs daemon is leaked. `all-squash` was never needed here: the JuiceFS root is `0777` and the API already runs as uid 1000.

**The fix** — Mount a volume that is actually backed by the plugin. `gaia_jfs_v2` was created on the prod node with the corrected option set (no `all-squash`) and verified before this PR was opened: `ino=1`, `drwxrwxrwx`, `.config` present, 344 user directories, 341 skills directories, and `mkdir` as uid 1000 succeeding both at the root and inside `users/` (probe directories removed afterwards). A new name rather than a recreated `gaia_jfs` keeps `docker volume rm` out of the critical path and leaves the broken volume as a rollback anchor.

**Regression test** — None in this PR; nothing here is exercisable from the test suite. The code-level guard is a follow-up, described under Post-merge steps.

**Why the suite missed it** — Three layers each swallowed the failure and none of them are covered by a test that could fail. `_is_mounted()` (`apps/api/app/services/storage/juicefs.py:34-49`) only asks whether the path is a mountpoint, and a bind-mounted local volume is one — zero `JuiceFSUnavailable` were raised in the entire retained log. `workspace_sync` catches a broad `Exception` per user and its summary event has no failure count, so `synced: 0` of 356 logs at INFO. `system_workspace.py:113-122` catches `OSError` and degrades to per-user copies. And no alert watches the storage layer at all — the JuiceFS-adjacent rules in `alert-rules.yaml` watch `jfs-meta-redis` liveness, which was healthy throughout.

---

## How to verify

Nothing in this diff is testable locally; it takes effect at deploy. After the deploy:

1. `docker exec $(docker ps -q -f name=gaia-backend) stat -c '%i %A' /mnt/jfs` → must print `1 drwxrwxrwx`. Any other inode means the mount is not JuiceFS and the deploy must be rolled back.
2. `docker exec $(docker ps -q -f name=gaia-backend) ls /mnt/jfs/users | wc -l` → 344 or more.
3. `workspace_sync.done` must report `synced > 0` out of ~356; it is `0` today.
4. The `Permission denied: '/mnt/jfs/users'` count must stop growing.

Failure path: if step 1 gives anything but inode 1, revert this commit and redeploy rather than debugging live — `gaia_jfs` is untouched and empty, so the rollback is lossless.

**Not verified:** the refcount hazard. Both services mount the same volume on one node, and in every published plugin build `Unmount` runs unconditionally with no refcount guard, so redeploying `arq_worker` alone can pull `/mnt/jfs` out from under a running `gaia-backend` (fixed upstream in `94d04619`, which is in no published tag). It is plain in the source but I never observed it — every mount test on the node used a single container. It is not made worse by this PR; it exists on `gaia_jfs` today.

## Post-merge steps

- [ ] **Before merging**, confirm `gaia_jfs_v2` exists on every node that schedules `gaia-backend` / `arq_worker`. It exists and is verified on the current prod node; any node added later needs the `docker volume create` from the compose comment. This is the one step CI cannot do — an `external: true` volume is never created by `stack deploy`.
- [ ] Nothing else to trigger: merging *is* the deploy. `infra/docker/docker-compose.prod.yml` marks `api` affected (`nx show projects --affected --files=infra/docker/docker-compose.prod.yml` → `["docker","voice-agent","api"]`), so the push to master runs main.yml → build.yml → `deploy-swarm-prod`, which runs `docker stack deploy` against the prod context. Swarm recreates only the two services whose spec changed.
- [ ] Run the four verification checks above.
- [ ] Once prod is confirmed healthy, remove the now-unused `gaia_jfs` local volume — separately, so it stays available as a rollback anchor until then.
- [ ] Separate PR, not folded in here so each is independently revertible: `_is_mounted()` asserting `st_ino == 1` so a conjured local volume raises `JuiceFSUnavailable` instead of a mystery EACCES; a `failed` count on `workspace_sync.done` with a raised level when `synced == 0`; and a storage alert rule, since nothing currently alerts on `/mnt/jfs` not being JuiceFS.

**Rollback:** revert this commit and redeploy. `gaia_jfs` is left in place and its `_data` directory is empty, so no state moves either way.

## Risk

Both services deploy `order: start-first` with `failure_action: rollback`, and the new tasks mount a *different* volume name than the old ones, so there is no window where the two fight over one mountpoint and no real downtime. If `gaia_jfs_v2` is missing or unmountable on the node, the new task never becomes healthy, Swarm rolls the service back to `gaia_jfs`, and the workflow's convergence step fails the run — prod ends up exactly as broken as it is today, not worse. The residual risk is the one below under Not verified: with both services now on the same plugin volume and no refcount guard in the released plugin, a later solo redeploy of `arq_worker` can disturb `gaia-backend`'s mount.


