### PR TITLE
fix(web): add iMessage to the Product nav dropdown

### DIFF
--- a/apps/web/src/config/appConfig.tsx
+++ b/apps/web/src/config/appConfig.tsx
@@ -173,6 +173,12 @@ export const appConfig = {
         "/images/icons/macos/discord.webp",
         "Add GAIA to your server",
       ),
+      botLink(
+        "/bots",
+        "iMessage",
+        "/images/icons/macos/imessage.webp",
+        "Text GAIA from your iPhone",
+      ),
       navLink(
         "/features",
         "Features",


### PR DESCRIPTION
The navbar's Product menu lists every chat platform GAIA supports — except iMessage:

> Use Cases · Integrations · Download · Self-Host CLI · **WhatsApp · Telegram · Slack · Discord**

`appConfig.tsx` defines four `botLink` entries and never got a fifth when iMessage shipped. Added it with the shared macOS icon, pointing at `/bots`, described in the same voice as its siblings ("Text GAIA from your iPhone").

![The GAIA navbar Product dropdown expanded, showing Use Cases, Integrations, Download, Self-Host CLI, WhatsApp, Telegram, Slack, Discord and a new iMessage entry with the Messages icon and the description Text GAIA from your iPhone.](https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/1058-imessage-docs/nav-dropdown.png)

If the image does not render: the dropdown now ends with an **iMessage** row carrying the Messages icon and the caption "Text GAIA from your iPhone", styled identically to the four platform rows above it.

## Why this is a separate PR

It was authored on the #1058 branch but pushed after that PR had already been squash-merged, so it never reached master. Cherry-picked onto a fresh branch off current master rather than left stranded.

## Verification

- `nx lint web` and `nx type-check web` pass.
- Opened the dropdown in a real browser and read back the rendered entries: `WhatsApp · Telegram · Slack · Discord · iMessage`.

## Context

This is the fifth hand-maintained list that enumerates bots and silently missed iMessage, after `nx-release-publish` (#1050), `BOTS_IMAGE_REPOS` and the CI type-check list (#1052), and the Prometheus probe targets (#1053). None of them derive from `BOT_PLATFORMS`, so the next platform will hit the same set. Worth a follow-up that makes them derive from the canonical config instead of being kept in sync by hand.