### PR TITLE
feat(memory): let an operator spare specific memories from the repair

### DIFF
--- a/apps/api/app/scripts/repair_memory_store.py
+++ b/apps/api/app/scripts/repair_memory_store.py
@@ -351,6 +351,11 @@ def main() -> None:
     contradictory = set(args.keep_ids or []) & set(args.retire_ids or [])
     if contradictory:
         parser.error(f"--keep-ids and --retire-ids both name {', '.join(sorted(contradictory))}")
+    # A memory id belongs to one user, so a batch cannot honour one: every user
+    # after the id's owner would reject it as unknown, and under --apply the
+    # users before it are already committed, leaving the batch half repaired.
+    if (args.keep_ids or args.retire_ids) and len(args.user) > 1:
+        parser.error("--keep-ids and --retire-ids name rows of one user, so pass a single --user")
     raise SystemExit(asyncio.run(_run(args)))
 
 

--- a/apps/api/app/scripts/repair_memory_store.py
+++ b/apps/api/app/scripts/repair_memory_store.py
@@ -233,18 +233,44 @@ async def _repair_user(user_id: str, args: argparse.Namespace) -> int:
     rows = await pg_store.get_all_live_memories(user_id)
     print(f"\n{'=' * 78}\nUser {user_id}: {len(rows)} live memories\n{'=' * 78}")
 
-    extends_pairs = extends_parents_to_retire(rows, containment=args.extends_containment)
+    keep = set(args.keep_ids or [])
+    retire = set(args.retire_ids or [])
+    # A typo in either list is silent otherwise: the row you meant to spare gets
+    # retired, or the row you meant to retire survives, and the plan looks right
+    # both times. Both lists name rows of the user being repaired.
+    unknown = (keep | retire) - {str(row.id) for row in rows}
+    if unknown:
+        raise SystemExit(
+            f"user {user_id} has no live memory {', '.join(sorted(unknown))} — "
+            "--keep-ids and --retire-ids name rows of the user being repaired"
+        )
+
+    if keep:
+        print(f"\nSpared by --keep-ids: {len(keep)}")
+        for row in rows:
+            if str(row.id) in keep:
+                print(f"  - keep   {row.id}: {row.content!r}")
+
+    extends_pairs = [
+        (parent, child)
+        for parent, child in extends_parents_to_retire(rows, containment=args.extends_containment)
+        if str(parent.id) not in keep
+    ]
     print(f"\nEXTENDS parents still live alongside their child: {len(extends_pairs)}")
     for parent, child in extends_pairs:
         print(f"  - retire {parent.id}: {parent.content!r}")
         print(f"      kept  {child.id}: {child.content!r}")
 
-    stale = state_rows_to_forget(rows, now=now, age_days=args.state_age_days)
+    stale = [
+        row
+        for row in state_rows_to_forget(rows, now=now, age_days=args.state_age_days)
+        if str(row.id) not in keep
+    ]
     print(f"\nStale state snapshots older than {args.state_age_days}d: {len(stale)}")
     for row in stale:
         print(f"  - forget {row.id} ({row.created_at:%Y-%m-%d}): {row.content!r}")
 
-    manual = [row for row in rows if str(row.id) in set(args.retire_ids or [])]
+    manual = [row for row in rows if str(row.id) in retire]
     if manual:
         print(f"\nExplicitly retired by --retire-ids: {len(manual)}")
         for row in manual:
@@ -305,6 +331,11 @@ def main() -> None:
         "--retire-ids", action="append", help="Forget this memory id outright (repeatable)."
     )
     parser.add_argument(
+        "--keep-ids",
+        action="append",
+        help="Never retire this memory id, whatever the plan says (repeatable).",
+    )
+    parser.add_argument(
         "--extends-containment",
         type=containment_share,
         default=_DEFAULT_EXTENDS_CONTAINMENT,
@@ -317,6 +348,9 @@ def main() -> None:
         help="Age past which a state-like row is retired.",
     )
     args = parser.parse_args()
+    contradictory = set(args.keep_ids or []) & set(args.retire_ids or [])
+    if contradictory:
+        parser.error(f"--keep-ids and --retire-ids both name {', '.join(sorted(contradictory))}")
     raise SystemExit(asyncio.run(_run(args)))
 
 

--- a/apps/api/tests/unit/scripts/test_repair_memory_store.py
+++ b/apps/api/tests/unit/scripts/test_repair_memory_store.py
@@ -713,8 +713,6 @@ class TestCommandLine:
             [
                 "--user",
                 "u1",
-                "--user",
-                "u2",
                 "--apply",
                 "--retire-ids",
                 "mem-1",
@@ -729,7 +727,7 @@ class TestCommandLine:
 
         assert code == 0
         (args,) = captured
-        assert args.user == ["u1", "u2"]
+        assert args.user == ["u1"]
         assert args.apply is True
         assert args.retire_ids == ["mem-1", "mem-2"]
         assert args.state_age_days == 30
@@ -757,7 +755,9 @@ class TestCommandLine:
             main()
 
         assert raised.value.code == 2
-        assert f"'{bad}' is not a share between 0.0 and 1.0" in capsys.readouterr().err
+        assert capsys.readouterr().err.endswith(
+            f"argument --extends-containment: {bad!r} is not a share between 0.0 and 1.0\n"
+        )
 
     def test_a_containment_that_is_not_a_number_refuses_to_start(self) -> None:
         with (
@@ -815,7 +815,43 @@ class TestCommandLine:
             main()
 
         assert raised.value.code == 2
-        assert "--keep-ids and --retire-ids both name m1, m2" in capsys.readouterr().err
+        assert capsys.readouterr().err.endswith(
+            "repair_memory_store: error: --keep-ids and --retire-ids both name m1, m2\n"
+        )
+
+    @pytest.mark.parametrize("flag", ["--keep-ids", "--retire-ids"])
+    def test_naming_rows_across_a_batch_of_users_refuses_to_start(
+        self, flag: str, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Under --apply the first user would already be committed by the time
+        # the second rejected the id, leaving the batch half repaired.
+        with (
+            patch(
+                "sys.argv",
+                ["repair_memory_store", "--user", "u1", "--user", "u2", flag, "m1", "--apply"],
+            ),
+            pytest.raises(SystemExit) as raised,
+        ):
+            main()
+
+        assert raised.value.code == 2
+        # endswith, not `in`: a mutant that pads the message still contains it.
+        assert capsys.readouterr().err.endswith(
+            "repair_memory_store: error: --keep-ids and --retire-ids name rows of "
+            "one user, so pass a single --user\n"
+        )
+
+    def test_a_batch_without_ids_is_still_allowed(self) -> None:
+        captured, code = self._run_main(["--user", "u1", "--user", "u2"])
+
+        assert code == 0
+        assert captured[0].user == ["u1", "u2"]
+
+    def test_one_user_with_ids_is_allowed(self) -> None:
+        captured, code = self._run_main(["--user", "u1", "--keep-ids", "m1"])
+
+        assert code == 0
+        assert captured[0].keep_ids == ["m1"]
 
     def test_a_run_with_no_user_refuses_to_start(self) -> None:
         with patch("sys.argv", ["repair_memory_store"]), pytest.raises(SystemExit) as raised:

--- a/apps/api/tests/unit/scripts/test_repair_memory_store.py
+++ b/apps/api/tests/unit/scripts/test_repair_memory_store.py
@@ -227,12 +227,14 @@ def make_args(
     *,
     apply: bool = False,
     retire_ids: list[str] | None = None,
+    keep_ids: list[str] | None = None,
     state_age_days: int | None = None,
     extends_containment: float = 0.8,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         apply=apply,
         retire_ids=retire_ids,
+        keep_ids=keep_ids,
         state_age_days=STATE_FACT_TTL_DAYS if state_age_days is None else state_age_days,
         extends_containment=extends_containment,
     )
@@ -598,6 +600,97 @@ class TestTheSnapshotLengthBound:
 
 
 @pytest.mark.unit
+class TestAnExplicitSpareOutranksThePlan:
+    """Both heuristics read wording, so both have honest false positives: a
+    residency fact phrased with "currently", a preference whose child is
+    narrower. --keep-ids is the operator's override, and it wins over every
+    rule in the script."""
+
+    async def test_a_spared_row_is_not_retired_as_a_duplicate(
+        self, store: SimpleNamespace, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        parent = make_row(content="sam works at acme")
+        child = make_row(
+            content="sam works at acme as a staff engineer",
+            parent_id=parent.id,
+            relation_type="extends",
+        )
+        store.get_all_live_memories.return_value = [parent, child]
+
+        await _repair_user("u1", make_args(apply=True, keep_ids=[str(parent.id)]))
+
+        out = capsys.readouterr().out
+        assert "EXTENDS parents still live alongside their child: 0" in out
+        assert f"\nSpared by --keep-ids: 1\n  - keep   {parent.id}: {parent.content!r}\n" in out
+        store.forget_memory.assert_not_awaited()
+
+    async def test_nothing_is_spared_when_no_id_is_given(
+        self, store: SimpleNamespace, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        store.get_all_live_memories.return_value = [make_row(content="sam works at acme")]
+
+        await _repair_user("u1", make_args())
+
+        assert "Spared by --keep-ids" not in capsys.readouterr().out
+
+    async def test_a_spared_row_is_not_forgotten_as_a_stale_snapshot(
+        self, store: SimpleNamespace, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        row = make_row(content="Aryan is currently a Resident Indian", age_days=90)
+        store.get_all_live_memories.return_value = [row]
+
+        await _repair_user("u1", make_args(apply=True, keep_ids=[str(row.id)]))
+
+        assert "Stale state snapshots older than 60d: 0" in capsys.readouterr().out
+        store.forget_memory.assert_not_awaited()
+
+    async def test_sparing_one_row_leaves_the_rest_of_the_plan_alone(
+        self, store: SimpleNamespace, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spared = make_row(content="Aryan is currently a Resident Indian", age_days=90)
+        doomed = make_row(content="Gmail is currently disconnected", age_days=90)
+        store.get_all_live_memories.return_value = [spared, doomed]
+
+        await _repair_user("u1", make_args(apply=True, keep_ids=[str(spared.id)]))
+
+        assert "Stale state snapshots older than 60d: 1" in capsys.readouterr().out
+        store.forget_memory.assert_awaited_once()
+        assert store.forget_memory.await_args.args[1] == str(doomed.id)
+
+    async def test_an_id_that_names_no_live_row_stops_the_run(self, store: SimpleNamespace) -> None:
+        store.get_all_live_memories.return_value = [make_row(content="sam works at acme")]
+
+        with pytest.raises(SystemExit) as raised:
+            await _repair_user("u1", make_args(keep_ids=["zz-row", "aa-row"]))
+
+        assert str(raised.value) == (
+            "user u1 has no live memory aa-row, zz-row — --keep-ids and --retire-ids "
+            "name rows of the user being repaired"
+        )
+        store.forget_memory.assert_not_awaited()
+
+    async def test_a_retire_id_that_names_no_live_row_stops_the_run_too(
+        self, store: SimpleNamespace
+    ) -> None:
+        store.get_all_live_memories.return_value = [make_row(content="sam works at acme")]
+
+        with pytest.raises(SystemExit) as raised:
+            await _repair_user("u1", make_args(retire_ids=["typo-id"]))
+
+        assert str(raised.value) == (
+            "user u1 has no live memory typo-id — --keep-ids and --retire-ids "
+            "name rows of the user being repaired"
+        )
+        store.forget_memory.assert_not_awaited()
+
+    async def test_a_live_id_passes_the_check(self, store: SimpleNamespace) -> None:
+        row = make_row(content="sam works at acme")
+        store.get_all_live_memories.return_value = [row]
+
+        assert await _repair_user("u1", make_args(keep_ids=[str(row.id)])) == 0
+
+
+@pytest.mark.unit
 class TestCommandLine:
     @staticmethod
     def _run_main(argv: list[str]) -> tuple[list[argparse.Namespace], int | str | None]:
@@ -684,6 +777,46 @@ class TestCommandLine:
         assert code == 0
         assert captured[0].extends_containment == float(edge)
 
+    def test_the_spare_list_parses_and_is_repeatable(self) -> None:
+        captured, code = self._run_main(
+            ["--user", "u1", "--keep-ids", "mem-1", "--keep-ids", "mem-2"]
+        )
+
+        assert code == 0
+        assert captured[0].keep_ids == ["mem-1", "mem-2"]
+
+    def test_a_run_with_no_spare_list_leaves_it_unset(self) -> None:
+        captured, _code = self._run_main(["--user", "u1"])
+
+        assert captured[0].keep_ids is None
+
+    def test_sparing_and_retiring_the_same_id_refuses_to_start(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "repair_memory_store",
+                    "--user",
+                    "u1",
+                    "--keep-ids",
+                    "m2",
+                    "--keep-ids",
+                    "m1",
+                    "--retire-ids",
+                    "m1",
+                    "--retire-ids",
+                    "m2",
+                ],
+            ),
+            pytest.raises(SystemExit) as raised,
+        ):
+            main()
+
+        assert raised.value.code == 2
+        assert "--keep-ids and --retire-ids both name m1, m2" in capsys.readouterr().err
+
     def test_a_run_with_no_user_refuses_to_start(self) -> None:
         with patch("sys.argv", ["repair_memory_store"]), pytest.raises(SystemExit) as raised:
             main()
@@ -728,4 +861,8 @@ class TestCommandLine:
         assert (
             "--extends-containment EXTENDS_CONTAINMENT Share of a parent's words its child must "
             "repeat before the parent is retired." in options
+        )
+        assert (
+            "--keep-ids KEEP_IDS Never retire this memory id, whatever the plan says "
+            "(repeatable)." in options
         )


### PR DESCRIPTION
# Summary

The memory repair script can now be told to leave specific rows alone: `--keep-ids <id>` spares a memory no matter what the plan says. Both of the script's rules read wording, so both have honest false positives, and until now there was no way to overrule one short of editing the code.

# Why

Reviewing the real plan for one user surfaced two rows the stale-snapshot rule wants to forget that are probably still true:

```
forget f0ec22b1 (2026-06-17): 'Aryan is a Resident Indian currently building his startup.'
forget 3f5af146 (2026-06-15): "Aryan's startup is currently enrolled in the Google for Startups program."
```

Both were selected because they contain the word "currently", which is what a dated snapshot usually looks like. Residency and programme enrolment are not snapshots. The rule is right often enough to keep, so the fix is an override rather than a weaker rule.

# What changed

- `--keep-ids` (repeatable) removes a row from every retirement list: duplicate parents, stale snapshots, and explicit retirements alike. Spared rows are printed at the top of the plan so the operator can see what the override actually caught.
- Passing the same id to both `--keep-ids` and `--retire-ids` is refused by argparse before any database work, rather than being resolved by whichever list happens to win.
- An id in either list that names no live row for the user now stops the run. This also tightens the pre-existing `--retire-ids`, which silently ignored unknown ids: a typo there meant the row you meant to retire quietly survived and the plan still looked correct. Both lists are scoped to the user being repaired.

# How to verify

From `apps/api`, against any user id:

```
uv run python -m app.scripts.repair_memory_store --user <id>                       # the plan
uv run python -m app.scripts.repair_memory_store --user <id> --keep-ids <row-id>   # one row spared
```

The second run should show `Spared by --keep-ids: 1` and one fewer retirement. A made-up id exits with a message naming it.

Tests: `TestAnExplicitSpareOutranksThePlan` covers sparing a duplicate parent, sparing a stale snapshot, leaving the rest of the plan intact, and both unknown-id refusals; `TestCommandLine` covers parsing, the default, and the contradiction. The mutation lane runs clean on the module.