### PR TITLE
fix(ci): build and publish the imessage bot image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
             api=true
           fi
 
-          if echo "$AFFECTED" | grep -qx "bot-discord" || echo "$AFFECTED" | grep -qx "bot-slack" || echo "$AFFECTED" | grep -qx "bot-telegram" || echo "$AFFECTED" | grep -qx "bot-whatsapp"; then
+          if echo "$AFFECTED" | grep -qx "bot-discord" || echo "$AFFECTED" | grep -qx "bot-slack" || echo "$AFFECTED" | grep -qx "bot-telegram" || echo "$AFFECTED" | grep -qx "bot-whatsapp" || echo "$AFFECTED" | grep -qx "bot-imessage"; then
             bots=true
           fi
 
@@ -134,7 +134,8 @@ jobs:
                if image_missing "ghcr.io/theexperiencecompany/gaia-bot-discord:latest" || \
                   image_missing "ghcr.io/theexperiencecompany/gaia-bot-slack:latest" || \
                   image_missing "ghcr.io/theexperiencecompany/gaia-bot-telegram:latest" || \
-                  image_missing "ghcr.io/theexperiencecompany/gaia-bot-whatsapp:latest"; then
+                  image_missing "ghcr.io/theexperiencecompany/gaia-bot-whatsapp:latest" || \
+                  image_missing "ghcr.io/theexperiencecompany/gaia-bot-imessage:latest"; then
                 echo "⚠️ Bot image(s) missing from GHCR — forcing build"
                 bots=true
               fi
@@ -175,7 +176,7 @@ jobs:
         id: ensure-bot-images
         if: steps.affected.outputs.bots == 'true'
         run: |
-          for bot in discord slack telegram whatsapp; do
+          for bot in discord slack telegram whatsapp imessage; do
             img="ghcr.io/theexperiencecompany/gaia-bot-${bot}:latest"
             if docker image inspect "$img" &>/dev/null; then
               echo "Pushing $img..."


### PR DESCRIPTION
## Problem

`gaia-prod_imessage-bot` is `0/1` in production, rejecting every task:

```
"No such image: ghcr.io/theexperiencecompany/gaia-bot-imessage:2608.15.abba20d"
```

No iMessage image has ever been published to GHCR. Confirmed this is not a registry-auth artifact — `gaia-bot-whatsapp:2608.18.6e5ff4c` resolves fine with the same credentials from the same host.

`nx.json` already lists `bot-imessage` in the `bots` release group, so `nx release --group=bots` covers it. But three lists in `build.yml` still hardcode only the original four bots:

1. **Affected gate (line 115)** — an iMessage-only change sets `bots=false`, so nothing builds.
2. **Bootstrap `image_missing` check (lines 134-137)** — never notices the missing iMessage image.
3. **Fallback push loop (line 178)** — this exists precisely because, per its own comment, *"nx release may skip publishing on first run (no prior version history)."* iMessage is exactly that first-run case, and the safety net skips it.

Together: the build rarely triggers for iMessage, and when it does, the fallback that would have saved it doesn't cover it.

## Change

Adds `imessage` / `bot-imessage` to those three lists. No other changes.

## Verification

- `yaml.safe_load` parses the workflow
- `bash -n` passes on both modified `run:` blocks
- Not yet proven end-to-end: this needs a master run to actually publish the image. After merge, confirm `gaia-bot-imessage:latest` exists in GHCR and the service reaches `1/1`.

## Related

Production nginx was missing a route to port 3204 (`/bots/imessage/webhook` returned 404, so Photon webhooks never reached the bot). That was fixed by hand on the box, mirroring the existing WhatsApp blocks. Prod nginx config is not version-controlled, which is worth addressing separately — it is the reason this went unnoticed.