### PR TITLE
feat(pricing): show platform icons inline in plan features and gate iMessage to Pro

### DIFF
--- a/apps/api/scripts/payment_setup.py
+++ b/apps/api/scripts/payment_setup.py
@@ -82,6 +82,7 @@ def build_plan_catalogue(monthly_product_id: str, yearly_product_id: str) -> lis
     """The subscription plans GAIA offers, as they should exist in the database."""
     now = datetime.now(UTC)
     pro_features = [
+        "Chat on iMessage",
         "Much higher usage limits",
         "Unlimited memories",
         "More powerful models",
@@ -101,6 +102,7 @@ def build_plan_catalogue(monthly_product_id: str, yearly_product_id: str) -> lis
             max_users=1,
             features=[
                 "All tools & 100s of integrations",
+                "Chat on WhatsApp, Telegram, Discord & Slack",
                 "Standard models",
                 "Daily AI usage allowance",
                 f"{FREE_MEMORY_FACT_LIMIT} saved memories",

--- a/apps/api/scripts/payment_setup.py
+++ b/apps/api/scripts/payment_setup.py
@@ -81,13 +81,15 @@ Outcome = Literal["created", "updated", "unchanged"]
 def build_plan_catalogue(monthly_product_id: str, yearly_product_id: str) -> list[PlanDocument]:
     """The subscription plans GAIA offers, as they should exist in the database."""
     now = datetime.now(UTC)
+    # Ordered to line up row-for-row with the Free card's list below, so each
+    # upgrade sits on the same line as the limit it replaces.
     pro_features = [
         "Chat on iMessage",
+        "More powerful models",
         "Much higher usage limits",
         "Unlimited memories",
-        "More powerful models",
-        "Long running tasks",
         "Priority support",
+        "Long running tasks",
         "Early access to new features",
     ]
 
@@ -101,12 +103,12 @@ def build_plan_catalogue(monthly_product_id: str, yearly_product_id: str) -> lis
             duration="monthly",
             max_users=1,
             features=[
-                "All tools & 100s of integrations",
                 "Chat on WhatsApp, Telegram, Discord & Slack",
                 "Standard models",
                 "Daily AI usage allowance",
                 f"{FREE_MEMORY_FACT_LIMIT} saved memories",
                 "Community support",
+                "All tools & 100s of integrations",
             ],
             is_active=True,
             created_at=now,

--- a/apps/web/src/features/pricing/components/PlanFeature.tsx
+++ b/apps/web/src/features/pricing/components/PlanFeature.tsx
@@ -15,47 +15,82 @@ const PLATFORM_PATTERN = new RegExp(
   "g",
 );
 
-interface PlatformToken {
-  platform: BotPlatform;
+const SEPARATOR_ONLY = /^[\s,]*(?:&|and)?[\s,]*$/;
+
+interface PlatformRun {
+  platforms: BotPlatform[];
   at: number;
 }
 
-function tokenize(feature: string): {
+function parseFeature(feature: string): {
   segments: string[];
-  platforms: PlatformToken[];
+  runs: PlatformRun[];
 } {
   const segments: string[] = [];
-  const platforms: PlatformToken[] = [];
+  const runs: PlatformRun[] = [];
   let cursor = 0;
 
   for (const match of feature.matchAll(PLATFORM_PATTERN)) {
     const platform = PLATFORM_BY_LABEL.get(match[0]);
     if (platform === undefined || match.index === undefined) continue;
-    segments.push(feature.slice(cursor, match.index));
-    platforms.push({ platform, at: match.index });
+
+    const gap = feature.slice(cursor, match.index);
+    const previous = runs.at(-1);
+    if (previous !== undefined && SEPARATOR_ONLY.test(gap)) {
+      previous.platforms.push(platform);
+    } else {
+      segments.push(gap);
+      runs.push({ platforms: [platform], at: match.index });
+    }
     cursor = match.index + match[0].length;
   }
   segments.push(feature.slice(cursor));
 
-  return { segments, platforms };
+  return { segments, runs };
 }
 
-interface PlatformMentionProps {
-  platform: BotPlatform;
+interface PlatformIconsProps {
+  platforms: BotPlatform[];
 }
 
-function PlatformMention({ platform }: PlatformMentionProps) {
+function PlatformIcons({ platforms }: PlatformIconsProps) {
+  const label = platforms.map((p) => BOT_PLATFORM_LABELS[p]).join(", ");
+
+  if (platforms.length === 1) {
+    const platform = platforms[0];
+    return (
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap align-middle">
+        <Image
+          src={BOT_PLATFORM_ICONS[platform]}
+          alt=""
+          width={18}
+          height={18}
+          aria-hidden
+          className="inline-block size-[18px] shrink-0 rounded-[5px]"
+        />
+        {BOT_PLATFORM_LABELS[platform]}
+      </span>
+    );
+  }
+
   return (
-    <span className="inline-flex items-center gap-1 whitespace-nowrap align-middle">
-      <Image
-        src={BOT_PLATFORM_ICONS[platform]}
-        alt=""
-        width={16}
-        height={16}
-        aria-hidden
-        className="inline-block h-4 w-4 shrink-0 rounded-[4px]"
-      />
-      {BOT_PLATFORM_LABELS[platform]}
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      className="mx-1 inline-flex items-center gap-1 align-middle"
+    >
+      {platforms.map((platform) => (
+        <Image
+          key={platform}
+          src={BOT_PLATFORM_ICONS[platform]}
+          alt=""
+          width={22}
+          height={22}
+          aria-hidden
+          className="size-[22px] shrink-0 rounded-[6px]"
+        />
+      ))}
     </span>
   );
 }
@@ -65,18 +100,18 @@ interface PlanFeatureProps {
 }
 
 export function PlanFeature({ feature }: PlanFeatureProps) {
-  const { segments, platforms } = tokenize(feature);
+  const { segments, runs } = parseFeature(feature);
 
-  if (platforms.length === 0) {
+  if (runs.length === 0) {
     return <span className="whitespace-nowrap text-zinc-300">{feature}</span>;
   }
 
   return (
     <span className="text-zinc-300">
       {segments[0]}
-      {platforms.map(({ platform, at }, index) => (
-        <span key={`${platform}-${at}`}>
-          <PlatformMention platform={platform} />
+      {runs.map(({ platforms, at }, index) => (
+        <span key={at}>
+          <PlatformIcons platforms={platforms} />
           {segments[index + 1]}
         </span>
       ))}

--- a/apps/web/src/features/pricing/components/PlanFeature.tsx
+++ b/apps/web/src/features/pricing/components/PlanFeature.tsx
@@ -17,6 +17,16 @@ const PLATFORM_PATTERN = new RegExp(
 
 const SEPARATOR_ONLY = /^[\s,]*(?:&|and)?[\s,]*$/;
 
+const FAN_ROTATIONS: Record<number, string[]> = {
+  1: ["rotate-0"],
+  2: ["-rotate-6", "rotate-6"],
+  3: ["-rotate-6", "rotate-0", "rotate-6"],
+  4: ["-rotate-12", "-rotate-6", "rotate-6", "rotate-12"],
+  5: ["-rotate-12", "-rotate-6", "rotate-0", "rotate-6", "rotate-12"],
+};
+
+const STACK_ORDER = ["z-[1]", "z-[2]", "z-[3]", "z-[4]", "z-[5]"];
+
 interface PlatformRun {
   platforms: BotPlatform[];
   at: number;
@@ -78,18 +88,21 @@ function PlatformIcons({ platforms }: PlatformIconsProps) {
       role="img"
       aria-label={label}
       title={label}
-      className="mx-1 inline-flex items-center gap-1 align-middle"
+      className="-space-x-1 mx-1.5 inline-flex align-middle leading-none"
     >
-      {platforms.map((platform) => (
-        <Image
+      {platforms.map((platform, index) => (
+        <span
           key={platform}
-          src={BOT_PLATFORM_ICONS[platform]}
-          alt=""
-          width={22}
-          height={22}
-          aria-hidden
-          className="size-[22px] shrink-0 rounded-[6px]"
-        />
+          className={`relative block size-7 ${FAN_ROTATIONS[platforms.length]?.[index] ?? "rotate-0"} ${STACK_ORDER[index] ?? "z-0"}`}
+        >
+          <Image
+            src={BOT_PLATFORM_ICONS[platform]}
+            alt=""
+            fill
+            aria-hidden
+            className="object-contain drop-shadow-[0_2px_5px_rgba(0,0,0,0.6)] transition hover:-translate-y-1 hover:scale-110"
+          />
+        </span>
       ))}
     </span>
   );

--- a/apps/web/src/features/pricing/components/PlanFeature.tsx
+++ b/apps/web/src/features/pricing/components/PlanFeature.tsx
@@ -1,0 +1,77 @@
+import Image from "next/image";
+import {
+  BOT_PLATFORM_ICONS,
+  BOT_PLATFORM_LABELS,
+  BOT_PLATFORMS,
+  type BotPlatform,
+} from "@/config/botPlatforms";
+
+const PLATFORM_BY_LABEL = new Map<string, BotPlatform>(
+  BOT_PLATFORMS.map((platform) => [BOT_PLATFORM_LABELS[platform], platform]),
+);
+
+const PLATFORM_PATTERN = new RegExp(
+  [...PLATFORM_BY_LABEL.keys()].join("|"),
+  "g",
+);
+
+interface PlatformToken {
+  platform: BotPlatform;
+  at: number;
+}
+
+function tokenize(feature: string): {
+  segments: string[];
+  platforms: PlatformToken[];
+} {
+  const segments: string[] = [];
+  const platforms: PlatformToken[] = [];
+  let cursor = 0;
+
+  for (const match of feature.matchAll(PLATFORM_PATTERN)) {
+    const platform = PLATFORM_BY_LABEL.get(match[0]);
+    if (platform === undefined || match.index === undefined) continue;
+    segments.push(feature.slice(cursor, match.index));
+    platforms.push({ platform, at: match.index });
+    cursor = match.index + match[0].length;
+  }
+  segments.push(feature.slice(cursor));
+
+  return { segments, platforms };
+}
+
+function PlatformMention({ platform }: { platform: BotPlatform }) {
+  return (
+    <span className="inline-flex items-center gap-1 whitespace-nowrap align-middle">
+      <Image
+        src={BOT_PLATFORM_ICONS[platform]}
+        alt=""
+        width={16}
+        height={16}
+        aria-hidden
+        className="inline-block h-4 w-4 shrink-0 rounded-[4px]"
+      />
+      {BOT_PLATFORM_LABELS[platform]}
+    </span>
+  );
+}
+
+export function PlanFeature({ feature }: { feature: string }) {
+  const { segments, platforms } = tokenize(feature);
+
+  if (platforms.length === 0) {
+    return <span className="whitespace-nowrap text-zinc-300">{feature}</span>;
+  }
+
+  return (
+    <span className="text-zinc-300">
+      {segments[0]}
+      {platforms.map(({ platform, at }, index) => (
+        <span key={`${platform}-${at}`}>
+          <PlatformMention platform={platform} />
+          {segments[index + 1]}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/apps/web/src/features/pricing/components/PlanFeature.tsx
+++ b/apps/web/src/features/pricing/components/PlanFeature.tsx
@@ -88,19 +88,19 @@ function PlatformIcons({ platforms }: PlatformIconsProps) {
       role="img"
       aria-label={label}
       title={label}
-      className="-space-x-1 mx-1.5 inline-flex align-middle leading-none"
+      className="-space-x-1 ml-1.5 inline-flex h-5 items-center align-middle leading-none"
     >
       {platforms.map((platform, index) => (
         <span
           key={platform}
-          className={`relative block size-7 ${FAN_ROTATIONS[platforms.length]?.[index] ?? "rotate-0"} ${STACK_ORDER[index] ?? "z-0"}`}
+          className={`relative block size-4 ${FAN_ROTATIONS[platforms.length]?.[index] ?? "rotate-0"} ${STACK_ORDER[index] ?? "z-0"}`}
         >
           <Image
             src={BOT_PLATFORM_ICONS[platform]}
             alt=""
             fill
             aria-hidden
-            className="object-contain drop-shadow-[0_2px_5px_rgba(0,0,0,0.6)] transition hover:-translate-y-1 hover:scale-110"
+            className="object-contain drop-shadow-[0_1px_2px_rgba(0,0,0,0.55)] transition hover:-translate-y-0.5 hover:scale-110"
           />
         </span>
       ))}

--- a/apps/web/src/features/pricing/components/PlanFeature.tsx
+++ b/apps/web/src/features/pricing/components/PlanFeature.tsx
@@ -40,7 +40,11 @@ function tokenize(feature: string): {
   return { segments, platforms };
 }
 
-function PlatformMention({ platform }: { platform: BotPlatform }) {
+interface PlatformMentionProps {
+  platform: BotPlatform;
+}
+
+function PlatformMention({ platform }: PlatformMentionProps) {
   return (
     <span className="inline-flex items-center gap-1 whitespace-nowrap align-middle">
       <Image
@@ -56,7 +60,11 @@ function PlatformMention({ platform }: { platform: BotPlatform }) {
   );
 }
 
-export function PlanFeature({ feature }: { feature: string }) {
+interface PlanFeatureProps {
+  feature: string;
+}
+
+export function PlanFeature({ feature }: PlanFeatureProps) {
   const { segments, platforms } = tokenize(feature);
 
   if (platforms.length === 0) {

--- a/apps/web/src/features/pricing/components/PricingCard.tsx
+++ b/apps/web/src/features/pricing/components/PricingCard.tsx
@@ -10,6 +10,7 @@ import { TextMorph } from "torph/react";
 import { RaisedButton } from "@/components/ui/raised-button";
 import { ShineBorder } from "@/components/ui/shine-border";
 import { useUser } from "@/features/auth/hooks/useUser";
+import { PlanFeature } from "@/features/pricing/components/PlanFeature";
 import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 import {
@@ -342,14 +343,14 @@ export function PricingCard({
           features.map((feature) => (
             <div
               key={feature}
-              className="flex items-center gap-3 text-sm font-light"
+              className="flex items-start gap-3 text-sm font-light"
             >
               <Tick02Icon
                 height="15"
                 width="15"
-                className={`shrink-0 ${isPro ? "text-primary" : "text-zinc-500"}`}
+                className={`mt-1 shrink-0 ${isPro ? "text-primary" : "text-zinc-500"}`}
               />
-              <span className="whitespace-nowrap text-zinc-300">{feature}</span>
+              <PlanFeature feature={feature} />
             </div>
           ))}
       </div>


### PR DESCRIPTION
Makes the plan bullets say which chat platforms each tier gets, and renders each platform's icon inline with its name. iMessage is Pro-only — already true in the backend (`PREMIUM_PLATFORMS` in `platform_link_service.py`, re-checked on every message) but invisible on the pricing page until now.

## After

![GAIA pricing cards side by side. The Free card lists Chat on followed by the WhatsApp, Telegram, Discord and Slack icons in a small tilted stack, then Standard models, Daily AI usage allowance, 100 saved memories, Community support, and All tools and 100s of integrations. The Pro card lists Chat on iMessage, More powerful models, Much higher usage limits, Unlimited memories, Priority support, Long running tasks, and Early access to new features, so each upgrade sits on the same row as the Free limit it replaces.](https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/1059-pricing-platform-icons/after-aligned.png)

## Before

![The same two pricing cards without any platform bullets. The Free card goes straight from All tools and 100s of integrations to Standard models, and the Pro card starts at Much higher usage limits. Nothing on either card mentions which chat platforms the tier includes.](https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/1059-pricing-platform-icons/before.png)

If the images do not render: **Free** gains one bullet, "Chat on WhatsApp, Telegram, Discord & Slack", with each name preceded by its 16px app icon and wrapping to two lines. **Pro** gains "Chat on iMessage" as its first bullet, directly under "Everything in Free, plus". No other bullet changes.

## How it works

Plan bullets are backend data (the `plans` collection, seeded by `payment_setup.py`), not frontend constants — so this does **not** change the feature schema. `PlanFeature` takes the bullet string it is already handed, finds any platform name inside it, and renders that name with its icon:

- A bullet with no platform name renders exactly as before, `whitespace-nowrap` included.
- **A run of two or more platforms collapses into a fanned icon stack** — the same treatment as the `/bots` hero, scaled to bullet size: each icon is rotated a step further than the last (`-12°/-6°/+6°/+12°` for four), overlapped by `-space-x-1`, stacked with an ascending z-index, and given a soft drop shadow so the overlapping edges stay readable. Icons are 16px inside a 20px-tall container, sized so the stack sits on the text line rather than growing the bullet: measured in the browser, the platform row is 21px against 20px for every other bullet, where a first pass at 28px pushed it visibly taller and made the list look uneven. The names and their separators drop out of the visible text, so "Chat on WhatsApp, Telegram, Discord & Slack" renders as "Chat on" plus the stack, on one line. Repeating each name beside its icon was noisy and wrapped to two lines.
- **A lone platform keeps its name** (`Chat on 💬 iMessage`), because a single unlabelled icon does not tell you which app it is — and this is the one the Pro tier is gated on.
- The icon row carries `role="img"` and an `aria-label` listing the platforms, so the names dropped from the visible text are still announced, and a `title` shows them on hover.
- Names come from `BOT_PLATFORM_LABELS` and icons from `BOT_PLATFORM_ICONS` (`@/config/botPlatforms`), so any future bullet mentioning a platform gets its icon for free, and a rename lands in one place.

Two bullets added to the seed catalogue:

| Plan | Bullet |
|---|---|
| Free | Chat on WhatsApp, Telegram, Discord & Slack |
| Pro | Chat on iMessage |

Free lists the four open platforms; Pro adds iMessage under "Everything in Free, plus", so the gate reads without any extra "Pro only" label.

Both lists are also **reordered** so each Pro upgrade sits on the same row as the Free limit it replaces — `Standard models` ↔ `More powerful models`, `Daily AI usage allowance` ↔ `Much higher usage limits`, `100 saved memories` ↔ `Unlimited memories`, `Community support` ↔ `Priority support`. Previously the two lists were ordered independently and no row lined up with its counterpart. This is purely the order of the strings in the seed catalogue; no layout or alignment code is involved.

## Deploying this

`payment_setup.py` upserts, so re-running it against prod applies the new bullets to the existing plan documents. **Until someone runs it, production will not show these two bullets** — the code change alone is not enough. The script supports `--dry-run`.

## Verification

- `nx lint web` and `nx type-check web` pass.
- Rendered against a stub `/payments/plans` at 1440px and at 390px. The icon row fits on one line at both widths; every other bullet is unchanged.
- The same `PricingCard` backs `PricingModal`, so the modal inherits this and uses the same width classes.

Two Biome findings fixed rather than suppressed: an array-index key (now keyed on the regex match offset) and `aria-label` on a roleless `<span>` (now `role="img"`, which is what the icon row is).




