### PR TITLE
fix(imessage): show the number to text instead of an Apple-only deep link

### DIFF
--- a/apps/api/app/api/v1/endpoints/platform_links.py
+++ b/apps/api/app/api/v1/endpoints/platform_links.py
@@ -328,8 +328,9 @@ async def initiate_platform_connect(
         log.set(outcome="success", auth_type="manual")  # pragma: no mutate
         return InitiatePlatformConnectResponse(
             auth_type="manual",
-            instructions="Open the link on your iPhone or Mac, then text /auth to your GAIA iMessage number to link your account.",
+            instructions="Text /auth to your GAIA iMessage number from the phone you just registered.",
             action_link=redirect_deep_link(photon_user.id),
+            contact_number=photon_user.assignedPhoneNumber,
         )
 
     raise HTTPException(status_code=501, detail=f"{platform} OAuth not configured")

--- a/apps/api/app/models/platform_models.py
+++ b/apps/api/app/models/platform_models.py
@@ -130,3 +130,6 @@ class InitiatePlatformConnectResponse(BaseModel):
     action_link: str | None = Field(
         default=None, description="Optional deep-link for manual auth (e.g. Telegram bot URL)"
     )
+    contact_number: str | None = Field(
+        default=None, description="Number the user sends the linking command to (manual auth)"
+    )

--- a/apps/api/app/services/photon/photon_client.py
+++ b/apps/api/app/services/photon/photon_client.py
@@ -25,6 +25,7 @@ _RETRY_FIX = "verify the Photon project credentials and plan user limit, then re
 class PhotonUser(BaseModel):
     id: str
     phoneNumber: str
+    assignedPhoneNumber: str
 
 
 class _ListedPhotonUser(PhotonUser):

--- a/apps/api/tests/unit/api/test_platform_links_endpoint.py
+++ b/apps/api/tests/unit/api/test_platform_links_endpoint.py
@@ -456,7 +456,9 @@ class TestImessagePremiumGate:
 
     @pytest.mark.asyncio
     async def test_pro_user_connect_returns_photon_deep_link(self, client: AsyncClient) -> None:
-        photon_user = PhotonUser(id="pu_123", phoneNumber="+15551234567")
+        photon_user = PhotonUser(
+            id="pu_123", phoneNumber="+15551234567", assignedPhoneNumber="+14155955082"
+        )
         with (
             patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO),
             patch(
@@ -480,15 +482,41 @@ class TestImessagePremiumGate:
         assert body["auth_type"] == "manual"
         assert body["auth_url"] is None
         assert body["instructions"] == (
-            "Open the link on your iPhone or Mac, then text /auth to your GAIA iMessage "
-            "number to link your account."
+            "Text /auth to your GAIA iMessage number from the phone you just registered."
         )
         assert body["action_link"] == "https://spectrum.photon.codes/users/pu_123/redirect"
         mock_register.assert_awaited_once_with("+15551234567")
 
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_pro_user_connect_returns_the_number_to_text(self, client: AsyncClient) -> None:
+        """The deep link is an Apple-only `sms:` URL — a desktop browser opens it to a
+        blank tab. The number the user has to text must reach the client as data."""
+        photon_user = PhotonUser(
+            id="pu_123", phoneNumber="+15551234567", assignedPhoneNumber="+14155955082"
+        )
+        with (
+            patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO),
+            patch(
+                "app.api.v1.endpoints.platform_links.register_shared_user",
+                new_callable=AsyncMock,
+                return_value=photon_user,
+            ),
+            patch(
+                "app.api.v1.endpoints.platform_links.register_pending_imessage_number",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resp = await client.post(f"{BASE}/imessage/connect", json={"phone": "+15551234567"})
+
+        assert resp.status_code == 200
+        assert resp.json()["contact_number"] == "+14155955082"
+
     @pytest.mark.asyncio
     async def test_pro_user_connect_charges_registration_quota(self, client: AsyncClient) -> None:
-        photon_user = PhotonUser(id="pu_123", phoneNumber="+15551234567")
+        photon_user = PhotonUser(
+            id="pu_123", phoneNumber="+15551234567", assignedPhoneNumber="+14155955082"
+        )
         with (
             patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO),
             patch(
@@ -535,7 +563,9 @@ class TestImessagePremiumGate:
         self, client: AsyncClient
     ) -> None:
         """Unrecorded, an abandoned registration holds its pool seat forever."""
-        photon_user = PhotonUser(id="pu_123", phoneNumber="+15551234567")
+        photon_user = PhotonUser(
+            id="pu_123", phoneNumber="+15551234567", assignedPhoneNumber="+14155955082"
+        )
         with (
             patch(PLAN_PATCH, new_callable=AsyncMock, return_value=PlanType.PRO),
             patch("app.api.v1.endpoints.platform_links.enforce_rate_limit", new_callable=AsyncMock),

--- a/apps/api/tests/unit/services/photon/test_photon_client.py
+++ b/apps/api/tests/unit/services/photon/test_photon_client.py
@@ -30,6 +30,8 @@ PYDANTIC_DOC_URL = "https://errors.pydantic.dev"
 
 PHONE = "+9779743679108"
 USERS_URL = "https://spectrum.photon.codes/projects/pid/users/"
+# The pool line Photon assigns the user — the number they text, not their own.
+POOL_NUMBER = "+14155955082"
 
 PHOTON_USER_PAYLOAD = {
     "succeed": True,
@@ -38,7 +40,7 @@ PHOTON_USER_PAYLOAD = {
         "projectId": "d5b07b02-0000-4000-8000-000000000000",
         "type": "shared",
         "phoneNumber": PHONE,
-        "assignedPhoneNumber": "+14155955082",
+        "assignedPhoneNumber": POOL_NUMBER,
         "createdAt": "2026-08-14T19:19:47.168Z",
     },
 }
@@ -50,7 +52,7 @@ def _listed_user(user_id: str, phone_number: str, user_type: str = "shared") -> 
         "projectId": "d5b07b02-0000-4000-8000-000000000000",
         "type": user_type,
         "phoneNumber": phone_number,
-        "assignedPhoneNumber": "+14155955082",
+        "assignedPhoneNumber": POOL_NUMBER,
         "createdAt": "2026-08-14T19:19:47.168Z",
     }
 
@@ -104,6 +106,7 @@ class TestRegisterSharedUser:
         assert user == PhotonUser(
             id="63506fde-32a7-4da9-bfe1-a88f6c25d52a",
             phoneNumber=PHONE,
+            assignedPhoneNumber=POOL_NUMBER,
         )
         assert [(r.method, str(r.url)) for r in seen] == [("POST", USERS_URL)]
         assert json.loads(seen[0].content) == {"type": "shared", "phoneNumber": PHONE}

--- a/apps/web/src/config/botPlatforms.ts
+++ b/apps/web/src/config/botPlatforms.ts
@@ -24,6 +24,8 @@ export const BOT_PLATFORM_ICONS: Record<BotPlatform, string> = {
   discord: "/images/icons/macos/discord.webp",
 };
 
+export const BOT_AUTH_COMMAND = "/auth";
+
 export function isBotPlatform(value: string): value is BotPlatform {
   return (BOT_PLATFORMS as readonly string[]).includes(value);
 }

--- a/apps/web/src/features/settings/components/LinkedAccountsSettings.tsx
+++ b/apps/web/src/features/settings/components/LinkedAccountsSettings.tsx
@@ -93,6 +93,10 @@ export default function LinkedAccountsSettings() {
   const [phoneLinkTarget, setPhoneLinkTarget] =
     useState<PhoneLinkTarget | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Registering a number takes a round trip to Photon. Closing the modal (or
+  // starting over) invalidates that request, so a late reply cannot drop the
+  // previous attempt's number into the session the user is now in.
+  const connectAttemptRef = useRef(0);
   const { data: subscriptionStatus } = useUserSubscriptionStatus();
   const openPricingModal = usePricingModalStore((s) => s.openModal);
 
@@ -143,6 +147,7 @@ export default function LinkedAccountsSettings() {
   };
 
   const handleConnect = async (platformId: string, phoneNumber?: string) => {
+    const attempt = ++connectAttemptRef.current;
     try {
       setConnectingPlatform(platformId);
 
@@ -159,6 +164,8 @@ export default function LinkedAccountsSettings() {
         phoneNumber ? { phone: phoneNumber } : {},
         { silent: true },
       );
+
+      if (attempt !== connectAttemptRef.current) return;
 
       if (data.auth_url) {
         const width = 600;
@@ -224,6 +231,7 @@ export default function LinkedAccountsSettings() {
         setConnectingPlatform(null);
       }
     } catch {
+      if (attempt !== connectAttemptRef.current) return;
       toast.error(`Failed to connect ${platformId}`);
       setConnectingPlatform(null);
     }
@@ -350,6 +358,8 @@ export default function LinkedAccountsSettings() {
           if (phoneModalPlatform) handleConnect(phoneModalPlatform, phone);
         }}
         onClose={() => {
+          connectAttemptRef.current += 1;
+          setConnectingPlatform(null);
           setPhoneModalPlatform(null);
           setPhoneLinkTarget(null);
           fetchPlatformLinks();

--- a/apps/web/src/features/settings/components/LinkedAccountsSettings.tsx
+++ b/apps/web/src/features/settings/components/LinkedAccountsSettings.tsx
@@ -2,18 +2,18 @@
 
 import { Button } from "@heroui/button";
 import { Chip } from "@heroui/chip";
-import { Input } from "@heroui/input";
-import {
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-} from "@heroui/modal";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import { BOT_PLATFORM_ICONS, BOT_PLATFORM_LABELS } from "@/config/botPlatforms";
+import {
+  BOT_AUTH_COMMAND,
+  BOT_PLATFORM_ICONS,
+  BOT_PLATFORM_LABELS,
+} from "@/config/botPlatforms";
 import { useUserSubscriptionStatus } from "@/features/pricing/hooks/usePricing";
+import {
+  PhoneLinkModal,
+  type PhoneLinkTarget,
+} from "@/features/settings/components/PhoneLinkModal";
 import { SettingsPage } from "@/features/settings/components/ui/SettingsPage";
 import { SettingsRow } from "@/features/settings/components/ui/SettingsRow";
 import { SettingsSection } from "@/features/settings/components/ui/SettingsSection";
@@ -21,8 +21,6 @@ import { apiService } from "@/lib/api/service";
 import { toast } from "@/lib/toast";
 import { usePricingModalStore } from "@/stores/pricingModalStore";
 import type { PlatformLink } from "@/types/platform";
-
-const E164_PHONE_PATTERN = /^\+[1-9]\d{6,14}$/;
 
 interface PlatformConfig {
   id: string;
@@ -91,7 +89,8 @@ export default function LinkedAccountsSettings() {
   const [phoneModalPlatform, setPhoneModalPlatform] = useState<string | null>(
     null,
   );
-  const [phone, setPhone] = useState("");
+  const [phoneLinkTarget, setPhoneLinkTarget] =
+    useState<PhoneLinkTarget | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const { data: subscriptionStatus } = useUserSubscriptionStatus();
   const openPricingModal = usePricingModalStore((s) => s.openModal);
@@ -130,7 +129,7 @@ export default function LinkedAccountsSettings() {
       return;
     }
     if (platform.requiresPhone) {
-      setPhone("");
+      setPhoneLinkTarget(null);
       setPhoneModalPlatform(platform.id);
       return;
     }
@@ -145,6 +144,7 @@ export default function LinkedAccountsSettings() {
         auth_url?: string;
         instructions?: string;
         action_link?: string;
+        contact_number?: string;
         auth_type: string;
       }>(
         `/platform-links/${platformId}/connect`,
@@ -172,6 +172,15 @@ export default function LinkedAccountsSettings() {
             setConnectingPlatform(null);
           }
         }, 500);
+      } else if (data.contact_number) {
+        // An sms: deep link resolves on Apple devices only, so the number and
+        // the command have to be readable (and copyable) on any device.
+        setPhoneLinkTarget({
+          contactNumber: data.contact_number,
+          command: BOT_AUTH_COMMAND,
+          actionLink: data.action_link,
+        });
+        setConnectingPlatform(null);
       } else if (data.auth_type === "manual" && data.instructions) {
         const platformConfig = PLATFORMS.find((p) => p.id === platformId);
         toast.info(`Connect ${platformConfig?.name ?? platformId}`, {
@@ -312,51 +321,22 @@ export default function LinkedAccountsSettings() {
         </div>
       </SettingsSection>
 
-      <Modal
+      <PhoneLinkModal
         isOpen={phoneModalPlatform != null}
-        onClose={() => setPhoneModalPlatform(null)}
-        size="sm"
-      >
-        <ModalContent>
-          <ModalHeader>Your phone number</ModalHeader>
-          <ModalBody>
-            <p className="text-sm text-zinc-400">
-              iMessage delivers to registered numbers only, so GAIA needs the
-              number you text from.
-            </p>
-            <Input
-              autoFocus
-              type="tel"
-              placeholder="+15551234567"
-              value={phone}
-              onValueChange={setPhone}
-              isInvalid={phone.length > 0 && !E164_PHONE_PATTERN.test(phone)}
-              errorMessage="Use E.164 format, e.g. +15551234567"
-            />
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              variant="flat"
-              size="sm"
-              onPress={() => setPhoneModalPlatform(null)}
-            >
-              Cancel
-            </Button>
-            <Button
-              color="primary"
-              size="sm"
-              isDisabled={!E164_PHONE_PATTERN.test(phone)}
-              onPress={() => {
-                const platformId = phoneModalPlatform;
-                setPhoneModalPlatform(null);
-                if (platformId) handleConnect(platformId, phone);
-              }}
-            >
-              Continue
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+        platformName={
+          PLATFORMS.find((p) => p.id === phoneModalPlatform)?.name ?? "iMessage"
+        }
+        isSubmitting={connectingPlatform === phoneModalPlatform}
+        target={phoneLinkTarget}
+        onSubmit={(phone) => {
+          if (phoneModalPlatform) handleConnect(phoneModalPlatform, phone);
+        }}
+        onClose={() => {
+          setPhoneModalPlatform(null);
+          setPhoneLinkTarget(null);
+          fetchPlatformLinks();
+        }}
+      />
     </SettingsPage>
   );
 }

--- a/apps/web/src/features/settings/components/PhoneLinkModal.tsx
+++ b/apps/web/src/features/settings/components/PhoneLinkModal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Input } from "@heroui/input";
+import { Link } from "@heroui/link";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { useEffect, useState } from "react";
+import CopyButton from "@/components/ui/CopyButton";
+
+const E164_PHONE_PATTERN = /^\+[1-9]\d{6,14}$/;
+
+export interface PhoneLinkTarget {
+  contactNumber: string;
+  command: string;
+  actionLink?: string;
+}
+
+interface PhoneLinkModalProps {
+  isOpen: boolean;
+  platformName: string;
+  isSubmitting: boolean;
+  target: PhoneLinkTarget | null;
+  onSubmit: (phone: string) => void;
+  onClose: () => void;
+}
+
+function CopyableValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl bg-zinc-800 px-3 py-2">
+      <div className="min-w-0">
+        <p className="text-xs text-zinc-500">{label}</p>
+        <p className="truncate font-medium text-sm text-zinc-100">{value}</p>
+      </div>
+      <CopyButton textToCopy={value} />
+    </div>
+  );
+}
+
+export function PhoneLinkModal({
+  isOpen,
+  platformName,
+  isSubmitting,
+  target,
+  onSubmit,
+  onClose,
+}: PhoneLinkModalProps) {
+  const [phone, setPhone] = useState("");
+
+  useEffect(() => {
+    if (isOpen) setPhone("");
+  }, [isOpen]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="sm">
+      <ModalContent>
+        {target ? (
+          <>
+            <ModalHeader>Text GAIA to finish linking</ModalHeader>
+            <ModalBody className="gap-2">
+              <p className="text-sm text-zinc-400">
+                Send {target.command} to this number from the phone you just
+                registered.
+              </p>
+              <CopyableValue label="Number" value={target.contactNumber} />
+              <CopyableValue label="Send" value={target.command} />
+              {target.actionLink && (
+                <div className="pt-1">
+                  <Button
+                    as={Link}
+                    href={target.actionLink}
+                    isExternal
+                    variant="flat"
+                    size="sm"
+                  >
+                    Open in Messages
+                  </Button>
+                  <p className="pt-1.5 text-xs text-zinc-500">
+                    Opens the Messages app on iPhone and Mac only.
+                  </p>
+                </div>
+              )}
+            </ModalBody>
+            <ModalFooter>
+              <Button color="primary" size="sm" onPress={onClose}>
+                Done
+              </Button>
+            </ModalFooter>
+          </>
+        ) : (
+          <>
+            <ModalHeader>Your phone number</ModalHeader>
+            <ModalBody>
+              <p className="text-sm text-zinc-400">
+                {platformName} delivers to registered numbers only, so GAIA
+                needs the number you text from.
+              </p>
+              <Input
+                autoFocus
+                type="tel"
+                placeholder="+15551234567"
+                value={phone}
+                onValueChange={setPhone}
+                isInvalid={phone.length > 0 && !E164_PHONE_PATTERN.test(phone)}
+                errorMessage="Use E.164 format, e.g. +15551234567"
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="flat" size="sm" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button
+                color="primary"
+                size="sm"
+                isLoading={isSubmitting}
+                isDisabled={!E164_PHONE_PATTERN.test(phone)}
+                onPress={() => onSubmit(phone)}
+              >
+                Continue
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
Connecting iMessage from a desktop browser dead-ends. The connect response's only affordance is `action_link` = `https://spectrum.photon.codes/users/{id}/redirect`, which **302s to an `sms:` deep link** (confirmed in Photon's live OpenAPI and in our own client docstring). A browser with no handler for the `sms:` scheme — Linux always, Windows usually — opens that in a new tab and lands on `about:blank`: blank page, empty address bar, no way forward.

The instructions made it worse: *"text /auth to your GAIA iMessage number"* — while the number was never shown anywhere. Photon returns it as `assignedPhoneNumber` on `POST /users/` (the pool line assigned to that user, not their own number) and `PhotonUser` parsed it away.

So the fix is to stop treating an Apple-only deep link as the whole flow:

- `PhotonUser` now parses `assignedPhoneNumber` (required in Photon's schema for both the create response and the user listing).
- `InitiatePlatformConnectResponse` carries `contact_number`; the iMessage branch fills it, and the instructions no longer refer to a number the client never received.
- The phone modal keeps its place after submit and shows the number and the `/auth` command, each with a copy button. "Open in Messages" stays as a secondary button, now labelled as Apple-only instead of being the only path. Extracted to `PhoneLinkModal` — it has two stages and its own state, and `LinkedAccountsSettings` was already ~380 lines.

The client branches on `contact_number` being present rather than on the platform name, so any other manual "text this number" platform gets the same treatment for free.

## Tests
`test_pro_user_connect_returns_the_number_to_text` (marked `regression`) — proven red on master by the `regression-proof` gate, since the field did not exist there. Existing Photon fixtures already carried `assignedPhoneNumber`, so the client test now asserts it is parsed rather than dropped. Mutation lane run locally on the CI matrix: OK for `photon_client.py` and `platform_links.py`, documented SKIP for `platform_models.py` (field declarations, nothing mutatable).

## Not verified
The frontend change was not driven against a live Photon registration — that registers a number on the production Photon project, a real side effect I did not take unprompted. The `sms:` redirect behaviour is from Photon's published OpenAPI, not from a `Location` header I read myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJsJ8rdW1qyNFdiZoTJkTL
