### PR TITLE
fix(ci): register the imessage bot image in the bots tag group

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -312,7 +312,7 @@ jobs:
             # Python typing is already enforced by the dedicated python-mypy lane.
             pnpm exec nx affected -t type-check --base=origin/$GITHUB_BASE_REF --exclude=api,voice-agent
           else
-            pnpm exec nx run-many -t type-check --projects=web,desktop,mobile,cli,bot-discord,bot-slack,bot-telegram,bot-whatsapp
+            pnpm exec nx run-many -t type-check --projects=web,desktop,mobile,cli,bot-discord,bot-slack,bot-telegram,bot-whatsapp,bot-imessage
           fi
           echo "::endgroup::"
           echo "TypeScript: OK (all affected workspaces pass strict tsc)"

--- a/scripts/ci/lib/image-repos.sh
+++ b/scripts/ci/lib/image-repos.sh
@@ -8,6 +8,6 @@
 GHCR_NAMESPACE="ghcr.io/theexperiencecompany"
 # nx release group "apps" — one commit produces the same tag for both.
 APPS_IMAGE_REPOS=(gaia gaia-voice-agent)
-# nx release group "bots" — fixed relationship, all four share the tag.
-BOTS_IMAGE_REPOS=(gaia-bot-discord gaia-bot-slack gaia-bot-telegram gaia-bot-whatsapp)
+# nx release group "bots" — fixed relationship, all five share the tag.
+BOTS_IMAGE_REPOS=(gaia-bot-discord gaia-bot-slack gaia-bot-telegram gaia-bot-whatsapp gaia-bot-imessage)
 GRAFANA_IMAGE_REPO="gaia-grafana"


### PR DESCRIPTION
## Problem

The deploy of `19ec4c114` failed again, same as `f0e211bfa`:

```
##[error]gaia-prod_imessage-bot was rolled back by Swarm (state: rollback_paused)
```

After that run, GHCR held:

| image | versioned tag `2608.18.3cc2603` |
|---|---|
| `gaia-bot-discord` | present (12 tags) |
| `gaia-bot-imessage` | **absent — still only `latest`** |

`docker-compose.prod.yml` pins every bot, iMessage included, to `${GAIA_BOTS_IMAGE_TAG}`. So Swarm is told to run a tag that was never pushed for that one repo, the task cannot start, Swarm auto-rolls back, and the deploy fails. Convergence never succeeds, so `:latest` is never re-pointed — which also blocks the backend promotion.

## Root cause

`scripts/ci/lib/image-repos.sh` — the declared single source of truth for which GHCR repos each tag group covers — never had iMessage added:

```bash
# nx release group "bots" — fixed relationship, all four share the tag.
BOTS_IMAGE_REPOS=(gaia-bot-discord gaia-bot-slack gaia-bot-telegram gaia-bot-whatsapp)
```

The comment still says "all four". Both consumers inherit the gap:

- `resolve-image-tags.sh` iterates this list to verify each repo carries the tag and **pushes it when nx skipped publishing**. iMessage was never in the loop, so its versioned tag was never pushed — the existing safety net simply did not cover it.
- `retag-latest-alias.sh` iterates the same list, so iMessage's `:latest` alias was never re-pointed after a successful deploy either.

That is why #1050 (adding the missing `nx-release-publish` target) was necessary but not sufficient: nx can publish it now, but the script that guarantees the pinned tag exists still wasn't looking at that repo.

## Fix

Add `gaia-bot-imessage` to `BOTS_IMAGE_REPOS` and correct the comment to "all five".

## Also folded in

`code-quality.yml` ran `type-check` over `bot-discord,bot-slack,bot-telegram,bot-whatsapp` but not `bot-imessage` — the same "added the bot, didn't register it everywhere" omission, meaning the iMessage bot's TypeScript has never been type-checked in CI. Added it. Verified it passes cleanly first (`nx type-check bot-imessage` → success), so it cannot redden this PR.