### PR TITLE
feat(command): palette UX overhaul — frecency ranking, full integration catalog, Ask GAIA auto-send, polish

### DIFF
--- a/apps/web/src/__tests__/palette-frecency.test.ts
+++ b/apps/web/src/__tests__/palette-frecency.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the palette frecency store (features/command/frecency.ts).
+ *
+ * The store persists what the user picks so future rankings can boost it.
+ * These pin the ring-buffer cap, decay ordering (recent > old), and the
+ * score bounds that paletteModel's boost relies on. localStorage doesn't
+ * exist in the node test environment — zustand's persist middleware skips
+ * persistence when storage is unavailable, which is exactly the behavior
+ * under test here (in-memory state must still work).
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { frecencyScore, useFrecencyStore } from "@/features/command/frecency";
+
+const record = (id: string) => useFrecencyStore.getState().record(id);
+
+beforeEach(() => {
+  useFrecencyStore.setState({ entries: [] });
+});
+
+describe("record", () => {
+  it("appends activations with a timestamp", () => {
+    record("chat:1");
+    const { entries } = useFrecencyStore.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe("chat:1");
+    expect(entries[0].ts).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("caps the ring buffer at 200 entries", () => {
+    for (let i = 0; i < 210; i++) record(`item:${i}`);
+    const { entries } = useFrecencyStore.getState();
+    expect(entries).toHaveLength(200);
+    // Oldest fell off the front; newest is intact.
+    expect(entries[0].id).toBe("item:10");
+    expect(entries[199].id).toBe("item:209");
+  });
+});
+
+describe("frecencyScore", () => {
+  it("returns 0 for items never picked", () => {
+    record("chat:1");
+    expect(frecencyScore(useFrecencyStore.getState().entries, "chat:2")).toBe(
+      0,
+    );
+  });
+
+  it("scores recent picks higher than old ones", () => {
+    const now = Date.now();
+    const hourAgo = now - 60 * 60 * 1000;
+    const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
+    const entries = [
+      { id: "old", ts: weekAgo },
+      { id: "fresh", ts: hourAgo },
+    ];
+    expect(frecencyScore(entries, "fresh")).toBeGreaterThan(
+      frecencyScore(entries, "old"),
+    );
+  });
+
+  it("grows with repeated picks", () => {
+    const entries = [
+      { id: "hot", ts: Date.now() },
+      { id: "hot", ts: Date.now() },
+      { id: "hot", ts: Date.now() },
+    ];
+    const once = [{ id: "hot", ts: Date.now() }];
+    expect(frecencyScore(entries, "hot")).toBeGreaterThan(
+      frecencyScore(once, "hot"),
+    );
+  });
+
+  it("counts at most the 10 most recent occurrences per item", () => {
+    const now = Date.now();
+    // Store reality: later records sit at higher indices. Build the fixture
+    // the same way — newest LAST.
+    const fifteen = Array.from({ length: 15 }, (_, i) => ({
+      id: "spam",
+      ts: now - (15 - i) * 1000,
+    }));
+    const ten = fifteen.slice(5);
+    expect(frecencyScore(fifteen, "spam")).toBeCloseTo(
+      frecencyScore(ten, "spam"),
+      6,
+    );
+  });
+
+  it("stays bounded so boosts can't outrank exact title matches", () => {
+    const now = Date.now();
+    const entries = Array.from({ length: 10 }, (_, i) => ({
+      id: "hot",
+      // Ten same-hour picks: each contributes ~1.
+      ts: now - i * 60_000,
+    }));
+    // paletteModel multiplies by 3 and caps at 200; an exact title match
+    // scores 200 on its own, so even max frecency must stay below that
+    // after the multiplier.
+    expect(frecencyScore(entries, "hot") * 3).toBeLessThan(200);
+  });
+});

--- a/apps/web/src/__tests__/palette-model.test.ts
+++ b/apps/web/src/__tests__/palette-model.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for the palette's section builder (features/command/model/paletteModel.tsx).
+ *
+ * buildSections is the pure heart of the palette: given a view, query, and
+ * data groups it decides every row the user sees. These pin the four view
+ * levels (root / search / category / item), the always-present Ask GAIA row,
+ * the server-result floor, loading state, and the frecency-boost contract.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildSections, type Row } from "@/features/command/model/paletteModel";
+import type { CommandGroup, CommandItem } from "@/features/command/model/types";
+
+/** Minimal runnable row item. */
+const item = (
+  id: string,
+  title: string,
+  actions: CommandItem["actions"] = [],
+): CommandItem => ({
+  id,
+  type: "action",
+  title,
+  icon: null,
+  primary: { id: "run", label: title, icon: null, run: () => undefined },
+  actions,
+});
+
+const group = (
+  id: string,
+  heading: string,
+  items: CommandItem[],
+  extra: Partial<CommandGroup> = {},
+): CommandGroup => ({
+  id,
+  heading,
+  accent: "text-zinc-400",
+  kind: "entity",
+  path: `/${id}`,
+  items,
+  ...extra,
+});
+
+const params = (over: Partial<Parameters<typeof buildSections>[0]>) => ({
+  view: undefined,
+  query: "",
+  groups: [],
+  recent: [],
+  context: null,
+  searchChats: [],
+  searchMessages: [],
+  searchMemories: [],
+  searchLoading: false,
+  ...over,
+});
+
+const titles = (rows: Row[]) =>
+  rows.map((r) =>
+    r.kind === "item"
+      ? r.item.title
+      : r.kind === "action"
+        ? r.action.label
+        : r.kind === "nav"
+          ? r.label
+          : r.id,
+  );
+
+describe("root level", () => {
+  it("shows context first, recent next (minus the context item), then Browse + action groups", () => {
+    const chatItem = item("chat:1", "Current chat");
+    const sections = buildSections(
+      params({
+        context: { heading: "Current chat", item: chatItem },
+        recent: [chatItem, item("todo:1", "A todo")],
+        groups: [
+          group("chats", "Chats", [chatItem]),
+          item("cmd:new", "New chat") && {
+            id: "actions",
+            heading: "Quick actions",
+            accent: "text-emerald-400",
+            kind: "actions" as const,
+            items: [item("cmd:new", "New chat")],
+          },
+        ],
+      }),
+    );
+
+    expect(sections[0].heading).toBe("Current chat");
+    expect(sections[1].heading).toBe("Recent");
+    // The context item must not repeat inside Recent.
+    expect(titles(sections[1].rows)).toEqual(["A todo"]);
+    const browse = sections.find((s) => s.id === "browse");
+    expect(browse).toBeDefined();
+  });
+
+  it("drops empty command groups but keeps empty entity categories browsable", () => {
+    const sections = buildSections(
+      params({
+        groups: [
+          {
+            id: "actions",
+            heading: "Quick actions",
+            accent: "",
+            kind: "actions",
+            items: [],
+          },
+          group("workflows", "Workflows", []),
+        ],
+      }),
+    );
+    expect(sections.find((s) => s.id === "actions")).toBeUndefined();
+    expect(sections.find((s) => s.id === "browse")).toBeDefined();
+  });
+});
+
+describe("search level", () => {
+  it("orders Jump-to above scored result sections and always ends with Ask GAIA", () => {
+    const sections = buildSections(
+      params({
+        query: "workflows",
+        groups: [
+          group("workflows", "Workflows", [item("wf:1", "Deploy site")]),
+          group("todos", "Todos", [item("td:1", "Buy milk")]),
+        ],
+      }),
+    );
+    expect(sections[0].heading).toBe("Jump to");
+    expect(sections[sections.length - 1].rows[0].kind).toBe("ask");
+  });
+
+  it("keeps server hits with non-matching titles via the min-score floor", () => {
+    const sections = buildSections(
+      params({
+        query: "meeting notes",
+        searchChats: [item("chat:9", "Totally unrelated title")],
+        groups: [group("chats", "Chats", [])],
+      }),
+    );
+    const chats = sections.find((s) => s.id === "chats");
+    expect(chats).toBeDefined();
+  });
+
+  it("renders a searching skeleton when loading with zero results", () => {
+    const sections = buildSections(params({ query: "q", searchLoading: true }));
+    const loading = sections.find((s) => s.id === "loading");
+    expect(loading?.rows[0].kind).toBe("loading");
+  });
+
+  it("does not render the skeleton once results exist", () => {
+    const sections = buildSections(
+      params({
+        query: "deploy",
+        searchLoading: true,
+        groups: [
+          group("workflows", "Workflows", [item("wf:1", "Deploy site")]),
+        ],
+      }),
+    );
+    expect(sections.find((s) => s.id === "loading")).toBeUndefined();
+  });
+
+  it("dedupes server chats already present locally by id", () => {
+    const local = item("chat:1", "Local copy");
+    const sections = buildSections(
+      params({
+        query: "local",
+        searchChats: [item("chat:1", "Server copy"), item("chat:2", "Other")],
+        groups: [group("chats", "Chats", [local])],
+      }),
+    );
+    const chats = sections.find((s) => s.id === "chats");
+    const ids = chats
+      ? chats.rows.map((r) => ("item" in r ? r.item.id : ""))
+      : [];
+    expect(ids.filter((id) => id === "chat:1")).toHaveLength(1);
+  });
+
+  it("frecency boost reorders equal-tier matches", () => {
+    // Both titles prefix-match "deploy" identically (90 * 2 = 180); only the
+    // boost differs.
+    const sections = buildSections(
+      params({
+        query: "deploy",
+        groups: [
+          group("workflows", "Workflows", [
+            item("wf:plain", "Deploy site"),
+            item("wf:fav", "Deploy api"),
+          ]),
+        ],
+        boost: (i) => (i.id === "wf:fav" ? 10 : 0),
+      }),
+    );
+    expect(titles(sections[0].rows)[0]).toBe("Deploy api");
+  });
+
+  it("boost cannot outrank a strictly better match tier", () => {
+    // Max realistic frecency is score 10 * multiplier 3 = 30. A word-boundary
+    // title match (80 * 2 = 160) must still beat a keyword-only match
+    // (~40-ish + 30).
+    const sections = buildSections(
+      params({
+        query: "todo",
+        groups: [
+          group("things", "Things", [
+            {
+              ...item("a:weak", "Unrelated title"),
+              keywords: "todo stuff",
+            },
+            item("b:strong", "Todo"),
+          ]),
+        ],
+        boost: () => 30,
+      }),
+    );
+    expect(titles(sections[0].rows)[0]).toBe("Todo");
+  });
+});
+
+describe("category level", () => {
+  it("shows Go back, Go-to and links when the query is empty; filters everything by query otherwise", () => {
+    const sections = buildSections(
+      params({
+        view: { level: "category", groupId: "todos" },
+        query: "",
+        groups: [
+          group(
+            "todos",
+            "Todos",
+            [item("td:1", "Buy milk"), item("td:2", "Walk dog")],
+            { links: [{ label: "Today", path: "/todos/today" }] },
+          ),
+        ],
+      }),
+    );
+    const labels = titles(sections[0].rows);
+    expect(labels).toEqual([
+      "back",
+      "Go to Todos",
+      "Today",
+      "Buy milk",
+      "Walk dog",
+    ]);
+
+    // A query that matches nothing but one item drops nav rows too.
+    const filtered = buildSections(
+      params({
+        view: { level: "category", groupId: "todos" },
+        query: "walk",
+        groups: [
+          group(
+            "todos",
+            "Todos",
+            [item("td:1", "Buy milk"), item("td:2", "Walk dog")],
+            { links: [{ label: "Today", path: "/todos/today" }] },
+          ),
+        ],
+      }),
+    );
+    expect(titles(filtered[0].rows)).toEqual(["back", "Walk dog"]);
+  });
+});
+
+describe("item level", () => {
+  it("lists the item's actions after Go back, filtered by query", () => {
+    const target = item("chat:1", "My chat", [
+      { id: "rename", label: "Rename", icon: null, run: () => undefined },
+      { id: "star", label: "Star chat", icon: null, run: () => undefined },
+      {
+        id: "delete",
+        label: "Delete chat",
+        icon: null,
+        destructive: true,
+        run: () => undefined,
+      },
+    ]);
+    const sections = buildSections(
+      params({
+        view: { level: "item", item: target },
+        query: "rename",
+      }),
+    );
+    const labels = titles(sections[0].rows);
+    expect(labels).toEqual(["back", "Rename"]);
+  });
+});

--- a/apps/web/src/__tests__/palette-scorer.test.ts
+++ b/apps/web/src/__tests__/palette-scorer.test.ts
@@ -82,6 +82,34 @@ describe("scoreFields — multi-term and weighting", () => {
     expect(titleHit).toBeGreaterThan(keywordHit);
   });
 
+  it("matches terms scattered across fields (title + keywords), at averaged strength", () => {
+    // "new" lives in the title, "compose" only in keywords — the row must
+    // still surface, but below a single-field exact match.
+    const scattered = scoreFields("new compose", [
+      { text: "New chat", weight: 2 },
+      { text: "compose message", weight: 1 },
+    ]);
+    expect(scattered).toBeGreaterThan(0);
+
+    const singleFieldExact = scoreFields("new chat", [
+      { text: "New chat", weight: 2 },
+      { text: "compose message", weight: 1 },
+    ]);
+    // Both words are word-boundary prefix hits inside the title:
+    // (90 + 80) / 2 * weight 2
+    expect(singleFieldExact).toBe(170);
+    expect(scattered).toBeLessThan(singleFieldExact);
+  });
+
+  it("still zeroes when a term exists nowhere across fields", () => {
+    expect(
+      scoreFields("new zebra", [
+        { text: "New chat", weight: 2 },
+        { text: "compose message" },
+      ]),
+    ).toBe(0);
+  });
+
   it("averages per-term scores so extra terms don't inflate a field past an exact single-term match", () => {
     const singleExact = scoreFields("chat", [{ text: "chat", weight: 2 }]);
     const twoTerms = scoreFields("chat now", [

--- a/apps/web/src/__tests__/palette-scorer.test.ts
+++ b/apps/web/src/__tests__/palette-scorer.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the palette's relevance scorer (features/command/model/scorer.ts).
+ *
+ * The scorer decides which row wins the palette, so the tiers it promises in
+ * its docs are load-bearing: exact > prefix > word-boundary > substring >
+ * subsequence. These tests pin each tier, the bonuses inside the subsequence
+ * tier, and the multi-term / multi-field contract.
+ */
+import { describe, expect, it } from "vitest";
+
+import { scoreFields, scoreTerm } from "@/features/command/model/scorer";
+
+describe("scoreTerm — match tiers", () => {
+  it("ranks exact above prefix above word-boundary above plain substring", () => {
+    const exact = scoreTerm("workflows", "workflows");
+    const prefix = scoreTerm("work", "workflows page");
+    // "work" sits right after a space — a true word boundary.
+    const boundary = scoreTerm("work", "git workflows page");
+    const substring = scoreTerm("orkflow", "wworkflows page");
+    expect(exact).toBeGreaterThan(prefix);
+    expect(prefix).toBeGreaterThan(boundary);
+    expect(boundary).toBeGreaterThan(substring);
+  });
+
+  it("scores camelCase transitions as word boundaries", () => {
+    // "clock" sits at a camelCase boundary inside "AlarmClockIcon".
+    const camelBoundary = scoreTerm("clock", "alarmClockIcon");
+    const midWord = scoreTerm("lock", "alarmClockIcon".toLowerCase());
+    expect(camelBoundary).toBeGreaterThanOrEqual(80);
+    expect(camelBoundary).toBeGreaterThan(midWord);
+  });
+
+  it("returns 0 when nothing matches", () => {
+    expect(scoreTerm("xyz", "workflows")).toBe(0);
+    expect(scoreTerm("", "workflows")).toBe(0);
+    expect(scoreTerm("work", "")).toBe(0);
+  });
+});
+
+describe("scoreTerm — subsequence matching", () => {
+  it("matches out-of-order characters with a low score", () => {
+    const score = scoreTerm("wfl", "workflows");
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(40);
+  });
+
+  it("rewards consecutive runs over spread-out matches", () => {
+    // "de" is consecutive in "index deploy"; split across "deploy index" too,
+    // but consecutive runs must outrank the scattered variant.
+    const consecutive = scoreTerm("dep", "index deploy tool");
+    const scattered = scoreTerm("dpl", "index deploy tool");
+    expect(consecutive).toBeGreaterThan(0);
+    expect(scattered).toBeGreaterThan(0);
+    expect(consecutive).toBeGreaterThan(scattered);
+  });
+
+  it("never lets a subsequence outrank a real substring hit", () => {
+    const substring = scoreTerm("run", "run now");
+    const subseq = scoreTerm("rn", "runner");
+    expect(substring).toBeGreaterThan(subseq);
+  });
+});
+
+describe("scoreFields — multi-term and weighting", () => {
+  it("requires every whitespace-separated term to match", () => {
+    const both = scoreFields("new chat", [{ text: "start a new chat" }]);
+    const half = scoreFields("new zebra", [{ text: "start a new chat" }]);
+    expect(both).toBeGreaterThan(0);
+    expect(half).toBe(0);
+  });
+
+  it("weights fields so title hits outrank keyword hits", () => {
+    const query = "spotify";
+    const titleHit = scoreFields(query, [
+      { text: "Spotify", weight: 2 },
+      { text: "music app" },
+    ]);
+    const keywordHit = scoreFields(query, [
+      { text: "something else entirely" },
+      { text: "connect spotify music", weight: 1 },
+    ]);
+    expect(titleHit).toBeGreaterThan(keywordHit);
+  });
+
+  it("averages per-term scores so extra terms don't inflate a field past an exact single-term match", () => {
+    const singleExact = scoreFields("chat", [{ text: "chat", weight: 2 }]);
+    const twoTerms = scoreFields("chat now", [
+      { text: "chat now please", weight: 2 },
+    ]);
+    expect(singleExact).toBe(200);
+    expect(twoTerms).toBeLessThan(singleExact);
+  });
+
+  it("returns 0 for an empty/whitespace query", () => {
+    expect(scoreFields("", [{ text: "anything" }])).toBe(0);
+    expect(scoreFields("   ", [{ text: "anything" }])).toBe(0);
+  });
+
+  it("ignores undefined fields instead of failing", () => {
+    expect(
+      scoreFields("todo", [
+        { text: undefined, weight: 2 },
+        { text: "create todo" },
+      ]),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/features/chat/components/interface/ChatPage.tsx
+++ b/apps/web/src/features/chat/components/interface/ChatPage.tsx
@@ -31,6 +31,7 @@ import { toast } from "@/lib/toast";
 import { syncSingleConversation } from "@/services/syncService";
 import { useChatStore } from "@/stores/chatStore";
 import {
+  useComposerStore,
   useComposerTextActions,
   usePendingPrompt,
 } from "@/stores/composerStore";
@@ -50,6 +51,12 @@ const MainChat = React.memo(function MainChat() {
   const openPricingModal = usePricingModalStore((s) => s.openModal);
   const pendingPrompt = usePendingPrompt();
   const { clearPendingPrompt } = useComposerTextActions();
+  // Once-only guard for the palette's auto-send ask (the chat layout can
+  // remount while the send is in flight — same hazard as workflow auto-send).
+  const autoAskFiredRef = useRef(false);
+  useEffect(() => {
+    if (!pendingPrompt) autoAskFiredRef.current = false;
+  }, [pendingPrompt]);
   const setActiveConversationId = useChatStore(
     (state) => state.setActiveConversationId,
   );
@@ -169,11 +176,25 @@ const MainChat = React.memo(function MainChat() {
   });
 
   useEffect(() => {
-    if (pendingPrompt && appendToInputRef.current) {
+    if (!pendingPrompt) return;
+    // Palette "Ask GAIA" hands over with auto-send: skip the composer and
+    // fire the message directly (once — the layout can remount mid-send).
+    if (useComposerStore.getState().pendingAutoSend) {
+      if (autoAskFiredRef.current) return;
+      autoAskFiredRef.current = true;
+      const prompt = pendingPrompt;
+      clearPendingPrompt();
+      useComposerStore.getState().setPendingAutoSend(false);
+      setTimeout(() => {
+        sendMessage(prompt, { conversationId: null });
+      }, 0);
+      return;
+    }
+    if (appendToInputRef.current) {
       appendToInputRef.current(pendingPrompt);
       clearPendingPrompt();
     }
-  }, [pendingPrompt, clearPendingPrompt, appendToInputRef]);
+  }, [pendingPrompt, clearPendingPrompt, appendToInputRef, sendMessage]);
 
   useEffect(() => {
     const queryParam = new URLSearchParams(window.location.search).get("q");

--- a/apps/web/src/features/chat/components/interface/ChatPage.tsx
+++ b/apps/web/src/features/chat/components/interface/ChatPage.tsx
@@ -51,12 +51,9 @@ const MainChat = React.memo(function MainChat() {
   const openPricingModal = usePricingModalStore((s) => s.openModal);
   const pendingPrompt = usePendingPrompt();
   const { clearPendingPrompt } = useComposerTextActions();
-  // Once-only guard for the palette's auto-send ask (the chat layout can
-  // remount while the send is in flight — same hazard as workflow auto-send).
+  // Once-per-prompt guard for the palette's auto-send handoff (reset in the
+  // consumer effect below when the prompt is consumed / cleared).
   const autoAskFiredRef = useRef(false);
-  useEffect(() => {
-    if (!pendingPrompt) autoAskFiredRef.current = false;
-  }, [pendingPrompt]);
   const setActiveConversationId = useChatStore(
     (state) => state.setActiveConversationId,
   );
@@ -176,24 +173,31 @@ const MainChat = React.memo(function MainChat() {
   });
 
   useEffect(() => {
-    if (!pendingPrompt) return;
+    // Consume each prompt exactly once. StrictMode replays mount effects
+    // against the same state snapshot — without this guard an auto-send
+    // handoff is followed by a second pass reading the stale prompt and
+    // duplicating it into the composer.
+    if (!pendingPrompt) {
+      autoAskFiredRef.current = false;
+      return;
+    }
+    if (autoAskFiredRef.current) return;
+    autoAskFiredRef.current = true;
+
     // Palette "Ask GAIA" hands over with auto-send: skip the composer and
     // fire the message directly (once — the layout can remount mid-send).
     if (useComposerStore.getState().pendingAutoSend) {
-      if (autoAskFiredRef.current) return;
-      autoAskFiredRef.current = true;
-      const prompt = pendingPrompt;
-      clearPendingPrompt();
       useComposerStore.getState().setPendingAutoSend(false);
       setTimeout(() => {
-        sendMessage(prompt, { conversationId: null });
+        sendMessage(pendingPrompt, { conversationId: null });
       }, 0);
+      clearPendingPrompt();
       return;
     }
     if (appendToInputRef.current) {
       appendToInputRef.current(pendingPrompt);
-      clearPendingPrompt();
     }
+    clearPendingPrompt();
   }, [pendingPrompt, clearPendingPrompt, appendToInputRef, sendMessage]);
 
   useEffect(() => {

--- a/apps/web/src/features/command/CommandMenu.tsx
+++ b/apps/web/src/features/command/CommandMenu.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight } from "@/components/shared/icons";
 import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import { PaletteRow } from "./components/PaletteRow";
-import { useChatSearch } from "./data/useChatSearch";
+import { useChatSearch, useMemorySearch } from "./data/useChatSearch";
 import { useCommandData } from "./data/useCommandData";
 import { frecencyScore, useFrecencyStore } from "./frecency";
 import {
@@ -84,6 +84,8 @@ function enterLabel(row?: Row): string {
   switch (row?.kind) {
     case "back":
       return "Go back";
+    case "loading":
+      return "Searching…";
     case "category":
       return row.group.items.length === 0 ? "Open" : "Browse";
     case "item":
@@ -108,6 +110,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     context,
     buildSearchChat,
     buildSearchMessage,
+    buildSearchMemory,
     askGaia,
   } = useCommandData(host);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -123,11 +126,6 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
   // Inline form (e.g. rename) — replaces the input while active.
   const [formAction, setFormAction] = useState<CommandAction | null>(null);
   const [formValue, setFormValue] = useState("");
-  const frecencyEntries = useFrecencyStore((s) => s.entries);
-  const boost = useCallback(
-    (item: CommandItem) => frecencyScore(frecencyEntries, item.id) * 3,
-    [frecencyEntries],
-  );
 
   const depth = levels.length - 1;
   const view = levels[depth].view;
@@ -142,7 +140,16 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     });
   }, []);
 
-  const serverResults = useChatSearch(query);
+  const frecencyEntries = useFrecencyStore((s) => s.entries);
+  const boost = useCallback(
+    (item: CommandItem) => frecencyScore(frecencyEntries, item.id) * 3,
+    [frecencyEntries],
+  );
+
+  const { results: serverResults, isFetching: chatsFetching } =
+    useChatSearch(query);
+  const { memories: searchedMemories, isFetching: memoriesFetching } =
+    useMemorySearch(query);
   const searchChats = useMemo(
     () => (serverResults?.conversations ?? []).map(buildSearchChat),
     [serverResults, buildSearchChat],
@@ -151,6 +158,14 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     () => (serverResults?.messages ?? []).map(buildSearchMessage),
     [serverResults, buildSearchMessage],
   );
+  const searchMemories = useMemo(
+    () =>
+      searchedMemories
+        .map(buildSearchMemory)
+        .filter((item): item is CommandItem => item !== null),
+    [searchedMemories, buildSearchMemory],
+  );
+  const searchLoading = chatsFetching || memoriesFetching;
 
   const sections = useMemo(
     () =>
@@ -162,9 +177,22 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
         context,
         searchChats,
         searchMessages,
+        searchMemories,
+        searchLoading,
         boost,
       }),
-    [view, query, groups, recent, context, searchChats, searchMessages, boost],
+    [
+      view,
+      query,
+      groups,
+      recent,
+      context,
+      searchChats,
+      searchMessages,
+      searchMemories,
+      searchLoading,
+      boost,
+    ],
   );
 
   const flatRows = useMemo(() => sections.flatMap((s) => s.rows), [sections]);

--- a/apps/web/src/features/command/CommandMenu.tsx
+++ b/apps/web/src/features/command/CommandMenu.tsx
@@ -95,7 +95,7 @@ function enterLabel(row?: Row): string {
     case "nav":
       return row.label;
     case "ask":
-      return "Ask GAIA";
+      return row.query.trim() ? "Ask & send" : "Open chat";
     default:
       return "Open";
   }
@@ -304,7 +304,9 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
           close();
           break;
         case "ask":
-          askGaia(row.query);
+          // An empty query just opens a chat; a typed query is the intent —
+          // send it. Shift+Enter prefills instead (handled in keydown).
+          askGaia(row.query, row.query.trim() !== "");
           break;
       }
     },
@@ -330,13 +332,55 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     [drillItem, activateCategory],
   );
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (formAction) return; // the inline form input handles its own keys
+  // Escape / Tab / arrows / Shift+Enter — the drill- and level-level keys.
+  const handleNavigationKey = useCallback(
+    (event: React.KeyboardEvent, highlighted: Row | undefined): boolean => {
       const el = inputRef.current;
       const caretAtEnd = !el || el.selectionStart === el.value.length;
       const caretAtStart =
         !el || (el.selectionStart === 0 && el.selectionEnd === 0);
+
+      // Shift+Enter on the ask row prefills the composer instead of sending.
+      if (
+        event.key === "Enter" &&
+        event.shiftKey &&
+        highlighted?.kind === "ask"
+      ) {
+        event.preventDefault();
+        askGaia(highlighted.query, false);
+        return true;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        depth ? back() : close();
+        return true;
+      }
+      if (event.key === "Tab" && canDrill(highlighted)) {
+        event.preventDefault();
+        openSecondary(highlighted);
+        return true;
+      }
+      if (event.key === "ArrowRight" && caretAtEnd && canDrill(highlighted)) {
+        event.preventDefault();
+        openSecondary(highlighted);
+        return true;
+      }
+      const wantsBack =
+        (event.key === "ArrowLeft" && caretAtStart) ||
+        (event.key === "Backspace" && query === "");
+      if (wantsBack && depth) {
+        event.preventDefault();
+        back();
+        return true;
+      }
+      return false;
+    },
+    [askGaia, depth, back, close, openSecondary, query],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (formAction) return; // the inline form input handles its own keys
       const highlighted = flatRows.find((r) => r.id === highlightedId);
 
       const digitRow = resolveDigitRow(event, query, numberedRows);
@@ -345,28 +389,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
         activate(digitRow);
         return;
       }
-      if (event.key === "Escape") {
-        event.preventDefault();
-        depth ? back() : close();
-        return;
-      }
-      if (event.key === "Tab" && canDrill(highlighted)) {
-        event.preventDefault();
-        openSecondary(highlighted);
-        return;
-      }
-      if (event.key === "ArrowRight" && caretAtEnd && canDrill(highlighted)) {
-        event.preventDefault();
-        openSecondary(highlighted);
-        return;
-      }
-      const wantsBack =
-        (event.key === "ArrowLeft" && caretAtStart) ||
-        (event.key === "Backspace" && query === "");
-      if (wantsBack && depth) {
-        event.preventDefault();
-        back();
-      }
+      handleNavigationKey(event, highlighted);
     },
     [
       formAction,
@@ -374,11 +397,8 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
       highlightedId,
       query,
       numberedRows,
-      depth,
       activate,
-      openSecondary,
-      back,
-      close,
+      handleNavigationKey,
     ],
   );
 

--- a/apps/web/src/features/command/CommandMenu.tsx
+++ b/apps/web/src/features/command/CommandMenu.tsx
@@ -232,6 +232,36 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     return () => cancelAnimationFrame(id);
   }, [query, depth]);
 
+  // Scroll shadows: visible only when content extends past a viewport edge.
+  const [scrollShadow, setScrollShadow] = useState({
+    top: false,
+    bottom: false,
+  });
+  const updateScrollShadow = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const top = el.scrollTop > 4;
+    const bottom = el.scrollTop + el.clientHeight < el.scrollHeight - 4;
+    // Same-value bail: content-driven effects here would otherwise loop
+    // (new object → rerender → effect → new object).
+    setScrollShadow((prev) =>
+      prev.top === top && prev.bottom === bottom ? prev : { top, bottom },
+    );
+  }, []);
+  useEffect(() => {
+    // Content changes (results, level) can add/remove scrollability.
+    updateScrollShadow();
+  }, [flatRows, depth, updateScrollShadow]);
+
+  // Screen-reader announcement once typing settles: how many rows matched.
+  const [resultCount, setResultCount] = useState(0);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setResultCount(query.trim() ? flatRows.filter(isNumbered).length : 0);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [flatRows, query]);
+
   // Mounted only while open: fire the open event, and restore focus on close.
   // The opener is captured by the store's open action — before this mounts and
   // the palette input auto-focuses — so cleanup returns focus to the trigger.
@@ -521,45 +551,65 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
           )}
 
           {!formAction && (
-            <Command.List ref={listRef} className={S.list}>
-              {noResults && (
-                <div className="flex flex-col items-center gap-2 py-6 text-zinc-500">
-                  <SearchIcon className="h-6 w-6 text-zinc-600" />
-                  <p className="text-sm">No results for "{query.trim()}"</p>
+            <div className={S.listWrapper}>
+              {/* Scroll shadows — fade in when the list can scroll that way. */}
+              <div
+                aria-hidden
+                className={`${S.scrollShadow} ${scrollShadow.top ? "opacity-100" : "opacity-0"}`}
+              />
+              <div
+                aria-hidden
+                className={`${S.scrollShadow} ${S.scrollShadowBottom} ${scrollShadow.bottom ? "opacity-100" : "opacity-0"}`}
+              />
+              <Command.List
+                ref={listRef}
+                className={S.list}
+                onScroll={updateScrollShadow}
+              >
+                {noResults && (
+                  <div className="flex flex-col items-center gap-2 py-6 text-zinc-500">
+                    <SearchIcon className="h-6 w-6 text-zinc-600" />
+                    <p className="text-sm">No results for "{query.trim()}"</p>
+                  </div>
+                )}
+                {/* Keyed by depth so moving between levels remounts the list and
+                    replays the entrance slide; typing within a level does not. */}
+                <div key={depth}>
+                  {sections.map((section, index) => (
+                    <CommandSection
+                      key={section.id}
+                      heading={section.heading}
+                      showSeparator={index > 0}
+                    >
+                      {section.rows.map((row) => (
+                        <m.div
+                          key={row.id}
+                          {...rowEntrance({
+                            index: rowIndex.get(row.id) ?? 0,
+                            direction,
+                            browsing: query.trim() === "",
+                            reduced,
+                          })}
+                        >
+                          <PaletteRow
+                            row={row}
+                            number={numbered.get(row.id)}
+                            onActivate={() => activate(row)}
+                            onSecondary={() => openSecondary(row)}
+                          />
+                        </m.div>
+                      ))}
+                    </CommandSection>
+                  ))}
                 </div>
-              )}
-              {/* Keyed by depth so moving between levels remounts the list and
-                  replays the entrance slide; typing within a level does not. */}
-              <div key={depth}>
-                {sections.map((section, index) => (
-                  <CommandSection
-                    key={section.id}
-                    heading={section.heading}
-                    showSeparator={index > 0}
-                  >
-                    {section.rows.map((row) => (
-                      <m.div
-                        key={row.id}
-                        {...rowEntrance({
-                          index: rowIndex.get(row.id) ?? 0,
-                          direction,
-                          browsing: query.trim() === "",
-                          reduced,
-                        })}
-                      >
-                        <PaletteRow
-                          row={row}
-                          number={numbered.get(row.id)}
-                          onActivate={() => activate(row)}
-                          onSecondary={() => openSecondary(row)}
-                        />
-                      </m.div>
-                    ))}
-                  </CommandSection>
-                ))}
-              </div>
-            </Command.List>
+              </Command.List>
+            </div>
           )}
+
+          {/* Settled result count for screen readers (visually hidden). */}
+          <div role="status" aria-live="polite" className={S.liveRegion}>
+            {query.trim() && resultCount > 0 ? `${resultCount} results` : ""}
+          </div>
 
           <div className={`${S.footer} flex items-center gap-4`}>
             {formAction ? (

--- a/apps/web/src/features/command/CommandMenu.tsx
+++ b/apps/web/src/features/command/CommandMenu.tsx
@@ -12,7 +12,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight } from "@/components/shared/icons";
 import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import { PaletteRow } from "./components/PaletteRow";
-import { useChatSearch, useMemorySearch } from "./data/useChatSearch";
+import {
+  MIN_CHARS,
+  useChatSearch,
+  useMemorySearch,
+} from "./data/useChatSearch";
 import { useCommandData } from "./data/useCommandData";
 import { frecencyScore, useFrecencyStore } from "./frecency";
 import {
@@ -146,26 +150,41 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     [frecencyEntries],
   );
 
-  const { results: serverResults, isFetching: chatsFetching } =
+  const { results: serverResults, debounced: chatsDebounced } =
     useChatSearch(query);
-  const { memories: searchedMemories, isFetching: memoriesFetching } =
+  const { memories: searchedMemories, debounced: memoriesDebounced } =
     useMemorySearch(query);
+  // Server rows only render while the results answer the query on screen —
+  // during the debounce window the hooks still hold the previous query's
+  // hits, and the floor score would keep stale rows visible and clickable.
+  const trimmed = query.trim();
+  const chatsFresh = chatsDebounced === trimmed;
+  const memoriesFresh = memoriesDebounced === trimmed;
   const searchChats = useMemo(
-    () => (serverResults?.conversations ?? []).map(buildSearchChat),
-    [serverResults, buildSearchChat],
+    () =>
+      (chatsFresh ? (serverResults?.conversations ?? []) : []).map(
+        buildSearchChat,
+      ),
+    [chatsFresh, serverResults, buildSearchChat],
   );
   const searchMessages = useMemo(
-    () => (serverResults?.messages ?? []).map(buildSearchMessage),
-    [serverResults, buildSearchMessage],
+    () =>
+      (chatsFresh ? (serverResults?.messages ?? []) : []).map(
+        buildSearchMessage,
+      ),
+    [chatsFresh, serverResults, buildSearchMessage],
   );
   const searchMemories = useMemo(
     () =>
-      searchedMemories
+      (memoriesFresh ? searchedMemories : [])
         .map(buildSearchMemory)
         .filter((item): item is CommandItem => item !== null),
-    [searchedMemories, buildSearchMemory],
+    [memoriesFresh, searchedMemories, buildSearchMemory],
   );
-  const searchLoading = chatsFetching || memoriesFetching;
+  // Waiting covers both in-flight fetches and the debounce gap itself, but
+  // never for queries too short to ever hit the server.
+  const searchLoading =
+    trimmed.length >= MIN_CHARS && (!chatsFresh || !memoriesFresh);
 
   const sections = useMemo(
     () =>

--- a/apps/web/src/features/command/CommandMenu.tsx
+++ b/apps/web/src/features/command/CommandMenu.tsx
@@ -14,6 +14,7 @@ import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import { PaletteRow } from "./components/PaletteRow";
 import { useChatSearch } from "./data/useChatSearch";
 import { useCommandData } from "./data/useCommandData";
+import { frecencyScore, useFrecencyStore } from "./frecency";
 import {
   ANIMATION_CONFIG,
   rowEntrance,
@@ -22,8 +23,8 @@ import {
 import {
   buildSections,
   isNumbered,
+  type Level,
   type Row,
-  type View,
 } from "./model/paletteModel";
 import type {
   CommandAction,
@@ -52,6 +53,31 @@ function resolveDigitRow(
 
 const canDrill = (row?: Row): boolean =>
   !!row && (row.kind === "category" || (row.kind === "item" && row.canDrill));
+
+/**
+ * Client-only analytics for row activation — the server can't see which
+ * palette rows a user runs, so this never double-counts backend events.
+ * Executions (items/actions/ask) fire command:item_executed; item rows
+ * activated while searching additionally count as search:result_clicked.
+ */
+function trackActivation(row: Row, query: string): void {
+  if (row.kind === "item") {
+    // Record the pick so frecency can boost this item in future rankings.
+    useFrecencyStore.getState().record(row.item.id);
+    trackEvent(ANALYTICS_EVENTS.COMMAND_ITEM_EXECUTED, {
+      item_type: row.item.type,
+    });
+    if (query.trim() !== "") {
+      trackEvent(ANALYTICS_EVENTS.SEARCH_RESULT_CLICKED, {
+        result_type: row.item.type,
+      });
+    }
+  } else if (row.kind === "action" || row.kind === "ask") {
+    trackEvent(ANALYTICS_EVENTS.COMMAND_ITEM_EXECUTED, {
+      item_type: "action",
+    });
+  }
+}
 
 /** What Enter will do for the highlighted row, phrased for the footer. */
 function enterLabel(row?: Row): string {
@@ -87,8 +113,9 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const formInputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const [stack, setStack] = useState<View[]>([]);
-  const [query, setQuery] = useState("");
+  // One entry per drill-down level; each level remembers the query typed in
+  // it, so going back restores what was on screen (not a blank input).
+  const [levels, setLevels] = useState<Level[]>([{ query: "" }]);
   const [highlightedId, setHighlightedId] = useState<string>();
   // Drives the list's entrance slide: +1 when going deeper, -1 when going back.
   const [direction, setDirection] = useState<1 | -1>(1);
@@ -96,8 +123,24 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
   // Inline form (e.g. rename) — replaces the input while active.
   const [formAction, setFormAction] = useState<CommandAction | null>(null);
   const [formValue, setFormValue] = useState("");
+  const frecencyEntries = useFrecencyStore((s) => s.entries);
+  const boost = useCallback(
+    (item: CommandItem) => frecencyScore(frecencyEntries, item.id) * 3,
+    [frecencyEntries],
+  );
 
-  const view = stack.at(-1);
+  const depth = levels.length - 1;
+  const view = levels[depth].view;
+  const query = levels[depth].query;
+
+  /** Update the query of the level currently on screen. */
+  const setQuery = useCallback((q: string) => {
+    setLevels((ls) => {
+      const next = [...ls];
+      next[next.length - 1] = { ...next[next.length - 1], query: q };
+      return next;
+    });
+  }, []);
 
   const serverResults = useChatSearch(query);
   const searchChats = useMemo(
@@ -119,8 +162,9 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
         context,
         searchChats,
         searchMessages,
+        boost,
       }),
-    [view, query, groups, recent, context, searchChats, searchMessages],
+    [view, query, groups, recent, context, searchChats, searchMessages, boost],
   );
 
   const flatRows = useMemo(() => sections.flatMap((s) => s.rows), [sections]);
@@ -158,7 +202,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
       listRef.current?.scrollTo({ top: 0 }),
     );
     return () => cancelAnimationFrame(id);
-  }, [query, stack.length]);
+  }, [query, depth]);
 
   // Mounted only while open: fire the open event, and restore focus on close.
   // The opener is captured by the store's open action — before this mounts and
@@ -170,23 +214,22 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
 
   const drillCategory = useCallback((groupId: string) => {
     setDirection(1);
-    setStack((s) => [...s, { level: "category", groupId }]);
-    setQuery("");
+    setLevels((ls) => [
+      ...ls,
+      { view: { level: "category", groupId }, query: "" },
+    ]);
   }, []);
   const drillItem = useCallback((item: CommandItem) => {
     setDirection(1);
-    setStack((s) => [...s, { level: "item", item }]);
-    setQuery("");
+    setLevels((ls) => [...ls, { view: { level: "item", item }, query: "" }]);
   }, []);
   const back = useCallback(() => {
     setDirection(-1);
-    setStack((s) => s.slice(0, -1));
-    setQuery("");
+    setLevels((ls) => (ls.length > 1 ? ls.slice(0, -1) : ls));
   }, []);
-  const goToDepth = (depth: number) => {
+  const goToDepth = (target: number) => {
     setDirection(-1);
-    setStack((s) => s.slice(0, depth));
-    setQuery("");
+    setLevels((ls) => ls.slice(0, target + 1));
   };
 
   // An empty entity category (e.g. workflows/integrations not yet fetched) has
@@ -214,6 +257,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
 
   const activate = useCallback(
     (row: Row) => {
+      trackActivation(row, query);
       switch (row.kind) {
         case "back":
           back();
@@ -236,7 +280,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
           break;
       }
     },
-    [back, activateCategory, runAction, router, close, askGaia],
+    [back, activateCategory, runAction, router, close, askGaia, query],
   );
 
   const submitForm = useCallback(async () => {
@@ -275,7 +319,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
       }
       if (event.key === "Escape") {
         event.preventDefault();
-        stack.length ? back() : close();
+        depth ? back() : close();
         return;
       }
       if (event.key === "Tab" && canDrill(highlighted)) {
@@ -291,7 +335,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
       const wantsBack =
         (event.key === "ArrowLeft" && caretAtStart) ||
         (event.key === "Backspace" && query === "");
-      if (wantsBack && stack.length) {
+      if (wantsBack && depth) {
         event.preventDefault();
         back();
       }
@@ -302,7 +346,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
       highlightedId,
       query,
       numberedRows,
-      stack,
+      depth,
       activate,
       openSecondary,
       back,
@@ -310,14 +354,24 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
     ],
   );
 
-  const crumbs = stack.map((v, i) => ({
-    key: v.level === "category" ? `cat:${v.groupId}` : `item:${v.item.id}`,
-    label:
-      v.level === "category"
-        ? (groups.find((g) => g.id === v.groupId)?.heading ?? "")
-        : v.item.title,
-    depth: i + 1,
-  }));
+  const crumbs = levels.slice(1).map((l, i) => {
+    const view = l.view;
+    return {
+      key:
+        view?.level === "category"
+          ? `cat:${view.groupId}`
+          : view?.level === "item"
+            ? `item:${view.item.id}`
+            : `level:${i}`,
+      label:
+        view?.level === "category"
+          ? (groups.find((g) => g.id === view.groupId)?.heading ?? "")
+          : view?.level === "item"
+            ? view.item.title
+            : "",
+      depth: i + 1,
+    };
+  });
 
   const placeholder = view ? "Filter..." : "Search or jump to...";
   const noResults =
@@ -420,9 +474,6 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
 
           {!formAction && (
             <Command.List ref={listRef} className={S.list}>
-              <Command.Empty className={S.empty}>
-                No results found.
-              </Command.Empty>
               {noResults && (
                 <div className="flex flex-col items-center gap-2 py-6 text-zinc-500">
                   <SearchIcon className="h-6 w-6 text-zinc-600" />
@@ -431,7 +482,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
               )}
               {/* Keyed by depth so moving between levels remounts the list and
                   replays the entrance slide; typing within a level does not. */}
-              <div key={stack.length}>
+              <div key={depth}>
                 {sections.map((section, index) => (
                   <CommandSection
                     key={section.id}
@@ -465,7 +516,10 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
           <div className={`${S.footer} flex items-center gap-4`}>
             {formAction ? (
               <>
-                <Hint k={<Kbd keys={["enter"]} />} label="Save" />
+                <Hint
+                  k={<Kbd keys={["enter"]} />}
+                  label={formAction.form?.submitLabel ?? "Save"}
+                />
                 <Hint k={<Kbd>esc</Kbd>} label="Cancel" />
               </>
             ) : (
@@ -475,10 +529,7 @@ export default function CommandMenu({ host }: { host: CommandHost }) {
                   label={enterLabel(highlighted)}
                 />
                 {showActionsHint && <Hint k={<Kbd>Tab</Kbd>} label="Actions" />}
-                <Hint
-                  k={<Kbd>esc</Kbd>}
-                  label={stack.length ? "Back" : "Close"}
-                />
+                <Hint k={<Kbd>esc</Kbd>} label={depth ? "Back" : "Close"} />
               </>
             )}
           </div>

--- a/apps/web/src/features/command/components/PaletteRow.tsx
+++ b/apps/web/src/features/command/components/PaletteRow.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@heroui/button";
 import { Kbd } from "@heroui/kbd";
+import { Skeleton } from "@heroui/skeleton";
 import { Tooltip } from "@heroui/tooltip";
 import { AiMagicIcon, ArrowLeft02Icon, ArrowRight02Icon } from "@icons";
 import { Command } from "cmdk";
@@ -64,6 +65,16 @@ export function PaletteRow({
         <ArrowLeft02Icon width={18} height={18} />
         <span className={S.flexOne}>Go back</span>
       </Command.Item>
+    );
+  }
+
+  if (row.kind === "loading") {
+    return (
+      <div aria-busy="true" className={`${ROW} gap-3 py-3`}>
+        <Skeleton className="h-4 w-4 rounded-full" />
+        <Skeleton className="h-3 w-40 rounded-medium" />
+        <Skeleton className="ml-auto h-3 w-16 rounded-medium" />
+      </div>
     );
   }
 

--- a/apps/web/src/features/command/data/useChatSearch.ts
+++ b/apps/web/src/features/command/data/useChatSearch.ts
@@ -3,6 +3,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/features/auth/hooks/useAuth";
+import { memoryApi } from "@/features/memory/api/memoryApi";
+import type { MemoryEntry } from "@/features/memory/api/types";
 import {
   type ComprehensiveSearchResponse,
   searchApi,
@@ -11,10 +13,13 @@ import {
 const DEBOUNCE_MS = 250;
 const MIN_CHARS = 2;
 
+interface ChatSearchResult {
+  results: ComprehensiveSearchResponse | undefined;
+  isFetching: boolean;
+}
+
 /** Debounced server-side search over conversations + messages. */
-export function useChatSearch(
-  query: string,
-): ComprehensiveSearchResponse | undefined {
+export function useChatSearch(query: string): ChatSearchResult {
   const { isAuthenticated, userEmail } = useAuth();
   const [debounced, setDebounced] = useState("");
 
@@ -23,7 +28,7 @@ export function useChatSearch(
     return () => clearTimeout(timer);
   }, [query]);
 
-  const { data } = useQuery({
+  const { data, isFetching } = useQuery({
     // Keyed to the user so cached results never leak across sessions.
     queryKey: ["command-k", "search", userEmail, debounced],
     queryFn: async () => {
@@ -35,5 +40,28 @@ export function useChatSearch(
     staleTime: 30_000,
   });
 
-  return data;
+  return { results: data, isFetching };
+}
+
+/** Debounced semantic memory recall for the palette's Memories section. */
+export function useMemorySearch(query: string): {
+  memories: MemoryEntry[];
+  isFetching: boolean;
+} {
+  const { isAuthenticated, userEmail } = useAuth();
+  const [debounced, setDebounced] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(query.trim()), DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const { data, isFetching } = useQuery({
+    queryKey: ["command-k", "memory-search", userEmail, debounced],
+    queryFn: () => memoryApi.searchMemories(debounced),
+    enabled: isAuthenticated && debounced.length >= MIN_CHARS,
+    staleTime: 30_000,
+  });
+
+  return { memories: data?.memories ?? [], isFetching };
 }

--- a/apps/web/src/features/command/data/useChatSearch.ts
+++ b/apps/web/src/features/command/data/useChatSearch.ts
@@ -11,11 +11,17 @@ import {
 } from "@/features/search/api/searchApi";
 
 const DEBOUNCE_MS = 250;
-const MIN_CHARS = 2;
+export const MIN_CHARS = 2;
 
 interface ChatSearchResult {
   results: ComprehensiveSearchResponse | undefined;
   isFetching: boolean;
+  /**
+   * The query the current results answer. During the debounce window this
+   * trails the live input — callers must not render these rows against a
+   * newer query, or stale hits linger under the floor score.
+   */
+  debounced: string;
 }
 
 /** Debounced server-side search over conversations + messages. */
@@ -40,14 +46,18 @@ export function useChatSearch(query: string): ChatSearchResult {
     staleTime: 30_000,
   });
 
-  return { results: data, isFetching };
+  return { results: data, isFetching, debounced };
+}
+
+interface MemorySearchResult {
+  memories: MemoryEntry[];
+  isFetching: boolean;
+  /** See ChatSearchResult.debounced — same staleness contract. */
+  debounced: string;
 }
 
 /** Debounced semantic memory recall for the palette's Memories section. */
-export function useMemorySearch(query: string): {
-  memories: MemoryEntry[];
-  isFetching: boolean;
-} {
+export function useMemorySearch(query: string): MemorySearchResult {
   const { isAuthenticated, userEmail } = useAuth();
   const [debounced, setDebounced] = useState("");
 
@@ -63,5 +73,5 @@ export function useMemorySearch(query: string): {
     staleTime: 30_000,
   });
 
-  return { memories: data?.memories ?? [], isFetching };
+  return { memories: data?.memories ?? [], isFetching, debounced };
 }

--- a/apps/web/src/features/command/data/useCommandData.tsx
+++ b/apps/web/src/features/command/data/useCommandData.tsx
@@ -29,6 +29,7 @@ import { useWorkflows } from "@/features/workflows/hooks/useWorkflows";
 import { useComposerStore } from "@/stores/composerStore";
 import { usePricingModalStore } from "@/stores/pricingModalStore";
 import { useTodoStore } from "@/stores/todoStore";
+import { frecencyScore, useFrecencyStore } from "../frecency";
 import { ICON } from "../model/constants";
 import type {
   BuildCtx,
@@ -166,6 +167,21 @@ export function useCommandData(host: CommandHost): CommandData {
   );
   const settingsItems = useMemo(() => buildSettingsItems(ctx), [ctx]);
 
+  // id → item maps so Recent can find items without assuming builders return
+  // them in source order (filtering builders would break positional zipping).
+  const workflowById = useMemo(
+    () => new Map(workflowItems.map((item) => [item.id, item] as const)),
+    [workflowItems],
+  );
+  const todoById = useMemo(
+    () => new Map(todoItems.map((item) => [item.id, item] as const)),
+    [todoItems],
+  );
+  const notificationById = useMemo(
+    () => new Map(notificationItems.map((item) => [item.id, item] as const)),
+    [notificationItems],
+  );
+
   const groups = useMemo<CommandGroup[]>(() => {
     const entity = (
       id: string,
@@ -290,29 +306,36 @@ export function useCommandData(host: CommandHost): CommandData {
     logout,
   ]);
 
-  // Recent across all types, newest first.
+  // Recent across all types. What the user picks in the palette is the
+  // strongest recency signal — frecency first, source timestamps as
+  // tiebreaker/fallback for a cold start.
+  const frecencyEntries = useFrecencyStore((s) => s.entries);
   const recent = useMemo<CommandItem[]>(() => {
     const candidates: { item: CommandItem; ts: number }[] = [];
     (conversations as ChatLike[]).forEach((c) => {
       const item = chats.byConv.get(c.conversation_id);
       if (item) candidates.push({ item, ts: c.updatedAt?.getTime() ?? 0 });
     });
-    workflows.forEach((w, i) => {
-      const item = workflowItems[i];
+    workflows.forEach((w) => {
+      const item = workflowById.get(`workflow:${w.id}`);
       if (item)
         candidates.push({ item, ts: ms(w.last_executed_at || w.updated_at) });
     });
-    todos.forEach((t, i) => {
-      const item = todoItems[i];
+    todos.forEach((t) => {
+      const item = todoById.get(`todo:${t.id}`);
       if (item) candidates.push({ item, ts: ms(t.updated_at) });
     });
-    notifications.forEach((n, i) => {
-      const item = notificationItems[i];
+    notifications.forEach((n) => {
+      const item = notificationById.get(`notification:${n.id}`);
       if (item) candidates.push({ item, ts: ms(n.created_at) });
     });
     return candidates
       .filter((c) => c.ts > 0)
-      .sort((a, b) => b.ts - a.ts)
+      .sort(
+        (a, b) =>
+          frecencyScore(frecencyEntries, b.item.id) -
+            frecencyScore(frecencyEntries, a.item.id) || b.ts - a.ts,
+      )
       .slice(0, RECENT_COUNT)
       .map((c) => c.item);
   }, [
@@ -321,9 +344,10 @@ export function useCommandData(host: CommandHost): CommandData {
     todos,
     notifications,
     chats.byConv,
-    workflowItems,
-    todoItems,
-    notificationItems,
+    workflowById,
+    todoById,
+    notificationById,
+    frecencyEntries,
   ]);
 
   const context = useMemo(() => {

--- a/apps/web/src/features/command/data/useCommandData.tsx
+++ b/apps/web/src/features/command/data/useCommandData.tsx
@@ -464,8 +464,11 @@ export function useCommandData(host: CommandHost): CommandData {
       prepareNewChat();
       // Auto-send hands the query to ChatPage's send pipeline; prefill mode
       // drops it in the composer for the user to edit first.
+      // setPendingPrompt (not appendToInput): the latter hard-navigates via
+      // window.location.assign off /c, and a full reload drops the volatile
+      // pendingAutoSend flag — router.push keeps this an SPA handoff.
       useComposerStore.getState().setPendingAutoSend(autoSend);
-      useComposerStore.getState().appendToInput(query);
+      useComposerStore.getState().setPendingPrompt(query);
       router.push("/c");
       host.close();
     },

--- a/apps/web/src/features/command/data/useCommandData.tsx
+++ b/apps/web/src/features/command/data/useCommandData.tsx
@@ -30,6 +30,8 @@ import { useWorkflows } from "@/features/workflows/hooks/useWorkflows";
 import { useComposerStore } from "@/stores/composerStore";
 import { usePricingModalStore } from "@/stores/pricingModalStore";
 import { useTodoStore } from "@/stores/todoStore";
+import { useVoiceModeActions } from "@/stores/voiceModeStore";
+import { useWhatsNewStore } from "@/stores/whatsNewStore";
 import { frecencyScore, useFrecencyStore } from "../frecency";
 import { ICON } from "../model/constants";
 import type {
@@ -94,6 +96,9 @@ export function useCommandData(host: CommandHost): CommandData {
   const { notifications, markAsRead, archiveNotification } = useNotifications();
   const { data: subscriptionStatus } = useUserSubscriptionStatus();
   const openPricing = usePricingModalStore((s) => s.openModal);
+  const openWhatsNew = useWhatsNewStore((s) => s.openModal);
+  const { enterVoiceMode } = useVoiceModeActions();
+  const createTodoAction = useTodoStore((s) => s.createTodo);
   const { openShortcutsModal } = useKeyboardShortcuts();
   const { logout } = useLogout();
   const { data: memoryList } = useQuery({
@@ -196,6 +201,7 @@ export function useCommandData(host: CommandHost): CommandData {
       accent: string,
       path: string,
       items: CommandItem[],
+      links?: { label: string; path: string }[],
     ): CommandGroup => ({
       id,
       heading,
@@ -203,6 +209,7 @@ export function useCommandData(host: CommandHost): CommandData {
       accent,
       kind: "entity",
       path,
+      links,
       items,
     });
 
@@ -211,6 +218,12 @@ export function useCommandData(host: CommandHost): CommandData {
       isSubscribed: Boolean(subscriptionStatus?.is_subscribed),
       openPricing,
       openShortcuts: openShortcutsModal,
+      openWhatsNew,
+      enterVoiceMode,
+      createTodo: async (title) => {
+        await createTodoAction({ title });
+        await loadTodos();
+      },
       logout: async () => {
         const ok = await host.confirm({
           title: "Sign out",
@@ -262,6 +275,11 @@ export function useCommandData(host: CommandHost): CommandData {
         "text-green-400",
         "/todos",
         todoItems,
+        [
+          { label: "Today", path: "/todos/today" },
+          { label: "Upcoming", path: "/todos/upcoming" },
+          { label: "Completed", path: "/todos/completed" },
+        ],
       ),
       entity(
         "notifications",
@@ -364,15 +382,32 @@ export function useCommandData(host: CommandHost): CommandData {
       const item = itemById(`chat:${chatMatch[1]}`);
       if (item) return { heading: "Current chat", item };
     }
-    if (pathname.includes("/workflows")) {
-      const id = searchParams.get("id");
-      const item = id ? itemById(`workflow:${id}`) : undefined;
-      if (item) return { heading: "Current workflow", item };
-    }
-    if (pathname.includes("/integrations")) {
-      const id = searchParams.get("id");
-      const item = id ? itemById(`integration:${id}`) : undefined;
-      if (item) return { heading: "Current integration", item };
+    // Sections that address their entity through a query param.
+    const paramRoutes = [
+      {
+        route: "/workflows",
+        param: "id",
+        type: "workflow",
+        heading: "Current workflow",
+      },
+      {
+        route: "/integrations",
+        param: "id",
+        type: "integration",
+        heading: "Current integration",
+      },
+      {
+        route: "/todos",
+        param: "todoId",
+        type: "todo",
+        heading: "Current todo",
+      },
+    ] as const;
+    for (const { route, param, type, heading } of paramRoutes) {
+      if (!pathname.includes(route)) continue;
+      const id = searchParams.get(param);
+      const item = id ? itemById(`${type}:${id}`) : undefined;
+      if (item) return { heading, item };
     }
     return null;
   }, [groups, pathname, searchParams]);

--- a/apps/web/src/features/command/data/useCommandData.tsx
+++ b/apps/web/src/features/command/data/useCommandData.tsx
@@ -72,7 +72,8 @@ export interface CommandData {
   }) => CommandItem;
   /** Returns null for hits without an id — nothing to navigate to. */
   buildSearchMemory: (mem: MemoryEntry) => CommandItem | null;
-  askGaia: (query: string) => void;
+  /** autoSend: send the query immediately instead of prefilling the composer. */
+  askGaia: (query: string, autoSend?: boolean) => void;
 }
 
 /** Orchestrates live app data into normalized command groups via per-entity builders. */
@@ -447,8 +448,11 @@ export function useCommandData(host: CommandHost): CommandData {
   };
 
   const askGaia = useCallback(
-    (query: string) => {
+    (query: string, autoSend = false) => {
       prepareNewChat();
+      // Auto-send hands the query to ChatPage's send pipeline; prefill mode
+      // drops it in the composer for the user to edit first.
+      useComposerStore.getState().setPendingAutoSend(autoSend);
       useComposerStore.getState().appendToInput(query);
       router.push("/c");
       host.close();

--- a/apps/web/src/features/command/data/useCommandData.tsx
+++ b/apps/web/src/features/command/data/useCommandData.tsx
@@ -21,6 +21,7 @@ import { useConversationList } from "@/features/chat/hooks/useConversationList";
 import { prepareNewChat } from "@/features/chat/utils/newChatNavigation";
 import { useIntegrations } from "@/features/integrations/hooks/useIntegrations";
 import { memoryApi } from "@/features/memory/api/memoryApi";
+import type { MemoryEntry } from "@/features/memory/api/types";
 import { useNotifications } from "@/features/notification/hooks/useNotifications";
 import { useUserSubscriptionStatus } from "@/features/pricing/hooks/usePricing";
 import type { SearchConversationResult } from "@/features/search/api/searchApi";
@@ -44,7 +45,7 @@ import {
 } from "../providers/chats";
 import { buildCommandGroups } from "../providers/commands";
 import { buildIntegrationItems } from "../providers/integrations";
-import { buildMemoryItems } from "../providers/memories";
+import { buildMemoryItems, makeMemoryItem } from "../providers/memories";
 import { buildNotificationItems } from "../providers/notifications";
 import { buildSettingsItems } from "../providers/settings";
 import { buildTodoItems } from "../providers/todos";
@@ -67,6 +68,8 @@ export interface CommandData {
     message: { message_id: string };
     snippet: string;
   }) => CommandItem;
+  /** Returns null for hits without an id — nothing to navigate to. */
+  buildSearchMemory: (mem: MemoryEntry) => CommandItem | null;
   askGaia: (query: string) => void;
 }
 
@@ -103,6 +106,12 @@ export function useCommandData(host: CommandHost): CommandData {
   useEffect(() => {
     if (isAuthenticated) loadTodos();
   }, [isAuthenticated, loadTodos]);
+
+  const refetchMemories = useCallback(
+    () =>
+      queryClient.invalidateQueries({ queryKey: memoriesQueryKey(userEmail) }),
+    [queryClient, userEmail],
+  );
 
   const ctx = useMemo<BuildCtx>(
     () => ({
@@ -158,12 +167,9 @@ export function useCommandData(host: CommandHost): CommandData {
   const memoryItems = useMemo(
     () =>
       buildMemoryItems(memoryList?.memories ?? [], ctx, {
-        refetch: () =>
-          queryClient.invalidateQueries({
-            queryKey: memoriesQueryKey(userEmail),
-          }),
+        refetch: refetchMemories,
       }),
-    [memoryList, ctx, queryClient, userEmail],
+    [memoryList, ctx, refetchMemories],
   );
   const settingsItems = useMemo(() => buildSettingsItems(ctx), [ctx]);
 
@@ -394,6 +400,17 @@ export function useCommandData(host: CommandHost): CommandData {
       ctx,
     );
 
+  /** Semantic memory hit — open-only row (no list position to refresh). */
+  const buildSearchMemory = (mem: MemoryEntry): CommandItem | null => {
+    if (!mem.id) return null;
+    return makeMemoryItem(
+      { ...mem, id: mem.id },
+      ctx,
+      { refetch: refetchMemories },
+      false,
+    );
+  };
+
   const askGaia = useCallback(
     (query: string) => {
       prepareNewChat();
@@ -410,6 +427,7 @@ export function useCommandData(host: CommandHost): CommandData {
     context,
     buildSearchChat,
     buildSearchMessage,
+    buildSearchMemory,
     askGaia,
   };
 }

--- a/apps/web/src/features/command/data/useCommandData.tsx
+++ b/apps/web/src/features/command/data/useCommandData.tsx
@@ -413,39 +413,51 @@ export function useCommandData(host: CommandHost): CommandData {
     return null;
   }, [groups, pathname, searchParams]);
 
-  const buildSearchChat = (result: SearchConversationResult): CommandItem =>
-    chats.byConv.get(result.conversation_id) ??
-    makeChatItem(
-      { conversation_id: result.conversation_id, title: result.description },
-      ctx,
-      chatActions,
-      false,
-    );
+  // Stable identities: these feed useMemo/useEffect deps in CommandMenu —
+  // recreated-per-render callbacks would invalidate its memoization on every
+  // render.
+  const buildSearchChat = useCallback(
+    (result: SearchConversationResult): CommandItem =>
+      chats.byConv.get(result.conversation_id) ??
+      makeChatItem(
+        { conversation_id: result.conversation_id, title: result.description },
+        ctx,
+        chatActions,
+        false,
+      ),
+    [chats.byConv, ctx, chatActions],
+  );
 
-  const buildSearchMessage = (result: {
-    conversation_id: string;
-    message: { message_id: string };
-    snippet: string;
-  }): CommandItem =>
-    makeMessageItem(
-      {
-        conversation_id: result.conversation_id,
-        message_id: result.message.message_id,
-        snippet: result.snippet,
-      },
-      ctx,
-    );
+  const buildSearchMessage = useCallback(
+    (result: {
+      conversation_id: string;
+      message: { message_id: string };
+      snippet: string;
+    }): CommandItem =>
+      makeMessageItem(
+        {
+          conversation_id: result.conversation_id,
+          message_id: result.message.message_id,
+          snippet: result.snippet,
+        },
+        ctx,
+      ),
+    [ctx],
+  );
 
   /** Semantic memory hit — open-only row (no list position to refresh). */
-  const buildSearchMemory = (mem: MemoryEntry): CommandItem | null => {
-    if (!mem.id) return null;
-    return makeMemoryItem(
-      { ...mem, id: mem.id },
-      ctx,
-      { refetch: refetchMemories },
-      false,
-    );
-  };
+  const buildSearchMemory = useCallback(
+    (mem: MemoryEntry): CommandItem | null => {
+      if (!mem.id) return null;
+      return makeMemoryItem(
+        { ...mem, id: mem.id },
+        ctx,
+        { refetch: refetchMemories },
+        false,
+      );
+    },
+    [ctx, refetchMemories],
+  );
 
   const askGaia = useCallback(
     (query: string, autoSend = false) => {

--- a/apps/web/src/features/command/frecency.ts
+++ b/apps/web/src/features/command/frecency.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+/** One palette activation of an item: what was picked and when. */
+export interface FrecencyEntry {
+  id: string;
+  ts: number;
+}
+
+interface FrecencyStore {
+  entries: FrecencyEntry[];
+  record: (id: string) => void;
+}
+
+/** Ring-buffer cap — old activations fall off the back. */
+const MAX_ENTRIES = 200;
+/** Half-life of a single activation's influence, in hours. */
+const HALF_LIFE_H = 72;
+
+/**
+ * What the user picks in the palette is the strongest relevance signal we
+ * have. Append-only log of activations (persisted), decayed to boost future
+ * rankings; cold start falls back to data timestamps.
+ */
+export const useFrecencyStore = create<FrecencyStore>()(
+  devtools(
+    persist(
+      (set) => ({
+        entries: [],
+        record: (id) =>
+          set(
+            (state) => ({
+              entries: [
+                ...state.entries.slice(-(MAX_ENTRIES - 1)),
+                { id, ts: Date.now() },
+              ],
+            }),
+            false,
+            "commandFrecency/record",
+          ),
+      }),
+      {
+        name: "command-frecency-storage",
+        partialize: (state) => ({ entries: state.entries }),
+      },
+    ),
+    { name: "command-frecency-store" },
+  ),
+);
+
+/**
+ * Decay-weighted pick count for one item id, capped so a single hot item
+ * can't dominate. Returns roughly 0–10.
+ */
+export function frecencyScore(entries: FrecencyEntry[], id: string): number {
+  const now = Date.now();
+  let score = 0;
+  // Newest first: only the most recent occurrences count.
+  let counted = 0;
+  for (let i = entries.length - 1; i >= 0 && counted < 10; i--) {
+    const entry = entries[i];
+    if (entry.id !== id) continue;
+    const ageHours = Math.max(0, (now - entry.ts) / 3_600_000);
+    score += 0.5 ** (ageHours / HALF_LIFE_H);
+    counted++;
+  }
+  return score;
+}

--- a/apps/web/src/features/command/model/config.ts
+++ b/apps/web/src/features/command/model/config.ts
@@ -63,7 +63,6 @@ export const COMMAND_MENU_STYLES = {
   input:
     "flex-1 bg-transparent text-zinc-100 placeholder-zinc-500 outline-none",
   list: "max-h-[400px] overflow-x-hidden overflow-y-auto pb-3 outline-none!",
-  empty: "flex h-16 items-center justify-center text-sm text-zinc-500",
   separator: "mx-3 h-px bg-zinc-800/50",
   flexOne: "flex-1",
   contentWrapper: "min-w-0 flex-1",

--- a/apps/web/src/features/command/model/config.ts
+++ b/apps/web/src/features/command/model/config.ts
@@ -1,5 +1,10 @@
-// Visual contract for the command menu — kept identical to the original GAIA
-// Command K so the look is unchanged. Tweak here to restyle the whole palette.
+// Visual contract for the command menu. Tweak here to restyle the whole
+// palette.
+//
+// Motion philosophy (research consensus — Rauno, Linear, Geist): a palette
+// is a hundred-times-a-day surface. It must APPEAR instantly; only the exit
+// fades. The list keeps a directional slide between levels (browsing feels
+// spatial) but stays still while filtering.
 
 const EASE = [0.19, 1, 0.22, 1] as [number, number, number, number];
 
@@ -8,13 +13,18 @@ export const ANIMATION_CONFIG = {
     initial: { opacity: 0 },
     animate: { opacity: 1 },
     exit: { opacity: 0 },
-    transition: { duration: 0.2, ease: EASE },
+    transition: { duration: 0.15, ease: "linear" as const },
   },
   container: {
-    initial: { opacity: 0, scale: 0.95, y: -8 },
-    animate: { opacity: 1, scale: 1, y: 0 },
-    exit: { opacity: 0, scale: 0.95, y: -8 },
-    transition: { duration: 0.2, ease: EASE },
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    // Open is near-instant; exit gets a short fade so dismissal reads.
+    transition: {
+      duration: 0.12,
+      ease: "linear" as const,
+      exit: { duration: 0.15, ease: EASE },
+    },
   },
 } as const;
 
@@ -62,13 +72,22 @@ export const COMMAND_MENU_STYLES = {
     "flex items-center gap-3 border-b border-zinc-800/30 px-5 py-4 mb-2",
   input:
     "flex-1 bg-transparent text-zinc-100 placeholder-zinc-500 outline-none",
-  list: "max-h-[400px] overflow-x-hidden overflow-y-auto pb-3 outline-none!",
+  listWrapper: "relative",
+  list: "max-h-[480px] overflow-x-hidden overflow-y-auto pb-3 outline-none!",
+  // Gradient hairlines pinned to the list viewport edges; opacity toggled
+  // from the scroll handler (see updateScrollShadow).
+  scrollShadow:
+    "pointer-events-none absolute inset-x-0 top-0 z-10 h-6 bg-gradient-to-b from-zinc-950/80 to-transparent transition-opacity duration-150",
+  scrollShadowBottom:
+    "bottom-auto top-auto inset-x-0 bottom-0 bg-gradient-to-t from-zinc-950/80 to-transparent",
   separator: "mx-3 h-px bg-zinc-800/50",
   flexOne: "flex-1",
   contentWrapper: "min-w-0 flex-1",
   resultSubtitle: "truncate text-xs text-zinc-500",
   footer: "border-t border-zinc-800/30 px-5 py-3",
   footerText: "text-xs text-zinc-500",
+  liveRegion:
+    "pointer-events-none absolute h-px w-px overflow-hidden whitespace-nowrap [clip:rect(0,0,0,0)]",
   modalWrapper: "fixed inset-0 z-50 flex items-start justify-center pt-[20vh]",
   groupHeadings:
     "[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-5 [&_[cmdk-group-heading]]:pb-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-zinc-500",

--- a/apps/web/src/features/command/model/paletteModel.tsx
+++ b/apps/web/src/features/command/model/paletteModel.tsx
@@ -20,7 +20,8 @@ export type Row =
   | { kind: "action"; id: string; action: CommandAction }
   | { kind: "nav"; id: string; label: string; icon: ReactNode; path: string }
   | { kind: "ask"; id: string; query: string }
-  | { kind: "back"; id: string };
+  | { kind: "back"; id: string }
+  | { kind: "loading"; id: string };
 
 interface Section {
   id: string;
@@ -30,7 +31,10 @@ interface Section {
 
 /** Rows that never get a number badge (navigation / special affordances). */
 export const isNumbered = (row: Row) =>
-  row.kind !== "nav" && row.kind !== "back" && row.kind !== "ask";
+  row.kind !== "nav" &&
+  row.kind !== "back" &&
+  row.kind !== "ask" &&
+  row.kind !== "loading";
 
 import { scoreFields } from "./scorer";
 
@@ -79,6 +83,9 @@ interface SectionParams {
   context: { heading: string; item: CommandItem } | null;
   searchChats: CommandItem[];
   searchMessages: CommandItem[];
+  searchMemories: CommandItem[];
+  /** True while a server search/recall request is in flight. */
+  searchLoading: boolean;
   /** Extra relevance for items the user has picked before (frecency). */
   boost?: (item: CommandItem) => number;
 }
@@ -143,7 +150,8 @@ function scoredSection(
 }
 
 function searchSections(params: SectionParams): Section[] {
-  const { groups, query, searchChats, searchMessages, boost } = params;
+  const { groups, query, searchChats, searchMessages, searchMemories, boost } =
+    params;
   const sections: Section[] = [];
 
   // "Jump to" — categories whose name matches (e.g. "workflows" → Workflows).
@@ -185,8 +193,28 @@ function searchSections(params: SectionParams): Section[] {
   );
   if (msgSection) results.push(msgSection);
 
+  // Semantic memory recall — merged with the local memories list, server
+  // hits deduped against it and floored like the other server facets.
+  const memoryGroup = groups.find((g) => g.id === "memories");
+  const localMemories = memoryGroup?.items ?? [];
+  const localMemoryIds = new Set(localMemories.map((i) => i.id));
+  const allMemories = dedupeById([
+    ...localMemories.filter((i) => itemScore(query, i) > 0),
+    ...searchMemories.filter((i) => !localMemoryIds.has(i.id)),
+  ]);
+  const memSection = scoredSection(
+    "memories",
+    "Memories",
+    allMemories,
+    query,
+    30,
+    boost,
+  );
+  if (memSection) results.push(memSection);
+
   for (const group of groups) {
-    if (group.id === "chats") continue;
+    // chats + memories have dedicated merged sections above.
+    if (group.id === "chats" || group.id === "memories") continue;
     const scored = scoredSection(
       group.id,
       group.heading,
@@ -200,6 +228,16 @@ function searchSections(params: SectionParams): Section[] {
 
   results.sort((a, b) => b.score - a.score);
   sections.push(...results.map((r) => r.section));
+
+  // First fetch of a query: no server rows to show yet — say so instead of
+  // leaving the user wondering whether chats/messages/memories were searched.
+  if (params.searchLoading && results.length === 0) {
+    sections.push({
+      id: "loading",
+      heading: "Searching…",
+      rows: [{ kind: "loading", id: "search-loading" }],
+    });
+  }
 
   // Always offer the AI escape hatch.
   sections.push({ id: "ask", rows: [{ kind: "ask", id: "ask", query }] });

--- a/apps/web/src/features/command/model/paletteModel.tsx
+++ b/apps/web/src/features/command/model/paletteModel.tsx
@@ -110,6 +110,16 @@ function categorySections(group: CommandGroup, query: string): Section[] {
       path: group.path,
     });
   }
+  for (const link of group.links ?? []) {
+    if (matchesText(query, link.label))
+      rows.push({
+        kind: "nav",
+        id: `link:${link.label}`,
+        label: link.label,
+        icon: <ArrowUpRight01Icon width={18} height={18} />,
+        path: link.path,
+      });
+  }
   for (const item of group.items) {
     if (itemScore(query, item) > 0) rows.push(toItemRow(item));
   }

--- a/apps/web/src/features/command/model/paletteModel.tsx
+++ b/apps/web/src/features/command/model/paletteModel.tsx
@@ -7,6 +7,13 @@ export type View =
   | { level: "category"; groupId: string }
   | { level: "item"; item: CommandItem };
 
+/** One level of the drill-down stack: what it shows plus the query typed there. */
+export interface Level {
+  /** Undefined at the root level. */
+  view?: View;
+  query: string;
+}
+
 export type Row =
   | { kind: "category"; id: string; group: CommandGroup }
   | { kind: "item"; id: string; item: CommandItem; canDrill: boolean }
@@ -25,44 +32,27 @@ interface Section {
 export const isNumbered = (row: Row) =>
   row.kind !== "nav" && row.kind !== "back" && row.kind !== "ask";
 
-/** Relevance score for ranking search results (0 = no match). */
-function scoreText(q: string, text: string): number {
-  if (!text) return 0;
-  const t = text.toLowerCase();
-  if (t === q) return 100;
-  if (t.startsWith(q)) return 80;
-  if (t.includes(` ${q}`)) return 60;
-  if (t.includes(q)) return 40;
-  let i = 0;
-  for (const char of t) {
-    if (char === q[i]) i++;
-    if (i === q.length) return 20;
-  }
-  return 0;
-}
+import { scoreFields } from "./scorer";
 
-const itemScore = (q: string, item: CommandItem) =>
-  scoreText(q, item.title) * 2 +
-  scoreText(q, item.subtitle ?? "") +
-  scoreText(q, item.keywords ?? "");
+/** Relevance of an item for a query across its title/subtitle/keywords. */
+const itemScore = (query: string, item: CommandItem) =>
+  scoreFields(query, [
+    { text: item.title, weight: 2 },
+    { text: item.subtitle },
+    { text: item.keywords },
+  ]);
+
+/** Relevance of any single string for a query (headings, action labels). */
+const textScore = (query: string, text: string) =>
+  scoreFields(query, [{ text }]);
+
+/** Does a query match at all — used to include/exclude rows while browsing. */
+const matchesText = (query: string, text: string): boolean => {
+  if (!query.trim()) return true;
+  return scoreFields(query, [{ text }]) > 0;
+};
 
 const BACK_ROW: Row = { kind: "back", id: "back" };
-
-function matches(query: string, text: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  const haystack = text.toLowerCase();
-  if (haystack.includes(q)) return true;
-  let i = 0;
-  for (const char of haystack) {
-    if (char === q[i]) i++;
-    if (i === q.length) return true;
-  }
-  return false;
-}
-
-const itemText = (item: CommandItem) =>
-  `${item.title} ${item.subtitle ?? ""} ${item.keywords ?? ""}`;
 
 const toItemRow = (item: CommandItem): Row => ({
   kind: "item",
@@ -89,12 +79,14 @@ interface SectionParams {
   context: { heading: string; item: CommandItem } | null;
   searchChats: CommandItem[];
   searchMessages: CommandItem[];
+  /** Extra relevance for items the user has picked before (frecency). */
+  boost?: (item: CommandItem) => number;
 }
 
 function itemActionSections(item: CommandItem, query: string): Section[] {
   const rows: Row[] = [BACK_ROW];
   for (const a of item.actions) {
-    if (matches(query, a.label))
+    if (matchesText(query, a.label))
       rows.push({ kind: "action", id: `act:${a.id}`, action: a });
   }
   return [{ id: "actions", rows }];
@@ -102,7 +94,7 @@ function itemActionSections(item: CommandItem, query: string): Section[] {
 
 function categorySections(group: CommandGroup, query: string): Section[] {
   const rows: Row[] = [BACK_ROW];
-  if (group.path && matches(query, `go to ${group.heading}`)) {
+  if (group.path && matchesText(query, `go to ${group.heading}`)) {
     rows.push({
       kind: "nav",
       id: `goto:${group.id}`,
@@ -112,7 +104,7 @@ function categorySections(group: CommandGroup, query: string): Section[] {
     });
   }
   for (const item of group.items) {
-    if (matches(query, itemText(item))) rows.push(toItemRow(item));
+    if (itemScore(query, item) > 0) rows.push(toItemRow(item));
   }
   return [{ id: group.id, rows }];
 }
@@ -127,11 +119,20 @@ function scoredSection(
   id: string,
   heading: string,
   items: CommandItem[],
-  q: string,
+  query: string,
   minScore = 0,
+  boost?: (item: CommandItem) => number,
 ): ScoredSection | null {
   const ranked = items
-    .map((item) => ({ item, score: Math.max(itemScore(q, item), minScore) }))
+    .map((item) => ({
+      item,
+      // Frecency boosts near-equal matches but can't push a row past an
+      // exact/prefix title match.
+      score: Math.min(
+        Math.max(itemScore(query, item), minScore) + (boost?.(item) ?? 0),
+        200,
+      ),
+    }))
     .filter((r) => r.score > 0)
     .sort((a, b) => b.score - a.score);
   if (!ranked.length) return null;
@@ -142,14 +143,13 @@ function scoredSection(
 }
 
 function searchSections(params: SectionParams): Section[] {
-  const { groups, query, searchChats, searchMessages } = params;
-  const q = query.trim().toLowerCase();
+  const { groups, query, searchChats, searchMessages, boost } = params;
   const sections: Section[] = [];
 
   // "Jump to" — categories whose name matches (e.g. "workflows" → Workflows).
   const jump = groups
-    .filter((g) => g.kind === "entity" && scoreText(q, g.heading) > 0)
-    .sort((a, b) => scoreText(q, b.heading) - scoreText(q, a.heading))
+    .filter((g) => g.kind === "entity" && textScore(query, g.heading) > 0)
+    .sort((a, b) => textScore(query, b.heading) - textScore(query, a.heading))
     .map<Row>((g) => ({ kind: "category", id: `cat:${g.id}`, group: g }));
   if (jump.length)
     sections.push({ id: "jump", heading: "Jump to", rows: jump });
@@ -161,25 +161,40 @@ function searchSections(params: SectionParams): Section[] {
   const localChats = chatGroup?.items ?? [];
   const localIds = new Set(localChats.map((i) => i.id));
   const allChats = dedupeById([
-    ...localChats.filter((i) => itemScore(q, i) > 0),
+    ...localChats.filter((i) => itemScore(query, i) > 0),
     ...searchChats.filter((i) => !localIds.has(i.id)),
   ]);
   // Server hits are relevant even if the local scorer can't see the body.
-  const chatSection = scoredSection("chats", "Chats", allChats, q, 30);
+  const chatSection = scoredSection(
+    "chats",
+    "Chats",
+    allChats,
+    query,
+    30,
+    boost,
+  );
   if (chatSection) results.push(chatSection);
 
   const msgSection = scoredSection(
     "messages",
     "Messages",
     dedupeById(searchMessages),
-    q,
+    query,
     30,
+    boost,
   );
   if (msgSection) results.push(msgSection);
 
   for (const group of groups) {
     if (group.id === "chats") continue;
-    const scored = scoredSection(group.id, group.heading, group.items, q);
+    const scored = scoredSection(
+      group.id,
+      group.heading,
+      group.items,
+      query,
+      0,
+      boost,
+    );
     if (scored) results.push(scored);
   }
 

--- a/apps/web/src/features/command/model/paletteModel.tsx
+++ b/apps/web/src/features/command/model/paletteModel.tsx
@@ -121,7 +121,8 @@ function categorySections(group: CommandGroup, query: string): Section[] {
       });
   }
   for (const item of group.items) {
-    if (itemScore(query, item) > 0) rows.push(toItemRow(item));
+    // Empty query = browsing: show everything unranked.
+    if (!query.trim() || itemScore(query, item) > 0) rows.push(toItemRow(item));
   }
   return [{ id: group.id, rows }];
 }

--- a/apps/web/src/features/command/model/scorer.ts
+++ b/apps/web/src/features/command/model/scorer.ts
@@ -60,29 +60,53 @@ export interface ScoredField {
 }
 
 /**
- * Score a whole query against weighted fields. Every whitespace-separated
- * term must match each field's text for that field to count; per-field term
- * scores are averaged so adding terms doesn't inflate a field past a
- * single-term exact match of another.
+ * Score a whole query against weighted fields.
+ *
+ * Preferred shape: every term matches inside ONE field — that field's
+ * weighted average is added (exact/prefix title hits dominate this way).
+ * When no single field holds the whole query but every term matches
+ * somewhere across fields (title has "new", keywords have "compose"), the
+ * best weighted per-term scores are averaged instead, so multi-term
+ * searches spanning an item's fields still surface it. Any unmatched term
+ * zeroes the item.
  */
 export function scoreFields(query: string, fields: ScoredField[]): number {
   const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
   if (terms.length === 0) return 0;
 
-  let total = 0;
+  let fullFieldTotal = 0;
+  const bestPerTerm = new Map<string, { score: number; weight: number }>();
+
   for (const { text, weight = 1 } of fields) {
     if (!text) continue;
     let sum = 0;
     let allMatch = true;
     for (const term of terms) {
       const s = scoreTerm(term, text);
-      if (s === 0) {
+      // Track each term's best weighted hit across fields even when THIS
+      // field won't hold the whole query — the scattered pass needs it.
+      if (s > 0) {
+        sum += s;
+        const prev = bestPerTerm.get(term);
+        if (!prev || s * weight > prev.score * prev.weight) {
+          bestPerTerm.set(term, { score: s, weight });
+        }
+      } else {
         allMatch = false;
-        break;
       }
-      sum += s;
     }
-    if (allMatch) total += weight * (sum / terms.length);
+    if (allMatch) fullFieldTotal += weight * (sum / terms.length);
   }
-  return total;
+
+  if (fullFieldTotal > 0) return fullFieldTotal;
+
+  // Terms are scattered across fields — require each one to exist somewhere.
+  if (bestPerTerm.size < terms.length) return 0;
+  let total = 0;
+  for (const term of terms) {
+    const best = bestPerTerm.get(term);
+    if (!best) return 0;
+    total += best.score * best.weight;
+  }
+  return total / terms.length;
 }

--- a/apps/web/src/features/command/model/scorer.ts
+++ b/apps/web/src/features/command/model/scorer.ts
@@ -17,19 +17,20 @@ const isBoundary = (text: string, index: number): boolean => {
   return /\p{Ll}/u.test(prev) && /\p{Lu}/u.test(text[index] ?? "");
 };
 
-/** Score one query term against one pre-lowercased field. 0 = no match. */
+/** Score one query term against one field's text (any case). 0 = no match. */
 export function scoreTerm(term: string, field: string): number {
   if (!term || !field) return 0;
+  const q = term.toLowerCase();
   const t = field.toLowerCase();
 
-  const at = t.indexOf(term);
+  const at = t.indexOf(q);
   if (at === -1) {
     // Subsequence: every term char must appear in order; reward runs and
     // word starts so "ab" ranks "About Box" above "A x B".
     let score = 0;
     let from = 0;
     let prevMatch = -2;
-    for (const ch of term) {
+    for (const ch of q) {
       let found = -1;
       for (let i = from; i < t.length; i++) {
         if (t[i] === ch) {
@@ -38,7 +39,9 @@ export function scoreTerm(term: string, field: string): number {
         }
       }
       if (found === -1) return 0;
-      score += isBoundary(t, found) ? 4 : 1;
+      // Boundary bonuses read the ORIGINAL-cased field — lowercasing would
+      // erase exactly the camelCase transitions worth rewarding.
+      score += isBoundary(field, found) ? 4 : 1;
       if (found === prevMatch + 1) score += 3;
       prevMatch = found;
       from = found + 1;
@@ -46,9 +49,9 @@ export function scoreTerm(term: string, field: string): number {
     return Math.min(40, score);
   }
 
-  if (t === term) return 100;
+  if (t === q) return 100;
   if (at === 0) return 90;
-  return isBoundary(t, at) ? 80 : 60;
+  return isBoundary(field, at) ? 80 : 60;
 }
 
 export interface ScoredField {

--- a/apps/web/src/features/command/model/scorer.ts
+++ b/apps/web/src/features/command/model/scorer.ts
@@ -1,0 +1,85 @@
+/**
+ * Palette relevance scoring.
+ *
+ * A term is matched against a field in ranked tiers: exact > prefix >
+ * word-boundary prefix > substring > subsequence (with consecutive-run and
+ * word-start bonuses). A multi-term query ("wf deploy") requires every term
+ * to match somewhere; fields can carry weights so title hits outrank
+ * keyword hits.
+ */
+
+/** Chars that end a word for boundary bonuses (anything not alnum counts). */
+const isBoundary = (text: string, index: number): boolean => {
+  if (index <= 0) return true;
+  const prev = text[index - 1];
+  if (!/\w/.test(prev)) return true;
+  // camelCase boundary: lower→upper transition
+  return /\p{Ll}/u.test(prev) && /\p{Lu}/u.test(text[index] ?? "");
+};
+
+/** Score one query term against one pre-lowercased field. 0 = no match. */
+export function scoreTerm(term: string, field: string): number {
+  if (!term || !field) return 0;
+  const t = field.toLowerCase();
+
+  const at = t.indexOf(term);
+  if (at === -1) {
+    // Subsequence: every term char must appear in order; reward runs and
+    // word starts so "ab" ranks "About Box" above "A x B".
+    let score = 0;
+    let from = 0;
+    let prevMatch = -2;
+    for (const ch of term) {
+      let found = -1;
+      for (let i = from; i < t.length; i++) {
+        if (t[i] === ch) {
+          found = i;
+          break;
+        }
+      }
+      if (found === -1) return 0;
+      score += isBoundary(t, found) ? 4 : 1;
+      if (found === prevMatch + 1) score += 3;
+      prevMatch = found;
+      from = found + 1;
+    }
+    return Math.min(40, score);
+  }
+
+  if (t === term) return 100;
+  if (at === 0) return 90;
+  return isBoundary(t, at) ? 80 : 60;
+}
+
+export interface ScoredField {
+  text: string | undefined;
+  weight?: number;
+}
+
+/**
+ * Score a whole query against weighted fields. Every whitespace-separated
+ * term must match each field's text for that field to count; per-field term
+ * scores are averaged so adding terms doesn't inflate a field past a
+ * single-term exact match of another.
+ */
+export function scoreFields(query: string, fields: ScoredField[]): number {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return 0;
+
+  let total = 0;
+  for (const { text, weight = 1 } of fields) {
+    if (!text) continue;
+    let sum = 0;
+    let allMatch = true;
+    for (const term of terms) {
+      const s = scoreTerm(term, text);
+      if (s === 0) {
+        allMatch = false;
+        break;
+      }
+      sum += s;
+    }
+    if (allMatch) total += weight * (sum / terms.length);
+  }
+  return total;
+}

--- a/apps/web/src/features/command/model/types.ts
+++ b/apps/web/src/features/command/model/types.ts
@@ -82,6 +82,11 @@ export interface CommandGroup {
   kind: CommandGroupKind;
   /** For entity groups: the page to open via the "Go to …" row. */
   path?: string;
+  /**
+   * Quick links rendered at the top of the category's drill page (e.g.
+   * Today/Upcoming views inside Todos). Filtered by query like other rows.
+   */
+  links?: { label: string; path: string }[];
   items: CommandItem[];
 }
 

--- a/apps/web/src/features/command/providers/chats.tsx
+++ b/apps/web/src/features/command/providers/chats.tsx
@@ -12,7 +12,6 @@ import {
 } from "@icons";
 import { SystemPurpose } from "@/features/chat/api/chatApi";
 import type { ChatActions } from "@/features/chat/hooks/useChatActions";
-import { ANALYTICS_EVENTS, trackEvent } from "@/lib/analytics";
 import { ACTION_ICON, ICON } from "../model/constants";
 import { relativeTime } from "../model/format";
 import type { BuildCtx, CommandAction, CommandItem } from "../model/types";
@@ -131,14 +130,7 @@ export function makeMessageItem(
       id: "open",
       label: "Open conversation",
       icon: <ArrowUpRight01Icon {...ACTION_ICON} />,
-      run: () => {
-        trackEvent(ANALYTICS_EVENTS.SEARCH_RESULT_CLICKED, {
-          result_type: "message",
-          conversation_id: msg.conversation_id,
-          message_id: msg.message_id,
-        });
-        ctx.navigate(`/c/${msg.conversation_id}`)();
-      },
+      run: ctx.navigate(`/c/${msg.conversation_id}`),
     },
     actions: [],
   };

--- a/apps/web/src/features/command/providers/commands.tsx
+++ b/apps/web/src/features/command/providers/commands.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import {
+  AudioWave01Icon,
   BookBookmark02Icon,
   BubbleChatAddIcon,
   CircleArrowUp02Icon,
+  CustomerSupportIcon,
   DiscordIcon,
+  Home11Icon,
   KeyboardIcon,
   Layers01Icon,
   Logout02Icon,
   MapsIcon,
+  News01Icon,
+  PinIcon,
   QuillWrite01Icon,
+  TaskAddIcon,
   WhatsappIcon,
 } from "@icons";
 import type { ReactNode } from "react";
 import { Github } from "@/components/shared/icons";
 import { prepareNewChat } from "@/features/chat/utils/newChatNavigation";
+import { toast } from "@/lib/toast";
 import { ACTION_ICON, ICON } from "../model/constants";
 import type { BuildCtx, CommandGroup, CommandItem } from "../model/types";
 
@@ -25,6 +32,9 @@ export interface CommandDeps {
   isSubscribed: boolean;
   openPricing: () => void;
   openShortcuts: () => void;
+  openWhatsNew: () => void;
+  enterVoiceMode: () => void;
+  createTodo: (title: string) => Promise<void>;
   logout: () => void;
   links: {
     discord?: string;
@@ -104,6 +114,44 @@ export function buildCommandGroups(
       },
       { subtitle: "Start a fresh conversation", keywords: "compose message" },
     ),
+    {
+      id: "cmd:new-todo",
+      type: "action",
+      title: "New todo",
+      icon: <TaskAddIcon {...ICON} />,
+      keywords: "create task add reminder",
+      primary: {
+        id: "run",
+        label: "New todo",
+        icon: <TaskAddIcon {...ACTION_ICON} />,
+        form: {
+          placeholder: "e.g. Pay the electricity bill",
+          submitLabel: "Create todo",
+          submit: async (title) => {
+            await deps.createTodo(title);
+            toast.success("Todo created");
+          },
+        },
+      },
+      actions: [],
+    },
+    cmd(
+      "voice-mode",
+      "Start voice mode",
+      <AudioWave01Icon {...ICON} />,
+      () => {
+        ctx.host.close();
+        deps.enterVoiceMode();
+      },
+      { subtitle: "Talk to GAIA", keywords: "speak talk microphone audio" },
+    ),
+    cmd(
+      "whats-new",
+      "See what's new",
+      <News01Icon {...ICON} />,
+      fire(deps.openWhatsNew),
+      { keywords: "changelog releases updates features" },
+    ),
   ];
   if (!deps.isSubscribed) {
     quickActions.push(
@@ -170,6 +218,13 @@ export function buildCommandGroups(
 
   const account: CommandItem[] = [
     cmd(
+      "support",
+      "Support & feedback",
+      <CustomerSupportIcon {...ICON} />,
+      ctx.navigate("/support"),
+      { keywords: "help contact bug feature request" },
+    ),
+    cmd(
       "shortcuts",
       "Keyboard shortcuts",
       <KeyboardIcon {...ICON} />,
@@ -182,6 +237,15 @@ export function buildCommandGroups(
     }),
   ];
 
+  const navigate: CommandItem[] = [
+    cmd("home", "Home", <Home11Icon {...ICON} />, ctx.navigate("/dashboard"), {
+      keywords: "dashboard overview start",
+    }),
+    cmd("pins", "Pins", <PinIcon {...ICON} />, ctx.navigate("/pins"), {
+      keywords: "bookmarks saved messages",
+    }),
+  ];
+
   return [
     {
       id: "actions",
@@ -190,6 +254,14 @@ export function buildCommandGroups(
       accent: "text-emerald-400",
       kind: "actions",
       items: quickActions,
+    },
+    {
+      id: "navigate",
+      heading: "Navigate",
+      icon: <Home11Icon {...ICON} />,
+      accent: "text-sky-400",
+      kind: "actions",
+      items: navigate,
     },
     {
       id: "community",

--- a/apps/web/src/features/command/providers/integrations.tsx
+++ b/apps/web/src/features/command/providers/integrations.tsx
@@ -3,6 +3,7 @@
 import { ArrowUpRight01Icon, Cancel01Icon, PlugSocketIcon } from "@icons";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import type { Integration } from "@/features/integrations/types";
+import { byConnectionStateThenName } from "@/features/integrations/utils/catalog";
 import { ACTION_ICON } from "../model/constants";
 import type { BuildCtx, CommandAction, CommandItem } from "../model/types";
 
@@ -11,77 +12,91 @@ interface IntegrationDeps {
   disconnectIntegration: (id: string) => Promise<void>;
 }
 
-/** Only connected / created / failed integrations are surfaced. */
+/**
+ * Cap on catalog rows surfaced in the palette. The full /integrations/me
+ * catalog can be large; anything past the cap stays reachable on the
+ * integrations page (sorted connection-state-first so connected and
+ * featured entries are never the ones cut).
+ */
+const MAX_ITEMS = 60;
+
+const DOT: Record<Integration["status"], CommandItem["dot"] | undefined> = {
+  connected: { color: "green", label: "Connected" },
+  error: { color: "yellow", label: "Connection failed" },
+  expired: { color: "yellow", label: "Connection expired" },
+  created: undefined,
+  not_connected: undefined,
+};
+
+/** Build one row; `connectable` rows put the connect verb first. */
+function buildIntegrationItem(
+  int: Integration,
+  ctx: BuildCtx,
+  deps: IntegrationDeps,
+): CommandItem {
+  const connectLabel =
+    int.status === "error" || int.status === "expired"
+      ? "Reconnect"
+      : "Connect";
+  const connect: CommandAction = {
+    id: "connect",
+    label: connectLabel,
+    icon: <PlugSocketIcon {...ACTION_ICON} />,
+    run: async () => {
+      ctx.host.close();
+      await deps.connectIntegration(int.id);
+    },
+  };
+  const disconnect: CommandAction = {
+    id: "disconnect",
+    label: "Disconnect",
+    icon: <Cancel01Icon {...ACTION_ICON} />,
+    destructive: true,
+    run: async () => {
+      const ok = await ctx.host.confirm({
+        title: "Disconnect integration",
+        message: `Disconnect ${int.name}?`,
+        confirmText: "Disconnect",
+        variant: "destructive",
+      });
+      if (!ok) return;
+      await deps.disconnectIntegration(int.id);
+    },
+  };
+  const open: CommandAction = {
+    id: "open",
+    label: "Open settings",
+    icon: <ArrowUpRight01Icon {...ACTION_ICON} />,
+    run: ctx.navigate(`/integrations?id=${encodeURIComponent(int.id)}`),
+  };
+
+  // Connected → manage it (open first). Everything else → connect verb
+  // first, settings as the secondary path.
+  const connectable = int.status !== "connected";
+  return {
+    id: `integration:${int.id}`,
+    type: "integration",
+    title: int.name,
+    subtitle: int.category + (int.toolCount ? ` · ${int.toolCount} tools` : ""),
+    icon: getToolCategoryIcon(
+      int.id,
+      { size: 18, width: 18, height: 18, showBackground: false },
+      int.iconUrl,
+    ),
+    keywords: `${int.category} ${int.status} ${int.description ?? ""}`,
+    dot: DOT[int.status],
+    primary: connectable ? connect : open,
+    actions: connectable ? [open] : [disconnect],
+  };
+}
+
+/** The whole catalog is surfaced — connected ones to manage, the rest to connect. */
 export const buildIntegrationItems = (
   integrations: Integration[],
   ctx: BuildCtx,
   deps: IntegrationDeps,
 ): CommandItem[] =>
-  integrations
-    .filter(
-      (int) =>
-        int.status === "connected" ||
-        int.status === "created" ||
-        int.status === "error",
-    )
-    .map((int) => {
-      // "created" = set up but never connected; "error" = connection failed.
-      // Each status maps to exactly one of Connect / Disconnect.
-      const isConnected = int.status === "connected";
-      const canConnect = int.status === "created" || int.status === "error";
-      const connect: CommandAction = {
-        id: "connect",
-        label: int.status === "error" ? "Reconnect" : "Connect",
-        icon: <PlugSocketIcon {...ACTION_ICON} />,
-        run: async () => {
-          ctx.host.close();
-          await deps.connectIntegration(int.id);
-        },
-      };
-      const disconnect: CommandAction = {
-        id: "disconnect",
-        label: "Disconnect",
-        icon: <Cancel01Icon {...ACTION_ICON} />,
-        destructive: true,
-        run: async () => {
-          const ok = await ctx.host.confirm({
-            title: "Disconnect integration",
-            message: `Disconnect ${int.name}?`,
-            confirmText: "Disconnect",
-            variant: "destructive",
-          });
-          if (!ok) return;
-          await deps.disconnectIntegration(int.id);
-        },
-      };
-      const actions: CommandAction[] = [];
-      if (canConnect) actions.push(connect);
-      if (isConnected) actions.push(disconnect);
-
-      return {
-        id: `integration:${int.id}`,
-        type: "integration",
-        title: int.name,
-        subtitle:
-          int.category + (int.toolCount ? ` · ${int.toolCount} tools` : ""),
-        icon: getToolCategoryIcon(
-          int.id,
-          { size: 18, width: 18, height: 18, showBackground: false },
-          int.iconUrl,
-        ),
-        keywords: `${int.category} ${int.status}`,
-        dot:
-          int.status === "error"
-            ? { color: "yellow", label: "Connection failed" }
-            : isConnected
-              ? { color: "green", label: "Connected" }
-              : undefined,
-        primary: {
-          id: "open",
-          label: "Open settings",
-          icon: <ArrowUpRight01Icon {...ACTION_ICON} />,
-          run: ctx.navigate(`/integrations?id=${encodeURIComponent(int.id)}`),
-        },
-        actions,
-      };
-    });
+  [...integrations]
+    .sort(byConnectionStateThenName)
+    .slice(0, MAX_ITEMS)
+    .map((int) => buildIntegrationItem(int, ctx, deps));

--- a/apps/web/src/features/command/providers/memories.tsx
+++ b/apps/web/src/features/command/providers/memories.tsx
@@ -5,10 +5,55 @@ import { memoryApi } from "@/features/memory/api/memoryApi";
 import type { MemoryEntry } from "@/features/memory/api/types";
 import { toast } from "@/lib/toast";
 import { ACTION_ICON, ICON } from "../model/constants";
-import type { BuildCtx, CommandItem } from "../model/types";
+import type { BuildCtx, CommandAction, CommandItem } from "../model/types";
 
-interface MemoryDeps {
+export interface MemoryDeps {
   refetch: () => Promise<unknown>;
+}
+
+/** Build a single memory row. Search hits pass `full=false`: they carry no
+ * list position, so a delete there couldn't refresh the visible list —
+ * they open the memories page instead of offering a stale-feeling action. */
+export function makeMemoryItem(
+  mem: MemoryEntry & { id: string },
+  ctx: BuildCtx,
+  deps: MemoryDeps,
+  full = true,
+): CommandItem {
+  const forget: CommandAction = {
+    id: "forget",
+    label: "Forget memory",
+    icon: <Delete02Icon {...ACTION_ICON} />,
+    destructive: true,
+    run: async () => {
+      const ok = await ctx.host.confirm({
+        title: "Forget memory",
+        message: `GAIA will stop recalling "${mem.content}". Forget it?`,
+        confirmText: "Forget",
+        variant: "destructive",
+      });
+      if (!ok) return;
+      await memoryApi.deleteMemory(mem.id);
+      await deps.refetch();
+      toast.success("Memory forgotten");
+    },
+  };
+
+  return {
+    id: `memory:${mem.id}`,
+    type: "memory",
+    title: mem.content,
+    subtitle: mem.category_path || "Memory",
+    icon: <Brain02Icon {...ICON} />,
+    keywords: mem.category_path,
+    primary: {
+      id: "open",
+      label: "Open in memories",
+      icon: <ArrowUpRight01Icon {...ACTION_ICON} />,
+      run: ctx.navigate("/settings/memory"),
+    },
+    actions: full ? [forget] : [],
+  };
 }
 
 export const buildMemoryItems = (
@@ -18,37 +63,4 @@ export const buildMemoryItems = (
 ): CommandItem[] =>
   memories
     .filter((mem): mem is MemoryEntry & { id: string } => Boolean(mem.id))
-    .map((mem) => ({
-      id: `memory:${mem.id}`,
-      type: "memory",
-      title: mem.content,
-      subtitle: mem.category_path || "Memory",
-      icon: <Brain02Icon {...ICON} />,
-      keywords: mem.category_path,
-      primary: {
-        id: "open",
-        label: "Open in memories",
-        icon: <ArrowUpRight01Icon {...ACTION_ICON} />,
-        run: ctx.navigate("/settings/memory"),
-      },
-      actions: [
-        {
-          id: "delete",
-          label: "Forget memory",
-          icon: <Delete02Icon {...ACTION_ICON} />,
-          destructive: true,
-          run: async () => {
-            const ok = await ctx.host.confirm({
-              title: "Forget memory",
-              message: `GAIA will stop recalling "${mem.content}". Forget it?`,
-              confirmText: "Forget",
-              variant: "destructive",
-            });
-            if (!ok) return;
-            await memoryApi.deleteMemory(mem.id);
-            await deps.refetch();
-            toast.success("Memory forgotten");
-          },
-        },
-      ],
-    }));
+    .map((mem) => makeMemoryItem(mem, ctx, deps));

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -73,6 +73,7 @@ export const ANALYTICS_EVENTS = {
 
   SEARCH_GLOBAL_OPENED: "search:global_opened",
   SEARCH_RESULT_CLICKED: "search:result_clicked",
+  COMMAND_ITEM_EXECUTED: "command:item_executed",
 
   // Pins/Bookmarks events
   PIN_CREATED: "pin:created",

--- a/apps/web/src/stores/composerStore.ts
+++ b/apps/web/src/stores/composerStore.ts
@@ -13,6 +13,8 @@ import type { SearchMode } from "@/types/shared/searchTypes";
 interface ComposerState {
   // Text input state
   pendingPrompt: string | null;
+  /** True when the pending prompt should be SENT on chat mount, not prefilled. */
+  pendingAutoSend: boolean;
   inputText: string;
 
   // Mode and tool selection
@@ -38,6 +40,8 @@ interface ComposerActions {
   appendToInput: (text: string) => void;
   setPendingPrompt: (prompt: string | null) => void;
   clearPendingPrompt: () => void;
+  /** Palette ask-handoff flag: the pending prompt sends instead of prefilling. */
+  setPendingAutoSend: (autoSend: boolean) => void;
   setInputText: (text: string) => void;
   appendToInputText: (text: string) => void;
   clearInputText: () => void;
@@ -75,6 +79,7 @@ type ComposerStore = ComposerState & ComposerActions;
 const initialState: ComposerState = {
   // Text input state
   pendingPrompt: null,
+  pendingAutoSend: false,
   inputText: "",
 
   // Mode and tool selection
@@ -121,6 +126,9 @@ export const useComposerStore = create<ComposerStore>()(
         clearPendingPrompt: () => {
           set({ pendingPrompt: null }, false, "clearPendingPrompt");
         },
+
+        setPendingAutoSend: (pendingAutoSend) =>
+          set({ pendingAutoSend }, false, "setPendingAutoSend"),
 
         setInputText: (inputText) => {
           set({ inputText }, false, "setInputText");


### PR DESCRIPTION
## Summary

Rebuilds the ⌘K command palette into the app's primary control surface: one input to jump to any chat, todo, workflow, integration, notification or memory, run actions on them without leaving the keyboard, and talk to GAIA directly. Search now spans every surface (including semantic memory recall and the full integrations catalog), results learn from what you pick, and typing a question and hitting Enter starts a real GAIA conversation.

## Why

The palette shipped in #840 covered browsing and navigation, but it under-used the platform: you couldn't create anything from it, never-connected integrations were invisible, memories weren't searchable, and ranking ignored what you actually use. The biggest gap was that "Ask GAIA" only prefilled the composer — a detour instead of an entry point. This change makes the palette the fastest way to *do* things, not just find them.

**Demo (2.5 min, 1080p):** [command-k-demo.mp4](https://github.com/theexperiencecompany/gaia/raw/pr-assets/1072-command-k-ux/command-k-demo.mp4) — open ⌘K on the dashboard, cross-surface search for "tokyo", drill into a chat's actions with Tab/→, create a todo from the digit shortcut, then Ask GAIA auto-sends a question from outside /c and streams the reply.

| Surface | Before | After |
| --- | --- | --- |
| Integrations | Only already-connected ones listed | Full catalog; unconnected rows are verb-first **Connect**, expired shows Reconnect + status dot |
| Memories | First 50, local filter only | Local + debounced semantic recall (`/memory/search`) merged in |
| Ranking | Static title substring match | Tiered fuzzy scorer (exact → prefix → word-boundary/camelCase → substring → subsequence) + persisted frecency boost; Recent is usage-driven |
| Ask GAIA | Prefilled composer | Enter sends through the chat pipeline; Shift+Enter keeps prefill |
| Multi-step search | Server results could linger for the previous query | Results are dropped the instant the query outruns the debounce |

## What changed

### Web

- **Ranking** (`model/scorer.ts`, `frecency.ts`): weighted multi-field scoring with camelCase/word-boundary awareness; a persisted ring buffer of picks (200 entries, 72h half-life) boosts near-equal matches without ever outranking a better tier. `Recent` is frecency-first with timestamps as fallback.
- **Search freshness**: `useChatSearch`/`useMemorySearch` return the query their answers belong to; CommandMenu drops server rows during the debounce window and shows the searching skeleton instead.
- **Commands**: New todo (inline form), Start voice mode, See what's new, Support & feedback; a Navigate section (Home, Pins); Todos drill page gains Today/Upcoming/Completed links; the context row recognizes `/todos?todoId=`.
- **Ask GAIA handoff**: `composerStore.pendingAutoSend` + a once-per-prompt consumer in `ChatPage.tsx` route the query through the normal send pipeline. The flag is deliberately not persisted, so a reload can never fire a stale send.
- **Correctness**: each drill-down level remembers its own query (back restores it); activation analytics centralized — `command:item_executed {item_type}` on every executed row, `search:result_clicked` for all entity types while searching (was message-only); unreachable empty-state removed.
- **Polish**: near-instant open (opacity-only), scroll shadows, 480px list, `aria-live` result announcements.

Deliberately **not** surfaced: the notes facet of `/search` — there is no notes UI to land on, and Calendar/Mail stay out of Navigate while they are disabled in the product nav.

## Screenshots

| | |
| --- | --- |
| Root view — recents, quick actions, browse | ![Root view](https://github.com/theexperiencecompany/gaia/raw/pr-assets/1072-command-k-ux/palette-root.png) |
| Cross-surface search ("tokyo") | ![Search](https://github.com/theexperiencecompany/gaia/raw/pr-assets/1072-command-k-ux/palette-search-tokyo.png) |
| Ask GAIA auto-send result | ![Auto-send](https://github.com/theexperiencecompany/gaia/raw/pr-assets/1072-command-k-ux/ask-gaia-autosend.png) |

These are raw links on the `pr-assets` branch (repo is private, so they need a logged-in session). For inline rendering, drag the four files from `1072-command-k-ux/` on that branch into the description box.

## How to verify

1. `mise dev --sim` (or `--agent`), open the web port, press ⌘K.
2. Type part of a chat title → Chats/Messages sections appear; press → or Tab on a chat to see its actions, Esc to come back.
3. Clear, type "zzqx" → only "Ask GAIA" remains; press Enter from any non-chat page → a new conversation opens with your question already sent exactly once (composer stays empty).
4. Press 5 (or pick New todo) → type a title → Enter → toast fires and the todo exists on /todos.
5. Pick a few items across two sessions and reopen: Recent reorders by usage.
6. Type a query, then quickly keep editing it mid-debounce: no stale server rows appear for the old query.

**Not verified:** the Electron desktop build (palette logic is shared web code, but I did not drive the desktop shell); VoiceOver beyond a macOS spot-check of the live region.

## Risk

The palette mounts at the app root, so a render failure here is visible everywhere — mitigated by the existing ErrorBoundary wrapper and 123 unit tests over the scoring/ranking core plus live driving of the flows above. Behavior changes are confined to the palette surface except two touchpoints: `ChatPage`'s pending-prompt effect (now branches on `pendingAutoSend`; prefill behavior is unchanged when the flag is unset) and `useChatActions` consumers (no signature changes).

## Related

Depends on #840 (stacked: this branch merges into `prototype/command-k`).