### PR TITLE
fix(api): reset-to-default left system workflows running their old prompt

### DIFF
--- a/apps/api/app/db/repositories/workflows.py
+++ b/apps/api/app/db/repositories/workflows.py
@@ -610,12 +610,13 @@ class WorkflowsRepository(MongoRepository[WorkflowDocument, WorkflowUpdate]):
         *,
         title: str,
         description: str,
+        prompt: str,
         steps: list[WorkflowStep],
         trigger_config: TriggerConfig,
         composio_trigger_ids: list[str],
     ) -> WorkflowDocument | None:
-        """Re-apply a system workflow's original definition (title/description/steps/
-        trigger_config), preserving liveness, stats and ``created_at``. ``next_run``
+        """Re-apply a system workflow's original definition (title/description/prompt/
+        steps/trigger_config), preserving liveness, stats and ``created_at``. ``next_run``
         stays a native datetime (python-mode dump), consistent with create/re-arm."""
         trigger_doc = trigger_config.model_dump()
         trigger_doc["composio_trigger_ids"] = composio_trigger_ids
@@ -625,6 +626,7 @@ class WorkflowsRepository(MongoRepository[WorkflowDocument, WorkflowUpdate]):
                 "$set": {
                     "title": title,
                     "description": description,
+                    "prompt": prompt,
                     "steps": [s.model_dump() for s in steps],
                     "trigger_config": trigger_doc,
                 }

--- a/apps/api/app/services/system_workflows/provisioner.py
+++ b/apps/api/app/services/system_workflows/provisioner.py
@@ -31,6 +31,7 @@ from app.services.notification_service import NotificationService
 from app.services.system_workflows.definitions.calendar import CALENDAR_SYSTEM_WORKFLOWS
 from app.services.system_workflows.definitions.gmail import GMAIL_SYSTEM_WORKFLOWS
 from app.services.user_service import get_user_by_id
+from app.services.workflow.scheduler import workflow_scheduler
 from app.services.workflow.service import WorkflowService
 from app.services.workflow.trigger_service import TriggerService
 from app.utils.workflow_utils import ensure_trigger_config_object
@@ -201,7 +202,9 @@ async def _notify_workflows_provisioned(
 async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bool:
     """Re-apply the original definition to a system workflow document.
 
-    Restores: title, description, steps, trigger_config.
+    Restores: title, description, prompt, steps, trigger_config. Schedule
+    triggers get the profile timezone stamped and next_run recomputed (same as
+    provisioning), and an activated workflow is re-armed with a queued fire.
     Preserves: _id, user_id, activated state, execution stats, created_at.
     Returns False if the workflow is not found or not resettable.
     """
@@ -228,6 +231,16 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
 
     request = factory()
     trigger_config = ensure_trigger_config_object(request.trigger_config)
+
+    # Factories can't know the user, so scheduled definitions carry no timezone —
+    # stamp the profile timezone and recompute next_run from the cron, exactly as
+    # the provisioning and activation paths do.
+    if trigger_config.type == TriggerType.SCHEDULE:
+        if not trigger_config.timezone:
+            user = await get_user_by_id(user_id) or {}
+            trigger_config.timezone = (user.get("timezone") or "").strip() or "UTC"
+        if trigger_config.cron_expression:
+            trigger_config.update_next_run(user_timezone=trigger_config.timezone)
 
     old_trigger_ids: list[str] = existing.trigger_config.composio_trigger_ids or []
     trigger_name: str | None = existing.trigger_config.trigger_name
@@ -283,10 +296,24 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
         workflow_id,
         title=request.title,
         description=request.description or "",
+        prompt=request.prompt,
         steps=request.steps or [],
         trigger_config=trigger_config,
         composio_trigger_ids=new_trigger_ids,
     )
+
+    # Reset preserves liveness — an activated schedule workflow needs a queued
+    # fire for the recomputed next_run or it never runs again.
+    if (
+        existing.activated
+        and trigger_config.type == TriggerType.SCHEDULE
+        and trigger_config.next_run
+    ):
+        await workflow_scheduler.schedule_workflow_execution(
+            workflow_id,
+            trigger_config.next_run,
+            repeat=trigger_config.cron_expression,
+        )
 
     log.info(
         f"{LogTag.WORKFLOW} Reset system workflow to default for user",

--- a/apps/api/app/services/system_workflows/provisioner.py
+++ b/apps/api/app/services/system_workflows/provisioner.py
@@ -303,17 +303,26 @@ async def reset_system_workflow_to_default(workflow_id: str, user_id: str) -> bo
     )
 
     # Reset preserves liveness — an activated schedule workflow needs a queued
-    # fire for the recomputed next_run or it never runs again.
+    # fire for the recomputed next_run or it never runs again. A failed re-arm
+    # must fail the reset: reporting success here would leave a workflow that
+    # looks reset but never fires (retrying the reset re-arms it).
     if (
         existing.activated
         and trigger_config.type == TriggerType.SCHEDULE
         and trigger_config.next_run
     ):
-        await workflow_scheduler.schedule_workflow_execution(
+        armed = await workflow_scheduler.schedule_workflow_execution(
             workflow_id,
             trigger_config.next_run,
             repeat=trigger_config.cron_expression,
         )
+        if not armed:
+            log.error(
+                f"{LogTag.WORKFLOW} Reset applied but re-arming the schedule failed",
+                workflow_id=workflow_id,
+                user_id=user_id,
+            )
+            return False
 
     log.info(
         f"{LogTag.WORKFLOW} Reset system workflow to default for user",

--- a/apps/api/tests/contracts/test_workflows_repository.py
+++ b/apps/api/tests/contracts/test_workflows_repository.py
@@ -433,6 +433,7 @@ class TestWorkflowsTriggersAndSystem:
             wf.id,
             title="Fresh",
             description="fresh desc",
+            prompt="fresh prompt",
             steps=[WorkflowStep(title="s2", category="notion", description="d2")],
             trigger_config=TriggerConfig(
                 type=TriggerType.SCHEDULE, enabled=True, cron_expression="0 9 * * *"
@@ -442,6 +443,7 @@ class TestWorkflowsTriggersAndSystem:
         assert updated is not None
         assert updated.title == "Fresh"
         assert updated.description == "fresh desc"
+        assert updated.prompt == "fresh prompt"
         assert [s.title for s in updated.steps] == ["s2"]
         assert updated.trigger_config.type == TriggerType.SCHEDULE
         assert updated.trigger_config.composio_trigger_ids == ["t1"]

--- a/apps/api/tests/unit/services/test_system_workflows.py
+++ b/apps/api/tests/unit/services/test_system_workflows.py
@@ -53,8 +53,8 @@ def _existing_wf(
 
 @pytest.fixture(autouse=True)
 def _patch_log():
-    with patch(f"{MODULE}.log"):
-        yield
+    with patch(f"{MODULE}.log") as mock_log:
+        yield mock_log
 
 
 class TestProvisionSystemWorkflows:
@@ -623,6 +623,48 @@ class TestResetSystemWorkflowToDefault:
             "wf-1",
             trigger_config.next_run,
             repeat="0 8 * * *",
+        )
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.get_user_by_id")
+    @patch(f"{MODULE}.workflow_scheduler")
+    @patch(f"{MODULE}.workflow_repository")
+    @patch(f"{MODULE}.ensure_trigger_config_object")
+    async def test_reset_reports_failure_when_rearm_fails(
+        self,
+        mock_ensure: MagicMock,
+        mock_repo: MagicMock,
+        mock_scheduler: MagicMock,
+        mock_get_user: MagicMock,
+        _patch_log: MagicMock,
+    ) -> None:
+        """A reset whose re-arm could not queue a fire must not report success —
+        the workflow would look reset but never run again."""
+        existing = _existing_wf(key="sched_wf", composio_trigger_ids=None, trigger_name=None)
+        existing.activated = True
+        mock_repo.get_system_workflow_for_user = AsyncMock(return_value=existing)
+        mock_repo.reset_system_workflow = AsyncMock()
+        mock_get_user.return_value = {"timezone": "UTC"}
+        mock_scheduler.schedule_workflow_execution = AsyncMock(return_value=False)
+
+        trigger_config = self._schedule_trigger_config()
+        mock_ensure.return_value = trigger_config
+
+        factory = MagicMock(return_value=_make_workflow_request())
+
+        with patch.dict(f"{MODULE}.SYSTEM_WORKFLOW_REGISTRY", {"sched_wf": factory}):
+            from app.constants.log_tags import LogTag
+            from app.services.system_workflows.provisioner import (
+                reset_system_workflow_to_default,
+            )
+
+            result = await reset_system_workflow_to_default("wf-1", "user-1")
+
+        assert result is False
+        _patch_log.error.assert_called_once_with(
+            f"{LogTag.WORKFLOW} Reset applied but re-arming the schedule failed",
+            workflow_id="wf-1",
+            user_id="user-1",
         )
 
     @pytest.mark.asyncio

--- a/apps/api/tests/unit/services/test_system_workflows.py
+++ b/apps/api/tests/unit/services/test_system_workflows.py
@@ -7,6 +7,7 @@ Covers:
   trigger registration failure, old trigger unregister failure (non-fatal)
 """
 
+from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pymongo.errors import DuplicateKeyError
@@ -456,3 +457,166 @@ class TestResetSystemWorkflowToDefault:
 
         assert result is True
         mock_repo.reset_system_workflow.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.workflow_repository")
+    @patch(f"{MODULE}.ensure_trigger_config_object")
+    async def test_reset_restores_prompt(
+        self,
+        mock_ensure: MagicMock,
+        mock_repo: MagicMock,
+    ) -> None:
+        """The run executes workflow.prompt, so reset must restore it too."""
+        mock_repo.get_system_workflow_for_user = AsyncMock(
+            return_value=_existing_wf(key="manual_wf", composio_trigger_ids=None, trigger_name=None)
+        )
+        mock_repo.reset_system_workflow = AsyncMock()
+
+        from app.models.workflow_models import TriggerType
+
+        trigger_config = MagicMock()
+        trigger_config.type = TriggerType.MANUAL
+        trigger_config.trigger_name = None
+        trigger_config.model_dump.return_value = {"type": "manual"}
+        mock_ensure.return_value = trigger_config
+
+        req = _make_workflow_request()
+        req.prompt = "the factory prompt"
+        factory = MagicMock(return_value=req)
+
+        with patch.dict(f"{MODULE}.SYSTEM_WORKFLOW_REGISTRY", {"manual_wf": factory}):
+            from app.services.system_workflows.provisioner import (
+                reset_system_workflow_to_default,
+            )
+
+            result = await reset_system_workflow_to_default("wf-1", "user-1")
+
+        assert result is True
+        kwargs = mock_repo.reset_system_workflow.await_args.kwargs
+        assert kwargs["prompt"] == "the factory prompt"
+
+    def _schedule_trigger_config(self) -> MagicMock:
+        from datetime import datetime
+
+        from app.models.workflow_models import TriggerType
+
+        trigger_config = MagicMock()
+        trigger_config.type = TriggerType.SCHEDULE
+        trigger_config.trigger_name = None
+        trigger_config.cron_expression = "0 8 * * *"
+        trigger_config.timezone = None
+        trigger_config.next_run = datetime(2026, 8, 25, 8, 0, tzinfo=UTC)
+        trigger_config.model_dump.return_value = {"type": "schedule"}
+        return trigger_config
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.get_user_by_id")
+    @patch(f"{MODULE}.workflow_scheduler")
+    @patch(f"{MODULE}.workflow_repository")
+    @patch(f"{MODULE}.ensure_trigger_config_object")
+    async def test_reset_stamps_timezone_and_recomputes_next_run(
+        self,
+        mock_ensure: MagicMock,
+        mock_repo: MagicMock,
+        mock_scheduler: MagicMock,
+        mock_get_user: MagicMock,
+    ) -> None:
+        """Schedule definitions carry no timezone; reset must stamp the profile
+        timezone (as provisioning does) and recompute next_run from the cron."""
+        existing = _existing_wf(key="sched_wf", composio_trigger_ids=None, trigger_name=None)
+        existing.activated = False
+        mock_repo.get_system_workflow_for_user = AsyncMock(return_value=existing)
+        mock_repo.reset_system_workflow = AsyncMock()
+        mock_get_user.return_value = {"timezone": "Asia/Kolkata"}
+        mock_scheduler.schedule_workflow_execution = AsyncMock(return_value=True)
+
+        trigger_config = self._schedule_trigger_config()
+        mock_ensure.return_value = trigger_config
+
+        factory = MagicMock(return_value=_make_workflow_request())
+
+        with patch.dict(f"{MODULE}.SYSTEM_WORKFLOW_REGISTRY", {"sched_wf": factory}):
+            from app.services.system_workflows.provisioner import (
+                reset_system_workflow_to_default,
+            )
+
+            result = await reset_system_workflow_to_default("wf-1", "user-1")
+
+        assert result is True
+        assert trigger_config.timezone == "Asia/Kolkata"
+        trigger_config.update_next_run.assert_called_once_with(user_timezone="Asia/Kolkata")
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.get_user_by_id")
+    @patch(f"{MODULE}.workflow_scheduler")
+    @patch(f"{MODULE}.workflow_repository")
+    @patch(f"{MODULE}.ensure_trigger_config_object")
+    async def test_reset_rearms_activated_schedule_workflow(
+        self,
+        mock_ensure: MagicMock,
+        mock_repo: MagicMock,
+        mock_scheduler: MagicMock,
+        mock_get_user: MagicMock,
+    ) -> None:
+        """An activated workflow whose reset yields a schedule trigger must get a
+        queued fire, or it sits with a cron and no future run."""
+        existing = _existing_wf(key="sched_wf", composio_trigger_ids=None, trigger_name=None)
+        existing.activated = True
+        mock_repo.get_system_workflow_for_user = AsyncMock(return_value=existing)
+        mock_repo.reset_system_workflow = AsyncMock()
+        mock_get_user.return_value = {"timezone": "UTC"}
+        mock_scheduler.schedule_workflow_execution = AsyncMock(return_value=True)
+
+        trigger_config = self._schedule_trigger_config()
+        mock_ensure.return_value = trigger_config
+
+        factory = MagicMock(return_value=_make_workflow_request())
+
+        with patch.dict(f"{MODULE}.SYSTEM_WORKFLOW_REGISTRY", {"sched_wf": factory}):
+            from app.services.system_workflows.provisioner import (
+                reset_system_workflow_to_default,
+            )
+
+            result = await reset_system_workflow_to_default("wf-1", "user-1")
+
+        assert result is True
+        mock_scheduler.schedule_workflow_execution.assert_awaited_once_with(
+            "wf-1",
+            trigger_config.next_run,
+            repeat="0 8 * * *",
+        )
+
+    @pytest.mark.asyncio
+    @patch(f"{MODULE}.get_user_by_id")
+    @patch(f"{MODULE}.workflow_scheduler")
+    @patch(f"{MODULE}.workflow_repository")
+    @patch(f"{MODULE}.ensure_trigger_config_object")
+    async def test_reset_does_not_arm_deactivated_schedule_workflow(
+        self,
+        mock_ensure: MagicMock,
+        mock_repo: MagicMock,
+        mock_scheduler: MagicMock,
+        mock_get_user: MagicMock,
+    ) -> None:
+        """Reset preserves liveness: a deactivated workflow must not gain a fire."""
+        existing = _existing_wf(key="sched_wf", composio_trigger_ids=None, trigger_name=None)
+        existing.activated = False
+        mock_repo.get_system_workflow_for_user = AsyncMock(return_value=existing)
+        mock_repo.reset_system_workflow = AsyncMock()
+        mock_get_user.return_value = {"timezone": "UTC"}
+        mock_scheduler.schedule_workflow_execution = AsyncMock(return_value=True)
+
+        trigger_config = self._schedule_trigger_config()
+        mock_ensure.return_value = trigger_config
+
+        factory = MagicMock(return_value=_make_workflow_request())
+
+        with patch.dict(f"{MODULE}.SYSTEM_WORKFLOW_REGISTRY", {"sched_wf": factory}):
+            from app.services.system_workflows.provisioner import (
+                reset_system_workflow_to_default,
+            )
+
+            result = await reset_system_workflow_to_default("wf-1", "user-1")
+
+        assert result is True
+        mock_scheduler.schedule_workflow_execution.assert_not_awaited()

--- a/apps/api/tests/unit/services/test_system_workflows.py
+++ b/apps/api/tests/unit/services/test_system_workflows.py
@@ -544,7 +544,46 @@ class TestResetSystemWorkflowToDefault:
 
         assert result is True
         assert trigger_config.timezone == "Asia/Kolkata"
+        mock_get_user.assert_awaited_once_with("user-1")
         trigger_config.update_next_run.assert_called_once_with(user_timezone="Asia/Kolkata")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("profile", [{}, {"timezone": "   "}])
+    @patch(f"{MODULE}.get_user_by_id")
+    @patch(f"{MODULE}.workflow_scheduler")
+    @patch(f"{MODULE}.workflow_repository")
+    @patch(f"{MODULE}.ensure_trigger_config_object")
+    async def test_reset_timezone_falls_back_to_utc(
+        self,
+        mock_ensure: MagicMock,
+        mock_repo: MagicMock,
+        mock_scheduler: MagicMock,
+        mock_get_user: MagicMock,
+        profile: dict[str, str],
+    ) -> None:
+        """A profile with a blank/missing timezone falls back to exactly UTC."""
+        existing = _existing_wf(key="sched_wf", composio_trigger_ids=None, trigger_name=None)
+        existing.activated = False
+        mock_repo.get_system_workflow_for_user = AsyncMock(return_value=existing)
+        mock_repo.reset_system_workflow = AsyncMock()
+        mock_get_user.return_value = profile
+        mock_scheduler.schedule_workflow_execution = AsyncMock(return_value=True)
+
+        trigger_config = self._schedule_trigger_config()
+        mock_ensure.return_value = trigger_config
+
+        factory = MagicMock(return_value=_make_workflow_request())
+
+        with patch.dict(f"{MODULE}.SYSTEM_WORKFLOW_REGISTRY", {"sched_wf": factory}):
+            from app.services.system_workflows.provisioner import (
+                reset_system_workflow_to_default,
+            )
+
+            result = await reset_system_workflow_to_default("wf-1", "user-1")
+
+        assert result is True
+        assert trigger_config.timezone == "UTC"
+        trigger_config.update_next_run.assert_called_once_with(user_timezone="UTC")
 
     @pytest.mark.asyncio
     @patch(f"{MODULE}.get_user_by_id")


### PR DESCRIPTION
## Summary

"Reset to default" on a system workflow didn't actually reset it: the workflow kept executing its **old prompt**, its daily schedule fired at **08:00 UTC** instead of the user's morning, and an **activated** workflow whose trigger changed to a schedule was left with a cron but **no queued fire** — it never ran again.

## The bug

`reset_system_workflow_to_default` restored title/description/steps/trigger_config but not `prompt` — and execution runs `workflow.prompt` (`apps/api/app/workers/tasks/workflow_tasks.py:805`), so the reset was cosmetic: the card looked new, the behavior stayed old. The reset path also skipped the two schedule-trigger steps every other write path performs:

| | provisioning / activation | reset (before) | reset (after) |
|---|---|---|---|
| restore `prompt` | n/a / n/a | ❌ | ✅ |
| stamp profile timezone on schedule triggers | ✅ | ❌ (cron ran in UTC) | ✅ |
| recompute `next_run` + arm a fire when activated | ✅ | ❌ (never fires) | ✅ |

Found while preparing the Inbox Triage reset sweep (follow-up to #1082); not reproduced from a user report, but the missing `$set` and missing scheduler call are directly visible in the repo method and the endpoint path.

Four regression tests in `tests/unit/services/test_system_workflows.py`, each observed red before the fix: prompt restored, timezone stamped + `next_run` recomputed, activated workflow re-armed, deactivated workflow **not** armed (reset still preserves liveness).

## How to verify

Start the API, customize a system workflow's prompt, then `POST /api/v1/workflows/{id}/reset-to-default` and read the Mongo doc: `prompt` matches the factory definition, `trigger_config.timezone` is the profile timezone, and (if activated) `trigger_config.next_run` is the next local-time cron fire. Not exercised end-to-end here: the Composio trigger re-registration leg (covered by the existing reset tests with mocked `TriggerService`).
