### PR TITLE
fix(api): stop leaking host-side /users/<uid> paths to the LLM

### DIFF
--- a/apps/api/app/agents/tools/coding/_context.py
+++ b/apps/api/app/agents/tools/coding/_context.py
@@ -84,7 +84,7 @@ def canonical_path(path: str, *, session_id: str | None) -> tuple[str, MountRole
         path = posixpath.join(base, path)
     canonical = posixpath.normpath(path)
     if not is_under_workspace(canonical):
-        raise ValueError(f"Path escapes /workspace: {path}")
+        raise ValueError("path must stay inside /workspace")
     role, conv = classify(canonical)
     return canonical, role, conv
 

--- a/apps/api/app/agents/tools/coding/bash_tool.py
+++ b/apps/api/app/agents/tools/coding/bash_tool.py
@@ -146,7 +146,7 @@ def _resolve_cwd(cwd: str, session_id: str | None) -> tuple[str, str | None]:
         # reaching host-internal config (`/etc/gaia`).
         normalized = posixpath.normpath(cwd)
         if not is_under_workspace(normalized):
-            return cwd, f"Error: cwd must be under {WORKSPACE_ROOT} (got {cwd!r})"
+            return cwd, f"Error: cwd must be under {WORKSPACE_ROOT}"
         return normalized, None
     return cwd, None
 

--- a/apps/api/app/services/gaia_tasks_fs.py
+++ b/apps/api/app/services/gaia_tasks_fs.py
@@ -85,6 +85,5 @@ def _project(doc: TodoDocument) -> GaiaTaskProjection:
             "project_id": doc.project_id,
             "created_at": doc.created_at,
             "updated_at": doc.updated_at,
-            "vfs_path": doc.vfs_path,
         },
     }

--- a/apps/api/app/services/todo_canvas_storage.py
+++ b/apps/api/app/services/todo_canvas_storage.py
@@ -17,8 +17,10 @@ from app.services.gaia_tasks_fs import schedule_gaia_tasks_sync
 from shared.py.wide_events import log
 
 
-def build_vfs_label(todo_id: str) -> str:
+def build_vfs_label(todo_id: str, *, archived: bool = False) -> str:
     """Stable label used wherever the old VFS path was surfaced for display."""
+    if archived:
+        return f"/workspace/gaia-tasks/archive/{todo_id}"
     return f"/workspace/gaia-tasks/{todo_id}"
 
 

--- a/apps/api/app/services/todo_canvas_storage.py
+++ b/apps/api/app/services/todo_canvas_storage.py
@@ -23,6 +23,7 @@ def build_vfs_label(todo_id: str) -> str:
 
 
 async def read_canvas(todo_id: str, user_id: str) -> str | None:
+    """Return the todo's canvas body, or None when the todo does not exist."""
     doc = await todo_repository.get(todo_id, user_id=user_id)
     if not doc:
         return None
@@ -30,6 +31,7 @@ async def read_canvas(todo_id: str, user_id: str) -> str | None:
 
 
 async def write_canvas(todo_id: str, user_id: str, content: str) -> bool:
+    """Replace the canvas body; schedules the gaia-tasks VFS sync on success."""
     updated = await todo_repository.update(
         todo_id, user_id=user_id, update=TodoUpdate(canvas_content=content)
     )
@@ -40,6 +42,7 @@ async def write_canvas(todo_id: str, user_id: str, content: str) -> bool:
 
 
 async def append_canvas(todo_id: str, user_id: str, content: str) -> bool:
+    """Append to the canvas body, ensuring a leading newline separator."""
     current = await read_canvas(todo_id, user_id)
     if current is None:
         log.warning("todo_canvas.append_missing_todo", todo_id=todo_id)
@@ -49,6 +52,7 @@ async def append_canvas(todo_id: str, user_id: str, content: str) -> bool:
 
 
 async def read_log(todo_id: str, user_id: str) -> str | None:
+    """Return the todo's system-log body, or None when the todo does not exist."""
     doc = await todo_repository.get(todo_id, user_id=user_id)
     if not doc:
         return None
@@ -56,6 +60,7 @@ async def read_log(todo_id: str, user_id: str) -> str | None:
 
 
 async def write_log(todo_id: str, user_id: str, content: str) -> bool:
+    """Replace the system-log body; schedules the gaia-tasks VFS sync on success."""
     updated = await todo_repository.update(
         todo_id, user_id=user_id, update=TodoUpdate(log_content=content)
     )
@@ -66,6 +71,7 @@ async def write_log(todo_id: str, user_id: str, content: str) -> bool:
 
 
 async def append_log(todo_id: str, user_id: str, content: str) -> bool:
+    """Append to the system-log body, ensuring a leading newline separator."""
     current = await read_log(todo_id, user_id)
     if current is None:
         log.warning("todo_canvas.log_append_missing_todo", todo_id=todo_id)

--- a/apps/api/app/services/todo_canvas_storage.py
+++ b/apps/api/app/services/todo_canvas_storage.py
@@ -6,8 +6,9 @@ writing, and appending go through the todos repository — no FUSE mount or
 JuiceFS required, so tracked todos work in every dev mode.
 
 The legacy ``vfs_path`` field on the todo doc is retained as a stable
-display label (``/users/{user_id}/todos/{todo_id}``) but is no longer a
-real filesystem path.
+display label (``/workspace/gaia-tasks/{todo_id}``) but is no longer a
+real filesystem path. It never carries the host-side ``/users/<uid>``
+prefix — the LLM only ever sees the sandbox-visible workspace path.
 """
 
 from app.db.repositories.todos import todo_repository
@@ -16,9 +17,9 @@ from app.services.gaia_tasks_fs import schedule_gaia_tasks_sync
 from shared.py.wide_events import log
 
 
-def build_vfs_label(user_id: str, todo_id: str) -> str:
+def build_vfs_label(todo_id: str) -> str:
     """Stable label used wherever the old VFS path was surfaced for display."""
-    return f"/users/{user_id}/todos/{todo_id}"
+    return f"/workspace/gaia-tasks/{todo_id}"
 
 
 async def read_canvas(todo_id: str, user_id: str) -> str | None:

--- a/apps/api/app/services/tracked_todo_service.py
+++ b/apps/api/app/services/tracked_todo_service.py
@@ -210,7 +210,6 @@ class TrackedTodoService:
         if doc.completed:
             return True
 
-        vfs_path = doc.vfs_path or build_vfs_label(todo_id)
         now = datetime.now(UTC)
 
         await append_log(
@@ -219,8 +218,10 @@ class TrackedTodoService:
             f"\n## {now.isoformat()} [COMPLETED]\n- Summary: {summary}\n",
         )
 
-        # Switch the display label to the archived form (purely cosmetic).
-        archive_path = vfs_path.replace("/gaia-tasks/", "/gaia-tasks/archive/")
+        # Always derive the archived label — never persist a stored one back.
+        # Legacy docs still carry the host-side /users/<uid>/todos/<id> format;
+        # deriving here heals them on completion instead of re-saving the leak.
+        archive_path = build_vfs_label(todo_id, archived=True)
 
         # The repository refreshes the entity cache and bumps the generation, so
         # the frontend reflects completion immediately — no manual invalidation.

--- a/apps/api/app/services/tracked_todo_service.py
+++ b/apps/api/app/services/tracked_todo_service.py
@@ -2,7 +2,7 @@
 Tracked todo service — Mongo-backed lifecycle for GAIA's working memory todos.
 
 A tracked todo is a regular todo with:
-- vfs_path (display label) set to /users/{user_id}/todos/{todo_id}/
+- vfs_path (display label) set to /workspace/gaia-tasks/{todo_id}
 - 'gaia-tracked' label
 - canvas_content field (agent-written brain) indexed in ChromaDB
 - log_content field (system-written audit trail)
@@ -101,7 +101,7 @@ def _format_signal_entry(doc: TodoDocument, key_details: str) -> str:
     """Render one tracked todo as a signal-matching context bullet (+ indented key details)."""
     labels = [lbl for lbl in doc.labels if lbl != GAIA_TRACKED_LABEL]
     labels_str = f" [{', '.join(labels)}]" if labels else ""
-    entry = f'- "{doc.title}"{labels_str} (ID: {doc.id}, vfs: {doc.vfs_path or ""})'
+    entry = f'- "{doc.title}"{labels_str} (ID: {doc.id})'
     if key_details:
         for dl in key_details.split("\n")[:_KEY_DETAILS_MAX_LINES]:
             entry += f"\n    {dl.strip()}"
@@ -118,7 +118,7 @@ def _format_tracked_todo_line(doc: TodoDocument, now: datetime, active_todo_id: 
     return (
         f'  {prefix}"{doc.title}"{labels_str}{_format_due_string(doc.due_date, now)}'
         f" — {age_days}d old, updated {last_update}d ago"
-        f" | ID: {doc.id} | VFS: {doc.vfs_path or 'none'}"
+        f" | ID: {doc.id}"
     )
 
 
@@ -162,7 +162,7 @@ class TrackedTodoService:
         result = await TodoService.create_todo(todo, user_id)
         todo_id = result.id
 
-        vfs_path = build_vfs_label(user_id, todo_id)
+        vfs_path = build_vfs_label(todo_id)
         canvas_content = initial_canvas or CANVAS_TEMPLATE.format(title=title)
         now = datetime.now(UTC)
         log_content = (
@@ -210,7 +210,7 @@ class TrackedTodoService:
         if doc.completed:
             return True
 
-        vfs_path = doc.vfs_path or build_vfs_label(user_id, todo_id)
+        vfs_path = doc.vfs_path or build_vfs_label(todo_id)
         now = datetime.now(UTC)
 
         await append_log(
@@ -220,7 +220,7 @@ class TrackedTodoService:
         )
 
         # Switch the display label to the archived form (purely cosmetic).
-        archive_path = vfs_path.replace("/todos/", "/todos/archive/")
+        archive_path = vfs_path.replace("/gaia-tasks/", "/gaia-tasks/archive/")
 
         # The repository refreshes the entity cache and bumps the generation, so
         # the frontend reflects completion immediately — no manual invalidation.

--- a/apps/api/tests/unit/agents/tools/coding/test_edit_tool.py
+++ b/apps/api/tests/unit/agents/tools/coding/test_edit_tool.py
@@ -439,7 +439,7 @@ async def test_edit_path_escaping_workspace_is_rejected() -> None:
             config=CONFIG,
         )
 
-    assert result == "Error: Path escapes /workspace: /etc/passwd"
+    assert result == "Error: path must stay inside /workspace"
     mock_acquire.assert_not_called()
 
 

--- a/apps/api/tests/unit/agents/tools/coding/test_write_tool.py
+++ b/apps/api/tests/unit/agents/tools/coding/test_write_tool.py
@@ -185,7 +185,7 @@ async def test_path_escaping_workspace_is_rejected() -> None:
     with patch(f"{MODULE}.acquire_sandbox") as mock_acquire:
         result = await write.ainvoke({"path": "/etc/passwd", "content": "x"}, config=CONFIG)
 
-    assert result == "Error: Path escapes /workspace: /etc/passwd"
+    assert result == "Error: path must stay inside /workspace"
     mock_acquire.assert_not_called()
 
 

--- a/apps/api/tests/unit/services/test_todo_canvas_storage.py
+++ b/apps/api/tests/unit/services/test_todo_canvas_storage.py
@@ -58,8 +58,13 @@ class TestBuildVfsLabel:
     def test_label_format(self):
         assert build_vfs_label(TODO_ID) == f"/workspace/gaia-tasks/{TODO_ID}"
 
-    def test_label_never_contains_user_id(self):
+    def test_label_never_contains_user_id(self) -> None:
         assert USER_ID not in build_vfs_label(TODO_ID)
+
+    def test_archive_label_format(self) -> None:
+        assert build_vfs_label(TODO_ID, archived=True) == (
+            f"/workspace/gaia-tasks/archive/{TODO_ID}"
+        )
 
 
 class TestReadCanvas:

--- a/apps/api/tests/unit/services/test_todo_canvas_storage.py
+++ b/apps/api/tests/unit/services/test_todo_canvas_storage.py
@@ -56,7 +56,10 @@ def mock_sync():
 
 class TestBuildVfsLabel:
     def test_label_format(self):
-        assert build_vfs_label(USER_ID, TODO_ID) == f"/users/{USER_ID}/todos/{TODO_ID}"
+        assert build_vfs_label(TODO_ID) == f"/workspace/gaia-tasks/{TODO_ID}"
+
+    def test_label_never_contains_user_id(self):
+        assert USER_ID not in build_vfs_label(TODO_ID)
 
 
 class TestReadCanvas:

--- a/apps/api/tests/unit/services/test_tracked_todo_service.py
+++ b/apps/api/tests/unit/services/test_tracked_todo_service.py
@@ -30,7 +30,7 @@ def _todo_doc(**overrides: object) -> TodoDocument:
         "user_id": USER_ID,
         "title": "Prepare Q3 report",
         "labels": [GAIA_TRACKED_LABEL, "work"],
-        "vfs_path": f"/users/{USER_ID}/todos/{TODO_ID}",
+        "vfs_path": f"/workspace/gaia-tasks/{TODO_ID}",
         "canvas_content": "# Prepare Q3 report\n\n## Key Details\nthread: abc123\n\n## Timeline\n- step one\n",
         "log_content": "# System Log\n",
         "completed": False,
@@ -97,13 +97,13 @@ class TestCreateTrackedTodo:
         result = await TrackedTodoService.create_tracked_todo(USER_ID, "Prepare Q3 report")
 
         assert result.id == TODO_ID
-        assert result.vfs_path == f"/users/{USER_ID}/todos/{TODO_ID}"
+        assert result.vfs_path == f"/workspace/gaia-tasks/{TODO_ID}"
 
         todo_model: TodoModel = mock_deps.create.call_args.args[0]
         assert GAIA_TRACKED_LABEL in todo_model.labels
 
         update = mock_repo.update.await_args.kwargs["update"]
-        assert update.vfs_path == f"/users/{USER_ID}/todos/{TODO_ID}"
+        assert update.vfs_path == f"/workspace/gaia-tasks/{TODO_ID}"
         assert update.canvas_content == CANVAS_TEMPLATE.format(title="Prepare Q3 report")
         assert "[CREATED]" in update.log_content
         assert "Source: agent" in update.log_content
@@ -162,7 +162,7 @@ class TestCompleteTrackedTodo:
         update = mock_repo.update.await_args.kwargs["update"]
         assert update.completed is True
         assert update.completed_at is not None
-        assert update.vfs_path == f"/users/{USER_ID}/todos/archive/{TODO_ID}"
+        assert update.vfs_path == f"/workspace/gaia-tasks/archive/{TODO_ID}"
         mock_deps.mark.assert_awaited_once_with(TODO_ID)
         mock_deps.sync.assert_called_once_with(USER_ID)
 
@@ -170,6 +170,24 @@ class TestCompleteTrackedTodo:
 class TestGetActiveTrackedSummary:
     async def test_empty_string_without_docs(self, mock_repo):
         assert await TrackedTodoService.get_active_tracked_summary(USER_ID) == ""
+
+    @pytest.mark.regression
+    async def test_stored_user_scoped_vfs_path_never_leaks_into_agent_context(
+        self, mock_repo, mock_deps
+    ):
+        """Old docs store vfs_path as /users/<uid>/todos/<id> — that host-side
+        path must never reach the LLM, which only knows /workspace-scoped paths."""
+        stale_doc = _todo_doc(vfs_path=f"/users/{USER_ID}/todos/{TODO_ID}")
+        mock_repo.list_active_tracked.return_value = [stale_doc]
+        mock_deps.read.return_value = "## Key Details\nthread: abc123\n"
+
+        summary = await TrackedTodoService.get_active_tracked_summary(USER_ID)
+        context = await TrackedTodoService.get_signal_matching_context(USER_ID)
+
+        assert USER_ID not in summary
+        assert USER_ID not in context
+        assert "/users/" not in summary
+        assert "/users/" not in context
 
     async def test_renders_summary_lines(self, mock_repo):
         mock_repo.list_active_tracked.return_value = [_todo_doc()]
@@ -180,7 +198,8 @@ class TestGetActiveTrackedSummary:
         assert lines[0] == "ACTIVE TRACKED TODOS:"
         assert '"Prepare Q3 report" [work]' in lines[1]
         assert "ID: todo-1" in lines[1]
-        assert "VFS: /users/507f1f77bcf86cd799439011/todos/todo-1" in lines[1]
+        assert "VFS" not in lines[1]
+        assert USER_ID not in lines[1]
         assert lines[1].endswith("2d old, updated 0d ago") or "d old" in lines[1]
 
     async def test_active_todo_pinned_with_star(self, mock_repo):
@@ -286,8 +305,9 @@ class TestGetSignalMatchingContext:
         assert lines[0] == "ACTIVE TRACKED TODOS (check if incoming signal relates to any):"
         assert (
             lines[1]
-            == '- "Prepare Q3 report" [work] (ID: todo-1, vfs: /users/507f1f77bcf86cd799439011/todos/todo-1)'
+            == '- "Prepare Q3 report" [work] (ID: todo-1)'
         )
+        assert USER_ID not in context
         assert "    thread: abc123" in lines[2]
         assert "    email: x@y.com" in lines[3]
 

--- a/apps/api/tests/unit/services/test_tracked_todo_service.py
+++ b/apps/api/tests/unit/services/test_tracked_todo_service.py
@@ -167,11 +167,24 @@ class TestCompleteTrackedTodo:
         mock_deps.sync.assert_called_once_with(USER_ID)
 
     async def test_missing_vfs_path_falls_back_to_derived_workspace_label(
-        self, mock_repo, mock_deps
-    ):
+        self, mock_repo: MagicMock, mock_deps: SimpleNamespace
+    ) -> None:
         """A doc with no stored label must get the derived /workspace-scoped one —
         never None, and never a label derived from the wrong id."""
         mock_repo.get.return_value = _todo_doc(vfs_path=None)
+
+        ok = await TrackedTodoService.complete_tracked_todo(TODO_ID, USER_ID, "done")
+
+        assert ok is True
+        update = mock_repo.update.await_args.kwargs["update"]
+        assert update.vfs_path == f"/workspace/gaia-tasks/archive/{TODO_ID}"
+
+    async def test_legacy_user_scoped_label_is_healed_on_completion(
+        self, mock_repo: MagicMock, mock_deps: SimpleNamespace
+    ) -> None:
+        """A doc still storing the host-side /users/<uid> label must not have it
+        persisted back on completion — the derived archive label replaces it."""
+        mock_repo.get.return_value = _todo_doc(vfs_path=f"/users/{USER_ID}/todos/{TODO_ID}")
 
         ok = await TrackedTodoService.complete_tracked_todo(TODO_ID, USER_ID, "done")
 
@@ -186,8 +199,8 @@ class TestGetActiveTrackedSummary:
 
     @pytest.mark.regression
     async def test_stored_user_scoped_vfs_path_never_leaks_into_agent_context(
-        self, mock_repo, mock_deps
-    ):
+        self, mock_repo: MagicMock, mock_deps: SimpleNamespace
+    ) -> None:
         """Old docs store vfs_path as /users/<uid>/todos/<id> — that host-side
         path must never reach the LLM, which only knows /workspace-scoped paths."""
         stale_doc = _todo_doc(vfs_path=f"/users/{USER_ID}/todos/{TODO_ID}")

--- a/apps/api/tests/unit/services/test_tracked_todo_service.py
+++ b/apps/api/tests/unit/services/test_tracked_todo_service.py
@@ -316,10 +316,7 @@ class TestGetSignalMatchingContext:
 
         lines = context.split("\n")
         assert lines[0] == "ACTIVE TRACKED TODOS (check if incoming signal relates to any):"
-        assert (
-            lines[1]
-            == '- "Prepare Q3 report" [work] (ID: todo-1)'
-        )
+        assert lines[1] == '- "Prepare Q3 report" [work] (ID: todo-1)'
         assert USER_ID not in context
         assert "    thread: abc123" in lines[2]
         assert "    email: x@y.com" in lines[3]

--- a/apps/api/tests/unit/services/test_tracked_todo_service.py
+++ b/apps/api/tests/unit/services/test_tracked_todo_service.py
@@ -166,6 +166,19 @@ class TestCompleteTrackedTodo:
         mock_deps.mark.assert_awaited_once_with(TODO_ID)
         mock_deps.sync.assert_called_once_with(USER_ID)
 
+    async def test_missing_vfs_path_falls_back_to_derived_workspace_label(
+        self, mock_repo, mock_deps
+    ):
+        """A doc with no stored label must get the derived /workspace-scoped one —
+        never None, and never a label derived from the wrong id."""
+        mock_repo.get.return_value = _todo_doc(vfs_path=None)
+
+        ok = await TrackedTodoService.complete_tracked_todo(TODO_ID, USER_ID, "done")
+
+        assert ok is True
+        update = mock_repo.update.await_args.kwargs["update"]
+        assert update.vfs_path == f"/workspace/gaia-tasks/archive/{TODO_ID}"
+
 
 class TestGetActiveTrackedSummary:
     async def test_empty_string_without_docs(self, mock_repo):

--- a/apps/api/tests/unit/tools/coding/test_canonical_path.py
+++ b/apps/api/tests/unit/tools/coding/test_canonical_path.py
@@ -24,8 +24,18 @@ from app.agents.workspace.paths import WORKSPACE_ROOT, session_dir
     ],
 )
 def test_paths_escaping_workspace_are_rejected(escape: str) -> None:
-    with pytest.raises(ValueError, match="escapes"):
+    # The rejection message deliberately does NOT echo the path back — tool
+    # errors reach the LLM, and the path may carry host-side internals.
+    # Anchored: the exact message is LLM-facing contract, not an implementation
+    # detail — a mutated message still has to fail this test.
+    with pytest.raises(ValueError, match=r"^path must stay inside /workspace$"):
         canonical_path(escape, session_id="c1")
+
+
+def test_rejection_message_does_not_echo_the_path() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        canonical_path("/users/some-uid/todos/x/canvas.md", session_id="c1")
+    assert "/users/some-uid" not in str(exc_info.value)
 
 
 def test_containment_is_workspace_wide_not_session_scoped() -> None:

--- a/apps/api/tests/unit/tools/coding/test_resolve_cwd.py
+++ b/apps/api/tests/unit/tools/coding/test_resolve_cwd.py
@@ -44,7 +44,9 @@ def test_dotdot_escape_is_rejected_after_normalization(escape: str) -> None:
     # escaped. _resolve_cwd must normpath BEFORE the containment check.
     _, err = _resolve_cwd(escape, "c")
     assert err is not None, f"{escape!r} must be rejected — it escapes /workspace"
-    assert "must be under" in err
+    # Exact message: it goes back to the LLM, and it must not echo the
+    # rejected cwd back.
+    assert err == f"Error: cwd must be under {WORKSPACE_ROOT}"
 
 
 def test_relative_cwd_joins_to_session_dir_like_read_and_write() -> None:


### PR DESCRIPTION
## Summary

The executor LLM was being handed host-internal filesystem paths like `/users/67bdb436…/todos/<id>` in its context, then leaking them back in tool calls and error output — so the model knew it was running in a multi-user workspace and had a path it could never resolve. Tracked-todo labels are now workspace-scoped (`/workspace/gaia-tasks/<id>`), the label is no longer injected into agent context at all, and path-validation errors no longer echo the rejected path back.

## Why

A user-visible tool card showed the agent calling `read` with `/users/<uid>/todos/<id>/canvas.md` and failing with `Error: Path escapes /workspace: /users/<uid>/…` — the error echoed the host path a second time. The agent should only ever see its sandbox view (`/workspace/...`); the `/users/<uid>` prefix exposes the multi-tenant layout and a Mongo user id.

## What changed

### API

- `build_vfs_label` (`todo_canvas_storage.py`) now returns `/workspace/gaia-tasks/{todo_id}` instead of `/users/{user_id}/todos/{todo_id}`; the archive variant follows (`/workspace/gaia-tasks/archive/<id>`).
- The `VFS:` field is removed from both agent-facing tracked-todo renderers (`get_active_tracked_summary`, `get_signal_matching_context`) — the todo ID is what the agent acts on, and stale labels in existing docs can no longer reach the model.
- `vfs_path` is dropped from the materialized `meta.json` in `/workspace/gaia-tasks/` folders (`gaia_tasks_fs.py`), which the agent can `cat`. Because the per-doc signature changes, every folder is rewritten with the clean meta on the next sync — existing on-disk files self-heal.
- Path-containment errors in `canonical_path` (`_context.py`) and the bash `cwd` check no longer interpolate the rejected path into the message returned to the LLM.

---

## The bug

**Symptom** — The agent called `read` with `{"path": "/users/67bdb4367c7dd1f0ea343216/todos/6a85272d…/canvas.md"}` and got `Error: Path escapes /workspace: /users/67bdb436…/ca…` back as tool output.

**Reproduce** — Ask the executor about its tracked todos on master: the injected `ACTIVE TRACKED TODOS` context block carries `VFS: /users/<uid>/todos/<id>`, and the agent tries to read that path.

**Root cause** — `build_vfs_label` in `app/services/todo_canvas_storage.py` built the display label from the host-side JuiceFS layout (`/users/{user_id}/todos/{todo_id}`) rather than the sandbox-visible projection. That label flowed into agent context (`tracked_todo_service.py` renderers), onto disk via `meta.json` (`gaia_tasks_fs._project`), and the containment error in `_context.py:87` echoed it back a second time.

**The fix** — The label is derived from the todo ID alone and matches the path the sandbox actually exposes (`/workspace/gaia-tasks/<id>`). Removing the field from the agent-facing renderers and from `meta.json` means even already-stored leaky values cannot reach the model — no data migration is required for the LLM-facing surface.

**Regression test** — `test_stored_user_scoped_vfs_path_never_leaks_into_agent_context` (`tests/unit/services/test_tracked_todo_service.py`) feeds a doc with the old `/users/<uid>/todos/<id>` label through both renderers and asserts the path never appears. Verified red against master's `app/` and green with this fix.

**Why the suite missed it** — The renderer tests asserted the VFS field *was* present with the leaky value baked into the expectation, so the leak was pinned as correct behavior.

---

## How to verify

1. Run the API and ask the executor "what tracked todos do I have?" — the context the agent receives contains `ID: <todo-id>` with no `VFS:` field and no `/users/` prefix.
2. Ask it to read a tracked todo's canvas — it should use `/workspace/gaia-tasks/…` (or the todo ID) and succeed, instead of erroring with `Path escapes /workspace`.
3. Call a file tool with an escaping path (e.g. `read /etc/passwd`) — the error is `path must stay inside /workspace` with no path echoed.

**Not verified:** not driven against a live stack (`mise dev`) yet — verification above is from the unit suite; the live chat-turn check is still to do.

## Post-merge steps

- [ ] None required. Existing Mongo docs keep their stale `vfs_path` values, but no code path surfaces them to the LLM anymore; on-disk `meta.json` files are rewritten by the next scheduled gaia-tasks sync (the per-doc signature changed).

**Rollback:** revert this PR. Stale labels re-become LLM-visible only for docs whose `vfs_path` still holds the old format.

## Risk

Low blast radius: the only behavior change visible to the agent is the removal of the `VFS:` field from context lines it wasn't able to use anyway (every path in that format failed containment). The frontend still receives `vfs_path` on the todo response — newly created todos now show the workspace-scoped label, older ones show their stored value until completed.
