### PR TITLE
fix(bots): stop the imessage bundle colliding on createRequire

### DIFF
--- a/.github/workflows/deploy-swarm-prod.yml
+++ b/.github/workflows/deploy-swarm-prod.yml
@@ -144,7 +144,7 @@ jobs:
           # Bot/grafana aliases only move when their tags were deployed this
           # run — extend the health gate to match exactly what will be retagged.
           if [[ -n "${BOTS_IMAGE_TAG}" ]]; then
-            SERVICES="${SERVICES} discord-bot slack-bot telegram-bot whatsapp-bot"
+            SERVICES="${SERVICES} discord-bot slack-bot telegram-bot whatsapp-bot imessage-bot"
           fi
           if [[ -n "${GRAFANA_IMAGE_TAG}" ]]; then
             SERVICES="${SERVICES} grafana"
@@ -318,7 +318,7 @@ jobs:
         run: |
           if [ "$ROLLBACK_MODE" = "last" ]; then
             for svc in $(docker --context prod stack services gaia-prod --format '{{.Name}}' \
-              | grep -E 'gaia-backend|arq_worker|embedding-sidecar|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
+              | grep -E 'gaia-backend|arq_worker|embedding-sidecar|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot|imessage-bot'); do
               echo "Rolling back $svc..."
               docker --context prod service rollback "$svc"
             done
@@ -338,7 +338,7 @@ jobs:
         run: |
           if [ "$ROLLBACK_MODE" = "last" ]; then
             SERVICES=$(docker --context prod stack services gaia-prod --format '{{.Name}}' \
-              | grep -E 'gaia-backend|arq_worker|embedding-sidecar|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot')
+              | grep -E 'gaia-backend|arq_worker|embedding-sidecar|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot|imessage-bot')
           else
             SERVICES="gaia-prod_gaia-backend gaia-prod_arq_worker gaia-prod_embedding-sidecar"
           fi

--- a/apps/bots/discord/tsup.config.ts
+++ b/apps/bots/discord/tsup.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   clean: true,
   noExternal: [/.*/],
   banner: {
-    js: `import{createRequire}from"module";const require=createRequire(import.meta.url);`,
+    js: `import{createRequire as __gaiaCreateRequire}from"module";const require=__gaiaCreateRequire(import.meta.url);`,
   },
 });

--- a/apps/bots/imessage/tsup.config.ts
+++ b/apps/bots/imessage/tsup.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   clean: true,
   noExternal: [/.*/],
   banner: {
-    js: `import{createRequire}from"module";const require=createRequire(import.meta.url);`,
+    js: `import{createRequire as __gaiaCreateRequire}from"module";const require=__gaiaCreateRequire(import.meta.url);`,
   },
 });

--- a/apps/bots/slack/tsup.config.ts
+++ b/apps/bots/slack/tsup.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   clean: true,
   noExternal: [/.*/],
   banner: {
-    js: `import{createRequire}from"module";const require=createRequire(import.meta.url);`,
+    js: `import{createRequire as __gaiaCreateRequire}from"module";const require=__gaiaCreateRequire(import.meta.url);`,
   },
 });

--- a/apps/bots/telegram/tsup.config.ts
+++ b/apps/bots/telegram/tsup.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   clean: true,
   noExternal: [/.*/],
   banner: {
-    js: `import{createRequire}from"module";const require=createRequire(import.meta.url);`,
+    js: `import{createRequire as __gaiaCreateRequire}from"module";const require=__gaiaCreateRequire(import.meta.url);`,
   },
 });

--- a/apps/bots/whatsapp/tsup.config.ts
+++ b/apps/bots/whatsapp/tsup.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   clean: true,
   noExternal: [/.*/],
   banner: {
-    js: `import{createRequire}from"module";const require=createRequire(import.meta.url);`,
+    js: `import{createRequire as __gaiaCreateRequire}from"module";const require=__gaiaCreateRequire(import.meta.url);`,
   },
 });

--- a/scripts/ci/retag-latest-alias.sh
+++ b/scripts/ci/retag-latest-alias.sh
@@ -82,7 +82,7 @@ case "$MODE" in
       # re-point that repo's :latest at it. Deduped: gaia-backend and
       # arq_worker share the gaia repo.
       refs=$(for svc in $(docker --context "$DOCKER_CONTEXT" stack services "$STACK" --format '{{.Name}}' \
-          | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot'); do
+          | grep -E 'gaia-backend|arq_worker|voice-agent-worker|discord-bot|slack-bot|telegram-bot|whatsapp-bot|imessage-bot'); do
           docker --context "$DOCKER_CONTEXT" service inspect "$svc" \
             --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}'
         done | sort -u)


### PR DESCRIPTION
## Problem

`gaia-prod_imessage-bot` crash-loops in production. The container starts and Node refuses to load the bundle:

```
SyntaxError: Identifier 'createRequire' has already been declared
```

Reproduced locally — `node -e "import('./dist/index.js')"` on a fresh `pnpm exec tsup` build fails with the identical message.

**Cause.** Every bot's `tsup.config.ts` injects this banner:

```js
import{createRequire}from"module";const require=createRequire(import.meta.url);
```

With `noExternal: [/.*/]`, tsup inlines every dependency. `@photon-ai/otel` (transitive via `spectrum-ts`) has its own top-level `import { createRequire } from "module"`, which esbuild preserves because `module` is a builtin. Two imports bind the same name in one module scope:

```
line 1:       import{createRequire}from"module";        <- banner
line 182855:  import { createRequire } from "module";   <- @photon-ai/otel
```

Only iMessage depends on the Photon SDK, so only iMessage hits it — but the banner is identical in all five bots, so any bot that later pulls in a dep doing the same thing breaks the same way.

## Change

Alias the banner's import so it stops claiming a bare `createRequire` binding:

```js
import{createRequire as __gaiaCreateRequire}from"module";const require=__gaiaCreateRequire(import.meta.url);
```

Applied to all five bots to keep the configs identical and remove the latent failure.

**The banner itself is load-bearing — do not delete it.** Removing it was tested first and fails at runtime with `Dynamic require of "util" is not supported`.

Also adds `imessage-bot` to the deploy-side service lists that still enumerated only the original four (`deploy-swarm-prod.yml` health gate + both rollback greps, `retag-latest-alias.sh`). Without these the service is skipped by deploys, which is why it stayed pinned to a nonexistent `2608.15.abba20d` tag while the other four moved to the current one.

## Verification

Built and loaded every bot bundle:

```
discord    LOADS OK
slack      LOADS OK
telegram   LOADS OK
whatsapp   LOADS OK
imessage   LOADS OK
```

`LOADS OK` means the ESM bundle executes; the bots then stop at their own `Missing required config: GAIA_BOT_API_KEY, ...` check, which is expected without local secrets. Before this change iMessage failed with a hard `SyntaxError` at module load.

`deploy-swarm-prod.yml` parses as YAML; `retag-latest-alias.sh` passes `bash -n`.

**Not verified:** the full prod path. That needs a master build to publish a new image and a deploy to pick it up.

## Context

Third fix in a chain for the same outage: #1046 (show the number to text), #1047 (build the image at all), this one (make the image runnable). Production nginx was also missing a `/bots/imessage/*` route, fixed by hand on the box — that config is not version-controlled, which is the reason none of this surfaced earlier.