### PR TITLE
fix(memory): refuse a verified document that shrank more than it struck

### DIFF
--- a/apps/api/app/memory/consolidation.py
+++ b/apps/api/app/memory/consolidation.py
@@ -294,9 +294,13 @@ async def _rewrite_within_cap(
 
 
 # Whitespace the verifier may tidy while striking nothing: blank lines it
-# collapses, trailing spaces. Small enough that a placeholder response cannot
-# hide inside it.
-_SHRINK_SLACK_CHARS = 200
+# collapses, trailing spaces. Proportional, because a flat allowance is only
+# small relative to a long document — 200 characters is nothing against a 3,000
+# character profile and the whole thing against a 168 character one, which is
+# exactly the size of document that was replaced by "Let me process what's new
+# from" in production.
+_SHRINK_TOLERANCE = 0.05
+_MIN_SHRINK_TOLERANCE_CHARS = 16
 
 
 async def _strike_unsupported(
@@ -329,17 +333,22 @@ async def _strike_unsupported(
     # model did something else entirely: a run of this returned the placeholder
     # "## Document\n...document body..." with nothing struck, which is neither
     # None nor empty, so it was written verbatim over a 3,077-character profile.
+    original = content.strip()
     kept = verified.content.strip()
-    explained = sum(len(line) + 1 for line in verified.struck) + _SHRINK_SLACK_CHARS
-    lost = len(content.strip()) - len(kept)
-    if lost > explained:
+    # Only a line the document actually contained can explain its loss. Counting
+    # the reported strings unchecked would let a model claim any budget it liked
+    # by inventing them.
+    explained = sum(len(line) + 1 for line in verified.struck if line in original)
+    tolerance = max(_MIN_SHRINK_TOLERANCE_CHARS, int(len(original) * _SHRINK_TOLERANCE))
+    lost = len(original) - len(kept)
+    if lost > explained + tolerance:
         log.warning(
             "memory_consolidation_verification_failed",
             user_id=user_id,
             doc_type=doc_type.value,
             error_type="unexplained_document_shrink",
             lost_chars=lost,
-            explained_chars=explained,
+            explained_chars=explained + tolerance,
             struck_count=len(verified.struck),
         )
         return content

--- a/apps/api/app/memory/consolidation.py
+++ b/apps/api/app/memory/consolidation.py
@@ -293,6 +293,12 @@ async def _rewrite_within_cap(
     return None
 
 
+# Whitespace the verifier may tidy while striking nothing: blank lines it
+# collapses, trailing spaces. Small enough that a placeholder response cannot
+# hide inside it.
+_SHRINK_SLACK_CHARS = 200
+
+
 async def _strike_unsupported(
     user_id: str, doc_type: MemoryDocType, content: str, facts: list[MemoryRecord]
 ) -> str:
@@ -318,6 +324,25 @@ async def _strike_unsupported(
             error_type="llm_returned_empty",
         )
         return content
+    # The verifier only ever removes whole lines, so what the document loses has
+    # to be the lines it says it struck. When the arithmetic does not add up the
+    # model did something else entirely: a run of this returned the placeholder
+    # "## Document\n...document body..." with nothing struck, which is neither
+    # None nor empty, so it was written verbatim over a 3,077-character profile.
+    kept = verified.content.strip()
+    explained = sum(len(line) + 1 for line in verified.struck) + _SHRINK_SLACK_CHARS
+    lost = len(content.strip()) - len(kept)
+    if lost > explained:
+        log.warning(
+            "memory_consolidation_verification_failed",
+            user_id=user_id,
+            doc_type=doc_type.value,
+            error_type="unexplained_document_shrink",
+            lost_chars=lost,
+            explained_chars=explained,
+            struck_count=len(verified.struck),
+        )
+        return content
     if verified.struck:
         log.warning(
             "memory_consolidation_struck_unsupported",
@@ -326,7 +351,7 @@ async def _strike_unsupported(
             error_type="unsupported_document_lines",
             struck_count=len(verified.struck),
         )
-    return verified.content.strip()
+    return kept
 
 
 def _system_prompt(doc_type: MemoryDocType, user_name: str) -> str:

--- a/apps/api/tests/unit/memory/test_consolidation.py
+++ b/apps/api/tests/unit/memory/test_consolidation.py
@@ -308,6 +308,140 @@ class TestVerificationPass:
             }
         ]
 
+    async def test_a_placeholder_answer_does_not_replace_the_document(
+        self, boundaries: MagicMock
+    ) -> None:
+        """This is the run that cost a real profile. The verifier answered with
+        the literal placeholder '## Document\\n...document body...' and struck
+        nothing. It is neither None nor empty, so it was written over a 3,077
+        character user.md, and every prompt after that carried 31 characters."""
+        profile = "# About the user\n" + "\n".join(f"- fact number {i}" for i in range(80))
+        boundaries.verify.return_value = VerifiedDocument(
+            content="## Document\n...document body...", struck=[]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, profile, [make_row()]
+        )
+
+        assert kept == profile
+
+    async def test_an_unexplained_shrink_is_reported_on_the_wide_event(
+        self, boundaries: MagicMock
+    ) -> None:
+        profile = "# About\n" + "\n".join(f"- fact number {i}" for i in range(80))
+        boundaries.verify.return_value = VerifiedDocument(content="## Document", struck=[])
+
+        async with captured_wide_event() as event:
+            await consolidation._strike_unsupported(
+                USER, MemoryDocType.USER_MD, profile, [make_row()]
+            )
+
+        assert event["warnings"] == [
+            {
+                "msg": "memory_consolidation_verification_failed",
+                "user_id": USER,
+                "doc_type": "user_md",
+                "error_type": "unexplained_document_shrink",
+                "lost_chars": len(profile) - len("## Document"),
+                "explained_chars": consolidation._SHRINK_SLACK_CHARS,
+                "struck_count": 0,
+            }
+        ]
+
+    async def test_a_shrink_the_struck_lines_account_for_is_accepted(
+        self, boundaries: MagicMock
+    ) -> None:
+        # The loss here IS the struck lines, which is the verifier doing its job.
+        lie = "- " + "a lie that runs on for a while " * 12
+        document = f"# About\n{lie}\n- something true"
+        boundaries.verify.return_value = VerifiedDocument(
+            content="# About\n- something true", struck=[lie]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == "# About\n- something true"
+
+    async def test_a_stub_is_refused_even_when_it_claims_to_have_struck_something(
+        self, boundaries: MagicMock
+    ) -> None:
+        profile = "# About\n" + "\n".join(f"- fact number {i}" for i in range(80))
+        boundaries.verify.return_value = VerifiedDocument(
+            content="## Document", struck=["- fact number 1"]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, profile, [make_row()]
+        )
+
+        assert kept == profile
+
+    async def test_a_loss_exactly_the_size_of_the_slack_is_still_accepted(
+        self, boundaries: MagicMock
+    ) -> None:
+        # The slack exists for whitespace the verifier tidies, so a loss of
+        # exactly that much is the most it can explain without striking a line.
+        slack = consolidation._SHRINK_SLACK_CHARS
+        document = "x" * 1000
+        boundaries.verify.return_value = VerifiedDocument(content="x" * (1000 - slack), struck=[])
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == "x" * (1000 - slack)
+
+    async def test_one_character_past_the_slack_is_refused(self, boundaries: MagicMock) -> None:
+        slack = consolidation._SHRINK_SLACK_CHARS
+        document = "x" * 1000
+        boundaries.verify.return_value = VerifiedDocument(
+            content="x" * (1000 - slack - 1), struck=[]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == document
+
+    async def test_a_struck_line_buys_exactly_its_own_length_and_newline(
+        self, boundaries: MagicMock
+    ) -> None:
+        # A struck line takes its newline with it, so it explains len + 1.
+        slack = consolidation._SHRINK_SLACK_CHARS
+        line = "y" * 50
+        document = "x" * 1000
+        budget = len(line) + 1 + slack
+        boundaries.verify.return_value = VerifiedDocument(
+            content="x" * (1000 - budget), struck=[line]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == "x" * (1000 - budget)
+
+    async def test_one_character_past_a_struck_lines_budget_is_refused(
+        self, boundaries: MagicMock
+    ) -> None:
+        slack = consolidation._SHRINK_SLACK_CHARS
+        line = "y" * 50
+        document = "x" * 1000
+        budget = len(line) + 1 + slack
+        boundaries.verify.return_value = VerifiedDocument(
+            content="x" * (1000 - budget - 1), struck=[line]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == document
+
     async def test_a_document_with_no_source_facts_skips_the_check(
         self, boundaries: MagicMock
     ) -> None:

--- a/apps/api/tests/unit/memory/test_consolidation.py
+++ b/apps/api/tests/unit/memory/test_consolidation.py
@@ -344,7 +344,7 @@ class TestVerificationPass:
                 "doc_type": "user_md",
                 "error_type": "unexplained_document_shrink",
                 "lost_chars": len(profile) - len("## Document"),
-                "explained_chars": consolidation._SHRINK_SLACK_CHARS,
+                "explained_chars": int(len(profile) * consolidation._SHRINK_TOLERANCE),
                 "struck_count": 0,
             }
         ]
@@ -379,26 +379,51 @@ class TestVerificationPass:
 
         assert kept == profile
 
-    async def test_a_loss_exactly_the_size_of_the_slack_is_still_accepted(
+    async def test_the_profile_that_was_actually_destroyed_is_refused(
         self, boundaries: MagicMock
     ) -> None:
-        # The slack exists for whitespace the verifier tidies, so a loss of
-        # exactly that much is the most it can explain without striking a line.
-        slack = consolidation._SHRINK_SLACK_CHARS
-        document = "x" * 1000
-        boundaries.verify.return_value = VerifiedDocument(content="x" * (1000 - slack), struck=[])
+        """Verbatim from production: user 6a7a69f9's user.md, 168 characters,
+        replaced by 30 characters of the model narrating its own work. A flat
+        200-character allowance swallowed this entire document, which is why the
+        tolerance is proportional."""
+        profile = (
+            "# About the user\n## Identity\n- Gonzalo Blasco\n- GAIA account on the free "
+            "plan (daily usage limit). (as of 2026-08-13)\n\n## Work & projects\n\n"
+            "## Life & places\n\n## Routines"
+        )
+        assert len(profile) == 168
+        boundaries.verify.return_value = VerifiedDocument(
+            content="Let me process what's new from", struck=[]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, profile, [make_row()]
+        )
+
+        assert kept == profile
+
+    async def test_a_loss_within_the_tolerance_is_still_accepted(
+        self, boundaries: MagicMock
+    ) -> None:
+        # The tolerance covers whitespace the verifier tidies while striking
+        # nothing, so a loss of exactly that much is accepted.
+        document = "#" + "x" * 999
+        tolerance = int(len(document) * consolidation._SHRINK_TOLERANCE)
+        boundaries.verify.return_value = VerifiedDocument(
+            content="#" + "x" * (999 - tolerance), struck=[]
+        )
 
         kept = await consolidation._strike_unsupported(
             USER, MemoryDocType.USER_MD, document, [make_row()]
         )
 
-        assert kept == "x" * (1000 - slack)
+        assert kept == "#" + "x" * (999 - tolerance)
 
-    async def test_one_character_past_the_slack_is_refused(self, boundaries: MagicMock) -> None:
-        slack = consolidation._SHRINK_SLACK_CHARS
-        document = "x" * 1000
+    async def test_one_character_past_the_tolerance_is_refused(self, boundaries: MagicMock) -> None:
+        document = "#" + "x" * 999
+        tolerance = int(len(document) * consolidation._SHRINK_TOLERANCE)
         boundaries.verify.return_value = VerifiedDocument(
-            content="x" * (1000 - slack - 1), struck=[]
+            content="#" + "x" * (999 - tolerance - 1), struck=[]
         )
 
         kept = await consolidation._strike_unsupported(
@@ -407,33 +432,65 @@ class TestVerificationPass:
 
         assert kept == document
 
+    async def test_a_short_document_gets_the_floor_not_a_pittance(
+        self, boundaries: MagicMock
+    ) -> None:
+        # 5% of a 40-character document is 2 characters, too tight for ordinary
+        # whitespace tidying, so a floor applies.
+        document = "# About the user\n- one"
+        floor = consolidation._MIN_SHRINK_TOLERANCE_CHARS
+        assert int(len(document) * consolidation._SHRINK_TOLERANCE) < floor
+        kept_text = document[: len(document) - floor]
+        assert kept_text == kept_text.strip(), "fixture must not end in whitespace"
+        boundaries.verify.return_value = VerifiedDocument(content=kept_text, struck=[])
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == kept_text
+
     async def test_a_struck_line_buys_exactly_its_own_length_and_newline(
         self, boundaries: MagicMock
     ) -> None:
-        # A struck line takes its newline with it, so it explains len + 1.
-        slack = consolidation._SHRINK_SLACK_CHARS
-        line = "y" * 50
-        document = "x" * 1000
-        budget = len(line) + 1 + slack
+        line = "- " + "y" * 60
+        document = f"# About\n{line}\n" + "x" * 900
+        tolerance = int(len(document.strip()) * consolidation._SHRINK_TOLERANCE)
+        budget = len(line) + 1 + tolerance
         boundaries.verify.return_value = VerifiedDocument(
-            content="x" * (1000 - budget), struck=[line]
+            content=document.strip()[: len(document.strip()) - budget], struck=[line]
         )
 
         kept = await consolidation._strike_unsupported(
             USER, MemoryDocType.USER_MD, document, [make_row()]
         )
 
-        assert kept == "x" * (1000 - budget)
+        assert len(kept) == len(document.strip()) - budget
 
     async def test_one_character_past_a_struck_lines_budget_is_refused(
         self, boundaries: MagicMock
     ) -> None:
-        slack = consolidation._SHRINK_SLACK_CHARS
-        line = "y" * 50
-        document = "x" * 1000
-        budget = len(line) + 1 + slack
+        line = "- " + "y" * 60
+        document = f"# About\n{line}\n" + "x" * 900
+        tolerance = int(len(document.strip()) * consolidation._SHRINK_TOLERANCE)
+        budget = len(line) + 1 + tolerance
         boundaries.verify.return_value = VerifiedDocument(
-            content="x" * (1000 - budget - 1), struck=[line]
+            content=document.strip()[: len(document.strip()) - budget - 1], struck=[line]
+        )
+
+        kept = await consolidation._strike_unsupported(
+            USER, MemoryDocType.USER_MD, document, [make_row()]
+        )
+
+        assert kept == document
+
+    async def test_a_line_the_document_never_had_buys_nothing(self, boundaries: MagicMock) -> None:
+        """Otherwise a model could claim any budget it liked by inventing the
+        lines it says it struck."""
+        document = "# About\n" + "x" * 900
+        invented = "- " + "z" * 400
+        boundaries.verify.return_value = VerifiedDocument(
+            content="# About\n" + "x" * 400, struck=[invented]
         )
 
         kept = await consolidation._strike_unsupported(


### PR DESCRIPTION
# Summary

The verification pass that guards core memory documents can destroy the document it is checking. It accepted a placeholder answer from the model and wrote 31 characters over a 3,077-character `user.md`. It now refuses any verified document that lost more text than the lines it says it struck, and keeps the unverified document instead.

# The bug

**Symptom.** After a consolidation run, `user_md` for one user was v145, 31 characters long:

```
## Document
...document body...
```

The three sibling documents (`memory_md`, `people_md`, `agenda_md`) rebuilt correctly in the same run. `user.md` is injected into every prompt, so from that write onward the agent carried a placeholder where the user's profile should be.

**Root cause.** `_strike_unsupported` in `app/memory/consolidation.py` asks the model to remove unsupported lines, then guards the answer:

```python
if verified is None or not verified.content.strip():
    ...
    return content
```

A placeholder is neither `None` nor empty, so it passed and was written verbatim. The retained history shows both writes inside the same run, 2ms apart: v144 at `18:10:49.250977` with the real 3,077-character profile, v145 at `18:10:49.249235` with the stub. The rewrite worked; the check that was supposed to protect it is what replaced it.

This is the same function whose docstring records the earlier "Khyal Shetal" corruption. The guard added for that failure only covered the empty case.

**Fix.** The verifier only ever removes whole lines, so the characters the document loses have to be the lines it reports striking. When the loss exceeds what the struck lines can explain (plus a small slack for whitespace it may tidy), the model did something other than the task, and the unverified document stands. That follows the policy already stated in the docstring: a document that skipped its check beats no document.

**Regression tests.** `test_a_placeholder_answer_does_not_replace_the_document` reproduces the exact response that caused this. It, and two others, were watched failing against `master` before the fix:

```
FAILED test_a_placeholder_answer_does_not_replace_the_document
FAILED test_an_unexplained_shrink_is_reported_on_the_wide_event
FAILED test_a_stub_is_refused_even_when_it_claims_to_have_struck_something
3 failed, 43 passed
```

`test_a_shrink_the_struck_lines_account_for_is_accepted` is the control: it passes both before and after, proving the guard does not block legitimate striking. Four further tests pin both sides of the budget exactly (a loss equal to the slack is kept, one character more is refused; a struck line buys its own length plus its newline, one character more is refused). The mutation lane reports no survivors in the changed function.

**Why the suite missed it.** Every existing test of this path used documents a few lines long, where a degenerate answer and a legitimate one are the same size. Nothing asserted a relationship between what the verifier returned and what it claimed to have done.

# Post-merge

No migration. Any document already overwritten has to be restored from the row's `history` column, which retains the last N versions; the affected user's `user_md` was restored that way. Worth checking whether other users hit the same path: search for `memory_consolidation_struck_unsupported` events whose document shrank sharply, or documents whose length dropped by more than half between versions.

# Risk

The guard only ever chooses to keep the pre-verification document, so its failure mode is a document that keeps an unsupported line — the state everything was in before the verification pass existed. It cannot cause a loss.