### PR TITLE
fix(payments): accept Dodo payment webhooks whose tax and method are null

### DIFF
--- a/apps/api/app/models/webhook_models.py
+++ b/apps/api/app/models/webhook_models.py
@@ -61,10 +61,14 @@ class DodoPaymentData(BaseModel):
     total_amount: int
     settlement_amount: int
     settlement_currency: str
-    tax: int
-    settlement_tax: int
+    # Null whenever the payment never settled or no method was captured — a declined
+    # authorization or an abandoned checkout arrives with all three unset. Modelling
+    # them as required rejected those payloads, and since the endpoint answers 200 by
+    # design the event was acked and lost rather than retried.
+    tax: int | None = None
+    settlement_tax: int | None = None
     status: str
-    payment_method: str
+    payment_method: str | None = None
     card_network: str | None = None
     card_type: str | None = None
     card_last_four: str | None = None

--- a/apps/api/app/scripts/delete_user_account.py
+++ b/apps/api/app/scripts/delete_user_account.py
@@ -135,7 +135,7 @@ def _pg_inventory(conn: psycopg.Connection[Any], uid: str) -> dict[str, int]:
 def _chroma_inventory(client: chromadb.api.ClientAPI, uid: str) -> dict[str, int]:
     counts: dict[str, int] = {}
     for col in client.list_collections():
-        name = col if isinstance(col, str) else col.name
+        name = col.name
         got = client.get_collection(name).get(where={"user_id": uid}, limit=200_000, include=[])
         n = len(got.get("ids") or [])
         if n:

--- a/apps/api/tests/unit/scripts/test_delete_user_account.py
+++ b/apps/api/tests/unit/scripts/test_delete_user_account.py
@@ -1,0 +1,79 @@
+"""Inventory helpers for the operational account-deletion script.
+
+The script is the GDPR/erasure path, so its inventory is what tells an operator
+whether anything of the user's survived. A collection silently skipped here reads
+as "nothing left to delete" — the one failure this file exists to catch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.scripts.delete_user_account import _chroma_inventory
+
+UID = "67689b80006f6eec3f6f6df8"
+
+
+class FakeCollection:
+    """A chroma collection whose `.get()` records the filter it was called with."""
+
+    def __init__(self, name: str, ids: list[str]) -> None:
+        self.name = name
+        self._ids = ids
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"ids": list(self._ids)}
+
+
+class FakeClient:
+    def __init__(self, collections: list[FakeCollection]) -> None:
+        self._collections = {c.name: c for c in collections}
+
+    def list_collections(self) -> list[FakeCollection]:
+        return list(self._collections.values())
+
+    def get_collection(self, name: str) -> FakeCollection:
+        return self._collections[name]
+
+
+@pytest.mark.unit
+class TestChromaInventory:
+    def test_counts_each_collections_matching_vectors(self) -> None:
+        client = FakeClient(
+            [
+                FakeCollection("memories", ["a", "b", "c"]),
+                FakeCollection("conversations", ["d"]),
+            ]
+        )
+
+        assert _chroma_inventory(client, UID) == {"memories": 3, "conversations": 1}
+
+    def test_collections_holding_nothing_are_left_out(self) -> None:
+        """The inventory is a remnant report: a zero would read as a surviving
+        collection an operator then goes looking for."""
+        client = FakeClient([FakeCollection("memories", ["a"]), FakeCollection("empty", [])])
+
+        assert _chroma_inventory(client, UID) == {"memories": 1}
+
+    def test_every_collection_is_filtered_to_this_user(self) -> None:
+        """The filter is the whole safety story — an unfiltered read would report
+        (and the delete pass would then act on) other people's vectors."""
+        memories = FakeCollection("memories", ["a"])
+        client = FakeClient([memories])
+
+        _chroma_inventory(client, UID)
+
+        assert memories.calls[0]["where"] == {"user_id": UID}
+
+    def test_a_collection_with_no_ids_key_counts_as_empty(self) -> None:
+        """chroma omits `ids` rather than returning an empty list on some backends."""
+
+        class NoIds(FakeCollection):
+            def get(self, **kwargs: Any) -> dict[str, Any]:
+                return {}
+
+        assert _chroma_inventory(FakeClient([NoIds("memories", [])]), UID) == {}

--- a/apps/api/tests/unit/services/test_payment_service.py
+++ b/apps/api/tests/unit/services/test_payment_service.py
@@ -1313,6 +1313,33 @@ class TestHandlePaymentSucceeded:
 class TestHandlePaymentFailed:
     """Tests for _handle_payment_failed."""
 
+    async def test_processes_a_failure_whose_tax_and_method_are_null(
+        self,
+        webhook_service,
+        mock_processed_webhook_repository,
+        mock_webhook_users_collection,
+        mock_track_payment,
+    ):
+        """Regression: Dodo sends null tax/settlement_tax/payment_method when a payment
+        fails before anything settles or a method is captured. Modelling them as
+        required int/str rejected the payload, and because the endpoint answers 200 the
+        event was acked and dropped with no retry — the failed payment was never
+        tracked."""
+        payload = {
+            **PAYMENT_DATA_PAYLOAD,
+            "status": "failed",
+            "tax": None,
+            "settlement_tax": None,
+            "payment_method": None,
+        }
+        event_data = _make_webhook_event("payment.failed", payload)
+
+        result = await webhook_service.process_webhook(event_data, "wh_fail_null")
+
+        assert result.status == "processed"
+        assert result.payment_id == "pay_001"
+        mock_track_payment.assert_called_once()
+
     async def test_processes_payment_failure(
         self,
         webhook_service,


### PR DESCRIPTION
## The bug

Dodo sends `tax`, `settlement_tax` and `payment_method` as `null` when a payment
never settles and no method is captured — a declined authorization or an abandoned
checkout. `DodoPaymentData` modelled all three as required `int`/`str`, so Pydantic
rejected the payload:

```
[PAYMENT] Dodo payment webhook payload did not validate
3 validation errors for DodoPaymentData
tax             Input should be a valid integer  [input_value=None]
settlement_tax  Input should be a valid integer  [input_value=None]
payment_method  Input should be a valid string   [input_value=None]
```

Seen in production on `api.heygaia.io`, immediately after a **successful** signature
verification — so this is a genuine Dodo webhook we reject.

## Why it matters — the event is acked and lost

The failure is silent by construction:

1. `get_payment_data` logs and returns `None`.
2. Each handler turns that into `ValueError("Invalid payment data")`.
3. `process_webhook` catches it and returns `status="failed"`.
4. The endpoint answers **HTTP 200** — deliberate, so Dodo's retry policy follows the
   processing result rather than a request rejection.

Net effect: Dodo sees a 200 and **never retries**, `_mark_webhook_as_processed` is
never reached, and the event is dropped. No failure analytics, no dunning signal, and
a single ERROR line as the only evidence. Recovery is manual.

## The fix

Make the three fields `| None = None`. **None of them is read anywhere in the
codebase** (`grep` for `.tax` / `settlement_tax` / `payment_method` across
`apps/api/app` returns only their own declarations) — they were required but unused,
so their strictness bought nothing and cost us dropped webhooks. Every genuinely
nullable neighbour (`card_network`, `card_last_four`, `subscription_id`, …) was
already modelled this way; these three were the outliers.

## Test

`test_processes_a_failure_whose_tax_and_method_are_null` drives a `payment.failed`
event with all three null through `process_webhook`.

**Watched it fail first**, reproducing the exact production log line:

```
E  AssertionError: assert 'failed' == 'processed'
   [PAYMENT] Dodo payment webhook payload did not validate  (webhook_models.py:124)
```

Then green: `88 passed`.

The gap this closes: `PAYMENT_DATA_PAYLOAD` is a single fully-populated fixture reused
for *every* payment event type including `payment.failed`, so the real shape of a
failed payment was never exercised. `test_invalid_payment_data_raises` covers a
wholly-missing payload (`{"incomplete": True}`), not present-but-null fields.

## CI

The pre-existing `python-mypy` failure on `master` (an unrelated `[unreachable]`
error in `app/scripts/delete_user_account.py`, merged red in #1081) is **folded into
this PR** as two cherry-picked commits — the one-line fix plus the tests the mutation
gate requires for that module — so this PR is green standalone. The same commits ride
on the sibling PR; whichever merges first makes the other's copy a no-op.
