### PR TITLE
fix(ci): master deploys silently skipped since the two-phase build refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -560,7 +560,14 @@ jobs:
   # Trigger backend production deploy only when deploy plan allows it.
   trigger-deploy:
     needs: [deployment-plan]
-    if: inputs.phase != 'build' && needs.deployment-plan.outputs.backend_deploy == 'true'
+    # `!cancelled()` for the same reason deployment-plan carries `always()`:
+    # in phase=deploy the docker lanes are skipped BY DESIGN, and a job whose
+    # `if` has no status function gets an implicit success() that fails on any
+    # skipped ancestor in the transitive needs chain — so the deploy silently
+    # skipped on every master push while the plan said backend_deploy=true
+    # (observed: prod stranded three merges behind with green pipelines). The
+    # explicit result check restores the only gating success() provided here.
+    if: ${{ !cancelled() && inputs.phase != 'build' && needs.deployment-plan.result == 'success' && needs.deployment-plan.outputs.backend_deploy == 'true' }}
     uses: ./.github/workflows/deploy-swarm-prod.yml
     with:
       action: deploy


### PR DESCRIPTION
## Summary

Production deploys from master have been silently broken since the two-phase build refactor (#1064): every merge publishes gated images that never ship. One `if:` guard fixes it. Until this merges, production remains on Friday's code (`2608.22.a7f4a13`) — three merges behind, including the trigger-batching fix (#1082).

## The bug

**Symptom** — after #1064, every master push ends fully green, `deployment-plan` prints `Deploy plan => backend: true`, and `trigger-deploy` is `skipped`. Production never receives the new image.

**Root cause** — in `phase=deploy` the docker lanes are skipped by design (they ran in `phase=build`). `deployment-plan` carries `always()` precisely to survive that — its comment documents the pre-`always()` failure mode. But `trigger-deploy`, one hop downstream, has no status function in its `if:`, so it gets the implicit `success()` — which fails when **any ancestor in the transitive needs chain** was skipped, not just direct needs. The skipped docker lanes propagate through the successful `deployment-plan` and kill the deploy every time (`.github/workflows/build.yml:563`).

**Why nothing alerted** — the `notify-publish-without-deploy` orphan detector fires only when `backend_orphaned == 'true'`, which the plan sets only when `backend_deploy` is **false**. This bug only occurs when `backend_deploy` is true — the one case the detector structurally cannot see.

**Fix** — `!cancelled()` disables the implicit gate (without deploying after a cancellation); an explicit `needs.deployment-plan.result == 'success'` restores the only protection the implicit check actually provided.

**Reproduction** — any master push since #1064: run 32654127358 shows `trigger-build / deployment-plan → success` with `backend_deploy=true` in its log, and `trigger-build / trigger-deploy → skipped`, both invocation phases. Affected merges: a4d138100, f911fd7f6, 1cf2295de.

No regression test: workflow-graph semantics aren't exercisable in the repo's test tiers; verification is the first post-merge master push actually deploying (see below).

## How to verify

Merge, let the master pipeline run, and confirm `trigger-build / trigger-deploy` executes (not skipped) and gaia-prod's backend image flips to the new commit's tag. The merge commit of this PR is itself the test — and shipping it also finally deploys #1082.

## Risk

The guard only widens when the deploy runs; every substantive condition (`phase`, plan success, `backend_deploy`) is retained explicitly. Worst case is the prior behavior. Cancelled pipelines still never deploy (`!cancelled()`).
