### PR TITLE
fix(ci): publish versioned imessage bot images so the deploy can pin them

### DIFF
--- a/apps/bots/imessage/project.json
+++ b/apps/bots/imessage/project.json
@@ -61,7 +61,13 @@
         "cwd": "."
       },
       "cache": true,
-      "inputs": ["production", "^production"]
+      "inputs": ["production", "^production"],
+      "metadata": {
+        "technologies": ["docker"]
+      }
+    },
+    "nx-release-publish": {
+      "executor": "@nx/docker:release-publish"
     }
   }
 }


### PR DESCRIPTION
## Problem

The prod deploy of `f0e211bfa` failed with:

```
##[error]gaia-prod_imessage-bot was rolled back by Swarm (state: rollback_paused)
```

The deploy pins every bot service to the immutable per-commit tag for the run — `BOTS_IMAGE_TAG: 2608.18.f3f7cfe`. That tag exists for four of the five bots:

| image | tags in GHCR |
|---|---|
| `gaia-bot-discord` | 11, incl. `2608.18.f3f7cfe` |
| `gaia-bot-telegram` | 11, incl. `2608.18.f3f7cfe` |
| `gaia-bot-imessage` | **1 — only `latest`** |

So Swarm was told to run an image tag that does not exist, the task could not start, and Swarm auto-rolled the service back. That is what fails the deploy — and because convergence never succeeds, `:latest` is never re-pointed, which blocks the backend promotion too.

## Root cause

`apps/bots/imessage/project.json` was missing the `nx-release-publish` target. It is the only bot without it:

```
discord:  nx-release-publish = YES
slack:    nx-release-publish = YES
telegram: nx-release-publish = YES
whatsapp: nx-release-publish = YES
imessage: nx-release-publish = MISSING
```

Without that target `nx release --group=bots` cannot publish the image, so iMessage only ever got the `:latest` push from the "Ensure bot images are pushed to GHCR" fallback in `build.yml` — never a versioned tag. The image was being built and published all along, just not under the tag the deploy pins.

## Fix

Add the `nx-release-publish` target (and the `docker` metadata the other four carry) so the iMessage image is released under the same versioned scheme as its siblings.

## Verification

- `nx show project bot-imessage` now reports `nx-release-publish` → `@nx/docker:release-publish`.
- Registry state confirmed via the GHCR v2 tags API; the currently published `gaia-bot-imessage:latest` does contain the gRPC peer fix from #1049 (`/app/node_modules` has `@grpc/grpc-js`, `nice-grpc`, `nice-grpc-common`) — so the container itself is fixed, this is purely the tag it ships under.

Note: the underlying crash from #1049 is confirmed fixed — that image was booted locally against the real prod Photon project and reached `outcome: success` with `GET /health` → 200.