### PR TITLE
fix(web): canvas.md viewer hit double /api/v1 prefix and always 404'd

### DIFF
--- a/apps/web/src/__tests__/todo-canvas-url.test.ts
+++ b/apps/web/src/__tests__/todo-canvas-url.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test for the tracked-todo canvas viewer.
+ *
+ * CanvasViewer hardcoded `/api/v1/todos/<id>/canvas`, but the axios baseURL
+ * already ends in `/api/v1/`, so every open hit `/api/v1/api/v1/todos/...`
+ * and 404'd. The URL now lives in the shared `TODO_ENDPOINTS` map (unprefixed,
+ * like every other todo endpoint); these assertions fail if a version prefix
+ * ever sneaks back into it or if the fetch drifts off the shared constant.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api/service", () => ({
+  apiService: { get: vi.fn().mockResolvedValue({ content: "# canvas" }) },
+}));
+
+import { TODO_ENDPOINTS } from "@shared/api/todosApi";
+import { getTodoCanvas } from "@/features/todo/api/todoApi";
+import { apiService } from "@/lib/api/service";
+
+describe("todo canvas endpoint", () => {
+  it("builds an unprefixed path like every other todo endpoint", () => {
+    expect(TODO_ENDPOINTS.canvas("todo-1")).toBe("/todos/todo-1/canvas");
+    expect(TODO_ENDPOINTS.canvas("todo-1")).not.toContain("/api/");
+  });
+});
+
+describe("getTodoCanvas", () => {
+  beforeEach(() => {
+    vi.mocked(apiService.get).mockClear();
+  });
+
+  it("fetches via the shared endpoint map with silent toasts", async () => {
+    await getTodoCanvas("todo-1");
+    expect(apiService.get).toHaveBeenCalledWith("/todos/todo-1/canvas", {
+      silent: true,
+    });
+  });
+
+  it("returns the canvas content", async () => {
+    const res = await getTodoCanvas("todo-1");
+    expect(res.content).toBe("# canvas");
+  });
+});

--- a/apps/web/src/features/todo/api/todoApi.ts
+++ b/apps/web/src/features/todo/api/todoApi.ts
@@ -1,3 +1,4 @@
+import { TODO_ENDPOINTS } from "@shared/api/todosApi";
 import { createTodoApi, type HttpAdapter } from "@shared/todos";
 import { apiService } from "@/lib/api/service";
 
@@ -10,3 +11,10 @@ const httpAdapter: HttpAdapter = {
 };
 
 export const todoApi = createTodoApi(httpAdapter);
+
+export const getTodoCanvas = async (
+  todoId: string,
+): Promise<{ content: string }> =>
+  apiService.get<{ content: string }>(TODO_ENDPOINTS.canvas(todoId), {
+    silent: true,
+  });

--- a/apps/web/src/features/todo/components/CanvasViewer.tsx
+++ b/apps/web/src/features/todo/components/CanvasViewer.tsx
@@ -5,7 +5,7 @@ import { CanvasIcon } from "@icons";
 import type React from "react";
 import { useState } from "react";
 import MarkdownViewerModal from "@/components/common/MarkdownViewerModal";
-import { apiService } from "@/lib/api/service";
+import { getTodoCanvas } from "@/features/todo/api/todoApi";
 
 interface CanvasViewerProps {
   todoId: string;
@@ -26,10 +26,7 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ todoId, todoTitle }) => {
     setIsLoading(true);
     setHasError(false);
     try {
-      const res = await apiService.get<{ content: string }>(
-        `/api/v1/todos/${todoId}/canvas`,
-        { silent: true },
-      );
+      const res = await getTodoCanvas(todoId);
       setContent(res.content);
     } catch {
       setHasError(true);

--- a/libs/shared/ts/src/api/todosApi.ts
+++ b/libs/shared/ts/src/api/todosApi.ts
@@ -18,6 +18,7 @@ export const TODO_ENDPOINTS = {
   bulkPriority: "/todos/bulk/priority",
   bulkProject: "/todos/bulk/project",
   labels: "/todos/labels",
+  canvas: (todoId: string) => `/todos/${todoId}/canvas`,
   subtasks: (todoId: string) => `/todos/${todoId}/subtasks`,
   subtask: (todoId: string, subtaskId: string) =>
     `/todos/${todoId}/subtasks/${subtaskId}`,


### PR DESCRIPTION
## Summary

Opening `canvas.md` from the tracked-todos sidebar now works: the viewer was building its request URL with a hardcoded `/api/v1` prefix that the API base URL already includes, so every open 404'd. The URL now comes from the shared todo endpoint map, like every other todo call.

## Why

A tracked todo's canvas (its working notes) was completely unreachable from the UI — clicking the canvas.md row always landed on the error state.

## What changed

### Web
- `CanvasViewer` fetches through a new `getTodoCanvas` helper in the todo feature's API layer instead of an inline URL.
- The helper uses `TODO_ENDPOINTS.canvas(todoId)` from the shared endpoint map (unprefixed, matching every other todo endpoint — the axios base URL already carries `/api/v1/`).

### Shared TS
- Added `canvas: (todoId) => /todos/${todoId}/canvas` to `TODO_ENDPOINTS`.

---

## The bug

**Symptom** — Clicking canvas.md in the tracked-todos sidebar showed "Couldn't load canvas.md. Close and reopen to try again." The network tab showed a request to `/api/v1/api/v1/todos/<id>/canvas` returning 404.

**Reproduce** — Open a gaia-tracked todo (one with `vfs_path`) on master, click the canvas.md row. Fails every time; the backend route (`GET /todos/{todo_id}/canvas`) itself is healthy.

**Root cause** — `CanvasViewer.tsx` hardcoded `` `/api/v1/todos/${todoId}/canvas` `` while `NEXT_PUBLIC_API_BASE_URL` already ends in `/api/v1/`, producing a doubled prefix. Inferred from the code plus the observed request path; not reproduced against master in a live browser before the fix.

**The fix** — Single source of truth: the endpoint lives in the shared `TODO_ENDPOINTS` map alongside all other todo endpoints, so the version-prefix convention can't drift per call site again.

**Regression test** — `apps/web/src/__tests__/todo-canvas-url.test.ts` pins the unprefixed URL and asserts the fetch goes through the shared constant. Mutation-checked: re-introducing the prefix makes it fail.

**Why the suite missed it** — Nothing covered CanvasViewer at all; the component fetched inline with no testable seam.

---

## Screenshots

After fix, live stack (`mise dev --sim`, real API + Mongo): clicking canvas.md opens the modal rendering the stored markdown.

![canvas.md viewer rendering content](https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/1078-canvas-md-viewer/canvas-after.png)

## How to verify

1. Boot the stack with dev auth bypass (`mise dev --sim`) and seed a user.
2. Create a tracked todo (one with `vfs_path` set).
3. Open Tasks, select the tracked todo, click canvas.md.
4. Expect the modal to render the markdown content, not the error message.
5. Check the network tab: exactly one `/api/v1/todos/<id>/canvas` request, 200.

## Risk

Tiny blast radius: one fetch URL in one component. Worst case is the pre-fix behavior (error state on open); no data is written.

## Related

Fixes the tracked-todos canvas access blocker reported as P0.