### PR TITLE
fix(memory): let the repair script build the Postgres engine it needs

### DIFF
--- a/apps/api/app/scripts/repair_memory_store.py
+++ b/apps/api/app/scripts/repair_memory_store.py
@@ -47,6 +47,8 @@ from app.constants.memory import (
     MemoryRelationType,
     MemoryShelfLife,
 )
+from app.core.provider_registration import register_lazy_providers
+from app.db.postgresql import close_postgresql_db
 from app.memory import pg_store
 from app.memory.consolidation import consolidate, render_agenda_document
 from app.memory.management import forget_memory
@@ -159,8 +161,21 @@ async def _repair_user(user_id: str, args: argparse.Namespace) -> int:
 
 
 async def _run(args: argparse.Namespace) -> int:
-    for user_id in args.user:
-        await _repair_user(user_id, args)
+    """Bootstrap the providers a script has no lifespan to build, then repair.
+
+    Mongo self-initialises on first collection access, but the memory store's
+    Postgres engine is a lazy provider, and outside the API process nobody has
+    registered it: every query raised ``Provider 'postgresql_engine' not found in
+    registry``. Registration is bookkeeping only (no I/O); the engine itself is
+    built on first use and disposed here so the script exits without a warning
+    about an open pool.
+    """
+    register_lazy_providers("main_app")
+    try:
+        for user_id in args.user:
+            await _repair_user(user_id, args)
+    finally:
+        await close_postgresql_db()
     return 0
 
 

--- a/apps/api/tests/unit/scripts/test_repair_memory_store.py
+++ b/apps/api/tests/unit/scripts/test_repair_memory_store.py
@@ -404,6 +404,55 @@ class TestRunAllUsers:
 
 
 @pytest.mark.unit
+class TestRunBootstrapsWhatAScriptHasNoLifespanFor:
+    """Outside the API process nobody has registered the lazy providers, so the
+    memory store's Postgres engine has nobody to build it and every query raises
+    ``Provider 'postgresql_engine' not found in registry``. That is exactly how
+    the first production dry run of this script failed."""
+
+    async def test_providers_are_registered_before_the_first_repair(self) -> None:
+        args = make_args()
+        args.user = ["u1"]
+        order: list[str] = []
+
+        async def repair(user_id: str, _args: argparse.Namespace) -> None:
+            order.append(f"repair:{user_id}")
+
+        async def close() -> None:
+            order.append("close")
+
+        with (
+            patch.object(
+                repair_memory_store,
+                "register_lazy_providers",
+                lambda context: order.append(f"register:{context}"),
+            ),
+            patch.object(repair_memory_store, "_repair_user", repair),
+            patch.object(repair_memory_store, "close_postgresql_db", close),
+        ):
+            assert await _run(args) == 0
+
+        assert order == ["register:main_app", "repair:u1", "close"]
+
+    async def test_the_engine_is_disposed_even_when_a_repair_fails(self) -> None:
+        args = make_args()
+        args.user = ["u1"]
+        closed = AsyncMock(return_value=None)
+
+        with (
+            patch.object(repair_memory_store, "register_lazy_providers", lambda context: None),
+            patch.object(
+                repair_memory_store, "_repair_user", AsyncMock(side_effect=RuntimeError("pg down"))
+            ),
+            patch.object(repair_memory_store, "close_postgresql_db", closed),
+        ):
+            with pytest.raises(RuntimeError, match="pg down"):
+                await _run(args)
+
+        closed.assert_awaited_once()
+
+
+@pytest.mark.unit
 class TestCommandLine:
     @staticmethod
     def _run_main(argv: list[str]) -> tuple[list[argparse.Namespace], int | str | None]:


### PR DESCRIPTION
# Summary

The memory repair script could not run outside the API process. Its first production dry run died on `Provider 'postgresql_engine' not found in registry` before printing a single row of the plan. It now registers the lazy providers itself and disposes the engine when it exits, so `--user <id>` prints the plan and `--apply` can commit it.

# Why

Scripts get no FastAPI lifespan. Mongo self-initialises on first collection access, so the sibling session migration works, but the memory store reaches Postgres through the lazy provider registry, and nothing had registered `postgresql_engine`. That is not a theoretical gap: it is exactly how the first real run of `repair_memory_store` failed, on prod, against the merged code.

# What changed

- `apps/api/app/scripts/repair_memory_store.py`: `_run()` calls `register_lazy_providers("main_app")` before repairing anyone (bookkeeping only, no I/O; the engine builds on first use) and `close_postgresql_db()` in a `finally`, so a failed repair still disposes the pool.

# The bug

Symptom: `python -m app.scripts.repair_memory_store --user <id>` exits with `KeyError: "Provider 'postgresql_engine' not found in registry"` raised from `get_all_live_memories`. Root cause: `_run()` went straight to the repair loop; provider registration happens in `unified_startup`, which only the API and worker processes run. Fix: register in the script.

Regression tests (`apps/api/tests/unit/scripts/test_repair_memory_store.py`, `TestRunBootstrapsWhatAScriptHasNoLifespanFor`): one pins that registration happens before the first repair and disposal after it, the other that the engine is disposed even when a repair raises. Both were watched red against the previous `_run` body (2 failed) and pass with the fix (42 passed in the file).

# How to verify

From `apps/api` against a database with a user id you can read: `uv run python -m app.scripts.repair_memory_store --user <id>` prints the plan and writes nothing. Add `--apply` to commit it.