### PR TITLE
fix(bots): ship the grpc peer deps the photon sdk resolves at runtime

### DIFF
--- a/apps/bots/CLAUDE.md
+++ b/apps/bots/CLAUDE.md
@@ -131,7 +131,7 @@ Separate sink from the wide events above, and a separate purpose: Loki answers *
 
 ## Conventions
 
-- ESM only (`"type": "module"`). Build is `tsup` with `noExternal: [/.*/]` — bundles every dep into `dist/index.js` so the Docker image ships only `dist/` + `package.json` (no `node_modules`). A `banner` shims `require()` for CJS deps. All bots share one `BOT_NAME`-parameterized `apps/bots/Dockerfile`.
+- ESM only (`"type": "module"`). Build is `tsup` with `noExternal: [/.*/]` — bundles every dep into `dist/index.js` so the Docker image ships only `dist/` + `package.json` (no `node_modules`). The one exception is iMessage: Photon's gRPC transport calls `import.meta.resolve()` on `nice-grpc`, `nice-grpc-common` and `@grpc/grpc-js` at runtime, so the Dockerfile stages just those three into the runner and fails the build if any is missing. A `banner` shims `require()` for CJS deps. All bots share one `BOT_NAME`-parameterized `apps/bots/Dockerfile`.
 - Before adding a type, check `libs/shared/ts/src/bots/types/index.ts` — `BotCommand`, `RichMessage`, `RichMessageTarget`, `SentMessage`, `PlatformName`, etc. live there.
 - `SentMessage` is `{ id: string; edit: (text) => Promise<void> }`. On platforms without edit support, `edit` sends a new message guarded by a sent-once flag.
 - Tests use Vitest (not Jest), run sequentially (shared module-level mocks), all platform SDKs and `@gaia/shared` mocked with `vi.mock()`. `vitest.config.ts` aliases `@gaia/shared` to source, so no shared-lib build is needed. Real shared logic is tested in `__tests__/shared/`.

--- a/apps/bots/Dockerfile
+++ b/apps/bots/Dockerfile
@@ -28,6 +28,20 @@ RUN --mount=type=cache,id=gaia-pnpm-bots,target=/root/.local/share/pnpm/store \
 # single self-contained output — no node_modules needed at runtime.
 RUN pnpm --filter @gaia/bot-${BOT_NAME} build
 
+# Some SDKs (Photon's iMessage gRPC transport) call import.meta.resolve() on
+# their peer deps at runtime, so those packages must exist on disk even though
+# tsup already bundled their code. Stage any that are present; the directory is
+# always created so the COPY below works for every bot.
+RUN mkdir -p /peers/node_modules && \
+    for p in nice-grpc nice-grpc-common @grpc/grpc-js; do \
+      for base in "apps/bots/${BOT_NAME}/node_modules" "node_modules"; do \
+        if [ -e "$base/$p" ]; then \
+          mkdir -p "/peers/node_modules/$(dirname "$p")" && \
+          cp -RL "$base/$p" "/peers/node_modules/$p" && break; \
+        fi; \
+      done; \
+    done
+
 # ---- Production image ----
 FROM node:20-alpine AS runner
 ARG BOT_NAME
@@ -36,6 +50,7 @@ WORKDIR /app
 # Only the bundled dist is needed — no node_modules required
 COPY --from=builder /app/apps/bots/${BOT_NAME}/dist ./dist
 COPY --from=builder /app/apps/bots/${BOT_NAME}/package.json ./
+COPY --from=builder /peers/ ./
 
 # Entrypoint: reads Docker Swarm secrets into env vars before exec-ing the process
 COPY scripts/docker-entrypoint.sh /entrypoint.sh

--- a/apps/bots/Dockerfile
+++ b/apps/bots/Dockerfile
@@ -28,19 +28,23 @@ RUN --mount=type=cache,id=gaia-pnpm-bots,target=/root/.local/share/pnpm/store \
 # single self-contained output — no node_modules needed at runtime.
 RUN pnpm --filter @gaia/bot-${BOT_NAME} build
 
-# Some SDKs (Photon's iMessage gRPC transport) call import.meta.resolve() on
-# their peer deps at runtime, so those packages must exist on disk even though
-# tsup already bundled their code. Stage any that are present; the directory is
-# always created so the COPY below works for every bot.
-RUN mkdir -p /peers/node_modules && \
-    for p in nice-grpc nice-grpc-common @grpc/grpc-js; do \
-      for base in "apps/bots/${BOT_NAME}/node_modules" "node_modules"; do \
-        if [ -e "$base/$p" ]; then \
-          mkdir -p "/peers/node_modules/$(dirname "$p")" && \
-          cp -RL "$base/$p" "/peers/node_modules/$p" && break; \
-        fi; \
+# Photon's iMessage gRPC transport calls import.meta.resolve() on its peer deps
+# at runtime, so those packages must exist on disk even though tsup already
+# bundled their code. Only the iMessage bot needs them; the directory is always
+# created so the COPY below works for every bot.
+RUN set -e; \
+    mkdir -p /peers/node_modules; \
+    if [ "${BOT_NAME}" = "imessage" ]; then \
+      for p in nice-grpc nice-grpc-common @grpc/grpc-js; do \
+        src=""; \
+        for base in "apps/bots/${BOT_NAME}/node_modules" "node_modules"; do \
+          if [ -e "$base/$p" ]; then src="$base/$p"; break; fi; \
+        done; \
+        if [ -z "$src" ]; then echo "required gRPC peer not installed: $p" >&2; exit 1; fi; \
+        mkdir -p "/peers/node_modules/$(dirname "$p")"; \
+        cp -RL "$src" "/peers/node_modules/$p"; \
       done; \
-    done
+    fi
 
 # ---- Production image ----
 FROM node:20-alpine AS runner

--- a/apps/bots/imessage/package.json
+++ b/apps/bots/imessage/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@gaia/shared": "workspace:*",
+    "@grpc/grpc-js": "^1.14.4",
+    "nice-grpc": "^2.1.17",
+    "nice-grpc-common": "^2.0.4",
     "spectrum-ts": "^12.7.0"
   },
   "devDependencies": {

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -376,6 +376,15 @@ const config: KnipConfig = {
       ],
     },
 
+    // ── iMessage bot ─────────────────────────────────────────────────
+    // The Photon SDK's gRPC transport calls import.meta.resolve() on these at
+    // runtime, so they must be installed and shipped even though no source
+    // file imports them. knip cannot see a runtime-only resolve.
+    "apps/bots/imessage": {
+      project: ["**/*.ts", "!**/__tests__/**", "!**/*.test.ts"],
+      ignoreDependencies: ["@grpc/grpc-js", "nice-grpc", "nice-grpc-common"],
+    },
+
     // ── CLI Package ──────────────────────────────────────────────────
     "packages/cli": {
       entry: ["src/index.{ts,tsx}", "src/commands/**/*.{ts,tsx}"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,15 @@ importers:
       '@gaia/shared':
         specifier: workspace:*
         version: link:../../../libs/shared/ts
+      '@grpc/grpc-js':
+        specifier: ^1.14.4
+        version: 1.14.4
+      nice-grpc:
+        specifier: ^2.1.17
+        version: 2.1.17
+      nice-grpc-common:
+        specifier: ^2.0.4
+        version: 2.0.4
       spectrum-ts:
         specifier: ^12.7.0
         version: 12.7.0(typescript@7.0.2)


### PR DESCRIPTION
## Problem

With the bundle fix from #1048 in place, `gaia-prod_imessage-bot` boots further and then dies at `boot_stage: "connecting"`:

```
ConnectionError: `createGrpcClient` needs the optional peer dependencies of
"@photon-ai/advanced-imessage": nice-grpc, nice-grpc-common, and @grpc/grpc-js.
```

Infisical is fine (`injected: 116`) — this is the next layer down.

**Cause.** `@spectrum-ts/imessage` hardcodes `createGrpcClient`, and the SDK guards it with:

```js
function assertPeersResolvable() {
  if (typeof import.meta.resolve !== "function") return;
  for (const peer of ["nice-grpc", "nice-grpc-common", "@grpc/grpc-js"]) {
    import.meta.resolve(peer);
  }
}
```

`import.meta.resolve()` requires those packages to exist **on disk**, even though tsup already bundled their code (the prod bundle does contain `createChannel`). `apps/bots/Dockerfile` ships `dist/` and nothing else — *"no node_modules needed at runtime"* — which holds for the other four bots but not for the Photon SDK.

This is also why it worked locally: pnpm had the packages in `node_modules`, so the assertion passed. They were never declared in `apps/bots/imessage/package.json` — a phantom dependency.

## Change

1. Declare `nice-grpc`, `nice-grpc-common`, `@grpc/grpc-js` in `apps/bots/imessage/package.json` (pinned to the versions already in the lockfile).
2. In `apps/bots/Dockerfile`, stage those packages in the builder and copy them into the runner. The loop is bot-agnostic and the directory is always created, so the other four bots build unchanged and gain nothing.

## Verification

Built the image locally and probed the exact mechanism that was failing — `import.meta.resolve` from the bundle's own directory:

```
from /app/dist (where dist/index.js lives):
  RESOLVES: nice-grpc
  RESOLVES: nice-grpc-common
  RESOLVES: @grpc/grpc-js
```

A control probe run from `/tmp` correctly fails with `ERR_MODULE_NOT_FOUND`, confirming the probe is meaningful and not trivially passing.

**Not verified:** a full connection to Photon. A local `docker run` stops earlier at `InfisicalConfigError` (no prod credentials), so the gRPC path is only reachable in the real deployment. The `import.meta.resolve` probe tests the precise call the SDK makes, but it is not the same as a successful Photon connect.

## Context

Fifth and hopefully final layer of the same outage: #1046 (show the number), #1047 (build the image), #1048 (make the bundle loadable), this one (make the gRPC transport usable).