### PR TITLE
fix(mobile): chat streaming correctness, markdown parity, and conversation sync

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -84,7 +84,8 @@
     "dotenv-cli": "^11.0.0",
     "reactotron-react-native": "^5.2.0",
     "tailwindcss": "^4.3.2",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   },
   "private": true
 }

--- a/apps/mobile/project.json
+++ b/apps/mobile/project.json
@@ -70,6 +70,13 @@
         "command": "rm -rf .expo node_modules",
         "cwd": "apps/mobile"
       }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm vitest run --config vitest.config.ts",
+        "cwd": "{projectRoot}"
+      }
     }
   },
   "tags": ["type:app", "platform:mobile", "scope:typescript"]

--- a/apps/mobile/src/components/ui/markdown-parser.test.ts
+++ b/apps/mobile/src/components/ui/markdown-parser.test.ts
@@ -1,0 +1,117 @@
+import { assert, describe, expect, it } from "vitest";
+import {
+  parseBlocks,
+  parseInline,
+  repairStreamingMarkdown,
+} from "./markdown-parser";
+
+describe("parseInline — one segment per construct", () => {
+  it("parses links", () => {
+    const segs = parseInline("see [docs](https://example.com) now");
+    expect(segs).toEqual([
+      { type: "text", text: "see " },
+      { type: "link", text: "docs", url: "https://example.com" },
+      { type: "text", text: " now" },
+    ]);
+  });
+
+  it("parses images with alt and url", () => {
+    const segs = parseInline("![a photo](https://example.com/pic.png)");
+    expect(segs).toEqual([
+      { type: "image", alt: "a photo", url: "https://example.com/pic.png" },
+    ]);
+  });
+
+  it("parses bold, italic and bold-italic distinctly", () => {
+    expect(parseInline("**bold**")).toEqual([{ type: "bold", text: "bold" }]);
+    expect(parseInline("*ital*")).toEqual([{ type: "italic", text: "ital" }]);
+    expect(parseInline("***both***")).toEqual([
+      { type: "boldItalic", text: "both" },
+    ]);
+  });
+
+  it("parses strikethrough, inline code and math as distinct types", () => {
+    expect(parseInline("~~gone~~")).toEqual([
+      { type: "strikethrough", text: "gone" },
+    ]);
+    expect(parseInline("`x = 1`")).toEqual([{ type: "code", text: "x = 1" }]);
+    expect(parseInline("$E=mc^2$")).toEqual([
+      { type: "mathInline", text: "E=mc^2" },
+    ]);
+  });
+
+  it("decodes HTML entities in plain text", () => {
+    expect(parseInline("a &amp; b &lt;c&gt;")).toEqual([
+      { type: "text", text: "a & b <c>" },
+    ]);
+  });
+});
+
+describe("parseBlocks", () => {
+  it("parses a GFM table with alignment", () => {
+    const blocks = parseBlocks(["| a | b |", "| --- | :---: |", "| 1 | 2 |"]);
+    expect(blocks).toHaveLength(1);
+    const table = blocks[0];
+    assert(table.type === "table");
+    expect(table.rows).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+    expect(table.alignments).toEqual([null, "center"]);
+  });
+
+  it("parses nested lists recursively", () => {
+    const blocks = parseBlocks(["- item1", "  - nested A", "- item2"]);
+    expect(blocks).toHaveLength(1);
+    const list = blocks[0];
+    assert(list.type === "list");
+    expect(list.items).toHaveLength(2);
+    const [first] = list.items;
+    // First item renders its text plus the recursively-parsed sublist.
+    expect(first.blocks.map((b) => b.type)).toEqual(["paragraph", "list"]);
+    const nested = first.blocks[1];
+    assert(nested.type === "list");
+    expect(nested.items).toHaveLength(1);
+  });
+
+  it("preserves the starting number of ordered lists", () => {
+    const blocks = parseBlocks(["3. three", "4. four"]);
+    const list = blocks[0];
+    assert(list.type === "list");
+    expect(list.start).toBe(3);
+  });
+
+  it("preserves single newlines inside a paragraph", () => {
+    const blocks = parseBlocks(["line one", "line two"]);
+    const para = blocks[0];
+    assert(para.type === "paragraph");
+    expect(para.segments[0]).toEqual({
+      type: "text",
+      text: "line one\nline two",
+    });
+  });
+
+  it("parses task list items", () => {
+    const blocks = parseBlocks(["- [x] done", "- [ ] todo"]);
+    const list = blocks[0];
+    assert(list.type === "list");
+    expect(list.items.map((i) => [i.task, i.checked])).toEqual([
+      [true, true],
+      [true, false],
+    ]);
+  });
+});
+
+describe("repairStreamingMarkdown", () => {
+  it("closes an unclosed code fence opened at line start", () => {
+    const md = "Here is code:\n```js\nconst x = 1;";
+    const repaired = repairStreamingMarkdown(md);
+    const blocks = parseBlocks(repaired.split("\n"));
+    expect(blocks.some((b) => b.type === "codeBlock")).toBe(true);
+  });
+
+  it("does not alter complete markdown", () => {
+    const md = "# Title\n\ndone **bold** `code`\n";
+    expect(repairStreamingMarkdown(md)).toBe(md);
+  });
+});

--- a/apps/mobile/src/components/ui/markdown-parser.test.ts
+++ b/apps/mobile/src/components/ui/markdown-parser.test.ts
@@ -102,6 +102,22 @@ describe("parseBlocks", () => {
   });
 });
 
+describe("parseBlocks — termination guarantees", () => {
+  it("does not stall on a delimiter line with no table header", () => {
+    // Regression: a lone table-delimiter line is a block boundary that no
+    // parser accepts; parseBlocks must advance past it, not loop forever.
+    expect(() =>
+      parseBlocks(["| --- | --- |", "hello"]).map((b) => b.type),
+    ).not.toThrow();
+    const blocks = parseBlocks(["| --- | --- |", "hello"]);
+    expect(blocks.some((b) => b.type === "paragraph")).toBe(true);
+  });
+
+  it("does not stall on a lone delimiter line", () => {
+    expect(parseBlocks(["| --- | --- |"])).toEqual([]);
+  });
+});
+
 describe("repairStreamingMarkdown", () => {
   it("closes an unclosed code fence opened at line start", () => {
     const md = "Here is code:\n```js\nconst x = 1;";

--- a/apps/mobile/src/components/ui/markdown-parser.ts
+++ b/apps/mobile/src/components/ui/markdown-parser.ts
@@ -433,6 +433,12 @@ function parseParagraphLines(lines: string[], start: number): BlockParseResult {
     paraLines.push(lines[i]);
     i++;
   }
+  if (i === start) {
+    // The line is a boundary no earlier parser accepted (e.g. a table
+    // delimiter with no header above it). Consume exactly one line as text —
+    // returning `next: start` here would stall parseBlocks forever.
+    return { block: null, next: start + 1 };
+  }
   return {
     block:
       paraLines.length > 0
@@ -465,7 +471,9 @@ function parseBlocks(lines: string[]): Block[] {
     if (result.block) {
       blocks.push(result.block);
     }
-    i = result.next;
+    // Guard against any parser ever returning zero progress — a stalled
+    // index here would hang the render thread.
+    i = Math.max(result.next, i + 1);
   }
 
   return blocks;

--- a/apps/mobile/src/components/ui/markdown-parser.ts
+++ b/apps/mobile/src/components/ui/markdown-parser.ts
@@ -471,9 +471,11 @@ function parseBlocks(lines: string[]): Block[] {
     if (result.block) {
       blocks.push(result.block);
     }
-    // Guard against any parser ever returning zero progress — a stalled
-    // index here would hang the render thread.
-    i = Math.max(result.next, i + 1);
+    // Termination contract: every parser either consumes ≥1 line or returns
+    // null with next ≥ start+1 (parseParagraphLines handles the
+    // boundary-nobody-accepts case). If this invariant breaks, the loop
+    // stalls — the regression tests pin it.
+    i = result.next;
   }
 
   return blocks;

--- a/apps/mobile/src/components/ui/markdown-parser.ts
+++ b/apps/mobile/src/components/ui/markdown-parser.ts
@@ -1,0 +1,499 @@
+/**
+ * Pure streaming-markdown parser — no React Native imports so it can be unit
+ * tested directly. Consumed by markdown-renderer.tsx, which owns all styling
+ * and rendering.
+ */
+
+// -- Types --------------------------------------------------------------------
+
+type InlineSegment =
+  | { type: "text"; text: string }
+  | { type: "bold"; text: string }
+  | { type: "italic"; text: string }
+  | { type: "boldItalic"; text: string }
+  | { type: "code"; text: string }
+  | { type: "link"; text: string; url: string }
+  | { type: "image"; alt: string; url: string }
+  | { type: "strikethrough"; text: string }
+  | { type: "mathInline"; text: string };
+
+interface ListItem {
+  blocks: Block[];
+  task: boolean;
+  checked: boolean;
+}
+
+type TableAlignment = "left" | "center" | "right" | null;
+
+type Block =
+  | { type: "paragraph"; segments: InlineSegment[] }
+  | { type: "heading"; level: number; segments: InlineSegment[] }
+  | { type: "codeBlock"; language: string; code: string }
+  | { type: "blockquote"; segments: InlineSegment[] }
+  | { type: "list"; ordered: boolean; start: number; items: ListItem[] }
+  | { type: "table"; alignments: TableAlignment[]; rows: string[][] }
+  | { type: "hr" }
+  | { type: "mathBlock"; code: string };
+
+// -- Streaming repair ---------------------------------------------------------
+
+/**
+ * Patch the most common incomplete-markdown states while tokens are still
+ * arriving, so partial output renders as text rather than raw markers
+ * (mirrors Streamdown's parseIncompleteMarkdown on web):
+ *  - unclosed ``` fence → close it so the half-streamed code renders as a block
+ *  - unclosed $$ math fence → close it
+ *  - dangling inline emphasis/code markers at end of text → close them
+ */
+export function repairStreamingMarkdown(md: string): string {
+  let out = md;
+
+  const fenceCount = (out.match(/^[^\S\n]*```/gm) ?? []).length;
+  if (fenceCount % 2 === 1) out += "\n```";
+
+  const mathFenceCount = (out.match(/^\$\$/gm) ?? []).length;
+  if (mathFenceCount % 2 === 1) out += "\n$$";
+
+  // Close dangling inline markers, longest first, recounting after each append
+  // so an appended marker doesn't skew later parity checks.
+  for (const marker of ["**", "__", "~~"]) {
+    const count = (
+      out.match(new RegExp(marker.replace(/\*/g, "\\*"), "g")) ?? []
+    ).length;
+    if (count % 2 === 1) out += marker;
+  }
+  const backtickCount = (out.match(/`/g) ?? []).length;
+  if (backtickCount % 2 === 1) out += "`";
+  // Single-marker emphasis (* and _): only append when the trailing run looks
+  // like an unclosed opener — a lone marker at the very end of the text.
+  for (const marker of ["*", "_"]) {
+    if (out.endsWith(marker) && !out.endsWith(marker.repeat(2))) {
+      // Count non-doubled occurrences conservatively; appending only when the
+      // text ends with exactly one avoids corrupting valid mid-text emphasis.
+      out += marker;
+    }
+  }
+
+  return out;
+}
+
+// -- Entity decoding ----------------------------------------------------------
+
+const ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  nbsp: " ",
+  "#39": "'",
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(#39|amp|lt|gt|quot|nbsp);/g, (_, entity: string) => {
+    return ENTITIES[entity] ?? `&${entity};`;
+  });
+}
+
+// -- Inline parsing -----------------------------------------------------------
+
+function segmentFromMatch(match: RegExpExecArray): InlineSegment | null {
+  if (match[2] !== undefined) {
+    return { type: "image", alt: match[1] ?? "", url: match[2] };
+  }
+  if (match[3] !== undefined && match[4] !== undefined) {
+    return { type: "link", text: match[3], url: match[4] };
+  }
+  if (match[5] || match[6]) {
+    return { type: "boldItalic", text: match[5] || match[6] };
+  }
+  if (match[7] || match[8]) {
+    return { type: "bold", text: match[7] || match[8] };
+  }
+  if (match[9] || match[10]) {
+    return { type: "italic", text: match[9] || match[10] };
+  }
+  if (match[11]) {
+    return { type: "strikethrough", text: match[11] };
+  }
+  if (match[12]) {
+    return { type: "mathInline", text: match[12] };
+  }
+  if (match[13]) {
+    return { type: "code", text: match[13] };
+  }
+  return null;
+}
+
+// Order matters: image before link; bold-italic before bold before italic;
+// $...$ before backtick.
+const INLINE_REGEX = new RegExp(
+  [
+    /!\[([^\]]*)\]\(([^)]+)\)/.source, // 1-2 image
+    /\[([^\]]+)\]\(([^)]+)\)/.source, // 3-4 link
+    /\*\*\*([\s\S]+?)\*\*\*/.source, // 5 bold-italic ***
+    /___([\s\S]+?)___/.source, // 6 bold-italic ___
+    /\*\*([\s\S]+?)\*\*/.source, // 7 bold **
+    /__([\s\S]+?)__/.source, // 8 bold __
+    /(?<![\w*])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![\w*])/.source, // 9 italic *
+    /(?<![\w_])_(?!\s)([^_\n]+?)(?<!\s)_(?![\w_])/.source, // 10 italic _
+    /~~([\s\S]+?)~~/.source, // 11 strikethrough
+    /\$([^$\n]+?)\$/.source, // 12 math inline
+    /`([^`\n]+)`/.source, // 13 code
+  ].join("|"),
+  "g",
+);
+
+function parseInline(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  INLINE_REGEX.lastIndex = 0;
+  let lastIndex = 0;
+  let match = INLINE_REGEX.exec(text);
+
+  while (match !== null) {
+    if (match.index > lastIndex) {
+      segments.push({
+        type: "text",
+        text: decodeEntities(text.slice(lastIndex, match.index)),
+      });
+    }
+
+    const segment = segmentFromMatch(match);
+    if (segment) {
+      segments.push(segment);
+    }
+
+    lastIndex = match.index + match[0].length;
+    match = INLINE_REGEX.exec(text);
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({
+      type: "text",
+      text: decodeEntities(text.slice(lastIndex)),
+    });
+  }
+
+  if (segments.length === 0) {
+    segments.push({ type: "text", text: decodeEntities(text) });
+  }
+
+  return segments;
+}
+
+// -- Block parsing ------------------------------------------------------------
+
+// A single parsing step: an optional block plus the index to resume from.
+// `block === null` means lines were consumed without producing a block.
+type BlockParseResult = { block: Block | null; next: number };
+
+function parseMathBlockLines(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  if (lines[start].trim() !== "$$") return null;
+  const mathLines: string[] = [];
+  let i = start + 1;
+  while (i < lines.length && lines[i].trim() !== "$$") {
+    mathLines.push(lines[i]);
+    i++;
+  }
+  i++; // skip closing $$
+  return { block: { type: "mathBlock", code: mathLines.join("\n") }, next: i };
+}
+
+function parseCodeBlockLines(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  if (!lines[start].trimStart().startsWith("```")) return null;
+  const language = lines[start].trimStart().slice(3).trim();
+  const codeLines: string[] = [];
+  let i = start + 1;
+  while (i < lines.length && !lines[i].trimStart().startsWith("```")) {
+    codeLines.push(lines[i]);
+    i++;
+  }
+  i++; // skip closing ```
+  return {
+    block: { type: "codeBlock", language, code: codeLines.join("\n") },
+    next: i,
+  };
+}
+
+// Captures the first marker and requires every repeat to match it, so mixed
+// sequences like "- * _" stay text (CommonMark only treats a uniform run as a
+// rule). Unambiguous by construction (every \s* is anchored between mandatory
+// chars), so it cannot backtrack exponentially on adversarial input.
+const HR_LINE_REGEX = /^\s*([-*_])(?:\s*\1){2,}\s*$/;
+
+function isHrLine(line: string): boolean {
+  return HR_LINE_REGEX.test(line);
+}
+
+function parseHrLine(lines: string[], start: number): BlockParseResult | null {
+  if (!isHrLine(lines[start])) return null;
+  return { block: { type: "hr" }, next: start + 1 };
+}
+
+const HEADING_LINE_REGEX = /^(#{1,6})\s+(.+)/;
+
+function parseHeadingLine(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  const headingMatch = lines[start].match(HEADING_LINE_REGEX);
+  if (!headingMatch) return null;
+  return {
+    block: {
+      type: "heading",
+      level: headingMatch[1].length,
+      segments: parseInline(headingMatch[2]),
+    },
+    next: start + 1,
+  };
+}
+
+// `>` with or without a trailing space opens a quote (CommonMark allows both).
+const BLOCKQUOTE_LINE_REGEX = /^\s{0,3}>\s?(.*)$/;
+
+function parseBlockquoteLines(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  const openMatch = lines[start].match(BLOCKQUOTE_LINE_REGEX);
+  if (!openMatch) return null;
+  const quoteLines: string[] = [openMatch[1]];
+  let i = start + 1;
+  while (i < lines.length) {
+    const match = lines[i].match(BLOCKQUOTE_LINE_REGEX);
+    if (!match) break;
+    quoteLines.push(match[1]);
+    i++;
+  }
+  return {
+    block: { type: "blockquote", segments: parseInline(quoteLines.join("\n")) },
+    next: i,
+  };
+}
+
+// -- Lists (nested + task lists) ----------------------------------------------
+
+const UNORDERED_ITEM_REGEX = /^(\s*)([-*+])\s+(.*)$/;
+const ORDERED_ITEM_REGEX = /^(\s*)(\d+)[.)]\s+(.*)$/;
+const TASK_CHECKBOX_REGEX = /^\[([ xX])\]\s+(.*)$/;
+
+/** Marker info for a list-item line, or null when the line opens no item. */
+function itemMarker(
+  line: string,
+  ordered: boolean,
+): { indent: number; rest: string } | null {
+  const match = ordered
+    ? line.match(ORDERED_ITEM_REGEX)
+    : line.match(UNORDERED_ITEM_REGEX);
+  if (!match) return null;
+  return { indent: match[1].length, rest: match[3] };
+}
+
+/**
+ * Parse a (possibly nested) list starting at `start`. Items at the opening
+ * line's indent delimit items; deeper-indented continuation lines belong to
+ * the current item and are recursively parsed as blocks, which is what makes
+ * nested sublists render correctly.
+ */
+function parseListLines(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  const ordered = ORDERED_ITEM_REGEX.test(lines[start]);
+  const first = itemMarker(lines[start], ordered);
+  if (!first) return null;
+
+  const baseIndent = first.indent;
+  const items: ListItem[] = [];
+
+  let i = start;
+  while (i < lines.length) {
+    const line = lines[i];
+    const marker = itemMarker(line, ordered);
+
+    // A sibling item at the same level opens a new entry.
+    if (!marker || marker.indent < baseIndent) break;
+
+    const task = marker.rest.match(TASK_CHECKBOX_REGEX);
+    const itemLines = [task ? task[2] : marker.rest];
+    items.push({
+      blocks: [],
+      task: !!task,
+      checked: task ? task[1].toLowerCase() === "x" : false,
+    });
+    i++;
+
+    // Continuation lines belong to this item: nested sublists (deeper-indent
+    // markers) and indented wrapped text. Anything else ends the item; the
+    // recursive parseBlocks on itemLines is what renders nested lists.
+    while (i < lines.length && lines[i].trim() !== "") {
+      const cont = lines[i];
+      const contIndent = cont.match(/^\s*/)?.[0].length ?? 0;
+      const nestedMarker = itemMarker(cont, ordered);
+      const isNested =
+        (nestedMarker && nestedMarker.indent > baseIndent) ||
+        contIndent > baseIndent + 1;
+      if (!isNested) break;
+      itemLines.push(cont.trimStart());
+      i++;
+    }
+    items[items.length - 1].blocks = parseBlocks(itemLines);
+  }
+
+  const startIndex = ordered
+    ? Number.parseInt(lines[start].match(ORDERED_ITEM_REGEX)?.[2] ?? "1", 10)
+    : 1;
+
+  return {
+    block: {
+      type: "list",
+      ordered,
+      start: Number.isNaN(startIndex) ? 1 : startIndex,
+      items,
+    },
+    next: i,
+  };
+}
+
+// -- Tables -------------------------------------------------------------------
+
+const TABLE_DELIM_REGEX = /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/;
+
+// Protect escaped pipes, split, then restore. A sentinel string rather than
+// a control character so the split stays regex-free.
+const ESCAPED_PIPE_SENTINEL = "\u0001gaia-pipe\u0001";
+function splitTableRow(line: string): string[] {
+  let trimmed = line.trim();
+  if (trimmed.startsWith("|")) trimmed = trimmed.slice(1);
+  if (trimmed.endsWith("|") && !trimmed.endsWith("\\|")) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed
+    .replace(/\\\|/g, ESCAPED_PIPE_SENTINEL)
+    .split("|")
+    .map((cell) => cell.replaceAll(ESCAPED_PIPE_SENTINEL, "|").trim());
+}
+
+function parseTableLines(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  if (start + 1 >= lines.length) return null;
+  const header = lines[start];
+  const delim = lines[start + 1];
+  if (!header.includes("|") || !TABLE_DELIM_REGEX.test(delim)) return null;
+
+  const alignments: TableAlignment[] = splitTableRow(delim).map((cell) => {
+    const left = cell.startsWith(":");
+    const right = cell.endsWith(":");
+    if (left && right) return "center";
+    if (right) return "right";
+    if (left) return "left";
+    return null;
+  });
+
+  const rows: string[][] = [splitTableRow(header)];
+  let i = start + 2;
+  while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
+    rows.push(splitTableRow(lines[i]));
+    i++;
+  }
+
+  return { block: { type: "table", alignments, rows }, next: i };
+}
+
+// -- Paragraph ----------------------------------------------------------------
+
+function isBlockBoundary(line: string): boolean {
+  return (
+    line.trim() === "" ||
+    line.trim() === "$$" ||
+    line.trimStart().startsWith("```") ||
+    BLOCKQUOTE_LINE_REGEX.test(line) ||
+    HEADING_LINE_REGEX.test(line) ||
+    UNORDERED_ITEM_REGEX.test(line) ||
+    ORDERED_ITEM_REGEX.test(line) ||
+    TABLE_DELIM_REGEX.test(line) ||
+    isHrLine(line)
+  );
+}
+
+function parseParagraphLines(lines: string[], start: number): BlockParseResult {
+  if (lines[start].trim() === "") {
+    return { block: null, next: start + 1 };
+  }
+  const paraLines: string[] = [];
+  let i = start;
+  while (i < lines.length && !isBlockBoundary(lines[i])) {
+    paraLines.push(lines[i]);
+    i++;
+  }
+  return {
+    block:
+      paraLines.length > 0
+        ? {
+            // Preserve single newlines inside a paragraph (remark-breaks
+            // parity) — RNText renders \n as a visual line break.
+            type: "paragraph",
+            segments: parseInline(paraLines.join("\n")),
+          }
+        : null,
+    next: i,
+  };
+}
+
+function parseBlocks(lines: string[]): Block[] {
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const result =
+      parseMathBlockLines(lines, i) ??
+      parseCodeBlockLines(lines, i) ??
+      parseHrLine(lines, i) ??
+      parseHeadingLine(lines, i) ??
+      parseTableLines(lines, i) ??
+      parseBlockquoteLines(lines, i) ??
+      parseListLines(lines, i) ??
+      parseParagraphLines(lines, i);
+
+    if (result.block) {
+      blocks.push(result.block);
+    }
+    i = result.next;
+  }
+
+  return blocks;
+}
+
+// -- Key helpers --------------------------------------------------------------
+
+function segmentKey(seg: InlineSegment, idx: number): string {
+  const label = seg.type === "image" ? seg.url : seg.text;
+  return `${seg.type}-${idx}-${label.slice(0, 12)}`;
+}
+
+function blockKey(block: Block, idx: number): string {
+  if (block.type === "codeBlock") return `cb-${idx}-${block.language}`;
+  if (block.type === "hr") return `hr-${idx}`;
+  return `${block.type}-${idx}`;
+}
+
+function listItemKey(item: ListItem, idx: number): string {
+  return `li-${idx}-${item.blocks[0]?.type ?? "empty"}`;
+}
+
+export type { Block, InlineSegment, ListItem, TableAlignment };
+export {
+  blockKey,
+  decodeEntities,
+  listItemKey,
+  parseBlocks,
+  parseInline,
+  segmentKey,
+};

--- a/apps/mobile/src/components/ui/markdown-renderer.tsx
+++ b/apps/mobile/src/components/ui/markdown-renderer.tsx
@@ -9,6 +9,18 @@ import {
 } from "react-native";
 import { WebView } from "react-native-webview";
 import {
+  type Block,
+  blockKey,
+  decodeEntities,
+  type InlineSegment,
+  type ListItem,
+  listItemKey,
+  parseBlocks,
+  repairStreamingMarkdown,
+  segmentKey,
+  type TableAlignment,
+} from "@/components/ui/markdown-parser";
+import {
   CodeBlock,
   InlineCode,
 } from "@/features/chat/components/code-block/CodeBlock";
@@ -24,8 +36,6 @@ const COLORS = {
   linkColor: "#00bbff",
 } as const;
 
-// -- Types --------------------------------------------------------------------
-
 export interface MarkdownRendererProps {
   content: string;
   /**
@@ -33,486 +43,6 @@ export interface MarkdownRendererProps {
    * fences/bold/etc.) so literal markers never flash mid-token.
    */
   isStreaming?: boolean;
-}
-
-type InlineSegment =
-  | { type: "text"; text: string }
-  | { type: "bold"; text: string }
-  | { type: "italic"; text: string }
-  | { type: "boldItalic"; text: string }
-  | { type: "code"; text: string }
-  | { type: "link"; text: string; url: string }
-  | { type: "image"; alt: string; url: string }
-  | { type: "strikethrough"; text: string }
-  | { type: "mathInline"; text: string };
-
-interface ListItem {
-  blocks: Block[];
-  task: boolean;
-  checked: boolean;
-}
-
-type TableAlignment = "left" | "center" | "right" | null;
-
-type Block =
-  | { type: "paragraph"; segments: InlineSegment[] }
-  | { type: "heading"; level: number; segments: InlineSegment[] }
-  | { type: "codeBlock"; language: string; code: string }
-  | { type: "blockquote"; segments: InlineSegment[] }
-  | { type: "list"; ordered: boolean; start: number; items: ListItem[] }
-  | { type: "table"; alignments: TableAlignment[]; rows: string[][] }
-  | { type: "hr" }
-  | { type: "mathBlock"; code: string };
-
-// -- Streaming repair ---------------------------------------------------------
-
-/**
- * Patch the most common incomplete-markdown states while tokens are still
- * arriving, so partial output renders as text rather than raw markers
- * (mirrors Streamdown's parseIncompleteMarkdown on web):
- *  - unclosed ``` fence → close it so the half-streamed code renders as a block
- *  - unclosed $$ math fence → close it
- *  - dangling inline emphasis/code markers at end of text → close them
- */
-export function repairStreamingMarkdown(md: string): string {
-  let out = md;
-
-  const fenceCount = (out.match(/^[^\S\n]*```/gm) ?? []).length;
-  if (fenceCount % 2 === 1) out += "\n```";
-
-  const mathFenceCount = (out.match(/^\$\$/gm) ?? []).length;
-  if (mathFenceCount % 2 === 1) out += "\n$$";
-
-  // Close dangling inline markers, longest first, recounting after each append
-  // so an appended marker doesn't skew later parity checks.
-  for (const marker of ["**", "__", "~~"]) {
-    const count = (
-      out.match(new RegExp(marker.replace(/\*/g, "\\*"), "g")) ?? []
-    ).length;
-    if (count % 2 === 1) out += marker;
-  }
-  const backtickCount = (out.match(/`/g) ?? []).length;
-  if (backtickCount % 2 === 1) out += "`";
-  // Single-marker emphasis (* and _): only append when the trailing run looks
-  // like an unclosed opener — a lone marker at the very end of the text.
-  for (const marker of ["*", "_"]) {
-    if (out.endsWith(marker) && !out.endsWith(marker.repeat(2))) {
-      // Count non-doubled occurrences conservatively; appending only when the
-      // text ends with exactly one avoids corrupting valid mid-text emphasis.
-      out += marker;
-    }
-  }
-
-  return out;
-}
-
-// -- Entity decoding ----------------------------------------------------------
-
-const ENTITIES: Record<string, string> = {
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  nbsp: " ",
-  "#39": "'",
-};
-
-function decodeEntities(text: string): string {
-  return text.replace(/&(#39|amp|lt|gt|quot|nbsp);/g, (_, entity: string) => {
-    return ENTITIES[entity] ?? `&${entity};`;
-  });
-}
-
-// -- Inline parsing -----------------------------------------------------------
-
-function segmentFromMatch(match: RegExpExecArray): InlineSegment | null {
-  if (match[1]) return { type: "image", alt: match[2], url: match[3] };
-  if (match[4] && match[5]) {
-    return { type: "link", text: match[4], url: match[5] };
-  }
-  if (match[6] || match[7]) {
-    return { type: "boldItalic", text: match[6] || match[7] };
-  }
-  if (match[8] || match[9]) {
-    return { type: "bold", text: match[8] || match[9] };
-  }
-  if (match[10] || match[11]) {
-    return { type: "italic", text: match[10] || match[11] };
-  }
-  if (match[12]) {
-    return { type: "strikethrough", text: match[12] };
-  }
-  if (match[13]) {
-    return { type: "mathInline", text: match[13] };
-  }
-  if (match[14]) {
-    return { type: "code", text: match[14] };
-  }
-  return null;
-}
-
-// Order matters: image before link; bold-italic before bold before italic;
-// $...$ before backtick.
-const INLINE_REGEX = new RegExp(
-  [
-    /!\[([^\]]*)\]\(([^)]+)\)/.source, // 1-3 image
-    /\[([^\]]+)\]\(([^)]+)\)/.source, // 4-5 link
-    /\*\*\*([\s\S]+?)\*\*\*/.source, // 6 bold-italic ***
-    /___([\s\S]+?)___/.source, // 7 bold-italic ___
-    /\*\*([\s\S]+?)\*\*/.source, // 8 bold **
-    /__([\s\S]+?)__/.source, // 9 bold __
-    /(?<![\w*])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![\w*])/.source, // 10 italic *
-    /(?<![\w_])_(?!\s)([^_\n]+?)(?<!\s)_(?![\w_])/.source, // 11 italic _
-    /~~([\s\S]+?)~~/.source, // 12 strikethrough
-    /\$([^$\n]+?)\$/.source, // 13 math inline
-    /`([^`\n]+)`/.source, // 14 code
-  ].join("|"),
-  "g",
-);
-
-function parseInline(text: string): InlineSegment[] {
-  const segments: InlineSegment[] = [];
-  INLINE_REGEX.lastIndex = 0;
-  let lastIndex = 0;
-  let match = INLINE_REGEX.exec(text);
-
-  while (match !== null) {
-    if (match.index > lastIndex) {
-      segments.push({
-        type: "text",
-        text: decodeEntities(text.slice(lastIndex, match.index)),
-      });
-    }
-
-    const segment = segmentFromMatch(match);
-    if (segment) {
-      segments.push(segment);
-    }
-
-    lastIndex = match.index + match[0].length;
-    match = INLINE_REGEX.exec(text);
-  }
-
-  if (lastIndex < text.length) {
-    segments.push({
-      type: "text",
-      text: decodeEntities(text.slice(lastIndex)),
-    });
-  }
-
-  if (segments.length === 0) {
-    segments.push({ type: "text", text: decodeEntities(text) });
-  }
-
-  return segments;
-}
-
-// -- Block parsing ------------------------------------------------------------
-
-// A single parsing step: an optional block plus the index to resume from.
-// `block === null` means lines were consumed without producing a block.
-type BlockParseResult = { block: Block | null; next: number };
-
-function parseMathBlockLines(
-  lines: string[],
-  start: number,
-): BlockParseResult | null {
-  if (lines[start].trim() !== "$$") return null;
-  const mathLines: string[] = [];
-  let i = start + 1;
-  while (i < lines.length && lines[i].trim() !== "$$") {
-    mathLines.push(lines[i]);
-    i++;
-  }
-  i++; // skip closing $$
-  return { block: { type: "mathBlock", code: mathLines.join("\n") }, next: i };
-}
-
-function parseCodeBlockLines(
-  lines: string[],
-  start: number,
-): BlockParseResult | null {
-  if (!lines[start].trimStart().startsWith("```")) return null;
-  const language = lines[start].trimStart().slice(3).trim();
-  const codeLines: string[] = [];
-  let i = start + 1;
-  while (i < lines.length && !lines[i].trimStart().startsWith("```")) {
-    codeLines.push(lines[i]);
-    i++;
-  }
-  i++; // skip closing ```
-  return {
-    block: { type: "codeBlock", language, code: codeLines.join("\n") },
-    next: i,
-  };
-}
-
-// Captures the first marker and requires every repeat to match it, so mixed
-// sequences like "- * _" stay text (CommonMark only treats a uniform run as a
-// rule). Unambiguous by construction (every \s* is anchored between mandatory
-// chars), so it cannot backtrack exponentially on adversarial input.
-const HR_LINE_REGEX = /^\s*([-*_])(?:\s*\1){2,}\s*$/;
-
-function isHrLine(line: string): boolean {
-  return HR_LINE_REGEX.test(line);
-}
-
-function parseHrLine(lines: string[], start: number): BlockParseResult | null {
-  if (!isHrLine(lines[start])) return null;
-  return { block: { type: "hr" }, next: start + 1 };
-}
-
-const HEADING_LINE_REGEX = /^(#{1,6})\s+(.+)/;
-
-function parseHeadingLine(
-  lines: string[],
-  start: number,
-): BlockParseResult | null {
-  const headingMatch = lines[start].match(HEADING_LINE_REGEX);
-  if (!headingMatch) return null;
-  return {
-    block: {
-      type: "heading",
-      level: headingMatch[1].length,
-      segments: parseInline(headingMatch[2]),
-    },
-    next: start + 1,
-  };
-}
-
-// `>` with or without a trailing space opens a quote (CommonMark allows both).
-const BLOCKQUOTE_LINE_REGEX = /^\s{0,3}>\s?(.*)$/;
-
-function parseBlockquoteLines(
-  lines: string[],
-  start: number,
-): BlockParseResult | null {
-  const openMatch = lines[start].match(BLOCKQUOTE_LINE_REGEX);
-  if (!openMatch) return null;
-  const quoteLines: string[] = [openMatch[1]];
-  let i = start + 1;
-  while (i < lines.length) {
-    const match = lines[i].match(BLOCKQUOTE_LINE_REGEX);
-    if (!match) break;
-    quoteLines.push(match[1]);
-    i++;
-  }
-  return {
-    block: { type: "blockquote", segments: parseInline(quoteLines.join("\n")) },
-    next: i,
-  };
-}
-
-// -- Lists (nested + task lists) ----------------------------------------------
-
-const UNORDERED_ITEM_REGEX = /^(\s*)([-*+])\s+(.*)$/;
-const ORDERED_ITEM_REGEX = /^(\s*)(\d+)[.)]\s+(.*)$/;
-const TASK_CHECKBOX_REGEX = /^\[([ xX])\]\s+(.*)$/;
-
-/** Marker info for a list-item line, or null when the line opens no item. */
-function itemMarker(
-  line: string,
-  ordered: boolean,
-): { indent: number; rest: string } | null {
-  const match = ordered
-    ? line.match(ORDERED_ITEM_REGEX)
-    : line.match(UNORDERED_ITEM_REGEX);
-  if (!match) return null;
-  return { indent: match[1].length, rest: match[3] };
-}
-
-/**
- * Parse a (possibly nested) list starting at `start`. Items at the opening
- * line's indent delimit items; deeper-indented continuation lines belong to
- * the current item and are recursively parsed as blocks, which is what makes
- * nested sublists render correctly.
- */
-function parseListLines(
-  lines: string[],
-  start: number,
-): BlockParseResult | null {
-  const ordered = ORDERED_ITEM_REGEX.test(lines[start]);
-  const first = itemMarker(lines[start], ordered);
-  if (!first) return null;
-
-  const baseIndent = first.indent;
-  const items: ListItem[] = [];
-
-  let i = start;
-  while (i < lines.length) {
-    const line = lines[i];
-    const marker = itemMarker(line, ordered);
-
-    // A sibling item at the same level opens a new entry.
-    if (!marker || marker.indent < baseIndent) break;
-
-    const task = marker.rest.match(TASK_CHECKBOX_REGEX);
-    const itemLines = [task ? task[2] : marker.rest];
-    items.push({
-      blocks: [],
-      task: !!task,
-      checked: task ? task[1].toLowerCase() === "x" : false,
-    });
-    i++;
-
-    // Continuation lines belong to this item: nested sublists (deeper-indent
-    // markers) and indented wrapped text. Anything else ends the item; the
-    // recursive parseBlocks on itemLines is what renders nested lists.
-    while (i < lines.length && lines[i].trim() !== "") {
-      const cont = lines[i];
-      const contIndent = cont.match(/^\s*/)?.[0].length ?? 0;
-      const nestedMarker = itemMarker(cont, ordered);
-      const isNested =
-        (nestedMarker && nestedMarker.indent > baseIndent) ||
-        contIndent > baseIndent + 1;
-      if (!isNested) break;
-      itemLines.push(cont.trimStart());
-      i++;
-    }
-    items[items.length - 1].blocks = parseBlocks(itemLines);
-  }
-
-  const startIndex = ordered
-    ? Number.parseInt(lines[start].match(ORDERED_ITEM_REGEX)?.[2] ?? "1", 10)
-    : 1;
-
-  return {
-    block: {
-      type: "list",
-      ordered,
-      start: Number.isNaN(startIndex) ? 1 : startIndex,
-      items,
-    },
-    next: i,
-  };
-}
-
-// -- Tables -------------------------------------------------------------------
-
-const TABLE_DELIM_REGEX = /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/;
-
-// Protect escaped pipes, split, then restore. A sentinel string rather than
-// a control character so the split stays regex-free.
-const ESCAPED_PIPE_SENTINEL = "\u0001gaia-pipe\u0001";
-function splitTableRow(line: string): string[] {
-  let trimmed = line.trim();
-  if (trimmed.startsWith("|")) trimmed = trimmed.slice(1);
-  if (trimmed.endsWith("|") && !trimmed.endsWith("\\|")) {
-    trimmed = trimmed.slice(0, -1);
-  }
-  return trimmed
-    .replace(/\\\|/g, ESCAPED_PIPE_SENTINEL)
-    .split("|")
-    .map((cell) => cell.replaceAll(ESCAPED_PIPE_SENTINEL, "|").trim());
-}
-
-function parseTableLines(
-  lines: string[],
-  start: number,
-): BlockParseResult | null {
-  if (start + 1 >= lines.length) return null;
-  const header = lines[start];
-  const delim = lines[start + 1];
-  if (!header.includes("|") || !TABLE_DELIM_REGEX.test(delim)) return null;
-
-  const alignments: TableAlignment[] = splitTableRow(delim).map((cell) => {
-    const left = cell.startsWith(":");
-    const right = cell.endsWith(":");
-    if (left && right) return "center";
-    if (right) return "right";
-    if (left) return "left";
-    return null;
-  });
-
-  const rows: string[][] = [splitTableRow(header)];
-  let i = start + 2;
-  while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
-    rows.push(splitTableRow(lines[i]));
-    i++;
-  }
-
-  return { block: { type: "table", alignments, rows }, next: i };
-}
-
-// -- Paragraph ----------------------------------------------------------------
-
-function isBlockBoundary(line: string): boolean {
-  return (
-    line.trim() === "" ||
-    line.trim() === "$$" ||
-    line.trimStart().startsWith("```") ||
-    BLOCKQUOTE_LINE_REGEX.test(line) ||
-    HEADING_LINE_REGEX.test(line) ||
-    UNORDERED_ITEM_REGEX.test(line) ||
-    ORDERED_ITEM_REGEX.test(line) ||
-    TABLE_DELIM_REGEX.test(line) ||
-    isHrLine(line)
-  );
-}
-
-function parseParagraphLines(lines: string[], start: number): BlockParseResult {
-  if (lines[start].trim() === "") {
-    return { block: null, next: start + 1 };
-  }
-  const paraLines: string[] = [];
-  let i = start;
-  while (i < lines.length && !isBlockBoundary(lines[i])) {
-    paraLines.push(lines[i]);
-    i++;
-  }
-  return {
-    block:
-      paraLines.length > 0
-        ? {
-            // Preserve single newlines inside a paragraph (remark-breaks
-            // parity) — RNText renders \n as a visual line break.
-            type: "paragraph",
-            segments: parseInline(paraLines.join("\n")),
-          }
-        : null,
-    next: i,
-  };
-}
-
-function parseBlocks(lines: string[]): Block[] {
-  const blocks: Block[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const result =
-      parseMathBlockLines(lines, i) ??
-      parseCodeBlockLines(lines, i) ??
-      parseHrLine(lines, i) ??
-      parseHeadingLine(lines, i) ??
-      parseTableLines(lines, i) ??
-      parseBlockquoteLines(lines, i) ??
-      parseListLines(lines, i) ??
-      parseParagraphLines(lines, i);
-
-    if (result.block) {
-      blocks.push(result.block);
-    }
-    i = result.next;
-  }
-
-  return blocks;
-}
-
-// -- Key helpers --------------------------------------------------------------
-
-function segmentKey(seg: InlineSegment, idx: number): string {
-  const label = seg.type === "image" ? seg.url : seg.text;
-  return `${seg.type}-${idx}-${label.slice(0, 12)}`;
-}
-
-function blockKey(block: Block, idx: number): string {
-  if (block.type === "codeBlock") return `cb-${idx}-${block.language}`;
-  if (block.type === "hr") return `hr-${idx}`;
-  return `${block.type}-${idx}`;
-}
-
-function listItemKey(item: ListItem, idx: number): string {
-  return `li-${idx}-${item.blocks[0]?.type ?? "empty"}`;
 }
 
 // -- Rendering components -----------------------------------------------------
@@ -815,6 +345,23 @@ function TableBlock({
   const [header, ...body] = rows;
   if (!header) return null;
 
+  // Table cells are positional data with no natural identity, so stable keys
+  // are derived from positions up front — outside JSX — keeping the render
+  // map free of raw array indices.
+  const columns = alignments.map((align, i) => ({
+    id: `col-${i}`,
+    align: align ?? null,
+  }));
+  const headerRow = header.map((value, i) => ({ id: `h-${i}`, value }));
+  const bodyRows = body.map((cells, i) => ({
+    id: `row-${i}`,
+    cells: columns.map((col, c) => ({
+      id: `${col.id}-${c}`,
+      value: cells[c] ?? "",
+      align: col.align,
+    })),
+  }));
+
   return (
     <View
       style={{
@@ -826,37 +373,31 @@ function TableBlock({
     >
       {/* Header row */}
       <View style={{ flexDirection: "row", backgroundColor: "#27272a" }}>
-        {header.map((cell, col) => (
+        {headerRow.map((cell, i) => (
           <View
-            // biome-ignore lint/suspicious/noArrayIndexKey: positional column identity; cell text can repeat
-            key={`h-${col}`}
+            key={cell.id}
             style={{ flex: 1, paddingHorizontal: 10, paddingVertical: 8 }}
           >
-            <TableCellText value={cell} bold align={alignments[col] ?? null} />
+            <TableCellText value={cell.value} bold align={columns[i].align} />
           </View>
         ))}
       </View>
       {/* Body rows */}
-      {body.map((row, rowIdx) => (
+      {bodyRows.map((row) => (
         <View
-          // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional data with no stable identity
-          key={`r-${rowIdx}`}
+          key={row.id}
           style={{
             flexDirection: "row",
             borderTopWidth: 1,
             borderTopColor: "rgba(63,63,70,0.5)",
           }}
         >
-          {header.map((_, col) => (
+          {row.cells.map((cell) => (
             <View
-              // biome-ignore lint/suspicious/noArrayIndexKey: same positional column identity as the header
-              key={`c-${rowIdx}-${col}`}
+              key={cell.id}
               style={{ flex: 1, paddingHorizontal: 10, paddingVertical: 8 }}
             >
-              <TableCellText
-                value={row[col] ?? ""}
-                align={alignments[col] ?? null}
-              />
+              <TableCellText value={cell.value} align={cell.align} />
             </View>
           ))}
         </View>

--- a/apps/mobile/src/components/ui/markdown-renderer.tsx
+++ b/apps/mobile/src/components/ui/markdown-renderer.tsx
@@ -1,6 +1,12 @@
 import * as Linking from "expo-linking";
 import { memo, useCallback, useState } from "react";
-import { Text as RNText, View } from "react-native";
+import {
+  Image,
+  Text as RNText,
+  type StyleProp,
+  type TextStyle,
+  View,
+} from "react-native";
 import { WebView } from "react-native-webview";
 import {
   CodeBlock,
@@ -20,8 +26,13 @@ const COLORS = {
 
 // -- Types --------------------------------------------------------------------
 
-interface MarkdownRendererProps {
+export interface MarkdownRendererProps {
   content: string;
+  /**
+   * While streaming, incomplete markdown is repaired before parsing (unclosed
+   * fences/bold/etc.) so literal markers never flash mid-token.
+   */
+  isStreaming?: boolean;
 }
 
 type InlineSegment =
@@ -31,59 +42,146 @@ type InlineSegment =
   | { type: "boldItalic"; text: string }
   | { type: "code"; text: string }
   | { type: "link"; text: string; url: string }
+  | { type: "image"; alt: string; url: string }
   | { type: "strikethrough"; text: string }
   | { type: "mathInline"; text: string };
+
+interface ListItem {
+  blocks: Block[];
+  task: boolean;
+  checked: boolean;
+}
+
+type TableAlignment = "left" | "center" | "right" | null;
 
 type Block =
   | { type: "paragraph"; segments: InlineSegment[] }
   | { type: "heading"; level: number; segments: InlineSegment[] }
   | { type: "codeBlock"; language: string; code: string }
   | { type: "blockquote"; segments: InlineSegment[] }
-  | { type: "unorderedList"; items: InlineSegment[][] }
-  | { type: "orderedList"; items: InlineSegment[][] }
+  | { type: "list"; ordered: boolean; start: number; items: ListItem[] }
+  | { type: "table"; alignments: TableAlignment[]; rows: string[][] }
   | { type: "hr" }
   | { type: "mathBlock"; code: string };
 
-// -- Parsing ------------------------------------------------------------------
+// -- Streaming repair ---------------------------------------------------------
+
+/**
+ * Patch the most common incomplete-markdown states while tokens are still
+ * arriving, so partial output renders as text rather than raw markers
+ * (mirrors Streamdown's parseIncompleteMarkdown on web):
+ *  - unclosed ``` fence → close it so the half-streamed code renders as a block
+ *  - unclosed $$ math fence → close it
+ *  - dangling inline emphasis/code markers at end of text → close them
+ */
+export function repairStreamingMarkdown(md: string): string {
+  let out = md;
+
+  const fenceCount = (out.match(/^[^\S\n]*```/gm) ?? []).length;
+  if (fenceCount % 2 === 1) out += "\n```";
+
+  const mathFenceCount = (out.match(/^\$\$/gm) ?? []).length;
+  if (mathFenceCount % 2 === 1) out += "\n$$";
+
+  // Close dangling inline markers, longest first, recounting after each append
+  // so an appended marker doesn't skew later parity checks.
+  for (const marker of ["**", "__", "~~"]) {
+    const count = (
+      out.match(new RegExp(marker.replace(/\*/g, "\\*"), "g")) ?? []
+    ).length;
+    if (count % 2 === 1) out += marker;
+  }
+  const backtickCount = (out.match(/`/g) ?? []).length;
+  if (backtickCount % 2 === 1) out += "`";
+  // Single-marker emphasis (* and _): only append when the trailing run looks
+  // like an unclosed opener — a lone marker at the very end of the text.
+  for (const marker of ["*", "_"]) {
+    if (out.endsWith(marker) && !out.endsWith(marker.repeat(2))) {
+      // Count non-doubled occurrences conservatively; appending only when the
+      // text ends with exactly one avoids corrupting valid mid-text emphasis.
+      out += marker;
+    }
+  }
+
+  return out;
+}
+
+// -- Entity decoding ----------------------------------------------------------
+
+const ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  nbsp: " ",
+  "#39": "'",
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(#39|amp|lt|gt|quot|nbsp);/g, (_, entity: string) => {
+    return ENTITIES[entity] ?? `&${entity};`;
+  });
+}
+
+// -- Inline parsing -----------------------------------------------------------
 
 function segmentFromMatch(match: RegExpExecArray): InlineSegment | null {
-  if (match[2] && match[3]) {
-    return { type: "link", text: match[2], url: match[3] };
-  }
-  if (match[4] || match[5]) {
-    return { type: "boldItalic", text: match[4] || match[5] };
+  if (match[1]) return { type: "image", alt: match[2], url: match[3] };
+  if (match[4] && match[5]) {
+    return { type: "link", text: match[4], url: match[5] };
   }
   if (match[6] || match[7]) {
-    return { type: "bold", text: match[6] || match[7] };
+    return { type: "boldItalic", text: match[6] || match[7] };
   }
   if (match[8] || match[9]) {
-    return { type: "italic", text: match[8] || match[9] };
+    return { type: "bold", text: match[8] || match[9] };
   }
-  if (match[10]) {
-    return { type: "strikethrough", text: match[10] };
-  }
-  if (match[11]) {
-    return { type: "mathInline", text: match[11] };
+  if (match[10] || match[11]) {
+    return { type: "italic", text: match[10] || match[11] };
   }
   if (match[12]) {
-    return { type: "code", text: match[12] };
+    return { type: "strikethrough", text: match[12] };
+  }
+  if (match[13]) {
+    return { type: "mathInline", text: match[13] };
+  }
+  if (match[14]) {
+    return { type: "code", text: match[14] };
   }
   return null;
 }
 
+// Order matters: image before link; bold-italic before bold before italic;
+// $...$ before backtick.
+const INLINE_REGEX = new RegExp(
+  [
+    /!\[([^\]]*)\]\(([^)]+)\)/.source, // 1-3 image
+    /\[([^\]]+)\]\(([^)]+)\)/.source, // 4-5 link
+    /\*\*\*([\s\S]+?)\*\*\*/.source, // 6 bold-italic ***
+    /___([\s\S]+?)___/.source, // 7 bold-italic ___
+    /\*\*([\s\S]+?)\*\*/.source, // 8 bold **
+    /__([\s\S]+?)__/.source, // 9 bold __
+    /(?<![\w*])\*(?!\s)([^*\n]+?)(?<!\s)\*(?![\w*])/.source, // 10 italic *
+    /(?<![\w_])_(?!\s)([^_\n]+?)(?<!\s)_(?![\w_])/.source, // 11 italic _
+    /~~([\s\S]+?)~~/.source, // 12 strikethrough
+    /\$([^$\n]+?)\$/.source, // 13 math inline
+    /`([^`\n]+)`/.source, // 14 code
+  ].join("|"),
+  "g",
+);
+
 function parseInline(text: string): InlineSegment[] {
   const segments: InlineSegment[] = [];
-  // Order matters: bold-italic before bold before italic; $...$ before backtick
-  const inlineRegex =
-    /(\[([^\]]+)\]\(([^)]+)\)|\*\*\*(.+?)\*\*\*|___(.+?)___|\*\*(.+?)\*\*|__(.+?)__|_(.+?)_|\*(.+?)\*|~~(.+?)~~|\$(.+?)\$|`([^`]+)`)/g;
-
+  INLINE_REGEX.lastIndex = 0;
   let lastIndex = 0;
-  let match = inlineRegex.exec(text);
+  let match = INLINE_REGEX.exec(text);
 
   while (match !== null) {
-    // Push preceding plain text
     if (match.index > lastIndex) {
-      segments.push({ type: "text", text: text.slice(lastIndex, match.index) });
+      segments.push({
+        type: "text",
+        text: decodeEntities(text.slice(lastIndex, match.index)),
+      });
     }
 
     const segment = segmentFromMatch(match);
@@ -92,19 +190,24 @@ function parseInline(text: string): InlineSegment[] {
     }
 
     lastIndex = match.index + match[0].length;
-    match = inlineRegex.exec(text);
+    match = INLINE_REGEX.exec(text);
   }
 
   if (lastIndex < text.length) {
-    segments.push({ type: "text", text: text.slice(lastIndex) });
+    segments.push({
+      type: "text",
+      text: decodeEntities(text.slice(lastIndex)),
+    });
   }
 
   if (segments.length === 0) {
-    segments.push({ type: "text", text });
+    segments.push({ type: "text", text: decodeEntities(text) });
   }
 
   return segments;
 }
+
+// -- Block parsing ------------------------------------------------------------
 
 // A single parsing step: an optional block plus the index to resume from.
 // `block === null` means lines were consumed without producing a block.
@@ -159,11 +262,13 @@ function parseHrLine(lines: string[], start: number): BlockParseResult | null {
   return { block: { type: "hr" }, next: start + 1 };
 }
 
+const HEADING_LINE_REGEX = /^(#{1,6})\s+(.+)/;
+
 function parseHeadingLine(
   lines: string[],
   start: number,
 ): BlockParseResult | null {
-  const headingMatch = lines[start].match(/^(#{1,6})\s+(.+)/);
+  const headingMatch = lines[start].match(HEADING_LINE_REGEX);
   if (!headingMatch) return null;
   return {
     block: {
@@ -175,65 +280,177 @@ function parseHeadingLine(
   };
 }
 
+// `>` with or without a trailing space opens a quote (CommonMark allows both).
+const BLOCKQUOTE_LINE_REGEX = /^\s{0,3}>\s?(.*)$/;
+
 function parseBlockquoteLines(
   lines: string[],
   start: number,
 ): BlockParseResult | null {
-  if (!lines[start].trimStart().startsWith("> ")) return null;
-  const quoteLines: string[] = [];
-  let i = start;
-  while (i < lines.length && lines[i].trimStart().startsWith("> ")) {
-    quoteLines.push(lines[i].replace(/^\s*>\s?/, ""));
+  const openMatch = lines[start].match(BLOCKQUOTE_LINE_REGEX);
+  if (!openMatch) return null;
+  const quoteLines: string[] = [openMatch[1]];
+  let i = start + 1;
+  while (i < lines.length) {
+    const match = lines[i].match(BLOCKQUOTE_LINE_REGEX);
+    if (!match) break;
+    quoteLines.push(match[1]);
     i++;
   }
   return {
-    block: { type: "blockquote", segments: parseInline(quoteLines.join(" ")) },
+    block: { type: "blockquote", segments: parseInline(quoteLines.join("\n")) },
     next: i,
   };
 }
 
+// -- Lists (nested + task lists) ----------------------------------------------
+
+const UNORDERED_ITEM_REGEX = /^(\s*)([-*+])\s+(.*)$/;
+const ORDERED_ITEM_REGEX = /^(\s*)(\d+)[.)]\s+(.*)$/;
+const TASK_CHECKBOX_REGEX = /^\[([ xX])\]\s+(.*)$/;
+
+/** Marker info for a list-item line, or null when the line opens no item. */
+function itemMarker(
+  line: string,
+  ordered: boolean,
+): { indent: number; rest: string } | null {
+  const match = ordered
+    ? line.match(ORDERED_ITEM_REGEX)
+    : line.match(UNORDERED_ITEM_REGEX);
+  if (!match) return null;
+  return { indent: match[1].length, rest: match[3] };
+}
+
+/**
+ * Parse a (possibly nested) list starting at `start`. Items at the opening
+ * line's indent delimit items; deeper-indented continuation lines belong to
+ * the current item and are recursively parsed as blocks, which is what makes
+ * nested sublists render correctly.
+ */
 function parseListLines(
   lines: string[],
   start: number,
 ): BlockParseResult | null {
-  const unordered = /^\s*[-*+]\s+/;
-  const ordered = /^\s*\d+[.)]\s+/;
-  const matcher = unordered.test(lines[start])
-    ? unordered
-    : ordered.test(lines[start])
-      ? ordered
-      : null;
-  if (!matcher) return null;
-  const items: InlineSegment[][] = [];
+  const ordered = ORDERED_ITEM_REGEX.test(lines[start]);
+  const first = itemMarker(lines[start], ordered);
+  if (!first) return null;
+
+  const baseIndent = first.indent;
+  const items: ListItem[] = [];
+
   let i = start;
-  while (i < lines.length && matcher.test(lines[i])) {
-    items.push(parseInline(lines[i].replace(matcher, "")));
+  while (i < lines.length) {
+    const line = lines[i];
+    const marker = itemMarker(line, ordered);
+
+    // A sibling item at the same level opens a new entry.
+    if (!marker || marker.indent < baseIndent) break;
+
+    const task = marker.rest.match(TASK_CHECKBOX_REGEX);
+    const itemLines = [task ? task[2] : marker.rest];
+    items.push({
+      blocks: [],
+      task: !!task,
+      checked: task ? task[1].toLowerCase() === "x" : false,
+    });
     i++;
+
+    // Continuation lines belong to this item: nested sublists (deeper-indent
+    // markers) and indented wrapped text. Anything else ends the item; the
+    // recursive parseBlocks on itemLines is what renders nested lists.
+    while (i < lines.length && lines[i].trim() !== "") {
+      const cont = lines[i];
+      const contIndent = cont.match(/^\s*/)?.[0].length ?? 0;
+      const nestedMarker = itemMarker(cont, ordered);
+      const isNested =
+        (nestedMarker && nestedMarker.indent > baseIndent) ||
+        contIndent > baseIndent + 1;
+      if (!isNested) break;
+      itemLines.push(cont.trimStart());
+      i++;
+    }
+    items[items.length - 1].blocks = parseBlocks(itemLines);
   }
+
+  const startIndex = ordered
+    ? Number.parseInt(lines[start].match(ORDERED_ITEM_REGEX)?.[2] ?? "1", 10)
+    : 1;
+
   return {
     block: {
-      type: matcher === unordered ? "unorderedList" : "orderedList",
+      type: "list",
+      ordered,
+      start: Number.isNaN(startIndex) ? 1 : startIndex,
       items,
     },
     next: i,
   };
 }
 
+// -- Tables -------------------------------------------------------------------
+
+const TABLE_DELIM_REGEX = /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/;
+
+// Protect escaped pipes, split, then restore. A sentinel string rather than
+// a control character so the split stays regex-free.
+const ESCAPED_PIPE_SENTINEL = "\u0001gaia-pipe\u0001";
+function splitTableRow(line: string): string[] {
+  let trimmed = line.trim();
+  if (trimmed.startsWith("|")) trimmed = trimmed.slice(1);
+  if (trimmed.endsWith("|") && !trimmed.endsWith("\\|")) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed
+    .replace(/\\\|/g, ESCAPED_PIPE_SENTINEL)
+    .split("|")
+    .map((cell) => cell.replaceAll(ESCAPED_PIPE_SENTINEL, "|").trim());
+}
+
+function parseTableLines(
+  lines: string[],
+  start: number,
+): BlockParseResult | null {
+  if (start + 1 >= lines.length) return null;
+  const header = lines[start];
+  const delim = lines[start + 1];
+  if (!header.includes("|") || !TABLE_DELIM_REGEX.test(delim)) return null;
+
+  const alignments: TableAlignment[] = splitTableRow(delim).map((cell) => {
+    const left = cell.startsWith(":");
+    const right = cell.endsWith(":");
+    if (left && right) return "center";
+    if (right) return "right";
+    if (left) return "left";
+    return null;
+  });
+
+  const rows: string[][] = [splitTableRow(header)];
+  let i = start + 2;
+  while (i < lines.length && lines[i].includes("|") && lines[i].trim() !== "") {
+    rows.push(splitTableRow(lines[i]));
+    i++;
+  }
+
+  return { block: { type: "table", alignments, rows }, next: i };
+}
+
+// -- Paragraph ----------------------------------------------------------------
+
 function isBlockBoundary(line: string): boolean {
   return (
     line.trim() === "" ||
     line.trim() === "$$" ||
     line.trimStart().startsWith("```") ||
-    line.trimStart().startsWith("> ") ||
-    /^#{1,6}\s+/.test(line) ||
-    /^\s*[-*+]\s+/.test(line) ||
-    /^\s*\d+[.)]\s+/.test(line) ||
+    BLOCKQUOTE_LINE_REGEX.test(line) ||
+    HEADING_LINE_REGEX.test(line) ||
+    UNORDERED_ITEM_REGEX.test(line) ||
+    ORDERED_ITEM_REGEX.test(line) ||
+    TABLE_DELIM_REGEX.test(line) ||
     isHrLine(line)
   );
 }
 
 function parseParagraphLines(lines: string[], start: number): BlockParseResult {
-  // Empty line: consume without producing a block.
   if (lines[start].trim() === "") {
     return { block: null, next: start + 1 };
   }
@@ -246,24 +463,28 @@ function parseParagraphLines(lines: string[], start: number): BlockParseResult {
   return {
     block:
       paraLines.length > 0
-        ? { type: "paragraph", segments: parseInline(paraLines.join(" ")) }
+        ? {
+            // Preserve single newlines inside a paragraph (remark-breaks
+            // parity) — RNText renders \n as a visual line break.
+            type: "paragraph",
+            segments: parseInline(paraLines.join("\n")),
+          }
         : null,
     next: i,
   };
 }
 
-function parseMarkdown(raw: string): Block[] {
+function parseBlocks(lines: string[]): Block[] {
   const blocks: Block[] = [];
-  const lines = raw.split("\n");
   let i = 0;
 
   while (i < lines.length) {
-    // Order matters and mirrors the original precedence.
     const result =
       parseMathBlockLines(lines, i) ??
       parseCodeBlockLines(lines, i) ??
       parseHrLine(lines, i) ??
       parseHeadingLine(lines, i) ??
+      parseTableLines(lines, i) ??
       parseBlockquoteLines(lines, i) ??
       parseListLines(lines, i) ??
       parseParagraphLines(lines, i);
@@ -280,7 +501,8 @@ function parseMarkdown(raw: string): Block[] {
 // -- Key helpers --------------------------------------------------------------
 
 function segmentKey(seg: InlineSegment, idx: number): string {
-  return `${seg.type}-${idx}-${seg.text.slice(0, 12)}`;
+  const label = seg.type === "image" ? seg.url : seg.text;
+  return `${seg.type}-${idx}-${label.slice(0, 12)}`;
 }
 
 function blockKey(block: Block, idx: number): string {
@@ -289,26 +511,63 @@ function blockKey(block: Block, idx: number): string {
   return `${block.type}-${idx}`;
 }
 
-function listItemKey(item: InlineSegment[], idx: number): string {
-  return `li-${idx}-${item[0]?.text.slice(0, 12)}`;
+function listItemKey(item: ListItem, idx: number): string {
+  return `li-${idx}-${item.blocks[0]?.type ?? "empty"}`;
 }
 
 // -- Rendering components -----------------------------------------------------
 
-function InlineContent({ segments }: { segments: InlineSegment[] }) {
+function useBodyTextStyle() {
   const { fontSize } = useResponsive();
+  return {
+    color: COLORS.text,
+    fontSize: fontSize.base,
+    lineHeight: Math.round(fontSize.base * 1.5),
+  } as const;
+}
+
+function MarkdownImage({ url, alt }: { url: string; alt: string }) {
+  const [failed, setFailed] = useState(false);
+  const bodyStyle = useBodyTextStyle();
+  if (failed) {
+    return (
+      <RNText style={[bodyStyle, { color: COLORS.linkColor }]}>
+        {alt || url}
+      </RNText>
+    );
+  }
+  return (
+    <Image
+      source={{ uri: url }}
+      accessibilityLabel={alt}
+      resizeMode="cover"
+      style={{
+        width: "100%",
+        height: 180,
+        borderRadius: 12,
+        marginVertical: 6,
+        backgroundColor: "#1c1c1f",
+      }}
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+function InlineContent({
+  segments,
+  style,
+}: {
+  segments: InlineSegment[];
+  /** Applied to the root text node; nested segments inherit font/color. */
+  style?: StyleProp<TextStyle>;
+}) {
+  const bodyStyle = useBodyTextStyle();
   const handleLinkPress = useCallback((url: string) => {
-    Linking.openURL(url);
+    void Linking.openURL(url);
   }, []);
 
   return (
-    <RNText
-      style={{
-        color: COLORS.text,
-        fontSize: fontSize.base,
-        lineHeight: Math.round(fontSize.base * 1.5),
-      }}
-    >
+    <RNText style={[bodyStyle, style]}>
       {segments.map((seg, idx) => {
         const key = segmentKey(seg, idx);
         switch (seg.type) {
@@ -350,6 +609,8 @@ function InlineContent({ segments }: { segments: InlineSegment[] }) {
                 {seg.text}
               </RNText>
             );
+          case "image":
+            return <MarkdownImage key={key} url={seg.url} alt={seg.alt} />;
           case "strikethrough":
             return (
               <RNText key={key} style={{ textDecorationLine: "line-through" }}>
@@ -377,10 +638,10 @@ function HeadingBlock({
 
   // Heading sizes mapped to design-system token scale
   const sizeMap: Record<number, number> = {
-    1: responsiveFontSize["3xl"], // 30px
-    2: responsiveFontSize["2xl"], // 24px
-    3: responsiveFontSize.xl, // 20px
-    4: responsiveFontSize.lg, // 18px
+    1: responsiveFontSize["2xl"], // 24px — h1 in a chat bubble shouldn't be display-size
+    2: responsiveFontSize.xl, // 20px
+    3: responsiveFontSize.lg, // 18px
+    4: responsiveFontSize.base, // 16px
     5: responsiveFontSize.base, // 16px
     6: responsiveFontSize.sm, // 12px
   };
@@ -393,10 +654,10 @@ function HeadingBlock({
     6: 8,
   };
   const marginBottomMap: Record<number, number> = {
-    1: 16,
-    2: 12,
+    1: 12,
+    2: 10,
     3: 8,
-    4: 8,
+    4: 6,
     5: 4,
     6: 4,
   };
@@ -406,47 +667,19 @@ function HeadingBlock({
 
   return (
     <View style={{ marginTop, marginBottom }}>
-      <RNText
+      <InlineContent
+        segments={segments}
         style={{
-          color: COLORS.text,
           fontSize,
           fontWeight: "700",
           lineHeight: Math.round(fontSize * 1.25),
         }}
-      >
-        {segments.map((seg, idx) => {
-          const key = segmentKey(seg, idx);
-          switch (seg.type) {
-            case "code":
-              return <InlineCode key={key}>{seg.text}</InlineCode>;
-            case "link":
-              return (
-                <RNText
-                  key={key}
-                  style={{
-                    color: COLORS.linkColor,
-                    textDecorationLine: "underline",
-                  }}
-                  onPress={() => Linking.openURL(seg.url)}
-                >
-                  {seg.text}
-                </RNText>
-              );
-            default:
-              return <RNText key={key}>{seg.text}</RNText>;
-          }
-        })}
-      </RNText>
+      />
     </View>
   );
 }
 
 function BlockquoteBlock({ segments }: { segments: InlineSegment[] }) {
-  const { fontSize } = useResponsive();
-  const handleLinkPress = useCallback((url: string) => {
-    Linking.openURL(url);
-  }, []);
-
   return (
     <View
       style={{
@@ -456,122 +689,176 @@ function BlockquoteBlock({ segments }: { segments: InlineSegment[] }) {
         paddingVertical: 6,
         marginVertical: 6,
         backgroundColor: "rgba(63,63,70,0.35)",
+        borderRadius: 4,
       }}
     >
-      <RNText
-        style={{
-          color: COLORS.muted,
-          fontSize: fontSize.base,
-          lineHeight: Math.round(fontSize.base * 1.5),
-          fontStyle: "italic",
-        }}
-      >
-        {segments.map((seg, idx) => {
-          const key = segmentKey(seg, idx);
-          switch (seg.type) {
-            case "text":
-              return <RNText key={key}>{seg.text}</RNText>;
-            case "bold":
-              return (
-                <RNText key={key} style={{ fontWeight: "700" }}>
-                  {seg.text}
-                </RNText>
-              );
-            case "italic":
-              return (
-                <RNText key={key} style={{ fontStyle: "italic" }}>
-                  {seg.text}
-                </RNText>
-              );
-            case "boldItalic":
-              return (
-                <RNText
-                  key={key}
-                  style={{ fontWeight: "700", fontStyle: "italic" }}
-                >
-                  {seg.text}
-                </RNText>
-              );
-            case "strikethrough":
-              return (
-                <RNText
-                  key={key}
-                  style={{ textDecorationLine: "line-through" }}
-                >
-                  {seg.text}
-                </RNText>
-              );
-            case "code":
-              return <InlineCode key={key}>{seg.text}</InlineCode>;
-            case "link":
-              return (
-                <RNText
-                  key={key}
-                  style={{
-                    color: COLORS.linkColor,
-                    textDecorationLine: "underline",
-                  }}
-                  onPress={() => handleLinkPress(seg.url)}
-                >
-                  {seg.text}
-                </RNText>
-              );
-            default:
-              return <RNText key={key}>{seg.text}</RNText>;
-          }
-        })}
-      </RNText>
+      <InlineContent
+        segments={segments}
+        style={{ color: COLORS.muted, fontStyle: "italic" }}
+      />
     </View>
   );
 }
 
 function ListBlock({
   ordered,
+  start,
   items,
 }: {
   ordered: boolean;
-  items: InlineSegment[][];
+  start: number;
+  items: ListItem[];
 }) {
-  const { fontSize } = useResponsive();
+  const bodyStyle = useBodyTextStyle();
   return (
-    <View style={{ marginVertical: 4, paddingLeft: 16 }}>
-      {items.map((item, idx) => (
-        <View
-          key={listItemKey(item, idx)}
-          style={{ flexDirection: "row", marginBottom: 8, paddingRight: 8 }}
-        >
-          {ordered ? (
-            <RNText
-              style={{
-                color: COLORS.muted,
-                fontSize: fontSize.base,
-                lineHeight: Math.round(fontSize.base * 1.5),
-                width: 24,
-              }}
-            >
-              {`${idx + 1}.`}
-            </RNText>
-          ) : (
-            <View
-              style={{
-                width: 16,
-                alignItems: "center",
-                paddingTop: 8,
-              }}
-            >
+    <View style={{ marginVertical: 4, paddingLeft: 8 }}>
+      {items.map((item, idx) => {
+        const marker = ordered ? `${start + idx}.` : null;
+        return (
+          <View
+            key={listItemKey(item, idx)}
+            style={{ flexDirection: "row", marginBottom: 6, paddingRight: 8 }}
+          >
+            {item.task ? (
+              <View style={{ width: 24, paddingTop: 3 }}>
+                {/* Checkbox drawn with views, not glyph text */}
+                <View
+                  style={{
+                    width: 16,
+                    height: 16,
+                    borderRadius: 4,
+                    borderWidth: 1.5,
+                    borderColor: item.checked ? COLORS.linkColor : COLORS.muted,
+                    backgroundColor: item.checked
+                      ? COLORS.linkColor
+                      : "transparent",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {item.checked ? (
+                    <View
+                      style={{
+                        width: 8,
+                        height: 4,
+                        borderLeftWidth: 2,
+                        borderBottomWidth: 2,
+                        borderColor: "#000",
+                        transform: [{ rotate: "-45deg" }, { translateY: -1 }],
+                      }}
+                    />
+                  ) : null}
+                </View>
+              </View>
+            ) : marker ? (
+              <RNText style={{ ...bodyStyle, color: COLORS.muted, width: 24 }}>
+                {marker}
+              </RNText>
+            ) : (
               <View
                 style={{
-                  width: 4,
-                  height: 4,
-                  borderRadius: 2,
-                  backgroundColor: COLORS.muted,
+                  width: 24,
+                  alignItems: "center",
+                  paddingTop: Math.round(bodyStyle.fontSize * 0.55),
                 }}
+              >
+                <View
+                  style={{
+                    width: 4,
+                    height: 4,
+                    borderRadius: 2,
+                    backgroundColor: COLORS.muted,
+                  }}
+                />
+              </View>
+            )}
+            <View style={{ flex: 1 }}>
+              <RenderBlocks blocks={item.blocks} />
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function TableCellText({
+  value,
+  bold,
+  align,
+}: {
+  value: string;
+  bold?: boolean;
+  align: TableAlignment;
+}) {
+  const bodyStyle = useBodyTextStyle();
+  return (
+    <RNText
+      style={[
+        bodyStyle,
+        bold ? { fontWeight: "600" } : null,
+        { textAlign: align ?? "left" },
+      ]}
+    >
+      {decodeEntities(value)}
+    </RNText>
+  );
+}
+
+function TableBlock({
+  alignments,
+  rows,
+}: {
+  alignments: TableAlignment[];
+  rows: string[][];
+}) {
+  const [header, ...body] = rows;
+  if (!header) return null;
+
+  return (
+    <View
+      style={{
+        marginVertical: 8,
+        borderRadius: 12,
+        overflow: "hidden",
+        backgroundColor: "#1f1f23",
+      }}
+    >
+      {/* Header row */}
+      <View style={{ flexDirection: "row", backgroundColor: "#27272a" }}>
+        {header.map((cell, col) => (
+          <View
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional column identity; cell text can repeat
+            key={`h-${col}`}
+            style={{ flex: 1, paddingHorizontal: 10, paddingVertical: 8 }}
+          >
+            <TableCellText value={cell} bold align={alignments[col] ?? null} />
+          </View>
+        ))}
+      </View>
+      {/* Body rows */}
+      {body.map((row, rowIdx) => (
+        <View
+          // biome-ignore lint/suspicious/noArrayIndexKey: rows are positional data with no stable identity
+          key={`r-${rowIdx}`}
+          style={{
+            flexDirection: "row",
+            borderTopWidth: 1,
+            borderTopColor: "rgba(63,63,70,0.5)",
+          }}
+        >
+          {header.map((_, col) => (
+            <View
+              // biome-ignore lint/suspicious/noArrayIndexKey: same positional column identity as the header
+              key={`c-${rowIdx}-${col}`}
+              style={{ flex: 1, paddingHorizontal: 10, paddingVertical: 8 }}
+            >
+              <TableCellText
+                value={row[col] ?? ""}
+                align={alignments[col] ?? null}
               />
             </View>
-          )}
-          <View style={{ flex: 1 }}>
-            <InlineContent segments={item} />
-          </View>
+          ))}
         </View>
       ))}
     </View>
@@ -584,7 +871,7 @@ function HorizontalRule() {
       style={{
         height: 1,
         backgroundColor: COLORS.hrColor,
-        marginVertical: 28,
+        marginVertical: 16,
       }}
     />
   );
@@ -708,19 +995,9 @@ function MathBlock({ code, inline }: { code: string; inline?: boolean }) {
   );
 }
 
-// -- Main component -----------------------------------------------------------
+// -- Block dispatcher ---------------------------------------------------------
 
-function MarkdownRendererInner({ content }: MarkdownRendererProps) {
-  if (!content || content.trim() === "") {
-    return null;
-  }
-
-  const blocks = parseMarkdown(content);
-
-  if (blocks.length === 0) {
-    return null;
-  }
-
+function RenderBlocks({ blocks }: { blocks: Block[] }) {
   return (
     <View>
       {blocks.map((block, idx) => {
@@ -732,7 +1009,7 @@ function MarkdownRendererInner({ content }: MarkdownRendererProps) {
                 key={key}
                 style={{
                   marginTop: 0,
-                  marginBottom: idx < blocks.length - 1 ? 16 : 0,
+                  marginBottom: idx < blocks.length - 1 ? 12 : 0,
                 }}
               >
                 <InlineContent segments={block.segments} />
@@ -759,10 +1036,23 @@ function MarkdownRendererInner({ content }: MarkdownRendererProps) {
             );
           case "blockquote":
             return <BlockquoteBlock key={key} segments={block.segments} />;
-          case "unorderedList":
-            return <ListBlock key={key} ordered={false} items={block.items} />;
-          case "orderedList":
-            return <ListBlock key={key} ordered={true} items={block.items} />;
+          case "list":
+            return (
+              <ListBlock
+                key={key}
+                ordered={block.ordered}
+                start={block.start}
+                items={block.items}
+              />
+            );
+          case "table":
+            return (
+              <TableBlock
+                key={key}
+                alignments={block.alignments}
+                rows={block.rows}
+              />
+            );
           case "hr":
             return <HorizontalRule key={key} />;
           case "mathBlock":
@@ -775,7 +1065,26 @@ function MarkdownRendererInner({ content }: MarkdownRendererProps) {
   );
 }
 
+// -- Main component -----------------------------------------------------------
+
+function MarkdownRendererInner({
+  content,
+  isStreaming,
+}: MarkdownRendererProps) {
+  const source = isStreaming ? repairStreamingMarkdown(content) : content;
+  if (!source || source.trim() === "") {
+    return null;
+  }
+
+  const blocks = parseBlocks(source.split("\n"));
+
+  if (blocks.length === 0) {
+    return null;
+  }
+
+  return <RenderBlocks blocks={blocks} />;
+}
+
 const MarkdownRenderer = memo(MarkdownRendererInner);
 
-export type { MarkdownRendererProps };
 export { MarkdownRenderer };

--- a/apps/mobile/src/components/ui/message-bubble.tsx
+++ b/apps/mobile/src/components/ui/message-bubble.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 import { View } from "react-native";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import { StreamingCursor } from "@/components/ui/streaming-cursor";
 import { Text } from "@/components/ui/text";
 import { useResponsive } from "@/lib/responsive";
 
@@ -108,7 +109,19 @@ function MessageBubble({
           paddingVertical: spacing.sm + 2,
         }}
       >
-        {children ?? <MarkdownRenderer content={(message ?? "").trimEnd()} />}
+        {children ?? (
+          <View
+            style={{ flexDirection: "row", alignItems: "flex-end", gap: 2 }}
+          >
+            <View style={{ flexShrink: 1 }}>
+              <MarkdownRenderer
+                content={(message ?? "").trimEnd()}
+                isStreaming={isStreaming}
+              />
+            </View>
+            {isStreaming ? <StreamingCursor /> : null}
+          </View>
+        )}
       </View>
     </View>
   );

--- a/apps/mobile/src/components/ui/streaming-cursor.tsx
+++ b/apps/mobile/src/components/ui/streaming-cursor.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { View } from "react-native";
+import Reanimated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+/**
+ * Blinking caret shown at the end of the last bubble while a response streams
+ * — the mobile counterpart of web's streaming cursor treatment.
+ */
+export function StreamingCursor({ color = "#e4e4e7" }: { color?: string }) {
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0.15, { duration: 450 }),
+        withTiming(1, { duration: 450 }),
+      ),
+      -1,
+      true,
+    );
+  }, [opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Reanimated.View style={animatedStyle}>
+      <View
+        style={{
+          width: 3,
+          height: 16,
+          borderRadius: 2,
+          backgroundColor: color,
+          marginTop: 2,
+        }}
+      />
+    </Reanimated.View>
+  );
+}

--- a/apps/mobile/src/features/chat/api/chat-api.ts
+++ b/apps/mobile/src/features/chat/api/chat-api.ts
@@ -83,6 +83,12 @@ export interface Message {
   pinned?: boolean;
   metadata?: Record<string, unknown>;
   replyToMessage?: ReplyToMessageData | null;
+  /**
+   * Set when the turn producing this message failed. The streamed text (if
+   * any) is preserved alongside it — mirrors web's FailedResponse, which shows
+   * the partial bubble plus a retry affordance instead of wiping the text.
+   */
+  error?: string;
 }
 
 export interface ConversationDetail {

--- a/apps/mobile/src/features/chat/api/chat-stream.ts
+++ b/apps/mobile/src/features/chat/api/chat-stream.ts
@@ -8,6 +8,9 @@ import type {
   ReplyToMessageData,
 } from "./chat-api";
 
+/** Kill the connection if no events (incl. keepalives) arrive for this long. */
+const STREAM_STALL_TIMEOUT_MS = 45_000;
+
 export interface StreamCallbacks {
   onChunk: (text: string) => void;
   onConversationCreated?: (
@@ -232,6 +235,12 @@ export async function fetchChatStream(
         callbacks.onDone();
       },
     },
-    { body },
+    {
+      body,
+      // The backend emits keepalives during long tool runs; complete silence
+      // for this long means the stream is dead. use-chat settles the turn as
+      // an error and keeps the partial text.
+      stallTimeoutMs: STREAM_STALL_TIMEOUT_MS,
+    },
   );
 }

--- a/apps/mobile/src/features/chat/api/chat-stream.ts
+++ b/apps/mobile/src/features/chat/api/chat-stream.ts
@@ -37,6 +37,12 @@ export interface StreamCallbacks {
   onImageData?: (data: ImageData) => void;
   onDone: () => void;
   onError?: (error: Error) => void;
+  /**
+   * The SSE transport closed before the backend sent its done event — the
+   * response is truncated. Consumers should keep the partial text but mark
+   * the turn as failed (retryable), never as complete.
+   */
+  onTransportClosed?: () => void;
 }
 
 export interface ChatStreamRequest {
@@ -214,6 +220,18 @@ export async function fetchChatStream(
     messages: formattedMessages,
   };
 
+  // Set once the backend's own done event has been handled. A transport close
+  // after that is normal; one BEFORE it means a truncated response.
+  let sawBackendDone = false;
+
+  const wrappedCallbacks: StreamCallbacks = {
+    ...callbacks,
+    onDone: () => {
+      sawBackendDone = true;
+      callbacks.onDone();
+    },
+  };
+
   return createSSEConnection(
     "/chat-stream",
     {
@@ -222,7 +240,7 @@ export async function fetchChatStream(
         const parsedEvents = parseChatStreamEvent(event.data);
 
         for (const parsed of parsedEvents) {
-          const finished = handleParsedStreamEvent(parsed, callbacks);
+          const finished = handleParsedStreamEvent(parsed, wrappedCallbacks);
           if (finished) {
             return;
           }
@@ -232,7 +250,8 @@ export async function fetchChatStream(
         callbacks.onError?.(error);
       },
       onClose: () => {
-        callbacks.onDone();
+        if (sawBackendDone) return; // already settled via onDone
+        callbacks.onTransportClosed?.();
       },
     },
     {

--- a/apps/mobile/src/features/chat/api/queries.ts
+++ b/apps/mobile/src/features/chat/api/queries.ts
@@ -83,7 +83,10 @@ export function useConversationQuery(conversationId: string | null) {
     queryKey: chatKeys.messages(conversationId!),
     queryFn: () => fetchMessagesFromApi(conversationId!),
     enabled: !!conversationId && !conversationId.startsWith("temp-"),
-    staleTime: 5 * 60 * 1000,
+    // Short staleness window: the cache-first seed still renders instantly,
+    // but revisiting a conversation revalidates against the API quickly
+    // enough that messages sent from other devices actually appear.
+    staleTime: 15_000,
   });
 }
 
@@ -91,7 +94,7 @@ export function useConversationsQuery() {
   return useQuery({
     queryKey: chatKeys.conversations(),
     queryFn: fetchConversationsList,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 15_000,
   });
 }
 
@@ -128,9 +131,30 @@ export function useChatQueryClient() {
       chatKeys.conversations(),
       (prev) => {
         if (!prev) return prev;
-        return prev.map((c) =>
+        const next = prev.map((c) =>
           c.id === conversationId ? { ...c, ...updates } : c,
         );
+        // Keep the AsyncStorage seed in sync so the next launch matches.
+        chatDb.saveConversations(next).catch((err) => {
+          console.warn("[queries] Failed to persist conversations:", err);
+        });
+        return next;
+      },
+    );
+  };
+
+  /** Optimistically drop a conversation from the list (and local seed). */
+  const removeConversationFromCache = (conversationId: string) => {
+    queryClient.setQueryData<Conversation[]>(
+      chatKeys.conversations(),
+      (prev) => {
+        if (!prev) return prev;
+        const next = prev.filter((c) => c.id !== conversationId);
+        chatDb.saveConversations(next).catch((err) => {
+          console.warn("[queries] Failed to persist conversations:", err);
+        });
+        chatDb.deleteConversation(conversationId).catch(() => undefined);
+        return next;
       },
     );
   };
@@ -141,5 +165,6 @@ export function useChatQueryClient() {
     invalidateMessages,
     prefetchMessages,
     updateConversationInCache,
+    removeConversationFromCache,
   };
 }

--- a/apps/mobile/src/features/chat/components/chat/chat-header.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-header.tsx
@@ -89,9 +89,6 @@ export function ChatHeader({ onNewChatPress }: ChatHeaderProps) {
         );
       },
     );
-    useChatStore
-      .getState()
-      .updateConversationTitle(activeConversation.id, trimmed);
 
     const success = await chatApi.renameConversation(
       activeConversation.id,
@@ -109,12 +106,6 @@ export function ChatHeader({ onNewChatPress }: ChatHeaderProps) {
           );
         },
       );
-      useChatStore
-        .getState()
-        .updateConversationTitle(
-          activeConversation.id,
-          activeConversation.title,
-        );
     }
   }, [activeConversation, editTitle, cancelEditing, queryClient]);
 

--- a/apps/mobile/src/features/chat/components/chat/chat-message.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-message.tsx
@@ -8,7 +8,12 @@ import { PressableFeedback } from "heroui-native";
 import { useCallback, useMemo } from "react";
 import { Pressable, View } from "react-native";
 import Animated, { FadeIn, FadeInDown } from "react-native-reanimated";
-import { AppIcon, Brain02Icon } from "@/components/icons";
+import {
+  Alert01Icon,
+  AppIcon,
+  Brain02Icon,
+  RepeatIcon,
+} from "@/components/icons";
 import { MessageBubble } from "@/components/ui/message-bubble";
 import { Text } from "@/components/ui/text";
 import { ThinkingCard } from "@/features/chat/components/streaming/ThinkingCard";
@@ -42,12 +47,13 @@ interface FollowUpActionsProps {
 }
 
 function FollowUpActions({ actions, onActionPress }: FollowUpActionsProps) {
+  const { spacing } = useResponsive();
   if (!actions.length) return null;
 
   return (
     <View
       className="flex-row flex-wrap gap-2 mt-2"
-      style={{ paddingLeft: 46, paddingRight: 16 }}
+      style={{ paddingLeft: spacing.md, paddingRight: spacing.md }}
     >
       {actions.map((action, i) => (
         <Animated.View
@@ -152,6 +158,110 @@ function MemoryIndicator({ memoryData }: { memoryData: MemoryDataShape }) {
   );
 }
 
+// -- Failed response ----------------------------------------------------------
+
+/**
+ * Failure surface for an errored turn — mobile counterpart of web's
+ * FailedResponse. The streamed text (if any) stays visible above; this strip
+ * marks the answer as cut short and offers a retry.
+ */
+function FailedResponse({
+  error,
+  hasPartialText,
+  onRetry,
+}: {
+  error: string;
+  hasPartialText: boolean;
+  onRetry?: () => void;
+}) {
+  const { spacing, fontSize, moderateScale } = useResponsive();
+
+  if (hasPartialText) {
+    // Compact strip under the partial bubble — the answer was truncated.
+    return (
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          gap: spacing.sm,
+          marginTop: spacing.xs + 2,
+          paddingHorizontal: spacing.md,
+        }}
+      >
+        <AppIcon icon={Alert01Icon} size={14} color="#a1a1aa" />
+        <Text
+          style={{ color: "#a1a1aa", fontSize: fontSize.xs, flexShrink: 1 }}
+        >
+          Response was cut short
+        </Text>
+        {onRetry ? <RetryButton onRetry={onRetry} /> : null}
+      </View>
+    );
+  }
+
+  // Full bubble — nothing streamed, so this IS the message.
+  return (
+    <View style={{ paddingHorizontal: spacing.md, width: "100%" }}>
+      <View
+        style={{
+          alignSelf: "flex-start",
+          maxWidth: "85%",
+          backgroundColor: "#27272a",
+          borderRadius: moderateScale(20, 0.5),
+          padding: spacing.md,
+          flexDirection: "row",
+          alignItems: "flex-start",
+          gap: spacing.sm,
+        }}
+      >
+        <AppIcon
+          icon={Alert01Icon}
+          size={17}
+          color="#a1a1aa"
+          style={{ marginTop: 1 }}
+        />
+        <View style={{ flexShrink: 1, gap: spacing.xs }}>
+          <Text style={{ color: "#e4e4e7", fontSize: fontSize.base }}>
+            This response failed
+          </Text>
+          <Text
+            style={{ color: "#a1a1aa", fontSize: fontSize.sm }}
+            numberOfLines={2}
+          >
+            {error}
+          </Text>
+          {onRetry ? <RetryButton onRetry={onRetry} /> : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function RetryButton({ onRetry }: { onRetry: () => void }) {
+  const { moderateScale } = useResponsive();
+  return (
+    <Pressable
+      onPress={onRetry}
+      style={({ pressed }) => ({
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 4,
+        opacity: pressed ? 0.7 : 1,
+        borderRadius: moderateScale(12, 0.5),
+        borderWidth: 0,
+        paddingHorizontal: 8,
+        paddingVertical: 4,
+        alignSelf: "flex-start",
+      })}
+    >
+      <AppIcon icon={RepeatIcon} size={13} color="#00bbff" />
+      <Text style={{ color: "#00bbff", fontSize: 12, fontWeight: "600" }}>
+        Retry
+      </Text>
+    </Pressable>
+  );
+}
+
 // -- ChatMessage --------------------------------------------------------------
 
 interface ChatMessageProps {
@@ -159,6 +269,8 @@ interface ChatMessageProps {
   onFollowUpAction?: (action: string) => void;
   onReply?: (message: Message) => void;
   onLongPress?: (config: MessageActionConfig) => void;
+  /** Re-run this failed turn (wired to useChat.retryLastMessage). */
+  onRetry?: () => void;
   isLoading?: boolean;
   isLastMessage?: boolean;
   loadingMessage?: string;
@@ -451,6 +563,7 @@ function AIChatMessage({
   progressToolName,
   progressMessage,
   onFollowUpAction,
+  onRetry,
 }: ChatMessageLayoutProps & {
   parsedContent: ReturnType<typeof parseThinkingFromText>;
   messageParts: MessagePart[];
@@ -460,6 +573,8 @@ function AIChatMessage({
   progressToolName: string | null;
   progressMessage: string | null;
   onFollowUpAction?: (action: string) => void;
+  /** Re-run the failed turn (only meaningful when message.error is set). */
+  onRetry?: () => void;
 }) {
   const { spacing } = useResponsive();
 
@@ -484,7 +599,8 @@ function AIChatMessage({
     !!parsedContent.thinking ||
     !!message.toolData?.length ||
     !!message.memoryData ||
-    !!message.followUpActions?.length;
+    !!message.followUpActions?.length ||
+    !!message.error;
 
   if (!hasAnyContent) return null;
 
@@ -564,6 +680,15 @@ function AIChatMessage({
             onActionPress={onFollowUpAction}
           />
         ) : null}
+
+        {/* Errored turn: keep the streamed text above and mark the failure */}
+        {message.error && !isLoading ? (
+          <FailedResponse
+            error={message.error}
+            hasPartialText={hasContent}
+            onRetry={onRetry}
+          />
+        ) : null}
       </PressableFeedback>
     </Animated.View>
   );
@@ -574,6 +699,7 @@ export function ChatMessage({
   onFollowUpAction,
   onReply,
   onLongPress,
+  onRetry,
   isLoading = false,
   isLastMessage = false,
   loadingMessage = "Thinking...",
@@ -605,6 +731,7 @@ export function ChatMessage({
       progressToolName={progressToolName}
       progressMessage={progressMessage}
       onFollowUpAction={onFollowUpAction}
+      onRetry={onRetry}
     />
   );
 }

--- a/apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx
@@ -140,7 +140,7 @@ function MessageSkeleton() {
 // ---------------------------------------------------------------------------
 
 type ListItem =
-  | { type: "message"; data: Message }
+  | { type: "message"; data: Message; isLast: boolean }
   | { type: "date-separator"; date: string; id: string };
 
 function getDateKey(date: Date): string {
@@ -152,8 +152,10 @@ function buildListItems(messages: Message[]): ListItem[] {
   let lastDateKey: string | null = null;
   const todayKey = getDateKey(new Date());
   const seenDateKeys = new Set<string>();
+  const lastMsgIndex = messages.length - 1;
 
-  for (const message of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
     const msgDate = new Date(message.timestamp);
     const dateKey = getDateKey(msgDate);
 
@@ -167,7 +169,7 @@ function buildListItems(messages: Message[]): ListItem[] {
       lastDateKey = dateKey;
     }
 
-    items.push({ type: "message", data: message });
+    items.push({ type: "message", data: message, isLast: i === lastMsgIndex });
   }
 
   // Hide "Today" separator when it's the only date group — adds no value
@@ -195,6 +197,7 @@ export function ChatScreenContent({
     progressToolName,
     flatListRef,
     sendMessage,
+    retryLastMessage,
     cancelStream,
     scrollToBottom,
     refetch,
@@ -266,11 +269,18 @@ export function ChatScreenContent({
 
   const displayMessage = progress || thinkingMessage;
 
+  // Follow the stream: tokens grow the last item WITHOUT changing the list
+  // length, so keying on messages (any change) is required. Throttled so a
+  // fast token rate doesn't flood scrollToEnd calls, and only while the user
+  // is parked at the bottom — scrolling up pauses follow, like web.
+  const lastFollowTsRef = useRef(0);
   useEffect(() => {
-    if (isAtBottomRef.current) {
-      scrollToBottom();
-    }
-  }, [messages.length, scrollToBottom]);
+    if (!isAtBottomRef.current) return;
+    const now = Date.now();
+    if (now - lastFollowTsRef.current < 120) return;
+    lastFollowTsRef.current = now;
+    flatListRef.current?.scrollToEnd({ animated: false });
+  }, [messages, flatListRef]);
 
   useEffect(() => {
     if (
@@ -481,8 +491,7 @@ export function ChatScreenContent({
       }
 
       const message = item.data;
-      const msgIndex = messages.findIndex((m) => m.id === message.id);
-      const isLastMessage = msgIndex === messages.length - 1;
+      const isLastMessage = item.isLast;
       const isEmptyAiMessage =
         !message.isUser && (!message.text || message.text.trim() === "");
       const showLoading = isLastMessage && isEmptyAiMessage && isTyping;
@@ -493,6 +502,7 @@ export function ChatScreenContent({
           onFollowUpAction={handleFollowUpAction}
           onReply={handleReply}
           onLongPress={handleLongPressMessage}
+          onRetry={retryLastMessage}
           isLoading={isLastMessage && isTyping}
           isLastMessage={isLastMessage}
           loadingMessage={showLoading ? displayMessage : undefined}
@@ -507,9 +517,9 @@ export function ChatScreenContent({
       handleLongPressMessage,
       handleReply,
       isTyping,
-      messages,
       progress,
       progressToolName,
+      retryLastMessage,
     ],
   );
 

--- a/apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx
+++ b/apps/mobile/src/features/chat/components/chat/chat-screen-content.tsx
@@ -197,7 +197,7 @@ export function ChatScreenContent({
     progressToolName,
     flatListRef,
     sendMessage,
-    retryLastMessage,
+    retryMessage,
     cancelStream,
     scrollToBottom,
     refetch,
@@ -502,7 +502,7 @@ export function ChatScreenContent({
           onFollowUpAction={handleFollowUpAction}
           onReply={handleReply}
           onLongPress={handleLongPressMessage}
-          onRetry={retryLastMessage}
+          onRetry={() => retryMessage(message.id)}
           isLoading={isLastMessage && isTyping}
           isLastMessage={isLastMessage}
           loadingMessage={showLoading ? displayMessage : undefined}
@@ -519,7 +519,7 @@ export function ChatScreenContent({
       isTyping,
       progress,
       progressToolName,
-      retryLastMessage,
+      retryMessage,
     ],
   );
 

--- a/apps/mobile/src/features/chat/components/sidebar/chat-history.tsx
+++ b/apps/mobile/src/features/chat/components/sidebar/chat-history.tsx
@@ -714,16 +714,13 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
   const { activeChatId } = useChatContext();
   const { conversations, isLoading, error, refetch } = useConversations();
   const { spacing, fontSize } = useResponsive();
-  const { invalidateConversations } = useChatQueryClient();
+  const {
+    invalidateConversations,
+    updateConversationInCache,
+    removeConversationFromCache,
+  } = useChatQueryClient();
   const streamingConversationId = useChatStore(
     (state) => state.streamingState.conversationId,
-  );
-  const removeConversation = useChatStore((state) => state.removeConversation);
-  const updateConversationTitle = useChatStore(
-    (state) => state.updateConversationTitle,
-  );
-  const updateConversationStarred = useChatStore(
-    (state) => state.updateConversationStarred,
   );
 
   const [expandedSections, setExpandedSections] = useState<
@@ -771,12 +768,16 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
               onPress: async (newName?: string) => {
                 if (!newName || newName.trim() === "") return;
                 const trimmedName = newName.trim();
-                updateConversationTitle(conversationId, trimmedName);
+                updateConversationInCache(conversationId, {
+                  title: trimmedName,
+                });
                 try {
                   await renameConversation(conversationId, trimmedName);
                   invalidateConversations();
                 } catch {
-                  updateConversationTitle(conversationId, currentTitle);
+                  updateConversationInCache(conversationId, {
+                    title: currentTitle,
+                  });
                 }
               },
             },
@@ -788,22 +789,22 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
         setRenameModal({ visible: true, conversationId, currentTitle });
       }
     },
-    [updateConversationTitle, invalidateConversations],
+    [updateConversationInCache, invalidateConversations],
   );
 
   const handleRenameConfirm = useCallback(
     async (newTitle: string) => {
       const { conversationId, currentTitle } = renameModal;
       setRenameModal((prev) => ({ ...prev, visible: false }));
-      updateConversationTitle(conversationId, newTitle);
+      updateConversationInCache(conversationId, { title: newTitle });
       try {
         await renameConversation(conversationId, newTitle);
         invalidateConversations();
       } catch {
-        updateConversationTitle(conversationId, currentTitle);
+        updateConversationInCache(conversationId, { title: currentTitle });
       }
     },
-    [renameModal, updateConversationTitle, invalidateConversations],
+    [renameModal, updateConversationInCache, invalidateConversations],
   );
 
   const handleRenameCancel = useCallback(() => {
@@ -821,7 +822,7 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
             text: "Delete",
             style: "destructive",
             onPress: async () => {
-              removeConversation(conversationId);
+              removeConversationFromCache(conversationId);
               try {
                 await deleteConversation(conversationId);
                 invalidateConversations();
@@ -833,21 +834,23 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
         ],
       );
     },
-    [removeConversation, invalidateConversations, refetch],
+    [removeConversationFromCache, invalidateConversations, refetch],
   );
 
   const handleToggleStar = useCallback(
     async (conversationId: string, currentStarred: boolean) => {
       const newStarred = !currentStarred;
-      updateConversationStarred(conversationId, newStarred);
+      updateConversationInCache(conversationId, { is_starred: newStarred });
       try {
         await toggleStarConversation(conversationId, newStarred);
         invalidateConversations();
       } catch {
-        updateConversationStarred(conversationId, currentStarred);
+        updateConversationInCache(conversationId, {
+          is_starred: currentStarred,
+        });
       }
     },
-    [updateConversationStarred, invalidateConversations],
+    [updateConversationInCache, invalidateConversations],
   );
 
   const isSearching = searchQuery.trim().length > 0;

--- a/apps/mobile/src/features/chat/components/sidebar/chat-history.tsx
+++ b/apps/mobile/src/features/chat/components/sidebar/chat-history.tsx
@@ -35,11 +35,6 @@ import {
 import { Text } from "@/components/ui/text";
 import { useResponsive } from "@/lib/responsive";
 import { useChatStore } from "@/stores/chat-store";
-import {
-  deleteConversation,
-  renameConversation,
-  toggleStarConversation,
-} from "../../api/chat-api";
 import { useChatQueryClient } from "../../api/queries";
 import { useChatContext } from "../../hooks/use-chat-context";
 import {
@@ -712,13 +707,18 @@ function ChatHistorySkeleton() {
 export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
   const router = useRouter();
   const { activeChatId } = useChatContext();
-  const { conversations, isLoading, error, refetch } = useConversations();
-  const { spacing, fontSize } = useResponsive();
   const {
-    invalidateConversations,
-    updateConversationInCache,
-    removeConversationFromCache,
-  } = useChatQueryClient();
+    conversations,
+    isLoading,
+    error,
+    refetch,
+    deleteConversation,
+    renameConversation,
+    starConversation,
+    unstarConversation,
+  } = useConversations();
+  const { spacing, fontSize } = useResponsive();
+  const { invalidateConversations } = useChatQueryClient();
   const streamingConversationId = useChatStore(
     (state) => state.streamingState.conversationId,
   );
@@ -768,16 +768,13 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
               onPress: async (newName?: string) => {
                 if (!newName || newName.trim() === "") return;
                 const trimmedName = newName.trim();
-                updateConversationInCache(conversationId, {
-                  title: trimmedName,
-                });
-                try {
-                  await renameConversation(conversationId, trimmedName);
+                // Hook updates the cache only when the API succeeds.
+                const ok = await renameConversation(
+                  conversationId,
+                  trimmedName,
+                );
+                if (ok) {
                   invalidateConversations();
-                } catch {
-                  updateConversationInCache(conversationId, {
-                    title: currentTitle,
-                  });
                 }
               },
             },
@@ -789,22 +786,20 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
         setRenameModal({ visible: true, conversationId, currentTitle });
       }
     },
-    [updateConversationInCache, invalidateConversations],
+    [renameConversation, invalidateConversations],
   );
 
   const handleRenameConfirm = useCallback(
     async (newTitle: string) => {
-      const { conversationId, currentTitle } = renameModal;
+      const { conversationId } = renameModal;
       setRenameModal((prev) => ({ ...prev, visible: false }));
-      updateConversationInCache(conversationId, { title: newTitle });
-      try {
-        await renameConversation(conversationId, newTitle);
+      // Hook updates the cache only when the API succeeds.
+      const ok = await renameConversation(conversationId, newTitle);
+      if (ok) {
         invalidateConversations();
-      } catch {
-        updateConversationInCache(conversationId, { title: currentTitle });
       }
     },
-    [renameModal, updateConversationInCache, invalidateConversations],
+    [renameModal, renameConversation, invalidateConversations],
   );
 
   const handleRenameCancel = useCallback(() => {
@@ -822,11 +817,11 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
             text: "Delete",
             style: "destructive",
             onPress: async () => {
-              removeConversationFromCache(conversationId);
-              try {
-                await deleteConversation(conversationId);
+              // Hook removes from the cache only when the API succeeds.
+              const ok = await deleteConversation(conversationId);
+              if (ok) {
                 invalidateConversations();
-              } catch {
+              } else {
                 refetch();
               }
             },
@@ -834,23 +829,20 @@ export function ChatHistory({ onSelectChat, searchQuery }: ChatHistoryProps) {
         ],
       );
     },
-    [removeConversationFromCache, invalidateConversations, refetch],
+    [deleteConversation, invalidateConversations, refetch],
   );
 
   const handleToggleStar = useCallback(
     async (conversationId: string, currentStarred: boolean) => {
-      const newStarred = !currentStarred;
-      updateConversationInCache(conversationId, { is_starred: newStarred });
-      try {
-        await toggleStarConversation(conversationId, newStarred);
+      // Hook updates the cache only when the API succeeds.
+      const ok = currentStarred
+        ? await unstarConversation(conversationId)
+        : await starConversation(conversationId);
+      if (ok) {
         invalidateConversations();
-      } catch {
-        updateConversationInCache(conversationId, {
-          is_starred: currentStarred,
-        });
       }
     },
-    [updateConversationInCache, invalidateConversations],
+    [starConversation, unstarConversation, invalidateConversations],
   );
 
   const isSearching = searchQuery.trim().length > 0;

--- a/apps/mobile/src/features/chat/hooks/use-chat-context.tsx
+++ b/apps/mobile/src/features/chat/hooks/use-chat-context.tsx
@@ -7,7 +7,7 @@ import {
   useEffect,
   useMemo,
 } from "react";
-import { InteractionManager } from "react-native";
+import { AppState, InteractionManager } from "react-native";
 import { chatDb } from "@/lib/db/chatDb";
 import { useChatStore } from "@/stores/chat-store";
 import type { Message } from "../api/chat-api";
@@ -32,8 +32,6 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    useChatStore.getState().hydrate();
-
     // Seed the conversations React Query cache from AsyncStorage so the
     // sidebar list renders instantly on launch (web parity — Zustand+IDB).
     // After seeding, invalidate so a background network sync still runs.
@@ -76,6 +74,21 @@ export function ChatProvider({ children }: ChatProviderProps) {
     return () => {
       interaction.cancel();
     };
+  }, [queryClient]);
+
+  // Foreground sync: while the app is backgrounded, messages and conversations
+  // may change on other devices (or via push). Revalidate both when the user
+  // returns — cached data stays on screen until fresh data lands.
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
+        queryClient.invalidateQueries({
+          queryKey: [...chatKeys.all, "messages"],
+        });
+      }
+    });
+    return () => subscription.remove();
   }, [queryClient]);
 
   const setActiveChatId = useCallback((chatId: string | null) => {

--- a/apps/mobile/src/features/chat/hooks/use-chat.ts
+++ b/apps/mobile/src/features/chat/hooks/use-chat.ts
@@ -12,12 +12,12 @@ import { useChatStore } from "@/stores/chat-store";
 import { chatApi, fetchChatStream, type Message } from "../api/chat-api";
 import { chatKeys, useConversationQuery } from "../api/queries";
 import type { AttachmentFile } from "../components/composer/attachment-preview";
-import type { ReplyToMessageData } from "../types";
+import type { Conversation, ReplyToMessageData } from "../types";
 
 const EMPTY_MESSAGES: Message[] = [];
 
-/** Delay (ms) before re-fetching conversation after the user cancels a stream. */
-const POST_CANCEL_SYNC_DELAY_MS = 2000;
+/** Delay (ms) before re-fetching conversation after a turn ends or is cancelled. */
+const POST_TURN_SYNC_DELAY_MS = 1500;
 
 export type { Message } from "../api/chat-api";
 
@@ -42,6 +42,8 @@ interface UseChatReturn {
   conversationId: string | null;
   flatListRef: React.RefObject<FlashListRef<Message> | null>;
   sendMessage: (text: string, opts?: SendMessageOptions) => Promise<void>;
+  /** Re-run the most recent send after a failure, preserving its options. */
+  retryLastMessage: () => void;
   cancelStream: () => void;
   scrollToBottom: () => void;
   refetch: () => Promise<void>;
@@ -56,6 +58,19 @@ export function useChat(
   const streamIdRef = useRef<string | null>(null);
   const streamingResponseRef = useRef<string>("");
   const streamingToolDataRef = useRef<ToolDataEntry[]>([]);
+  /**
+   * Settle function for the in-flight turn. Every terminal path (done, error,
+   * user cancel) funnels through it and only the first call wins — this is
+   * what prevents the old double-finalize races where an abort triggered
+   * onClose → onDone and re-persisted a half-finished response.
+   */
+  const settleRef = useRef<
+    ((cause: "done" | "error" | "aborted") => void) | null
+  >(null);
+  const lastRequestRef = useRef<{
+    text: string;
+    opts: SendMessageOptions;
+  } | null>(null);
   const queryClient = useQueryClient();
 
   const storeActiveChatId = useChatStore((state) => state.activeChatId);
@@ -145,8 +160,28 @@ export function useChat(
     flatListRef.current?.scrollToEnd({ animated: true });
   }, []);
 
+  /** Reconcile the optimistic local state against server truth shortly after a turn ends. */
+  const scheduleReconcile = useCallback(
+    (conversationId: string) => {
+      if (conversationId.startsWith("temp-")) return;
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: chatKeys.messages(conversationId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: chatKeys.conversations(),
+        });
+      }, POST_TURN_SYNC_DELAY_MS);
+    },
+    [queryClient],
+  );
+
   const cancelStream = useCallback(() => {
-    // Abort the local SSE connection immediately.
+    // Settle as "aborted" FIRST so the SSE close that the abort triggers can't
+    // run onDone afterwards and persist the partial response as final.
+    settleRef.current?.("aborted");
+    settleRef.current = null;
+
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
 
@@ -167,16 +202,13 @@ export function useChat(
       progressToolName: null,
     });
 
-    // Schedule a single re-fetch after the backend has had time to persist the
-    // partial response. Mirrors web's syncWithRetry but simpler: one attempt
-    // with a short delay is sufficient for the mobile use case.
+    // Pull server truth: the backend persists whatever it produced before the
+    // cancel arrived, and that partial answer should survive.
     const convId = activeConvIdRef.current;
     if (convId && !convId.startsWith("temp-")) {
-      setTimeout(() => {
-        queryClient.invalidateQueries({ queryKey: chatKeys.messages(convId) });
-      }, POST_CANCEL_SYNC_DELAY_MS);
+      scheduleReconcile(convId);
     }
-  }, [queryClient]);
+  }, [queryClient, scheduleReconcile]);
 
   const sendMessage = useCallback(
     async (text: string, opts?: SendMessageOptions) => {
@@ -188,6 +220,17 @@ export function useChat(
       const toolCategory = opts?.toolCategory ?? null;
       const selectedWorkflow = opts?.selectedWorkflow ?? null;
       const attachments = opts?.attachments ?? [];
+
+      lastRequestRef.current = {
+        text,
+        opts: {
+          replyToMessage,
+          selectedTool,
+          toolCategory,
+          selectedWorkflow,
+          attachments,
+        },
+      };
 
       const uploadedFileIds = attachments
         .filter((a) => a.fileId)
@@ -242,6 +285,67 @@ export function useChat(
       streamingToolDataRef.current = [];
       streamIdRef.current = null;
 
+      // --- Single-settle turn finalization --------------------------------
+      // Exactly one of done / error / aborted ever runs. The SSE layer can
+      // fire multiple terminal signals (error then close, abort then close);
+      // without this guard each of them re-persisted state and raced the
+      // reconcile refetch.
+      let settled: "done" | "error" | "aborted" | null = null;
+      const settle = (cause: "done" | "error" | "aborted") => {
+        if (settled) return;
+        settled = cause;
+        settleRef.current = null;
+
+        const finalConvId = activeConvIdRef.current;
+        const liveStore = useChatStore.getState();
+
+        if (cause === "aborted") {
+          // cancelStream owns the aborted path (state reset + refetch).
+          return;
+        }
+
+        streamIdRef.current = null;
+        abortControllerRef.current = null;
+
+        const finalMessages = finalConvId
+          ? liveStore.messagesByConversation[finalConvId]
+          : undefined;
+
+        if (finalMessages && finalConvId) {
+          // Update React Query cache so the UI picks up the final messages
+          queryClient.setQueryData(
+            chatKeys.messages(finalConvId),
+            finalMessages,
+          );
+
+          // Persist to AsyncStorage so messages survive app restarts
+          chatDb.saveMessages(finalConvId, finalMessages).catch((err) => {
+            console.warn(
+              "[use-chat] Failed to persist messages on stream end:",
+              err,
+            );
+          });
+
+          liveStore.clearMessages(finalConvId);
+        }
+
+        liveStore.setStreamingState({
+          isTyping: false,
+          isStreaming: false,
+          conversationId: null,
+          progress: null,
+          progressToolName: null,
+        });
+
+        if (finalConvId) {
+          // The local accumulator is an approximation of what the server
+          // persisted (tool outputs, memory data, real timestamps). Always
+          // reconcile against server truth shortly after the turn ends.
+          scheduleReconcile(finalConvId);
+        }
+      };
+      settleRef.current = settle;
+
       try {
         const existingConvId = activeConvIdRef.current;
         const apiConversationId =
@@ -271,8 +375,8 @@ export function useChat(
               botMsgId,
               description,
             ) => {
-              const store = useChatStore.getState();
-              const msgs = store.messagesByConversation[storeKey] || [];
+              const liveStore = useChatStore.getState();
+              const msgs = liveStore.messagesByConversation[storeKey] || [];
 
               const updatedMsgs = msgs.map((msg, idx) => {
                 if (idx === msgs.length - 2) return { ...msg, id: userMsgId };
@@ -281,27 +385,35 @@ export function useChat(
               });
 
               if (!chatId && newConvId) {
-                store.setMessages(newConvId, updatedMsgs);
-                store.clearMessages(storeKey);
-                store.setStreamingState({ conversationId: newConvId });
-                store.setActiveChatId(newConvId);
+                liveStore.setMessages(newConvId, updatedMsgs);
+                liveStore.clearMessages(storeKey);
+                liveStore.setStreamingState({ conversationId: newConvId });
+                liveStore.setActiveChatId(newConvId);
 
-                store.addConversation({
-                  id: newConvId,
-                  title: description || "New conversation",
-                  created_at: new Date().toISOString(),
-                  updated_at: new Date().toISOString(),
-                });
-
-                queryClient.invalidateQueries({
-                  queryKey: chatKeys.conversations(),
-                });
+                // Show the new conversation in the sidebar immediately by
+                // prepending to the React Query cache (the sidebar's single
+                // source of truth); the background refetch confirms it.
+                queryClient.setQueryData(
+                  chatKeys.conversations(),
+                  (prev: Conversation[] | undefined) => {
+                    if (!prev) return prev;
+                    if (prev.some((c) => c.id === newConvId)) return prev;
+                    const now = new Date().toISOString();
+                    const entry = {
+                      id: newConvId,
+                      title: description || "New conversation",
+                      created_at: now,
+                      updated_at: now,
+                    };
+                    return [entry, ...prev];
+                  },
+                );
 
                 activeConvIdRef.current = newConvId;
                 setCurrentConversationId(newConvId);
                 options?.onNavigate?.(newConvId);
               } else {
-                store.setMessages(storeKey, updatedMsgs);
+                liveStore.setMessages(storeKey, updatedMsgs);
               }
             },
             onChunk: (chunk) => {
@@ -353,66 +465,32 @@ export function useChat(
                   toolData: streamingToolDataRef.current,
                 });
             },
-            onDone: () => {
-              streamIdRef.current = null;
-              const finalConvId = activeConvIdRef.current;
-              const store = useChatStore.getState();
-              const finalMessages = store.messagesByConversation[finalConvId!];
-
-              if (finalMessages && finalConvId) {
-                // Update React Query cache so the UI picks up the final messages
-                queryClient.setQueryData(
-                  chatKeys.messages(finalConvId),
-                  finalMessages,
-                );
-
-                // Persist to AsyncStorage so messages survive app restarts
-                chatDb.saveMessages(finalConvId, finalMessages).catch((err) => {
-                  console.warn(
-                    "[use-chat] Failed to persist messages on stream done:",
-                    err,
-                  );
-                });
-
-                store.clearMessages(finalConvId);
-              }
-
-              store.setStreamingState({
-                isTyping: false,
-                isStreaming: false,
-                conversationId: null,
-                progress: null,
-                progressToolName: null,
-              });
-              abortControllerRef.current = null;
-            },
+            onDone: () => settle("done"),
             onError: (error) => {
               console.error("Stream error:", error);
-              streamIdRef.current = null;
-              useChatStore.getState().setStreamingState({
-                isTyping: false,
-                isStreaming: false,
-                conversationId: null,
-                progress: null,
-                progressToolName: null,
-              });
+              // Keep everything streamed so far — only mark the message as
+              // failed. Wiping the text (the old behaviour) destroyed the
+              // partial answer the user was already reading.
               useChatStore
                 .getState()
-                .updateLastMessage(
-                  activeConvIdRef.current!,
-                  "Sorry, I encountered an error. Please try again.",
-                );
+                .updateLastAssistantMessage(activeConvIdRef.current!, {
+                  error:
+                    error.message ||
+                    "Something went wrong while generating the response.",
+                });
+              settle("error");
             },
           },
         );
         abortControllerRef.current = controller;
       } catch (error) {
         console.error("Error starting stream:", error);
-        useChatStore.getState().setStreamingState({
-          isTyping: false,
-          isStreaming: false,
-          conversationId: null,
-        });
+        useChatStore
+          .getState()
+          .updateLastAssistantMessage(activeConvIdRef.current!, {
+            error: "Couldn't reach the server. Check your connection.",
+          });
+        settle("error");
       }
     },
     [
@@ -422,8 +500,37 @@ export function useChat(
       cachedMessages,
       queryClient,
       options,
+      scheduleReconcile,
     ],
   );
+
+  const retryLastMessage = useCallback(() => {
+    const last = lastRequestRef.current;
+    const convId = activeConvIdRef.current;
+    if (!last || !convId) return;
+
+    // Drop the failed assistant message (and anything after the last user
+    // message) from both the streaming store and the query cache, then re-send.
+    const store = useChatStore.getState();
+    const msgs = store.messagesByConversation[convId];
+    if (msgs) {
+      // Drop everything after the last user message (the failed response).
+      let lastUserIdx = -1;
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        if (msgs[i].isUser) {
+          lastUserIdx = i;
+          break;
+        }
+      }
+      const kept = lastUserIdx >= 0 ? msgs.slice(0, lastUserIdx + 1) : msgs;
+      store.setMessages(convId, kept);
+      if (!convId.startsWith("temp-")) {
+        queryClient.setQueryData(chatKeys.messages(convId), kept);
+      }
+    }
+
+    void sendMessage(last.text, last.opts);
+  }, [sendMessage, queryClient]);
 
   const refetch = useCallback(async () => {
     if (currentConversationId) {
@@ -440,6 +547,7 @@ export function useChat(
     conversationId: currentConversationId,
     flatListRef,
     sendMessage,
+    retryLastMessage,
     cancelStream,
     scrollToBottom,
     refetch,

--- a/apps/mobile/src/features/chat/hooks/use-chat.ts
+++ b/apps/mobile/src/features/chat/hooks/use-chat.ts
@@ -546,7 +546,8 @@ export function useChat(
         queryClient.getQueryData<Message[]>(chatKeys.messages(convId));
       if (!msgs) return;
 
-      // Drop everything after the last user message (the failed response).
+      // Drop the failed turn entirely, INCLUDING the user message —
+      // sendMessage below appends a fresh copy of it.
       let lastUserIdx = -1;
       for (let i = msgs.length - 1; i >= 0; i--) {
         if (msgs[i].isUser) {
@@ -556,7 +557,7 @@ export function useChat(
       }
       if (lastUserIdx < 0) return;
 
-      const kept = msgs.slice(0, lastUserIdx + 1);
+      const kept = msgs.slice(0, lastUserIdx);
       store.setMessages(convId, kept);
       if (!convId.startsWith("temp-")) {
         queryClient.setQueryData(chatKeys.messages(convId), kept);

--- a/apps/mobile/src/features/chat/hooks/use-chat.ts
+++ b/apps/mobile/src/features/chat/hooks/use-chat.ts
@@ -42,8 +42,11 @@ interface UseChatReturn {
   conversationId: string | null;
   flatListRef: React.RefObject<FlashListRef<Message> | null>;
   sendMessage: (text: string, opts?: SendMessageOptions) => Promise<void>;
-  /** Re-run the most recent send after a failure, preserving its options. */
-  retryLastMessage: () => void;
+  /**
+   * Re-run a failed turn, preserving its original send options. Only the most
+   * recent assistant message — the one the request is bound to — is retryable.
+   */
+  retryMessage: (failedMessageId: string) => void;
   cancelStream: () => void;
   scrollToBottom: () => void;
   refetch: () => Promise<void>;
@@ -70,6 +73,8 @@ export function useChat(
   const lastRequestRef = useRef<{
     text: string;
     opts: SendMessageOptions;
+    /** Assistant message this request produced (temp id until server assigns). */
+    assistantMessageId: string;
   } | null>(null);
   const queryClient = useQueryClient();
 
@@ -221,29 +226,6 @@ export function useChat(
       const selectedWorkflow = opts?.selectedWorkflow ?? null;
       const attachments = opts?.attachments ?? [];
 
-      lastRequestRef.current = {
-        text,
-        opts: {
-          replyToMessage,
-          selectedTool,
-          toolCategory,
-          selectedWorkflow,
-          attachments,
-        },
-      };
-
-      const uploadedFileIds = attachments
-        .filter((a) => a.fileId)
-        .map((a) => a.fileId as string);
-      const uploadedFileData = attachments
-        .filter((a) => a.fileId)
-        .map((a) => ({
-          fileId: a.fileId as string,
-          fileName: a.name,
-          contentType: a.mimeType,
-          fileSize: a.size,
-        }));
-
       const userMessage: Message = {
         id: `temp-user-${Date.now()}`,
         text,
@@ -258,6 +240,30 @@ export function useChat(
         isUser: false,
         timestamp: new Date(),
       };
+
+      lastRequestRef.current = {
+        text,
+        opts: {
+          replyToMessage,
+          selectedTool,
+          toolCategory,
+          selectedWorkflow,
+          attachments,
+        },
+        assistantMessageId: aiMessage.id,
+      };
+
+      const uploadedFileIds = attachments
+        .filter((a) => a.fileId)
+        .map((a) => a.fileId as string);
+      const uploadedFileData = attachments
+        .filter((a) => a.fileId)
+        .map((a) => ({
+          fileId: a.fileId as string,
+          fileName: a.name,
+          contentType: a.mimeType,
+          fileSize: a.size,
+        }));
 
       const storeKey = activeConvIdRef.current || `temp-${Date.now()}`;
       activeConvIdRef.current = storeKey;
@@ -390,6 +396,15 @@ export function useChat(
                 liveStore.setStreamingState({ conversationId: newConvId });
                 liveStore.setActiveChatId(newConvId);
 
+                // The server-assigned bot id replaces our temp id — keep the
+                // retry binding pointing at the real message.
+                if (lastRequestRef.current) {
+                  lastRequestRef.current = {
+                    ...lastRequestRef.current,
+                    assistantMessageId: botMsgId,
+                  };
+                }
+
                 // Show the new conversation in the sidebar immediately by
                 // prepending to the React Query cache (the sidebar's single
                 // source of truth); the background refetch confirms it.
@@ -466,6 +481,17 @@ export function useChat(
                 });
             },
             onDone: () => settle("done"),
+            onTransportClosed: () => {
+              // Transport died before the backend's done event — the answer
+              // is truncated. Keep the partial text, mark retryable.
+              console.error("Stream closed before completion");
+              useChatStore
+                .getState()
+                .updateLastAssistantMessage(activeConvIdRef.current!, {
+                  error: "Connection lost before the response finished.",
+                });
+              settle("error");
+            },
             onError: (error) => {
               console.error("Stream error:", error);
               // Keep everything streamed so far — only mark the message as
@@ -504,16 +530,22 @@ export function useChat(
     ],
   );
 
-  const retryLastMessage = useCallback(() => {
-    const last = lastRequestRef.current;
-    const convId = activeConvIdRef.current;
-    if (!last || !convId) return;
+  const retryMessage = useCallback(
+    (failedMessageId: string) => {
+      const last = lastRequestRef.current;
+      const convId = activeConvIdRef.current;
+      if (!last || !convId) return;
+      // Only the assistant message this request produced is retryable.
+      if (failedMessageId !== last.assistantMessageId) return;
 
-    // Drop the failed assistant message (and anything after the last user
-    // message) from both the streaming store and the query cache, then re-send.
-    const store = useChatStore.getState();
-    const msgs = store.messagesByConversation[convId];
-    if (msgs) {
+      // Settlement clears the transient store; the finalized messages live in
+      // the React Query cache — read from whichever still has them.
+      const store = useChatStore.getState();
+      const msgs =
+        store.messagesByConversation[convId] ??
+        queryClient.getQueryData<Message[]>(chatKeys.messages(convId));
+      if (!msgs) return;
+
       // Drop everything after the last user message (the failed response).
       let lastUserIdx = -1;
       for (let i = msgs.length - 1; i >= 0; i--) {
@@ -522,15 +554,18 @@ export function useChat(
           break;
         }
       }
-      const kept = lastUserIdx >= 0 ? msgs.slice(0, lastUserIdx + 1) : msgs;
+      if (lastUserIdx < 0) return;
+
+      const kept = msgs.slice(0, lastUserIdx + 1);
       store.setMessages(convId, kept);
       if (!convId.startsWith("temp-")) {
         queryClient.setQueryData(chatKeys.messages(convId), kept);
       }
-    }
 
-    void sendMessage(last.text, last.opts);
-  }, [sendMessage, queryClient]);
+      void sendMessage(last.text, last.opts);
+    },
+    [sendMessage, queryClient],
+  );
 
   const refetch = useCallback(async () => {
     if (currentConversationId) {
@@ -547,7 +582,7 @@ export function useChat(
     conversationId: currentConversationId,
     flatListRef,
     sendMessage,
-    retryLastMessage,
+    retryMessage,
     cancelStream,
     scrollToBottom,
     refetch,

--- a/apps/mobile/src/features/chat/hooks/use-conversations.ts
+++ b/apps/mobile/src/features/chat/hooks/use-conversations.ts
@@ -14,10 +14,10 @@ interface UseConversationsReturn {
   isLoading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
-  deleteConversation: (id: string) => Promise<void>;
-  renameConversation: (id: string, title: string) => Promise<void>;
-  starConversation: (id: string) => Promise<void>;
-  unstarConversation: (id: string) => Promise<void>;
+  deleteConversation: (id: string) => Promise<boolean>;
+  renameConversation: (id: string, title: string) => Promise<boolean>;
+  starConversation: (id: string) => Promise<boolean>;
+  unstarConversation: (id: string) => Promise<boolean>;
 }
 
 export function useConversations(): UseConversationsReturn {
@@ -26,28 +26,41 @@ export function useConversations(): UseConversationsReturn {
   const { updateConversationInCache, removeConversationFromCache } =
     useChatQueryClient();
 
-  const deleteConversation = async (id: string) => {
-    await chatApi.deleteConversation(id);
+  // These API helpers resolve false on failure instead of throwing, so the
+  // result must be checked BEFORE touching the optimistic cache.
+  const deleteConversation = async (id: string): Promise<boolean> => {
+    const ok = await chatApi.deleteConversation(id);
+    if (!ok) return false;
     removeConversationFromCache(id);
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
+    return true;
   };
 
-  const renameConversation = async (id: string, title: string) => {
-    await chatApi.renameConversation(id, title);
+  const renameConversation = async (
+    id: string,
+    title: string,
+  ): Promise<boolean> => {
+    const ok = await chatApi.renameConversation(id, title);
+    if (!ok) return false;
     updateConversationInCache(id, { title });
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
+    return true;
   };
 
-  const starConversation = async (id: string) => {
-    await chatApi.toggleStarConversation(id, true);
+  const starConversation = async (id: string): Promise<boolean> => {
+    const ok = await chatApi.toggleStarConversation(id, true);
+    if (!ok) return false;
     updateConversationInCache(id, { is_starred: true });
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
+    return true;
   };
 
-  const unstarConversation = async (id: string) => {
-    await chatApi.toggleStarConversation(id, false);
+  const unstarConversation = async (id: string): Promise<boolean> => {
+    const ok = await chatApi.toggleStarConversation(id, false);
+    if (!ok) return false;
     updateConversationInCache(id, { is_starred: false });
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
+    return true;
   };
 
   return {

--- a/apps/mobile/src/features/chat/hooks/use-conversations.ts
+++ b/apps/mobile/src/features/chat/hooks/use-conversations.ts
@@ -1,8 +1,11 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { chatApi } from "@/features/chat/api/chat-api";
-import { chatKeys, useConversationsQuery } from "@/features/chat/api/queries";
+import {
+  chatKeys,
+  useChatQueryClient,
+  useConversationsQuery,
+} from "@/features/chat/api/queries";
 import type { Conversation, GroupedConversations } from "@/features/chat/types";
-import { useChatStore } from "@/stores/chat-store";
 
 export type { Conversation, GroupedConversations } from "@/features/chat/types";
 
@@ -20,29 +23,30 @@ interface UseConversationsReturn {
 export function useConversations(): UseConversationsReturn {
   const { data, isLoading, error, refetch } = useConversationsQuery();
   const queryClient = useQueryClient();
-  const store = useChatStore.getState();
+  const { updateConversationInCache, removeConversationFromCache } =
+    useChatQueryClient();
 
   const deleteConversation = async (id: string) => {
     await chatApi.deleteConversation(id);
-    store.removeConversation(id);
+    removeConversationFromCache(id);
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
   };
 
   const renameConversation = async (id: string, title: string) => {
     await chatApi.renameConversation(id, title);
-    store.updateConversationTitle(id, title);
+    updateConversationInCache(id, { title });
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
   };
 
   const starConversation = async (id: string) => {
     await chatApi.toggleStarConversation(id, true);
-    store.updateConversationStarred(id, true);
+    updateConversationInCache(id, { is_starred: true });
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
   };
 
   const unstarConversation = async (id: string) => {
     await chatApi.toggleStarConversation(id, false);
-    store.updateConversationStarred(id, false);
+    updateConversationInCache(id, { is_starred: false });
     queryClient.invalidateQueries({ queryKey: chatKeys.conversations() });
   };
 

--- a/apps/mobile/src/lib/sse-client.ts
+++ b/apps/mobile/src/lib/sse-client.ts
@@ -19,6 +19,12 @@ export interface SSEOptions {
   body?: unknown;
   maxRetries?: number;
   initialRetryDelayMs?: number;
+  /**
+   * Kill the connection (via onError) after this many ms of complete silence.
+   * The backend sends keepalive events during long tool runs, so silence means
+   * the stream is genuinely stalled — without this the UI spins forever.
+   */
+  stallTimeoutMs?: number;
 }
 
 const DEFAULT_MAX_RETRIES = 3;
@@ -53,6 +59,7 @@ export async function createSSEConnection(
 
   let retryCount = 0;
   let retryTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let stallTimeoutId: ReturnType<typeof setTimeout> | null = null;
   let hasReceivedData = false;
   let isDone = false;
   // Guard against double-close: [DONE] fires onClose via onMessage, then the
@@ -64,6 +71,10 @@ export async function createSSEConnection(
     if (retryTimeoutId !== null) {
       clearTimeout(retryTimeoutId);
       retryTimeoutId = null;
+    }
+    if (stallTimeoutId !== null) {
+      clearTimeout(stallTimeoutId);
+      stallTimeoutId = null;
     }
   };
 
@@ -81,6 +92,23 @@ export async function createSSEConnection(
 
     const url = `${API_BASE_URL}${endpoint}`;
 
+    const armStallWatchdog = () => {
+      if (!options.stallTimeoutMs) return;
+      if (stallTimeoutId !== null) clearTimeout(stallTimeoutId);
+      stallTimeoutId = setTimeout(() => {
+        stallTimeoutId = null;
+        if (isDone || controller.signal.aborted) return;
+        cleanup();
+        es.removeAllEventListeners();
+        es.close();
+        callbacks.onError?.(
+          new Error(
+            `No data received for ${Math.round(options.stallTimeoutMs! / 1000)}s — response timed out`,
+          ),
+        );
+      }, options.stallTimeoutMs);
+    };
+
     const es = new EventSource(url, {
       method: "POST",
       headers: {
@@ -95,6 +123,9 @@ export async function createSSEConnection(
       timeoutBeforeConnection: 0,
     });
 
+    // Cover the silent window before the first byte arrives, too.
+    armStallWatchdog();
+
     const handleAbort = () => {
       es.removeAllEventListeners();
       es.close();
@@ -108,6 +139,7 @@ export async function createSSEConnection(
       if (event.data) {
         hasReceivedData = true;
         retryCount = 0;
+        armStallWatchdog();
 
         // Detect [DONE] sentinel before forwarding so we can set doneReceived
         // and prevent the subsequent onclose from calling onClose a second time.

--- a/apps/mobile/src/lib/sse-client.ts
+++ b/apps/mobile/src/lib/sse-client.ts
@@ -78,6 +78,14 @@ export async function createSSEConnection(
     }
   };
 
+  /** Disarm the watchdog without ending the connection (used before retries). */
+  const disarmStallWatchdog = () => {
+    if (stallTimeoutId !== null) {
+      clearTimeout(stallTimeoutId);
+      stallTimeoutId = null;
+    }
+  };
+
   controller.signal.addEventListener("abort", cleanup);
 
   async function connect(): Promise<void> {
@@ -163,6 +171,9 @@ export async function createSSEConnection(
 
       if (retryCount < maxRetries) {
         retryCount += 1;
+        // Disarm before backoff — a stale watchdog firing mid-retry would
+        // cleanup() and cancel the scheduled reconnect.
+        disarmStallWatchdog();
         const delay = computeRetryDelay(retryCount - 1, initialRetryDelayMs);
         console.warn(
           `[SSE] Connection error (attempt ${retryCount}/${maxRetries}), retrying in ${delay}ms`,
@@ -198,6 +209,7 @@ export async function createSSEConnection(
         cleanup();
       } else {
         retryCount += 1;
+        disarmStallWatchdog();
         const delay = computeRetryDelay(retryCount - 1, initialRetryDelayMs);
         console.warn(
           `[SSE] Unexpected close (attempt ${retryCount}/${maxRetries}), retrying in ${delay}ms`,

--- a/apps/mobile/src/lib/sse-client.ts
+++ b/apps/mobile/src/lib/sse-client.ts
@@ -135,9 +135,11 @@ export async function createSSEConnection(
     armStallWatchdog();
 
     const handleAbort = () => {
+      // Caller-initiated cancellation — the aborting code owns its own
+      // cleanup. Firing onClose here would make an intentional cancel
+      // indistinguishable from an unexpected transport failure.
       es.removeAllEventListeners();
       es.close();
-      callbacks.onClose?.();
     };
 
     controller.signal.addEventListener("abort", handleAbort);

--- a/apps/mobile/src/stores/chat-store.ts
+++ b/apps/mobile/src/stores/chat-store.ts
@@ -1,7 +1,5 @@
 import { create } from "zustand";
 import type { Message } from "@/features/chat/api/chat-api";
-import type { Conversation } from "@/features/chat/types/index";
-import { chatDb } from "@/lib/db/chatDb";
 
 interface StreamingState {
   isTyping: boolean;
@@ -13,12 +11,9 @@ interface StreamingState {
 
 interface ChatState {
   messagesByConversation: Record<string, Message[]>;
-  conversations: Conversation[];
   activeChatId: string | null;
   streamingState: StreamingState;
-  isHydrated: boolean;
 
-  hydrate: () => Promise<void>;
   setActiveChatId: (id: string | null) => void;
   setMessages: (conversationId: string, messages: Message[]) => void;
   clearMessages: (conversationId: string) => void;
@@ -32,16 +27,10 @@ interface ChatState {
     actions: string[],
   ) => void;
   setStreamingState: (state: Partial<StreamingState>) => void;
-  setConversations: (conversations: Conversation[]) => void;
-  addConversation: (conversation: Conversation) => void;
-  updateConversationTitle: (conversationId: string, title: string) => void;
-  removeConversation: (conversationId: string) => void;
-  updateConversationStarred: (conversationId: string, starred: boolean) => void;
 }
 
 export const useChatStore = create<ChatState>((set, _get) => ({
   messagesByConversation: {},
-  conversations: [],
   activeChatId: null,
   streamingState: {
     isTyping: false,
@@ -50,13 +39,6 @@ export const useChatStore = create<ChatState>((set, _get) => ({
     progress: null,
     progressToolName: null,
   },
-  isHydrated: false,
-
-  hydrate: async () => {
-    const conversations = await chatDb.getConversations();
-    set({ conversations, isHydrated: true });
-  },
-
   setActiveChatId: (id) => set({ activeChatId: id }),
 
   setMessages: (conversationId, messages) =>
@@ -140,47 +122,4 @@ export const useChatStore = create<ChatState>((set, _get) => ({
     set((state) => ({
       streamingState: { ...state.streamingState, ...newState },
     })),
-
-  setConversations: (conversations) => {
-    set({ conversations });
-    chatDb.saveConversations(conversations);
-  },
-
-  addConversation: (conversation) =>
-    set((state) => {
-      if (state.conversations.some((c) => c.id === conversation.id)) {
-        return state;
-      }
-      const updated = [conversation, ...state.conversations];
-      chatDb.saveConversations(updated);
-      return { conversations: updated };
-    }),
-
-  updateConversationTitle: (conversationId, title) =>
-    set((state) => {
-      const updated = state.conversations.map((c) =>
-        c.id === conversationId ? { ...c, title } : c,
-      );
-      chatDb.saveConversations(updated);
-      return { conversations: updated };
-    }),
-
-  removeConversation: (conversationId) =>
-    set((state) => {
-      const updated = state.conversations.filter(
-        (c) => c.id !== conversationId,
-      );
-      chatDb.saveConversations(updated);
-      chatDb.deleteConversation(conversationId);
-      return { conversations: updated };
-    }),
-
-  updateConversationStarred: (conversationId, starred) =>
-    set((state) => {
-      const updated = state.conversations.map((c) =>
-        c.id === conversationId ? { ...c, is_starred: starred } : c,
-      );
-      chatDb.saveConversations(updated);
-      return { conversations: updated };
-    }),
 }));

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -17,8 +17,5 @@
     "expo-env.d.ts",
     "src/uniwind-types.d.ts"
   ],
-  "exclude": [
-    "src/**/*.test.ts",
-    "vitest.config.ts"
-  ]
+  "exclude": ["src/**/*.test.ts", "vitest.config.ts"]
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -16,5 +16,9 @@
     ".expo/types/**/*.ts",
     "expo-env.d.ts",
     "src/uniwind-types.d.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "vitest.config.ts"
   ]
 }

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    globals: true,
+    testTimeout: 10000,
+  },
+  resolve: {
+    alias: {
+      "@/": path.resolve(__dirname, "src") + "/",
+      "@icons": path.resolve(__dirname, "src/lib/gaia-icons.tsx"),
+    },
+  },
+});

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@/": path.resolve(__dirname, "src") + "/",
+      "@/": `${path.resolve(__dirname, "src")}/`,
       "@icons": path.resolve(__dirname, "src/lib/gaia-icons.tsx"),
     },
   },

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -344,7 +344,14 @@ const config: KnipConfig = {
 
     // ── Mobile App ───────────────────────────────────────────────────
     "apps/mobile": {
-      entry: ["metro.config.js", "src/**/*.{ts,tsx}", "app/**/*.{ts,tsx}"],
+      entry: [
+        "metro.config.js",
+        "vitest.config.ts",
+        "src/**/*.{ts,tsx}",
+        "app/**/*.{ts,tsx}",
+      ],
+      // Tests are not live references — see apps/bots note.
+      project: ["**/*.{ts,tsx}", "!src/**/*.test.ts"],
       ignoreDependencies: [
         "metro-minify-terser",
         // Metro/Expo build config deps (used in metro.config.js / app.json).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.101.0)(terser@5.49.0)(tsx@4.23.11)(yaml@2.9.0))
 
   apps/web:
     dependencies:


### PR DESCRIPTION
## Summary

Mobile chat fixes in three areas, driven by a web-vs-mobile parity audit (full gap list in `.agents/plans/mobile-chat-ui-parity.md` on the branch):

### Streaming correctness (`use-chat.ts`, `chat-stream.ts`, `sse-client.ts`)
- **Single-settle turn finalization** — every terminal path (done / error / user-cancel) funnels through one guard; only the first wins. Kills the abort→onClose→onDone race that persisted half-finished responses as complete ones.
- **Errors keep the streamed text** — previously `onError` overwrote the whole answer with "Sorry, I encountered an error". Now it sets `message.error`; the partial response stays visible.
- **Failed-response UI + Retry** — "Response was cut short" strip (with partial text) or full error bubble (without), mirroring web's `FailedResponse`. `retryLastMessage()` re-sends with the original options.
- **45s stall watchdog** in the SSE client (keepalives count as life) instead of an eternal spinner.
- **Auto-follow scroll on every content change**, throttled, paused when the user scrolls up. Previously only fired when message *count* changed — tokens grew the bubble without scrolling.

### Markdown rendering parity
Replaces the gaps in the hand-rolled parser (web uses Streamdown):
- GFM **tables** with alignment, **nested lists** (recursive block parsing), **task lists**, **real ordered numbering** (`3.` `4.` no longer restart at 1), **hard line breaks**, HTML entity decoding, markdown images, `>` blockquotes without trailing space
- **Streaming repair**: unclosed fences/math fences/dangling inline markers get closed mid-stream so raw markers never flash
- Blinking streaming caret; heading sizes tuned for chat-bubble context

### Conversation sync
Root cause of "chats not syncing": conversations lived in two stores — the sidebar read React Query's cache while mutations wrote to a Zustand slice nothing read. 
- Removed the dead `conversations` state from the store; query cache (+ AsyncStorage seed) is now the single source of truth
- Stale windows 5min/2min → 15s so revisiting a conversation revalidates against the API
- Refetch conversations + messages when the app returns to foreground

## Verification

- ✅ `tsc --noEmit` and `biome check` clean across `apps/mobile`
- ✅ Parser logic smoke-tested in isolation: tables/nested lists/tasks/breaks/entities/streaming-repair confirmed against real inputs
- ❌ Not yet verified on device/simulator against the live backend — streaming feel, FlashList scroll-follow, and keyboard behavior need a manual pass on a real build