### PR TITLE
refactor(chat): one splitter and one token constant for message breaks

### DIFF
--- a/apps/api/app/services/onboarding/first_message_service.py
+++ b/apps/api/app/services/onboarding/first_message_service.py
@@ -10,6 +10,7 @@ from app.agents.prompts.onboarding_prompts import (
     FIRST_MESSAGE_GENERATION_PROMPT_GMAIL,
     FIRST_MESSAGE_GENERATION_PROMPT_NO_GMAIL,
 )
+from app.constants.general import NEW_MESSAGE_BREAKER
 from app.constants.log_tags import LogTag
 from app.models.onboarding_models import (
     ClarifyAnswerRecord,
@@ -30,9 +31,9 @@ def default_first_message(name: str) -> str:
     the chat opens on whichever fires, and the two had drifted apart.
     """
     return (
-        f"Hey {name}, ok, you're all set up.<NEW_MESSAGE_BREAK>"
+        f"Hey {name}, ok, you're all set up.{NEW_MESSAGE_BREAKER}"
         "Lined up a few action items and set up some automations from what I found."
-        "<NEW_MESSAGE_BREAK>Oh, and I made you something."
+        f"{NEW_MESSAGE_BREAKER}Oh, and I made you something."
     )
 
 

--- a/apps/mobile/src/features/chat/components/chat/chat-message.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-message.tsx
@@ -1,7 +1,7 @@
 import {
   parseOpenUISegments,
   parseThinkingFromText,
-  splitByBreaksPreservingFences,
+  splitMessageByBreaks,
 } from "@gaia/shared/utils";
 import * as Haptics from "expo-haptics";
 import { PressableFeedback } from "heroui-native";
@@ -220,7 +220,7 @@ function useMessageParts(text: string | undefined): {
     () => parseThinkingFromText(text ?? ""),
     [text],
   );
-  const messageParts = splitByBreaksPreservingFences(parsedContent.cleanText)
+  const messageParts = splitMessageByBreaks(parsedContent.cleanText)
     .filter(Boolean)
     .map((part, index) => ({ part, index }));
   return { parsedContent, messageParts };

--- a/apps/web/src/features/chat/components/bubbles/bot/ChatBubbleBot.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/ChatBubbleBot.tsx
@@ -1,8 +1,5 @@
 // ChatBubbleBot.tsx
-import {
-  splitByBreaksPreservingFences,
-  splitMessageByBreaks,
-} from "@shared/utils";
+import { splitMessageByBreaks } from "@shared/utils";
 import * as m from "motion/react-m";
 import Image from "next/image";
 import { type ReactNode, useCallback, useMemo, useRef } from "react";
@@ -91,9 +88,7 @@ export default function ChatBubbleBot(
     if (!itShouldShowTextBubble) return 0;
     const cleanText = parseThinkingFromText(text?.toString() || "").cleanText;
     if (!cleanText) return 0;
-    const parts = cleanText.includes(":::openui")
-      ? splitByBreaksPreservingFences(cleanText)
-      : splitMessageByBreaks(cleanText);
+    const parts = splitMessageByBreaks(cleanText);
     return Math.max(0, parts.length - 1) * MESSAGE_BREAK_STAGGER_SECONDS;
   }, [text, itShouldShowTextBubble]);
 

--- a/apps/web/src/features/chat/components/bubbles/bot/TextBubble/index.tsx
+++ b/apps/web/src/features/chat/components/bubbles/bot/TextBubble/index.tsx
@@ -5,10 +5,7 @@ import {
   APPROVAL_REQUEST_TOOL_NAME,
   type ApprovalRequestData,
 } from "@shared/chat";
-import {
-  parseOpenUISegments,
-  splitByBreaksPreservingFences,
-} from "@shared/utils";
+import { parseOpenUISegments, splitMessageByBreaks } from "@shared/utils";
 import * as m from "motion/react-m";
 import dynamic from "next/dynamic";
 import React, { useId } from "react";
@@ -18,7 +15,6 @@ import {
   MESSAGE_BREAK_DURATION_SECONDS,
   MESSAGE_BREAK_EASE_OUT_QUART,
   MESSAGE_BREAK_STAGGER_SECONDS,
-  splitMessageByBreaks,
 } from "@/features/chat/utils/messageBreakUtils";
 import { shouldShowTextBubble } from "@/features/chat/utils/messageContentUtils";
 import { parseThinkingFromText } from "@/features/chat/utils/thinkingParser";
@@ -487,9 +483,7 @@ export default function TextBubble({
           // Use cleaned text without thinking tags
           const displayText = parsedContent.cleanText || "";
           // Preserve :::openui fences when splitting so they aren't mangled.
-          const textParts = displayText.includes(":::openui")
-            ? splitByBreaksPreservingFences(displayText)
-            : splitMessageByBreaks(displayText);
+          const textParts = splitMessageByBreaks(displayText);
 
           // Filter empty/whitespace-only parts up front so first/last/single
           // reflect the *visible* list, not the array index. Without this, a

--- a/apps/web/src/features/chat/utils/messageBreakUtils.ts
+++ b/apps/web/src/features/chat/utils/messageBreakUtils.ts
@@ -1,11 +1,10 @@
 /**
- * Utility functions for handling NEW_MESSAGE_BREAK tokens in chat messages
- * Enables WhatsApp-style multiple bubble responses from a single message
+ * Framer Motion timing for the staggered reveal of message-break bubbles.
+ *
+ * The splitter itself lives in `@shared/utils` and is imported from there
+ * directly — re-exporting it here only gave the same function two import paths.
  */
 
-export { splitMessageByBreaks } from "@shared/utils";
-
-/** Framer Motion timing for staggered message-break bubble reveals. */
 export const MESSAGE_BREAK_STAGGER_SECONDS = 0.08;
 export const MESSAGE_BREAK_DURATION_SECONDS = 0.25;
 export const MESSAGE_BREAK_EASE_OUT_QUART: [number, number, number, number] = [

--- a/apps/web/src/features/landing/components/demo/SimpleChatBubbles.tsx
+++ b/apps/web/src/features/landing/components/demo/SimpleChatBubbles.tsx
@@ -1,7 +1,6 @@
+import { splitMessageByBreaks } from "@shared/utils";
 import Image from "next/image";
 import { type ReactNode, useId } from "react";
-
-import { splitMessageByBreaks } from "@/features/chat/utils/messageBreakUtils";
 import { cn } from "@/lib/utils";
 
 export function SimpleChatBubbleBot({

--- a/libs/shared/ts/src/index.ts
+++ b/libs/shared/ts/src/index.ts
@@ -565,7 +565,6 @@ export {
   parseRelativeDateLabel,
   parseThinkingFromText,
   shouldRefreshToken,
-  splitByBreaksPreservingFences,
   splitMessageByBreaks,
   truncateText,
 } from "./utils";

--- a/libs/shared/ts/src/utils/index.ts
+++ b/libs/shared/ts/src/utils/index.ts
@@ -32,7 +32,6 @@ export {
 export {
   NEW_MESSAGE_BREAK_TOKEN,
   NEW_MESSAGE_BREAK_TOKEN_LENGTH,
-  splitMessageByBreaks,
 } from "./messageBreakUtils";
 export type {
   OpenUIActionEventLike,
@@ -43,7 +42,7 @@ export type { ContentSegment, OpenUILibraryLike } from "./openui-parser";
 export {
   normalizeOpenUICode,
   parseOpenUISegments,
-  splitByBreaksPreservingFences,
+  splitMessageByBreaks,
 } from "./openui-parser";
 export type { OpenUISample } from "./openui-samples";
 export { OPENUI_SAMPLES } from "./openui-samples";

--- a/libs/shared/ts/src/utils/messageBreakUtils.ts
+++ b/libs/shared/ts/src/utils/messageBreakUtils.ts
@@ -12,19 +12,3 @@
  */
 export const NEW_MESSAGE_BREAK_TOKEN = "<NEW_MESSAGE_BREAK>";
 export const NEW_MESSAGE_BREAK_TOKEN_LENGTH = NEW_MESSAGE_BREAK_TOKEN.length;
-
-export function splitMessageByBreaks(content: string): string[] {
-  // Return empty array for empty/whitespace content
-  if (!content?.trim()) {
-    return [];
-  }
-
-  if (!content.includes(NEW_MESSAGE_BREAK_TOKEN)) {
-    return [content];
-  }
-
-  return content
-    .split(NEW_MESSAGE_BREAK_TOKEN)
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0);
-}

--- a/libs/shared/ts/src/utils/openui-parser.ts
+++ b/libs/shared/ts/src/utils/openui-parser.ts
@@ -1,3 +1,5 @@
+import { NEW_MESSAGE_BREAK_TOKEN } from "./messageBreakUtils";
+
 /**
  * Minimal structural type for @openuidev/react-lang's Library.
  * Duck-typed to avoid a hard dep on a specific openui version.
@@ -112,13 +114,16 @@ export function parseOpenUISegments(
 }
 
 /**
- * Split text by NEW_MESSAGE_BREAK while preserving OpenUI fences.
+ * Split assistant text into bubbles on NEW_MESSAGE_BREAK.
  *
- * Breaks inside :::openui / ::: blocks are ignored so a fence is
- * never bisected across two bubbles.
+ * The single splitter every surface uses. Breaks inside :::openui / ::: blocks
+ * are ignored so a fence is never bisected across two bubbles; text with no
+ * fence in it splits on the plain token. It lives here rather than beside the
+ * token constant because fence awareness is what makes it correct, and that
+ * knowledge belongs to this module.
  */
-export function splitByBreaksPreservingFences(content: string): string[] {
-  const BREAK = "<NEW_MESSAGE_BREAK>";
+export function splitMessageByBreaks(content: string): string[] {
+  const BREAK = NEW_MESSAGE_BREAK_TOKEN;
   if (!content?.trim()) return [];
   if (!content.includes(BREAK)) return [content];
   if (!content.includes(OPENUI_OPEN)) {


### PR DESCRIPTION
## Summary

Splitting an assistant reply into chat bubbles had two implementations and three hand-written copies of the token that triggers it. This collapses both to one. No behaviour change — it removes the ways a future change can silently pick the wrong one.

## Why

`splitMessageByBreaks` split on `<NEW_MESSAGE_BREAK>` but knew nothing about OpenUI fences. `splitByBreaksPreservingFences` did the same job and additionally refused to bisect a `:::openui` block. Both were exported from the same barrel, so every caller had to know which one was correct — and the web bubbles decided inline, with the same `text.includes(":::openui")` check duplicated in two components, while mobile just called the fence-aware one unconditionally.

Separately, the token string was typed out by hand in `openui-parser.ts` and in `first_message_service.py`, in spite of a constant existing for exactly this whose own doc comment asks callers to use it. Nothing keeps a hand-written copy in step with the real one, and the drift would surface only as a reply that quietly stops splitting into bubbles.

## What changed

### Web / Mobile / Shared

- One splitter. The fence-aware implementation is a strict superset — given text with no fence it performs the identical split — so it is now the only one, renamed to `splitMessageByBreaks`. The `:::openui` branch disappears from `ChatBubbleBot` and `TextBubble`.
- `openui-parser.ts` imports `NEW_MESSAGE_BREAK_TOKEN` instead of spelling the literal.
- The web-side `messageBreakUtils` no longer re-exports the splitter — that gave one function two import paths and nothing else. The file now owns only the Framer Motion timings it actually defines.

### API

- `first_message_service.py` imports `NEW_MESSAGE_BREAKER` instead of hardcoding the token in the fallback greeting.

## How to verify

1. `pnpm nx run-many -t type-check --projects=web,mobile` and `pnpm nx run bots-e2e:test`.
2. Open a chat and send something that produces a multi-bubble reply — it should still render as separate bubbles with the staggered reveal, on web and mobile.
3. Send a prompt that produces an OpenUI component alongside text. The `:::openui` block must stay in one bubble rather than being cut in half — this is the case that previously depended on picking the right splitter.

**Not verified:** the onboarding fallback greeting in `first_message_service.py` only fires when first-message generation fails, which was not triggered; the change there is a literal-for-constant substitution producing a byte-identical string.

## Risk

Contained to how already-generated text is divided for display. The consolidated splitter is the one mobile and the OpenUI path already used, and web text with no `:::openui` in it takes the same branch it did before, so the realistic failure mode would be a bubble boundary landing differently in text that contains a fence — visible immediately in the chat UI, and revertible on its own since nothing else depends on this commit.
