### PR TITLE
fix(memory): retire a memory's parent only when its child restates it

### DIFF
--- a/apps/api/app/scripts/repair_memory_store.py
+++ b/apps/api/app/scripts/repair_memory_store.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 from datetime import UTC, datetime, timedelta
+import math
 import re
 import uuid
 
@@ -72,7 +73,9 @@ _STATE_PHRASES = re.compile(
 # ("uses nasal spray" vs "dislikes its taste").
 _DEFAULT_EXTENDS_CONTAINMENT = 0.8
 
-# Filler that carries no subject, so it never counts toward coverage.
+# Filler that carries no subject, so it never counts toward coverage. Negation
+# is deliberately absent: "not venture-backed" and "venture-backed" are
+# opposite claims, and the child must repeat the "not" to cover the parent.
 _CONTAINMENT_STOPWORDS = frozenset(
     {
         "a",
@@ -93,7 +96,6 @@ _CONTAINMENT_STOPWORDS = frozenset(
         "with",
         "and",
         "or",
-        "not",
         "his",
         "her",
         "their",
@@ -158,6 +160,14 @@ def _subject_tokens(content: str) -> set[str]:
         for word in re.findall(r"[a-z0-9']+", content.lower())
         if word not in _CONTAINMENT_STOPWORDS and len(word) > 2
     }
+
+
+def containment_share(raw: str) -> float:
+    """argparse type for --extends-containment: a share, so 0.0 to 1.0 inclusive."""
+    value = float(raw)
+    if math.isnan(value) or not 0.0 <= value <= 1.0:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not a share between 0.0 and 1.0")
+    return value
 
 
 def covers(parent: str, child: str, threshold: float) -> bool:
@@ -296,7 +306,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--extends-containment",
-        type=float,
+        type=containment_share,
         default=_DEFAULT_EXTENDS_CONTAINMENT,
         help="Share of a parent's words its child must repeat before the parent is retired.",
     )

--- a/apps/api/app/scripts/repair_memory_store.py
+++ b/apps/api/app/scripts/repair_memory_store.py
@@ -63,23 +63,123 @@ _STATE_PHRASES = re.compile(
     re.IGNORECASE,
 )
 
+# The old reconciler wrote an EXTENDS link for "more detail on a related claim",
+# so a link only means "topically adjacent", not "same fact restated". Retiring
+# every linked parent deleted preferences whose child was vaguer than they were:
+# "avoid em dashes" lost to "fluff-free marketing copy". A parent is only retired
+# when the child actually covers it. Measured on the production store: of 216
+# linked parents, 26 pass at 0.8, and the 190 spared are plainly different facts
+# ("uses nasal spray" vs "dislikes its taste").
+_DEFAULT_EXTENDS_CONTAINMENT = 0.8
+
+# Filler that carries no subject, so it never counts toward coverage.
+_CONTAINMENT_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "of",
+        "to",
+        "in",
+        "on",
+        "for",
+        "with",
+        "and",
+        "or",
+        "not",
+        "his",
+        "her",
+        "their",
+        "its",
+        "he",
+        "she",
+        "they",
+        "it",
+        "that",
+        "this",
+        "these",
+        "those",
+        "as",
+        "at",
+        "by",
+        "from",
+        "into",
+        "about",
+        "over",
+        "under",
+        "prefers",
+        "wants",
+        "has",
+        "have",
+        "had",
+        "does",
+        "do",
+        "will",
+        "would",
+        "can",
+        "could",
+        "should",
+    }
+)
+
+# The phrase heuristic below reads a snapshot's shape: short, one clock-bound
+# claim. A long biography that merely contains the word "currently" is not that,
+# and retiring it would strip the profile rebuild of its richest source row.
+_MAX_HEURISTIC_STATE_CHARS = 300
+
 _EXTENDS_RETIRE_REASON = "superseded by its EXTENDS child (memory-store repair)"
 _STATE_RETIRE_REASON = "stale state snapshot (memory-store repair)"
 _MANUAL_RETIRE_REASON = "retired by hand (memory-store repair)"
 
 
 def looks_like_state(content: str) -> bool:
-    """Whether a fact reads as a value that was only true as of some moment."""
+    """Whether a fact reads as a value that was only true as of some moment.
+
+    Bounded by length: the phrases mark a snapshot only in a sentence that IS
+    one. A 600-character biography that happens to say "currently pursuing" is a
+    durable profile, and the rebuild derives user.md from rows like it.
+    """
+    if len(content) > _MAX_HEURISTIC_STATE_CHARS:
+        return False
     return _STATE_PHRASES.search(content) is not None
+
+
+def _subject_tokens(content: str) -> set[str]:
+    """The words that carry the claim, lowercased, filler removed."""
+    return {
+        word
+        for word in re.findall(r"[a-z0-9']+", content.lower())
+        if word not in _CONTAINMENT_STOPWORDS and len(word) > 2
+    }
+
+
+def covers(parent: str, child: str, threshold: float) -> bool:
+    """Whether the child restates the parent rather than merely relating to it."""
+    parent_tokens = _subject_tokens(parent)
+    if not parent_tokens:
+        return False
+    shared = parent_tokens & _subject_tokens(child)
+    return len(shared) / len(parent_tokens) >= threshold
 
 
 def extends_parents_to_retire(
     rows: list[MemoryRecord],
+    *,
+    containment: float = _DEFAULT_EXTENDS_CONTAINMENT,
 ) -> list[tuple[MemoryRecord, MemoryRecord]]:
-    """``(parent, newest child)`` for every live parent of a live EXTENDS child.
+    """``(parent, newest child)`` for every live parent its child truly covers.
 
     Only EXTENDS pairs qualify: an UPDATES child already flipped its parent out
-    of the live set when it was written.
+    of the live set when it was written. A pair whose child does not cover the
+    parent is left alone: that link came from the old reconciler and means the
+    two are related, not that one replaces the other.
     """
     by_id = {row.id: row for row in rows}
     newest_child: dict[uuid.UUID, MemoryRecord] = {}
@@ -91,7 +191,11 @@ def extends_parents_to_retire(
         current = newest_child.get(row.parent_id)
         if current is None or row.created_at > current.created_at:
             newest_child[row.parent_id] = row
-    return [(by_id[parent_id], child) for parent_id, child in newest_child.items()]
+    return [
+        (by_id[parent_id], child)
+        for parent_id, child in newest_child.items()
+        if covers(by_id[parent_id].content, child.content, containment)
+    ]
 
 
 def state_rows_to_forget(
@@ -119,7 +223,7 @@ async def _repair_user(user_id: str, args: argparse.Namespace) -> int:
     rows = await pg_store.get_all_live_memories(user_id)
     print(f"\n{'=' * 78}\nUser {user_id}: {len(rows)} live memories\n{'=' * 78}")
 
-    extends_pairs = extends_parents_to_retire(rows)
+    extends_pairs = extends_parents_to_retire(rows, containment=args.extends_containment)
     print(f"\nEXTENDS parents still live alongside their child: {len(extends_pairs)}")
     for parent, child in extends_pairs:
         print(f"  - retire {parent.id}: {parent.content!r}")
@@ -189,6 +293,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--retire-ids", action="append", help="Forget this memory id outright (repeatable)."
+    )
+    parser.add_argument(
+        "--extends-containment",
+        type=float,
+        default=_DEFAULT_EXTENDS_CONTAINMENT,
+        help="Share of a parent's words its child must repeat before the parent is retired.",
     )
     parser.add_argument(
         "--state-age-days",

--- a/apps/api/tests/unit/scripts/test_repair_memory_store.py
+++ b/apps/api/tests/unit/scripts/test_repair_memory_store.py
@@ -67,7 +67,7 @@ class TestExtendsParentsToRetire:
     def test_a_live_parent_of_a_live_extends_child_is_retired(self) -> None:
         parent = make_row(content="sam works at acme")
         child = make_row(
-            content="sam is a staff engineer at acme",
+            content="sam works at acme as a staff engineer",
             parent_id=parent.id,
             relation_type="extends",
         )
@@ -223,12 +223,17 @@ MANUAL_REASON = "retired by hand (memory-store repair)"
 
 
 def make_args(
-    *, apply: bool = False, retire_ids: list[str] | None = None, state_age_days: int | None = None
+    *,
+    apply: bool = False,
+    retire_ids: list[str] | None = None,
+    state_age_days: int | None = None,
+    extends_containment: float = 0.8,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         apply=apply,
         retire_ids=retire_ids,
         state_age_days=STATE_FACT_TTL_DAYS if state_age_days is None else state_age_days,
+        extends_containment=extends_containment,
     )
 
 
@@ -259,7 +264,7 @@ class TestRepairUserPlan:
     ) -> None:
         parent = make_row(content="sam works at acme")
         child = make_row(
-            content="sam is a staff engineer at acme",
+            content="sam works at acme as a staff engineer",
             parent_id=parent.id,
             relation_type="extends",
         )
@@ -276,7 +281,7 @@ class TestRepairUserPlan:
             f"\n{RULE}\nUser u1: 3 live memories\n{RULE}\n"
             "\nEXTENDS parents still live alongside their child: 1\n"
             f"  - retire {parent.id}: 'sam works at acme'\n"
-            f"      kept  {child.id}: 'sam is a staff engineer at acme'\n"
+            f"      kept  {child.id}: 'sam works at acme as a staff engineer'\n"
             f"\nStale state snapshots older than {STATE_FACT_TTL_DAYS}d: 1\n"
             f"  - forget {stale.id} ({stale.created_at:%Y-%m-%d}): "
             "'Gmail is currently disconnected'\n"
@@ -401,6 +406,85 @@ class TestRunAllUsers:
             assert await _run(args) == 0
 
         assert [call.args for call in repair.await_args_list] == [("u1", args), ("u2", args)]
+
+
+@pytest.mark.unit
+class TestOnlyARestatementRetiresItsParent:
+    """The links being read here were written by the OLD reconciler, whose rule
+    was "more detail about a related claim". So an EXTENDS link means the two
+    rows are topically adjacent, not that the child replaces the parent. On the
+    production store, retiring every linked parent would have deleted "avoid em
+    dashes" in favour of "fluff-free marketing copy"."""
+
+    @staticmethod
+    def _pair(parent_content: str, child_content: str) -> list[MemoryRecord]:
+        parent = make_row(content=parent_content)
+        child = make_row(
+            content=child_content,
+            relation_type="extends",
+            parent_id=parent.id,
+        )
+        return [parent, child]
+
+    def test_a_child_that_restates_the_parent_retires_it(self) -> None:
+        rows = self._pair(
+            "Aryan's startup is not venture-backed.",
+            "Aryan's startup is bootstrapped and not venture-backed.",
+        )
+
+        assert [parent.id for parent, _ in extends_parents_to_retire(rows)] == [rows[0].id]
+
+    def test_a_child_that_only_shares_a_topic_leaves_the_parent_alone(self) -> None:
+        rows = self._pair(
+            "Aryan prefers direct, human-sounding communication, avoiding corporate jargon "
+            "and em dashes.",
+            "Aryan prefers direct, concise, fluff-free communication for marketing copy.",
+        )
+
+        assert extends_parents_to_retire(rows) == []
+
+    def test_the_bar_is_the_callers_containment(self) -> None:
+        rows = self._pair(
+            "Aryan uses PostHog for analytics.",
+            "Aryan uses PostHog for tracking user acquisition and metrics.",
+        )
+
+        assert extends_parents_to_retire(rows, containment=0.9) == []
+        assert len(extends_parents_to_retire(rows, containment=0.5)) == 1
+
+
+@pytest.mark.unit
+class TestALongProfileIsNotASnapshot:
+    """The phrase heuristic reads a snapshot's SHAPE: short, one clock-bound
+    claim. user.md is rebuilt from live rows, so retiring a 600-character
+    biography because it says "currently pursuing" would impoverish the rebuild
+    it is meant to repair."""
+
+    def test_a_short_snapshot_is_still_retired(self) -> None:
+        row = make_row(content="Aryan is currently unable to take screenshots.", age_days=90)
+
+        assert state_rows_to_forget([row], now=NOW) == [row]
+
+    def test_a_long_biography_carrying_the_word_is_kept(self) -> None:
+        biography = (
+            "Aryan Randeriya is a software developer, designer and entrepreneur based in "
+            "India, the founder of The Experience Company, and is currently pursuing a "
+            "B.Tech in Computer Science. " + "He has shipped several products. " * 8
+        )
+        assert len(biography) > 300
+        row = make_row(content=biography, age_days=90)
+
+        assert state_rows_to_forget([row], now=NOW) == []
+
+    def test_a_row_the_extractor_itself_called_state_is_retired_at_any_length(self) -> None:
+        row = make_row(
+            content="Aryan's signup count stands at 2,000. " * 12,
+            age_days=90,
+            shelf_life=MemoryShelfLife.STATE,
+        )
+        assert len(row.content) > 300
+
+        assert state_rows_to_forget([row], now=NOW) == [row]
 
 
 @pytest.mark.unit

--- a/apps/api/tests/unit/scripts/test_repair_memory_store.py
+++ b/apps/api/tests/unit/scripts/test_repair_memory_store.py
@@ -28,6 +28,7 @@ from app.scripts import repair_memory_store
 from app.scripts.repair_memory_store import (
     _repair_user,
     _run,
+    covers,
     extends_parents_to_retire,
     looks_like_state,
     main,
@@ -259,6 +260,25 @@ def store() -> Iterator[SimpleNamespace]:
 
 @pytest.mark.unit
 class TestRepairUserPlan:
+    async def test_the_containment_flag_is_what_decides_the_extends_plan(
+        self, store: SimpleNamespace, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        parent = make_row(content="avoid corporate jargon and em dashes")
+        child = make_row(
+            content="avoid fluff in marketing copy",
+            parent_id=parent.id,
+            relation_type="extends",
+        )
+        store.get_all_live_memories.return_value = [parent, child]
+
+        await _repair_user("u1", make_args(extends_containment=1.0))
+        strict = capsys.readouterr().out
+        await _repair_user("u1", make_args(extends_containment=0.0))
+        lax = capsys.readouterr().out
+
+        assert "EXTENDS parents still live alongside their child: 0" in strict
+        assert "EXTENDS parents still live alongside their child: 1" in lax
+
     async def test_the_dry_run_prints_the_whole_plan_and_writes_nothing(
         self, store: SimpleNamespace, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -537,6 +557,42 @@ class TestRunBootstrapsWhatAScriptHasNoLifespanFor:
 
 
 @pytest.mark.unit
+class TestWhatCountsAsCoverage:
+    def test_the_share_is_measured_against_the_parents_words_only(self) -> None:
+        # parent: startup, bootstrapped, venture, backed, india (5); child repeats 4.
+        parent = "startup bootstrapped venture backed india"
+        child = "startup bootstrapped venture backed berlin and a great deal more"
+
+        assert covers(parent, child, 0.8) is True
+        assert covers(parent, child, 0.81) is False
+
+    def test_a_parent_made_only_of_filler_is_never_covered(self) -> None:
+        assert covers("it is as it was", "it is as it was", 0.0) is False
+
+    def test_case_and_filler_do_not_count_toward_coverage(self) -> None:
+        assert covers("PostHog Analytics", "posthog analytics", 1.0) is True
+        assert covers("the a an of to", "the a an of to", 0.0) is False
+        assert covers("AI is useful", "useful", 1.0) is True
+
+    def test_two_letter_words_are_filler_and_three_letter_words_are_subject(self) -> None:
+        assert covers("uses AI", "uses", 1.0) is True
+        assert covers("uses zsh", "uses", 1.0) is False
+
+    def test_an_apostrophe_keeps_a_contraction_as_one_word(self) -> None:
+        assert covers("doesn't drink", "does not drink", 1.0) is False
+        assert covers("doesn't drink", "doesn't drink", 1.0) is True
+
+
+@pytest.mark.unit
+class TestTheSnapshotLengthBound:
+    def test_the_bound_is_inclusive(self) -> None:
+        exactly = "currently " + "x" * 290
+        assert len(exactly) == 300
+        assert looks_like_state(exactly) is True
+        assert looks_like_state(exactly + "x") is False
+
+
+@pytest.mark.unit
 class TestCommandLine:
     @staticmethod
     def _run_main(argv: list[str]) -> tuple[list[argparse.Namespace], int | str | None]:
@@ -568,6 +624,8 @@ class TestCommandLine:
                 "mem-2",
                 "--state-age-days",
                 "30",
+                "--extends-containment",
+                "0.5",
             ]
         )
 
@@ -577,6 +635,7 @@ class TestCommandLine:
         assert args.apply is True
         assert args.retire_ids == ["mem-1", "mem-2"]
         assert args.state_age_days == 30
+        assert args.extends_containment == 0.5
 
     def test_a_run_without_flags_is_a_dry_run_at_the_default_window(self) -> None:
         captured, _code = self._run_main(["--user", "u1"])
@@ -585,6 +644,7 @@ class TestCommandLine:
         assert args.apply is False
         assert args.retire_ids is None
         assert args.state_age_days == STATE_FACT_TTL_DAYS
+        assert args.extends_containment == 0.8
 
     def test_a_run_with_no_user_refuses_to_start(self) -> None:
         with patch("sys.argv", ["repair_memory_store"]), pytest.raises(SystemExit) as raised:
@@ -626,4 +686,8 @@ class TestCommandLine:
         assert "--retire-ids RETIRE_IDS Forget this memory id outright (repeatable)." in options
         assert (
             "--state-age-days STATE_AGE_DAYS Age past which a state-like row is retired." in options
+        )
+        assert (
+            "--extends-containment EXTENDS_CONTAINMENT Share of a parent's words its child must "
+            "repeat before the parent is retired." in options
         )

--- a/apps/api/tests/unit/scripts/test_repair_memory_store.py
+++ b/apps/api/tests/unit/scripts/test_repair_memory_store.py
@@ -578,6 +578,11 @@ class TestWhatCountsAsCoverage:
         assert covers("uses AI", "uses", 1.0) is True
         assert covers("uses zsh", "uses", 1.0) is False
 
+    def test_a_child_that_flips_the_parents_meaning_does_not_cover_it(self) -> None:
+        # "not" is the whole difference between these two claims.
+        assert covers("startup is not venture-backed", "startup is venture-backed", 0.8) is False
+        assert covers("startup is not venture-backed", "startup is not venture-backed", 1.0) is True
+
     def test_an_apostrophe_keeps_a_contraction_as_one_word(self) -> None:
         assert covers("doesn't drink", "does not drink", 1.0) is False
         assert covers("doesn't drink", "doesn't drink", 1.0) is True
@@ -645,6 +650,39 @@ class TestCommandLine:
         assert args.retire_ids is None
         assert args.state_age_days == STATE_FACT_TTL_DAYS
         assert args.extends_containment == 0.8
+
+    @pytest.mark.parametrize("bad", ["-1", "1.5", "nan"])
+    def test_a_containment_outside_zero_to_one_refuses_to_start(
+        self, bad: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch(
+                "sys.argv", ["repair_memory_store", "--user", "u1", "--extends-containment", bad]
+            ),
+            pytest.raises(SystemExit) as raised,
+        ):
+            main()
+
+        assert raised.value.code == 2
+        assert f"'{bad}' is not a share between 0.0 and 1.0" in capsys.readouterr().err
+
+    def test_a_containment_that_is_not_a_number_refuses_to_start(self) -> None:
+        with (
+            patch(
+                "sys.argv", ["repair_memory_store", "--user", "u1", "--extends-containment", "half"]
+            ),
+            pytest.raises(SystemExit) as raised,
+        ):
+            main()
+
+        assert raised.value.code == 2
+
+    @pytest.mark.parametrize("edge", ["0", "1"])
+    def test_the_ends_of_the_share_are_allowed(self, edge: str) -> None:
+        captured, code = self._run_main(["--user", "u1", "--extends-containment", edge])
+
+        assert code == 0
+        assert captured[0].extends_containment == float(edge)
 
     def test_a_run_with_no_user_refuses_to_start(self) -> None:
         with patch("sys.argv", ["repair_memory_store"]), pytest.raises(SystemExit) as raised:


### PR DESCRIPTION
# Summary

The memory repair script would have deleted 216 of the founder's memories, and most of them were not duplicates. It now retires a parent only when the child actually restates it, and it no longer reads a long biography as a stale snapshot. On the production store that is 26 retirements instead of 216, and 28 stale snapshots instead of 29.

# Why

The script decides what is a duplicate by reading the `EXTENDS` links the OLD reconciler wrote, and that reconciler's rule was "more detail about a related claim". A link therefore means the two rows are topically adjacent, not that one replaces the other. The first real dry run made that concrete:

```
retire: "prefers direct, human-sounding communication, avoiding corporate jargon and em dashes"
kept:   "prefers direct, concise, fluff-free communication for marketing copy"

retire: "reply style: lowercase subject and body, max ~5 sentences, one clear ask, signed 'best, aryan'"
kept:   "wants business email replies to avoid sales-management fluff"
```

Chains collapse to the wrong end: `8e1730ea -> c836125a -> f7decff9` retires the em dash rule and keeps a line about marketing copy. Separately, the stale-snapshot heuristic fires on any row containing "currently", which selected a 662 character biography, and `user.md` is rebuilt FROM live rows, so retiring it would impoverish the rebuild the script exists to fix.

# What changed

- `extends_parents_to_retire()` takes a `containment` threshold (default 0.8, `--extends-containment` on the CLI) and keeps a pair only when the child repeats that share of the parent's subject words. Filler words are ignored so "prefers" and "the" cannot carry a match.
- `looks_like_state()` applies its phrase heuristic only to rows under 300 characters. A row the extractor itself labelled `shelf_life='state'` is still retired at any length, because that is a declaration rather than a guess.

Measured on the production store (913 live rows, 216 linked parents): 15 retire at 0.9, 26 at 0.8, 36 at 0.7, 88 at 0.5. At 0.8 the retirements are real restatements ("not venture-backed" -> "bootstrapped and not venture-backed") and the spared pairs are plainly different facts ("uses nasal spray" vs "dislikes its taste", "billing account id" vs "reached 50% of budget").

# How to verify

From `apps/api`: `uv run python -m app.scripts.repair_memory_store --user <id>` prints the plan and writes nothing. `--extends-containment 0.5` widens it, `--extends-containment 0.95` narrows it.

Tests: `TestOnlyARestatementRetiresItsParent` and `TestALongProfileIsNotASnapshot` in `apps/api/tests/unit/scripts/test_repair_memory_store.py` pin both gates, including that the threshold is the caller's to choose. The pre-existing pairing tests now pass `containment=0` so they still test pairing rather than coverage, and the shared fixture's child was changed to an actual restatement.