### PR TITLE
fix(bots): keep the bot SSE socket alive through a proxy on long turns

### DIFF
--- a/apps/api/app/api/v1/endpoints/bot.py
+++ b/apps/api/app/api/v1/endpoints/bot.py
@@ -14,7 +14,7 @@ from app.constants.auth import AUDIT_ACTOR_BOT_API, AUDIT_ACTOR_UNAUTHENTICATED
 from app.constants.cache import PLATFORM_LINK_TOKEN_PREFIX, PLATFORM_LINK_TOKEN_TTL
 from app.constants.hil import APPROVAL_REQUEST_TOOL_NAME
 from app.constants.log_tags import LogTag
-from app.core.stream_manager import stream_manager
+from app.core.stream_manager import stream_manager, with_heartbeat
 from app.db.redis import redis_cache
 from app.decorators import enforce_daily_cost_budget, enforce_tiered_limit, tiered_rate_limit
 from app.models.bot_models import (
@@ -500,7 +500,11 @@ async def bot_chat_stream(request: Request, body: BotChatRequest) -> StreamingRe
                 )
                 yield f"data: {json.dumps({'error': 'Stream error occurred'})}\n\n"
 
-    return StreamingResponse(stream_from_redis(), media_type="text/event-stream")
+    # The translator above drops every web-only frame, so the socket can go
+    # quiet for minutes while the turn is busy. with_heartbeat guarantees a
+    # byte on the wire regardless, so no proxy in the path can mistake a
+    # working stream for a dead one.
+    return StreamingResponse(with_heartbeat(stream_from_redis()), media_type="text/event-stream")
 
 
 @router.post(

--- a/apps/api/app/constants/streaming.py
+++ b/apps/api/app/constants/streaming.py
@@ -6,6 +6,8 @@ Used by:
 - Tests
 """
 
+from typing import Final
+
 # Special control messages for pub/sub channel
 STREAM_DONE_SIGNAL = "__STREAM_DONE__"
 STREAM_CANCELLED_SIGNAL = "__STREAM_CANCELLED__"
@@ -16,3 +18,15 @@ STREAM_ERROR_SIGNAL = "__STREAM_ERROR__"
 # of an agent-initiated cancel — it lets the client clear the stuck
 # executor-pending loading state and finalize any in-flight tool cards.
 WS_EVENT_EXECUTOR_CANCELLED = "executor.cancelled"
+
+# SSE keepalive frame and cadence.
+#
+# `StreamManager.subscribe_stream` emits one when the Redis event log goes idle;
+# `with_heartbeat` emits one when nothing has reached the SOCKET for the same
+# interval, whatever the reason. Both must stay well under the read timeout a
+# reverse proxy applies to a silent upstream connection (nginx defaults to 60s).
+#
+# The frame is byte-sensitive: the compact literal (no space after the colon) is
+# the shape the frontend parser has always received. See models/stream_events.py.
+SSE_KEEPALIVE_INTERVAL_SECONDS: Final[float] = 15.0
+SSE_KEEPALIVE_FRAME: Final[str] = 'data: {"keepalive":true}\n\n'

--- a/apps/api/app/core/stream_manager.py
+++ b/apps/api/app/core/stream_manager.py
@@ -40,6 +40,7 @@ Usage:
 
 import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 import json
@@ -540,7 +541,15 @@ async def with_heartbeat(
             yield frame
     finally:
         if pending is not None:
+            # Await the cancellation before closing: the task is suspended
+            # INSIDE frames.__anext__(), so the generator is still running and
+            # aclose() would raise "asynchronous generator is already running"
+            # — leaving the event-log subscription to be closed by GC instead
+            # of here. This is the ordinary disconnect: a client that drops
+            # while the turn is quiet always has a pull in flight.
             pending.cancel()
+            with suppress(asyncio.CancelledError, StopAsyncIteration):
+                await pending
         await frames.aclose()
 
 

--- a/apps/api/app/core/stream_manager.py
+++ b/apps/api/app/core/stream_manager.py
@@ -38,6 +38,7 @@ Usage:
     await stream_manager.cancel_stream(stream_id)
 """
 
+import asyncio
 from collections.abc import AsyncGenerator
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -54,6 +55,8 @@ from app.constants.cache import (
 )
 from app.constants.log_tags import LogTag
 from app.constants.streaming import (
+    SSE_KEEPALIVE_FRAME,
+    SSE_KEEPALIVE_INTERVAL_SECONDS,
     STREAM_CANCELLED_SIGNAL,
     STREAM_DONE_SIGNAL,
     STREAM_ERROR_SIGNAL,
@@ -251,7 +254,7 @@ class StreamManager:
     async def subscribe_stream(
         cls,
         stream_id: str,
-        keepalive_interval: float = 15,
+        keepalive_interval: float = SSE_KEEPALIVE_INTERVAL_SECONDS,
         last_event_id: str | None = None,
     ) -> AsyncGenerator[str, None]:
         """
@@ -292,7 +295,7 @@ class StreamManager:
                     # event. SSE comment format (": keepalive") triggers
                     # onmessage with empty data in @microsoft/fetch-event-source
                     # due to a spec non-compliance, causing JSON.parse("") errors.
-                    yield 'data: {"keepalive":true}\n\n'
+                    yield SSE_KEEPALIVE_FRAME
                     continue
 
                 for _key, entries in results:
@@ -498,6 +501,47 @@ class StreamManager:
 
         # Notify subscribers of error
         await cls._publish(stream_id, STREAM_ERROR_SIGNAL)
+
+
+async def with_heartbeat(
+    frames: AsyncGenerator[str, None],
+    interval: float = SSE_KEEPALIVE_INTERVAL_SECONDS,
+) -> AsyncGenerator[str, None]:
+    """Forward ``frames``, injecting a keepalive whenever nothing has been
+    yielded for ``interval`` seconds.
+
+    ``subscribe_stream`` only emits its own keepalive when the Redis event log
+    is idle, which is not the same thing as the socket being idle: a consumer
+    that FILTERS frames (the bot translator drops web-only frames like
+    ``tool_data``) leaves the connection silent for as long as the turn stays
+    busy. A reverse proxy reads that silence as a dead upstream and hangs up
+    mid-turn — nginx's stock ``proxy_read_timeout`` is 60s.
+
+    Wrapping at the point bytes leave makes that impossible regardless of what
+    any stage upstream decides to swallow, so no proxy in the path needs to be
+    configured to tolerate a long-running stream.
+    """
+    iterator = frames.__aiter__()
+    pending: asyncio.Task[str] | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.ensure_future(iterator.__anext__())
+            try:
+                # shield keeps the in-flight read alive across a heartbeat: the
+                # timeout cancels the wrapper, not the pull from the event log.
+                frame = await asyncio.wait_for(asyncio.shield(pending), interval)
+            except TimeoutError:
+                yield SSE_KEEPALIVE_FRAME
+                continue
+            except StopAsyncIteration:
+                return
+            pending = None
+            yield frame
+    finally:
+        if pending is not None:
+            pending.cancel()
+        await frames.aclose()
 
 
 # Module-level singleton for convenient imports

--- a/apps/api/tests/unit/api/test_bot_endpoint.py
+++ b/apps/api/tests/unit/api/test_bot_endpoint.py
@@ -4,6 +4,8 @@ Tests the bot endpoints with mocked service layer to verify
 routing, status codes, response bodies, and auth checks.
 """
 
+import asyncio
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import HTTPException
@@ -11,6 +13,7 @@ from httpx import AsyncClient
 import pytest
 
 from app.api.v1.endpoints.bot import bot_chat_stream
+from app.core.stream_manager import with_heartbeat
 from app.models.bot_models import BotChatRequest
 from app.models.payment_models import PlanType
 from app.services.analytics_service import AnalyticsEvents
@@ -773,6 +776,104 @@ class TestBotChatStream:
         assert event["user"] == {"id": "uid1"}
         assert event["platform"] == "discord"
         assert event["outcome"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# The streamed body of POST /bot/chat-stream — translation + keepalive
+# ---------------------------------------------------------------------------
+
+
+class TestBotChatStreamBody:
+    """What actually reaches the bot over the wire.
+
+    The tests above stop at the gates (auth, plan, quota, analytics); none of
+    them read the response body, so the translator was uncovered. That is the
+    gap that let the 2026-08-18 outage ship: the translator drops every
+    web-only frame, and nothing checked that anything at all still reached the
+    socket while it did so.
+
+    `with_heartbeat` is exercised for real here — only its interval is shortened,
+    so the padding behaviour under test is the shipped implementation.
+    """
+
+    @staticmethod
+    def _fast_heartbeat(frames: AsyncGenerator[str, None]) -> AsyncGenerator[str, None]:
+        return with_heartbeat(frames, interval=0.05)
+
+    @staticmethod
+    async def _collect(client: AsyncClient, frames: AsyncGenerator[str, None]) -> str:
+        with (
+            patch("app.api.v1.endpoints.bot.require_bot_api_key", new=AsyncMock()),
+            patch("app.api.v1.endpoints.bot.spawn_background_task", new=MagicMock()),
+            patch("app.api.v1.endpoints.bot.run_chat_stream_background", new=AsyncMock()),
+            patch(
+                "app.api.v1.endpoints.bot.create_bot_session_token",
+                new=MagicMock(return_value="tok"),
+            ),
+            patch(
+                "app.api.v1.endpoints.bot.with_heartbeat",
+                new=TestBotChatStreamBody._fast_heartbeat,
+            ),
+            patch(
+                "app.api.v1.endpoints.bot.PlatformLinkService.get_user_by_platform_id",
+                new=AsyncMock(return_value={"user_id": "uid1", "_id": "uid1"}),
+            ),
+            patch("app.api.v1.endpoints.bot.BotService") as bot_svc,
+            patch("app.api.v1.endpoints.bot.capture_event", new=MagicMock()),
+            patch("app.api.v1.endpoints.bot.stream_manager") as sm,
+        ):
+            bot_svc.enforce_rate_limit = AsyncMock()
+            bot_svc.get_or_create_session = AsyncMock(return_value="conv-1")
+            bot_svc.load_conversation_history = AsyncMock(return_value=[])
+            sm.start_stream = AsyncMock()
+            sm.subscribe_stream.return_value = frames
+
+            response = await client.post(f"{BOT_BASE}/chat-stream", json=_CHAT_BODY("discord"))
+            assert response.status_code == 200
+            return (await response.aread()).decode()
+
+    async def test_a_silent_stretch_of_web_only_frames_still_reaches_the_socket(
+        self, client: AsyncClient
+    ):
+        """The regression. A turn busy with tool work publishes frames the bot
+        never sees; without padding the connection goes quiet and a proxy kills
+        it (nginx's stock proxy_read_timeout is 60s)."""
+
+        async def tool_work() -> AsyncGenerator[str, None]:
+            for i in range(3):
+                await asyncio.sleep(0.12)
+                yield f'data: {{"tool_data": {{"i": {i}}}}}\n\n'
+            yield "data: [DONE]\n\n"
+
+        body = await self._collect(client, tool_work())
+
+        assert '"keepalive"' in body, f"nothing kept the socket alive: {body!r}"
+        assert "tool_data" not in body, "web-only frames must not reach the bot"
+
+    async def test_text_frames_are_translated_and_the_turn_closes_with_done(
+        self, client: AsyncClient
+    ):
+        async def answer() -> AsyncGenerator[str, None]:
+            yield 'data: {"response": "hello "}\n\n'
+            yield 'data: {"response": "world"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        body = await self._collect(client, answer())
+
+        assert '"text": "hello "' in body
+        assert '"text": "world"' in body
+        assert '"done": true' in body
+        assert '"conversation_id": "conv-1"' in body
+
+    async def test_the_session_token_is_the_first_thing_the_bot_receives(self, client: AsyncClient):
+        """The bot stores this to authenticate follow-up calls for the turn."""
+
+        async def answer() -> AsyncGenerator[str, None]:
+            yield "data: [DONE]\n\n"
+
+        body = await self._collect(client, answer())
+
+        assert body.index('"session_token": "tok"') < body.index('"done"')
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/api/test_bot_endpoint.py
+++ b/apps/api/tests/unit/api/test_bot_endpoint.py
@@ -830,6 +830,9 @@ class TestBotChatStreamBody:
 
             response = await client.post(f"{BOT_BASE}/chat-stream", json=_CHAT_BODY("discord"))
             assert response.status_code == 200
+            # Not decoration: a bot client parses this stream as SSE and will
+            # not read a body served under any other media type.
+            assert response.headers["content-type"].startswith("text/event-stream")
             return (await response.aread()).decode()
 
     async def test_a_silent_stretch_of_web_only_frames_still_reaches_the_socket(

--- a/apps/api/tests/unit/core/test_stream_heartbeat.py
+++ b/apps/api/tests/unit/core/test_stream_heartbeat.py
@@ -84,6 +84,35 @@ async def test_producer_errors_propagate() -> None:
 
 
 @pytest.mark.asyncio
+async def test_closing_mid_heartbeat_closes_the_wrapped_producer() -> None:
+    """A disconnect while a read is in flight must still tear the read down.
+
+    This is the ordinary disconnect for the case the heartbeat exists to serve:
+    the turn is quiet (busy with tool work), so a pull from the event log is
+    always in flight when the client drops. Cancelling that pull without
+    awaiting it leaves the wrapped generator running, and `aclose()` then
+    raises "asynchronous generator is already running" — the subscription is
+    left to GC instead of being closed here.
+    """
+    closed = asyncio.Event()
+
+    async def never_speaks() -> AsyncGenerator[str, None]:
+        try:
+            await asyncio.sleep(10)
+            yield "data: unreachable\n\n"
+        finally:
+            closed.set()
+
+    stream = with_heartbeat(never_speaks(), interval=INTERVAL)
+    # Padding around a pull that has not returned — the racy state.
+    assert await stream.__anext__() == SSE_KEEPALIVE_FRAME
+
+    await stream.aclose()
+
+    await asyncio.wait_for(closed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_closing_early_closes_the_wrapped_producer() -> None:
     """A client disconnect must tear the event-log read down, not leak it."""
     closed = asyncio.Event()

--- a/apps/api/tests/unit/core/test_stream_heartbeat.py
+++ b/apps/api/tests/unit/core/test_stream_heartbeat.py
@@ -1,0 +1,103 @@
+"""Tests for `with_heartbeat` — the socket-level SSE keepalive.
+
+`subscribe_stream` keeps the connection alive only while the Redis event log is
+IDLE. That is not the same as the socket being idle: the bot translator drops
+every web-only frame, so a busy turn can produce a long silence on the wire and
+a reverse proxy will hang up on it (nginx's stock `proxy_read_timeout` is 60s —
+this is what killed the Discord turns on 2026-08-18). These tests pin the
+guarantee that no silence longer than the interval can reach the socket.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from app.constants.streaming import SSE_KEEPALIVE_FRAME
+from app.core.stream_manager import with_heartbeat
+
+INTERVAL = 0.05
+
+
+async def _drain(frames: AsyncGenerator[str, None]) -> list[str]:
+    return [frame async for frame in frames]
+
+
+@pytest.mark.asyncio
+async def test_silent_producer_still_writes_to_the_socket() -> None:
+    """A producer that yields nothing for several intervals is padded.
+
+    This is the regression: the bot translator swallows web-only frames, so the
+    inner generator can be busy and silent at the same time.
+    """
+
+    async def silent_then_speak() -> AsyncGenerator[str, None]:
+        await asyncio.sleep(INTERVAL * 3.5)
+        yield "data: real\n\n"
+
+    frames = await _drain(with_heartbeat(silent_then_speak(), interval=INTERVAL))
+
+    assert frames.count(SSE_KEEPALIVE_FRAME) >= 3, (
+        f"expected the gap to be padded with keepalives, got {frames!r}"
+    )
+    assert frames[-1] == "data: real\n\n", "the real frame must still arrive, last and intact"
+
+
+@pytest.mark.asyncio
+async def test_real_frames_are_forwarded_in_order_and_unmodified() -> None:
+    """The wrapper is transparent: it adds frames, it never drops or reorders."""
+
+    async def chatty() -> AsyncGenerator[str, None]:
+        for index in range(5):
+            yield f"data: {index}\n\n"
+
+    frames = await _drain(with_heartbeat(chatty(), interval=INTERVAL))
+
+    assert frames == [f"data: {index}\n\n" for index in range(5)]
+
+
+@pytest.mark.asyncio
+async def test_no_keepalive_when_the_producer_keeps_talking() -> None:
+    """A stream that never goes quiet gets no padding — keepalives are for gaps."""
+
+    async def steady() -> AsyncGenerator[str, None]:
+        for index in range(4):
+            await asyncio.sleep(INTERVAL / 4)
+            yield f"data: {index}\n\n"
+
+    frames = await _drain(with_heartbeat(steady(), interval=INTERVAL))
+
+    assert SSE_KEEPALIVE_FRAME not in frames
+    assert len(frames) == 4
+
+
+@pytest.mark.asyncio
+async def test_producer_errors_propagate() -> None:
+    """A failure inside the stream must surface, not be swallowed into silence."""
+
+    async def explodes() -> AsyncGenerator[str, None]:
+        yield "data: first\n\n"
+        raise RuntimeError("redis died")
+
+    with pytest.raises(RuntimeError, match="redis died"):
+        await _drain(with_heartbeat(explodes(), interval=INTERVAL))
+
+
+@pytest.mark.asyncio
+async def test_closing_early_closes_the_wrapped_producer() -> None:
+    """A client disconnect must tear the event-log read down, not leak it."""
+    closed = asyncio.Event()
+
+    async def tracked() -> AsyncGenerator[str, None]:
+        try:
+            while True:
+                yield "data: tick\n\n"
+                await asyncio.sleep(INTERVAL / 4)
+        finally:
+            closed.set()
+
+    stream = with_heartbeat(tracked(), interval=INTERVAL)
+    assert await stream.__anext__() == "data: tick\n\n"
+    await stream.aclose()
+
+    await asyncio.wait_for(closed.wait(), timeout=1)

--- a/libs/shared/ts/src/bots/api/chat-stream.test.ts
+++ b/libs/shared/ts/src/bots/api/chat-stream.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the bot SSE client's mid-stream failure handling.
+ *
+ * Regression context: on 2026-08-18 nginx hung up on two Discord turns after
+ * 60s of silence. The bot had already received 10 text frames, but the error
+ * path discarded them and posted a generic error card instead — and because
+ * Discord renders only at `onDone`, the user saw nothing of a reply that had
+ * fully arrived.
+ */
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { BotUserContext, ChatRequest } from "../types";
+import { streamChat } from "./chat-stream";
+
+const REQUEST: ChatRequest = {
+  message: "hi",
+  platform: "discord",
+  platformUserId: "u1",
+  channelId: "c1",
+};
+
+function frame(payload: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/** A response stream that emits `frames`, then dies with `error` mid-flight. */
+function dyingStream(frames: string[], error: Error): PassThrough {
+  const stream = new PassThrough();
+  setImmediate(() => {
+    for (const f of frames) stream.write(f);
+    setTimeout(() => stream.emit("error", error), 10);
+  });
+  return stream;
+}
+
+function deps(stream: PassThrough) {
+  return {
+    client: { post: vi.fn().mockResolvedValue({ data: stream }) },
+    userHeaders: (_ctx: BotUserContext) => ({}),
+    storeSessionToken: vi.fn(),
+    clearSessionToken: vi.fn(),
+  } as unknown as Parameters<typeof streamChat>[0];
+}
+
+async function run(stream: PassThrough) {
+  const onChunk = vi.fn();
+  const onDone = vi.fn();
+  const onError = vi.fn();
+  await streamChat(
+    deps(stream),
+    REQUEST,
+    onChunk,
+    onDone,
+    onError,
+    "/bot/chat-stream",
+    undefined,
+    0,
+  ).catch(() => undefined);
+  return { onChunk, onDone, onError };
+}
+
+describe("streamChat mid-stream abort", () => {
+  it("delivers the text already received when the connection dies", async () => {
+    const stream = dyingStream(
+      [frame({ text: "Hello " }), frame({ text: "world" })],
+      new Error("aborted"),
+    );
+
+    const { onDone, onError } = await run(stream);
+
+    expect(onDone).toHaveBeenCalledWith("Hello world", "");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error when the connection dies before any content", async () => {
+    const stream = dyingStream([], new Error("aborted"));
+
+    const { onDone, onError } = await run(stream);
+
+    expect(onDone).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("still reports a clean end-of-stream with no content as an error", async () => {
+    const stream = new PassThrough();
+    setImmediate(() => stream.end());
+
+    const { onDone, onError } = await run(stream);
+
+    expect(onDone).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+});

--- a/libs/shared/ts/src/bots/api/chat-stream.ts
+++ b/libs/shared/ts/src/bots/api/chat-stream.ts
@@ -350,8 +350,14 @@ async function streamChatOnce(
             if (isRetryable && !fullText) {
               // No content received yet — store for re-throw so streamChat can retry
               streamError = err;
+            } else if (fullText) {
+              // The connection died, but the answer is already assembled here.
+              // Deliver it exactly as the `end` handler does — replacing real
+              // content with an error card loses a reply the user had earned,
+              // and on a non-streaming platform (Discord/WhatsApp render only
+              // at onDone) it means they see nothing at all.
+              await onDone(fullText, conversationId);
             } else {
-              // Has partial content or non-retryable — surface to user
               await onError(new Error(toStreamErrorMessage(err.message)));
             }
           }

--- a/libs/shared/ts/src/bots/utils/formatters.ts
+++ b/libs/shared/ts/src/bots/utils/formatters.ts
@@ -591,7 +591,11 @@ export function formatBotError(error: unknown): string {
   if (
     message.includes("Connection interrupted") ||
     message.includes("ECONNRESET") ||
-    message.includes("socket hang up")
+    message.includes("socket hang up") ||
+    // Node's premature-close error, raised verbatim as `aborted` when a proxy
+    // hangs up mid-response. Without this it lands in the unhandled bucket
+    // below and shows up as a spurious `unhandled_bot_error`.
+    message === "aborted"
   ) {
     return "🔌 Connection interrupted. Please try again.";
   }


### PR DESCRIPTION
## Summary

Bot chat turns that spend more than a minute working — the ones that call a lot of tools — were dying partway through and showing the user "Something went wrong. Please try again later." The reply was usually already written; the connection just got cut before it could be delivered. Long bot turns now complete, and if a connection does drop mid-stream the text the user already received is delivered instead of being thrown away.

## Why

Two Discord turns failed for a real user on 2026-08-18, at 20:23:17 and 21:29:17 UTC. nginx on the production host logged, to the same second:

```
upstream timed out (110: Connection timed out) while reading upstream,
server: api.heygaia.io, request: "POST /api/v1/bot/chat-stream HTTP/1.1"
```

The backend was fine — it ran the turn to completion (140s and 125s) and persisted it. The user got an error card.

## What changed

### API

- `with_heartbeat` (`app/core/stream_manager.py`) wraps an SSE generator and emits a keepalive whenever nothing has reached the socket for the interval, whatever the reason. It shields the in-flight read so a heartbeat never cancels the pull it is waiting on.
- The bot chat-stream response is wrapped in it (`app/api/v1/endpoints/bot.py`).
- `SSE_KEEPALIVE_INTERVAL_SECONDS` / `SSE_KEEPALIVE_FRAME` (`app/constants/streaming.py`) are now the single source for both the wrapper and `subscribe_stream`'s existing idle keepalive, which had the interval hardcoded and the frame inline.

### Bots

- A mid-stream transport error no longer discards the reply: if text has already arrived it is delivered through `onDone`, the same as the clean end-of-stream path already did.
- Node's premature-close `aborted` is classified as a connection interruption instead of falling through to the unhandled-error bucket, where it was logging a misleading `unhandled_bot_error`.

---

## The bug

**Symptom** — The bot posts "❌ Something went wrong. Please try again later." after a long pause. The bot's own wide event recorded `chunk_count: 10, response_length: 0, error: "aborted"` — ten chunks of real answer received, none delivered.

**Reproduce** — On master:

1. Put nginx in front of the API with the production vhost from `/etc/nginx/sites-enabled/api` (`location /api/` with no `proxy_read_timeout`).
2. Start a bot chat turn whose agent emits only web-only frames — `tool_data`, `tool_output` — for more than 60 seconds.
3. The client fails at 60s with `Error: aborted`; nginx logs `upstream timed out`.

**Root cause** — The bot SSE translator drops every web-only frame with a bare `continue` (`app/api/v1/endpoints/bot.py:459-473`), so a tool-heavy turn writes nothing to the socket. The keepalive that should cover this only fires when the Redis event log is *idle* — `subscribe_stream` blocks on `XREAD` and emits one only when that block returns empty (`app/core/stream_manager.py:287-296`). During tool work the log is busy, so the keepalive never fires and the connection is silent while the turn is very much alive. nginx's stock `proxy_read_timeout` is 60s, and `/api/v1/bot/chat-stream` falls into a `location /api/` block that never got the `proxy_read_timeout 3600` its web sibling `/api/v1/chat-stream` has.

The web chat path survives the same workload only because it forwards every frame unfiltered (`app/api/v1/endpoints/chat.py:100`) and is therefore never quiet.

**The fix** — The heartbeat sits at the point bytes leave, so no stage upstream can starve the connection by filtering. Raising the nginx timeout would fix this one route and leave the next streaming endpoint to rediscover the same bug — `/api/v1/ws/device` and the `browser.heygaia.io` live view are both already in that position.

**Regression test** — `apps/api/tests/unit/core/test_stream_heartbeat.py` pins that a silent producer still reaches the socket, and `libs/shared/ts/src/bots/api/chat-stream.test.ts` pins that partial text survives a mid-stream abort. Both were mutation-checked: removing the heartbeat emit fails the first (`assert 0 >= 3`), reverting the delivery branch fails the second.

**Why the suite missed it** — Nothing covered the bot SSE path with a *filtered* stream. `test_stream_transport.py` covers the transport thoroughly but only for the web endpoint, which forwards everything, so the one behaviour that distinguishes the bot path — swallowing frames — was never exercised. No test put a proxy in front of either.

## How to verify

The failure needs a proxy in the path; the API alone will not show it.

1. Run nginx in front of the API with the production `location /api/` block (`proxy_buffering off`, no `proxy_read_timeout`).
2. Drive a bot turn through it whose agent publishes only `tool_data` frames for ~95s, then a final `response` frame.
3. On master the client errors with `aborted` at 60s and nginx logs `upstream timed out`. On this branch the stream survives and the final answer is delivered.
4. Unit coverage without the proxy: `nx run api:test:unit` and `pnpm vitest run` in `libs/shared/ts`.

**Not verified:** the fix has not run against production traffic, and the reproduction substitutes the agent with a frame producer that publishes the same frame types on a fixed schedule — everything else in the path (endpoint, translator, StreamManager, Redis, nginx, bot client) was real. The `aborted` reclassification in `formatBotError` is covered by the fix's behaviour change, not by a dedicated test.

## Post-merge steps

Nothing is required for this fix to work. Two related pieces of production config are wrong independently of it, and worth a follow-up:

- [ ] `/etc/nginx/sites-enabled/api` guards `^/api/v1/ws/(roadmap|connect)$`. `roadmap` no longer exists in the codebase; `/api/v1/ws/device` does exist and falls into `location /api/`, which sets no `Upgrade`/`Connection` headers — that handshake cannot complete. Replace the regex with a general `/api/v1/ws/` block carrying the upgrade headers.
- [ ] `location /api/` caps everything at nginx's default 60s while `RequestTimeoutMiddleware` allows 300s, so a slow-but-legitimate request between the two dies as an nginx 504 rather than the app's structured `{"error":"request_timeout"}`. Nothing hit this in the last 48h (0 non-stream requests over 55s), so it is a correctness fix, not urgent.

## Risk

Confined to SSE delivery on `/api/v1/bot/chat-stream`. If the wrapper misbehaves the failure is loud and immediate — every bot turn on every platform breaks at once, visible in the first message anyone sends. It cannot degrade quietly: the wrapper either forwards frames or it does not. Web chat, WebSockets, and every non-streaming route are untouched. The extra traffic is one small frame per 15s per active bot chat.
