### PR TITLE
fix(observability): health-probe the imessage bot so a dead one alerts

### DIFF
--- a/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
+++ b/infra/docker/observability/grafana/provisioning/alerting/alert-rules.yaml
@@ -141,7 +141,7 @@ groups:
             unreachable.{{ end }}
           description: >-
             Every product surface goes through this API — web and desktop chat,
-            mobile, all four bots, and the voice agent. Users are seeing failed
+            mobile, all five bots, and the voice agent. Users are seeing failed
             sends, blank conversations and broken integrations. Check the API
             Logs dashboard to find which handler is erroring, then the
             application logs for the exception behind it.
@@ -808,12 +808,12 @@ groups:
             this rule could not be evaluated, which almost always means Prometheus is
             down or unreachable.{{ end }}
           description: >-
-            These five targets have no metrics of their own and are health-probed
+            These six targets have no metrics of their own and are health-probed
             instead. If this is embedding-sidecar:8200, both the API and the ARQ
             worker lose embedding and reranking, so memory storage and semantic
             memory search break product-wide — there is no in-process fallback,
             the worker cannot fit the models in its memory limit. If it is one of
-            the discord, slack, telegram or whatsapp bots, that platform's users
+            the discord, slack, telegram, whatsapp or imessage bots, that platform's users
             get no replies even though the API itself is healthy.
           runbook_url: https://docs.lab.heygaia.io/production/runbooks/gaia-internal-service-down
           __dashboardUid__: gaia-containers

--- a/infra/docker/observability/prometheus.yml
+++ b/infra/docker/observability/prometheus.yml
@@ -114,6 +114,7 @@ scrape_configs:
           - http://slack-bot:3201/health
           - http://telegram-bot:3202/health
           - http://whatsapp-bot:3203/health
+          - http://imessage-bot:3204/health
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/tools/alert-rules/tests/gaia-api-5xx.yaml
+++ b/tools/alert-rules/tests/gaia-api-5xx.yaml
@@ -22,7 +22,7 @@ tests:
               service: api
             exp_annotations:
               description: >-
-                Every product surface goes through this API — web and desktop chat, mobile, all four bots, and the voice agent. Users are seeing failed sends, blank conversations and broken integrations. Check the API Logs dashboard to find which handler is erroring, then the application logs for the exception behind it.
+                Every product surface goes through this API — web and desktop chat, mobile, all five bots, and the voice agent. Users are seeing failed sends, blank conversations and broken integrations. Check the API Logs dashboard to find which handler is erroring, then the application logs for the exception behind it.
               runbook_url: https://docs.lab.heygaia.io/production/runbooks/gaia-api-5xx
               __dashboardUid__: gaia-api-prometheus
               __panelId__: '2'

--- a/tools/alert-rules/tests/gaia-internal-service-down.yaml
+++ b/tools/alert-rules/tests/gaia-internal-service-down.yaml
@@ -27,7 +27,7 @@ tests:
               instance: embedding-sidecar:8200
             exp_annotations:
               description: >-
-                These five targets have no metrics of their own and are health-probed instead. If this is embedding-sidecar:8200, both the API and the ARQ worker lose embedding and reranking, so memory storage and semantic memory search break product-wide — there is no in-process fallback, the worker cannot fit the models in its memory limit. If it is one of the discord, slack, telegram or whatsapp bots, that platform's users get no replies even though the API itself is healthy.
+                These six targets have no metrics of their own and are health-probed instead. If this is embedding-sidecar:8200, both the API and the ARQ worker lose embedding and reranking, so memory storage and semantic memory search break product-wide — there is no in-process fallback, the worker cannot fit the models in its memory limit. If it is one of the discord, slack, telegram, whatsapp or imessage bots, that platform's users get no replies even though the API itself is healthy.
               runbook_url: https://docs.lab.heygaia.io/production/runbooks/gaia-internal-service-down
               __dashboardUid__: gaia-containers
               __panelId__: '1'


### PR DESCRIPTION
## Problem

The iMessage bot was down in production and **nothing alerted**. It stayed down across several days and multiple deploys, and was only found by manually curling the endpoint.

`prometheus.yml`'s `blackbox_internal` job probes the health endpoint of every container with no native metrics — and its own comment states the stakes:

```yaml
# Gives each a probe_success series so the "container down" alert
# (alert-rules.yaml rule 13) covers them too — without this, a dead bot
# is invisible to alerting.
    static_configs:
      - targets:
          - http://embedding-sidecar:8200/health
          - http://discord-bot:3200/health
          - http://slack-bot:3201/health
          - http://telegram-bot:3202/health
          - http://whatsapp-bot:3203/health
```

`imessage-bot:3204` was never added. Alert rule 13 fires on `probe_success{job="blackbox_internal"}`, so with no target there is no series, and with no series there is nothing to go to 0. The bot had no monitoring at all — exactly the failure mode the comment warns about.

## Fix

Add `http://imessage-bot:3204/health` to the `blackbox_internal` targets. Port 3204 matches `IMESSAGE_SERVER_PORT`, the `docker-compose.prod.yml` healthcheck, and the service's network alias.

No rule change is needed — rule 13 already selects the whole job, so the new instance is covered the moment the target exists.

## Also corrected

Rule 13's description said "These five targets" (now six) and named only "the discord, slack, telegram or whatsapp bots"; rule 2's description said "all four bots". Both now include iMessage. These strings are what an on-call engineer reads at 3am, so a stale list is a real cost, not a typo.

## Verification

- Both files parse as valid YAML.
- `blackbox_internal` now resolves to six targets, iMessage included.
- No new metric or selector is introduced — `probe_success{job="blackbox_internal"}` already exists and is already scraped; this only adds an instance to it, so there is nothing for pint's `promql/series` to newly validate.

## Context

This is the fourth instance of the same underlying issue: iMessage was added as a bot but not registered in the hand-maintained lists that enumerate bots. The others were `BOTS_IMAGE_REPOS` (#1052, broke the deploy), the CI type-check list (#1052), and the `nx-release-publish` target (#1050).