### PR TITLE
fix(api): attribute every OpenRouter client, with a distinct dev identity

### DIFF
--- a/apps/api/app/agents/llm/client.py
+++ b/apps/api/app/agents/llm/client.py
@@ -1,6 +1,6 @@
 import asyncio
 from functools import cache
-from typing import Any, TypeVar, cast
+from typing import Any, TypedDict, TypeVar, cast
 
 from langchain_core.callbacks import BaseCallbackHandler, UsageMetadataCallbackHandler
 from langchain_core.language_models import LanguageModelInput, LanguageModelLike
@@ -50,6 +50,8 @@ from app.constants.llm import (
     MODEL_KWARGS_FIELD_ID,
     OPENROUTER_APP_CATEGORIES,
     OPENROUTER_APP_TITLE,
+    OPENROUTER_DEV_APP_TITLE,
+    OPENROUTER_DEV_APP_URL,
     OPENROUTER_MAX_OUTPUT_TOKENS,
     OPENROUTER_REASONING,
     REASONING_FIELD_ID,
@@ -190,6 +192,38 @@ def init_gemini_llm() -> LanguageModelLike:
     return llm.configurable_fields(model=_MODEL_FIELD)
 
 
+class _AppAttribution(TypedDict):
+    """Keyword shape of ChatOpenRouter's attribution params, so ``**`` unpacking
+    stays precisely checked against the client's signature."""
+
+    app_url: str
+    app_title: str
+    app_categories: list[str]
+
+
+def _app_attribution() -> _AppAttribution:
+    """OpenRouter app-attribution params, for EVERY real OpenRouter client.
+
+    Production attributes to the public site; development sends a fixed
+    synthetic referer, because a localhost FRONTEND_URL lands the traffic in the
+    dashboard's "unknown app" bucket where it is indistinguishable from a
+    misconfigured caller. Shared by the graph lane and the aux lane — the aux
+    lane shipped without any attribution, so memory extraction, follow-ups and
+    onboarding were all reporting as "unknown" from production too.
+    """
+    if settings.ENV == "production":
+        return {
+            "app_url": settings.FRONTEND_URL,
+            "app_title": OPENROUTER_APP_TITLE,
+            "app_categories": OPENROUTER_APP_CATEGORIES,
+        }
+    return {
+        "app_url": OPENROUTER_DEV_APP_URL,
+        "app_title": OPENROUTER_DEV_APP_TITLE,
+        "app_categories": OPENROUTER_APP_CATEGORIES,
+    }
+
+
 @lazy_provider(
     name=LLMProviderKey.OPENROUTER,
     required_keys=[SIM_STUB_API_KEY if settings.GAIA_SIM_MODE else settings.OPENROUTER_API_KEY],
@@ -221,9 +255,7 @@ def init_openrouter_llm() -> LanguageModelLike:
             # App attribution → OpenRouter rankings/analytics. ChatOpenRouter exposes
             # these as dedicated params (NOT `default_headers`, which it forwards to
             # send_async and crashes on). https://openrouter.ai/docs/app-attribution
-            app_url=settings.FRONTEND_URL,
-            app_title=OPENROUTER_APP_TITLE,
-            app_categories=OPENROUTER_APP_CATEGORIES,
+            **_app_attribution(),
             reasoning=OPENROUTER_REASONING,
         )
     )
@@ -483,6 +515,7 @@ def _build_default_llm(temperature: float) -> BaseChatModel:
             stream_usage=True,
             max_tokens=OPENROUTER_MAX_OUTPUT_TOKENS,
             api_key=settings.OPENROUTER_API_KEY,
+            **_app_attribution(),
             **_provider_order_kwargs(),
         )
     )

--- a/apps/api/app/constants/llm.py
+++ b/apps/api/app/constants/llm.py
@@ -318,9 +318,13 @@ DEV_LLM_MAX_OUTPUT_TOKENS = 64_000
 # OpenRouter app attribution (https://openrouter.ai/docs/app-attribution). The
 # OpenRouter client surfaces these as the HTTP-Referer / X-Title /
 # X-OpenRouter-Categories headers so GAIA appears on OpenRouter's app rankings.
-# The referer URL is the public site (settings.FRONTEND_URL); title + categories
-# are fixed app identity.
+# In production the referer is the public site (settings.FRONTEND_URL);
+# development sends a fixed synthetic referer instead, because a localhost
+# FRONTEND_URL cannot be attributed and the traffic lands in the dashboard's
+# "unknown app" bucket — indistinguishable from a misconfigured caller.
 OPENROUTER_APP_TITLE = "GAIA"
+OPENROUTER_DEV_APP_URL = "https://dev.heygaia.io"
+OPENROUTER_DEV_APP_TITLE = "GAIA (dev)"
 OPENROUTER_APP_CATEGORIES = ["personal-agent", "general-chat"]
 
 # DEV-ONLY model menu (ENV=development). The dev chat-header selector sends one of

--- a/apps/api/tests/unit/agents/test_llm_client.py
+++ b/apps/api/tests/unit/agents/test_llm_client.py
@@ -57,6 +57,10 @@ from app.constants.llm import (
     AUX_MODEL_NAME,
     DEFAULT_GEMINI_MODEL_NAME,
     DEFAULT_MODEL_NAME,
+    OPENROUTER_APP_CATEGORIES,
+    OPENROUTER_APP_TITLE,
+    OPENROUTER_DEV_APP_TITLE,
+    OPENROUTER_DEV_APP_URL,
     OPENROUTER_MAX_OUTPUT_TOKENS,
     STICKY_FLIP_RETRY_MIN_INPUT,
 )
@@ -466,6 +470,92 @@ class TestInitLlm:
 # ---------------------------------------------------------------------------
 # get_default_llm
 # ---------------------------------------------------------------------------
+
+
+class TestOpenRouterAppAttribution:
+    """Every real OpenRouter client must attribute itself, on both lanes.
+
+    The aux lane (_build_default_llm — memory extraction, follow-ups,
+    onboarding) shipped with no attribution at all, so its production traffic
+    reported as "unknown app" on the OpenRouter dashboard, indistinguishable
+    from a leaked key. And development used to send the localhost FRONTEND_URL,
+    which OpenRouter cannot attribute — same bucket.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_cache(self):
+        _build_default_llm.cache_clear()
+        yield
+        _build_default_llm.cache_clear()
+
+    @staticmethod
+    def _attribution_of(mock_chat_openrouter: MagicMock) -> dict[str, object]:
+        kwargs = mock_chat_openrouter.call_args.kwargs
+        return {k: kwargs.get(k) for k in ("app_url", "app_title", "app_categories")}
+
+    @patch("app.agents.llm.client.without_sdk_retry", new=lambda llm: llm)
+    @patch("app.agents.llm.client.ChatOpenRouter")
+    @patch("app.agents.llm.client.settings")
+    def test_the_aux_lane_attributes_itself(
+        self, mock_settings: MagicMock, mock_chat_openrouter: MagicMock
+    ) -> None:
+        mock_settings.ENV = "production"
+        mock_settings.FRONTEND_URL = "https://heygaia.io"
+        mock_settings.OPENROUTER_API_KEY = "or-key"  # pragma: allowlist secret
+        mock_settings.OPENROUTER_PROVIDER_ORDER = ""
+
+        _build_default_llm(0.7)
+
+        assert self._attribution_of(mock_chat_openrouter) == {
+            "app_url": "https://heygaia.io",
+            "app_title": OPENROUTER_APP_TITLE,
+            "app_categories": OPENROUTER_APP_CATEGORIES,
+        }
+
+    @patch("app.agents.llm.client.without_sdk_retry", new=lambda llm: llm)
+    @patch("app.agents.llm.client.ChatOpenRouter")
+    @patch("app.agents.llm.client.settings")
+    def test_development_reports_as_its_own_app_not_unknown(
+        self, mock_settings: MagicMock, mock_chat_openrouter: MagicMock
+    ) -> None:
+        """A localhost referer is unattributable; dev must send the fixed dev
+        identity so its spend is legible on the dashboard."""
+        mock_settings.ENV = "development"
+        mock_settings.FRONTEND_URL = "http://localhost:3000"
+        mock_settings.OPENROUTER_API_KEY = "or-key"  # pragma: allowlist secret
+        mock_settings.OPENROUTER_PROVIDER_ORDER = ""
+
+        _build_default_llm(0.7)
+
+        assert self._attribution_of(mock_chat_openrouter) == {
+            "app_url": OPENROUTER_DEV_APP_URL,
+            "app_title": OPENROUTER_DEV_APP_TITLE,
+            "app_categories": OPENROUTER_APP_CATEGORIES,
+        }
+
+    @patch("app.agents.llm.client._openrouter_wire_configurables", new=lambda llm: llm)
+    @patch("app.agents.llm.client.without_sdk_retry", new=lambda llm: llm)
+    @patch("app.agents.llm.client.ChatOpenRouter")
+    @patch("app.agents.llm.client.settings")
+    def test_the_graph_lane_attributes_itself(
+        self, mock_settings: MagicMock, mock_chat_openrouter: MagicMock
+    ) -> None:
+        mock_settings.GAIA_SIM_MODE = False
+        mock_settings.ENV = "production"
+        mock_settings.FRONTEND_URL = "https://heygaia.io"
+        mock_settings.OPENROUTER_API_KEY = "or-key"  # pragma: allowlist secret
+
+        # lazy_provider swaps the imported symbol for a registration hook; the
+        # real factory lives on the LazyLoader it returns. Running that is the
+        # only way to prove the GRAPH lane passes attribution through — the
+        # helper being correct proves nothing if this site never calls it.
+        client_module.init_openrouter_llm().loader_func()
+
+        assert self._attribution_of(mock_chat_openrouter) == {
+            "app_url": "https://heygaia.io",
+            "app_title": OPENROUTER_APP_TITLE,
+            "app_categories": OPENROUTER_APP_CATEGORIES,
+        }
 
 
 class TestGetDefaultLlm:

--- a/apps/api/tests/unit/config/test_settings_guards.py
+++ b/apps/api/tests/unit/config/test_settings_guards.py
@@ -204,7 +204,8 @@ def test_init_openrouter_llm_pins_context_window_profile(monkeypatch):
         DEFAULT_LLM_TEMPERATURE,
         DEFAULT_MAX_TOKENS,
         OPENROUTER_APP_CATEGORIES,
-        OPENROUTER_APP_TITLE,
+        OPENROUTER_DEV_APP_TITLE,
+        OPENROUTER_DEV_APP_URL,
         OPENROUTER_MAX_OUTPUT_TOKENS,
         OPENROUTER_REASONING,
     )
@@ -220,8 +221,10 @@ def test_init_openrouter_llm_pins_context_window_profile(monkeypatch):
     assert captured["model"] == PROVIDER_MODELS["openrouter"]
     assert captured["temperature"] == DEFAULT_LLM_TEMPERATURE
     assert captured["max_tokens"] == OPENROUTER_MAX_OUTPUT_TOKENS
-    assert captured["app_url"] == client.settings.FRONTEND_URL
-    assert captured["app_title"] == OPENROUTER_APP_TITLE
+    # ENV is development here, so attribution must be the fixed dev identity —
+    # a localhost FRONTEND_URL referer lands in OpenRouter's "unknown app" bucket.
+    assert captured["app_url"] == OPENROUTER_DEV_APP_URL
+    assert captured["app_title"] == OPENROUTER_DEV_APP_TITLE
     assert captured["app_categories"] == OPENROUTER_APP_CATEGORIES
     assert captured["reasoning"] == OPENROUTER_REASONING
     assert captured["streaming"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -1945,7 +1945,7 @@ wheels = [
 
 [[package]]
 name = "gaia"
-version = "0.21.0"
+version = "0.22.0"
 source = { virtual = "apps/api" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Every OpenRouter request GAIA makes now attributes itself on the OpenRouter dashboard, and local development shows up as its own app ("GAIA (dev)" / dev.heygaia.io) instead of vanishing into the "unknown app" bucket.

## Why

An Aug 24 usage RCA found 21M tokens/day under "unknown app" on the OpenRouter dashboard — unattributable traffic that is indistinguishable from a leaked key. Root cause was attribution living at one call site instead of being shared:

- The aux lane (`_build_default_llm` — memory extraction, follow-up actions, onboarding one-shots) constructed `ChatOpenRouter` with **no attribution at all**, so its production traffic reported as unknown.
- Development sent `FRONTEND_URL` as the referer, which is `localhost` locally — OpenRouter can't attribute it, so every dev laptop's traffic landed in the same unknown bucket.

## What changed

- `_app_attribution()` (client.py) — one helper feeding **both** `ChatOpenRouter` construction sites. Production: `FRONTEND_URL` + "GAIA", as before. Development: fixed `https://dev.heygaia.io` + "GAIA (dev)", so dev spend gets its own dashboard row. Returns a `TypedDict` so the `**` unpack stays precisely checked against the client's signature.
- `uv.lock` — one-line sync of gaia to 0.22.0: the release PR (#950) bumps `pyproject.toml` but release-please never regenerates the lock, so master is left with a version mismatch that every local `uv run` re-locks as a side effect. Folded here rather than left to keep reappearing in unrelated diffs.

## The bug

Symptom: OpenRouter dashboard shows large "unknown app" usage. Cause: see Why — verified by reading both construction sites and the dashboard split (prod app attribution has existed since `b10950968`, June 23, so labeled traffic was never the issue). Regression tests seen red first against the unfixed client: `test_the_aux_lane_attributes_itself` and `test_development_reports_as_its_own_app_not_unknown` fail on master; `test_the_graph_lane_attributes_itself` pins the wiring that already worked.

## How to verify

Run `nx test api` (attribution tests are in `tests/unit/agents/test_llm_client.py::TestOpenRouterAppAttribution`). Live: boot `mise dev --agent`, send one chat message, then check the OpenRouter activity page — the call should appear under a "dev.heygaia.io" app rather than "unknown". Not verified live from this branch: the dashboard-side rendering of the new dev app row (needs a real billed call; the header shape is what the tests pin).

## Risk

Header-only change on the request path; a wrong value would mis-label dashboard rows, never fail a call. Rollback: revert.
