### PR TITLE
fix(api): fail loud when a ChromaDB batch write fails, and correct the stale embedding dims

### DIFF
--- a/apps/api/app/constants/chroma.py
+++ b/apps/api/app/constants/chroma.py
@@ -11,3 +11,10 @@ Tunables for the ChromaDB-backed LangGraph store.
 # ~72 fds baseline usage, so 20 clears it with wide margin even when startup
 # fans out indexing across every provider toolkit concurrently.
 MAX_CONCURRENT_CHROMA_WRITES = 20
+
+# Native output width of models/gemini-embedding-001 (app/agents/tools/core/store.py),
+# which embeds every vector in the tools and triggers collections. ChromaDB pins a
+# collection's dimensionality from the first vectors written to it, so this must match
+# the model or every later write is rejected with InvalidArgumentError. Distinct from
+# EMBEDDING_DIM (app/constants/memory.py) — that is the memory subsystem's own model.
+GEMINI_EMBEDDING_DIM = 3072

--- a/apps/api/app/db/chroma/chroma_store.py
+++ b/apps/api/app/db/chroma/chroma_store.py
@@ -41,6 +41,10 @@ from shared.py.wide_events import VectorContext, log
 FilterValue = str | int | float | bool | None | dict[str, Any] | list[Any]
 
 
+class ChromaBatchWriteError(RuntimeError):
+    """Raised when one or more writes in a ChromaDB batch failed."""
+
+
 class ChromaStore(BaseStore):
     """ChromaDB-backed store with vector search capabilities.
 
@@ -565,6 +569,14 @@ class ChromaStore(BaseStore):
                     doc_id=d,
                     error_type=type(exc).__name__,
                 )
+            # Returning normally here reported success to the caller, which then
+            # logged "Successfully updated tools in ChromaDB" over a batch that
+            # wrote nothing. Raise so the caller sees the write actually failed;
+            # the indexers already catch this and log a verdict.
+            raise ChromaBatchWriteError(
+                f"{len(failures)} of {len(results)} ChromaDB writes failed "
+                f"(first: {type(failures[0][1]).__name__}: {failures[0][1]})"
+            ) from failures[0][1]
 
     async def _delete_item(self, doc_id: str, collection: AsyncCollection) -> None:
         """Delete a single item.

--- a/apps/api/app/db/chroma/chroma_tools_store.py
+++ b/apps/api/app/db/chroma/chroma_tools_store.py
@@ -19,7 +19,7 @@ from app.db.chroma.chromadb import ChromaClient
 from app.db.redis import delete_cache, get_cache, set_cache
 from shared.py.wide_events import VectorContext, log
 
-from .chroma_store import ChromaStore
+from .chroma_store import ChromaBatchWriteError, ChromaStore
 
 
 class IndexableTool(Protocol):
@@ -305,14 +305,40 @@ async def _execute_batch_operations(
 
     total_ops = len(put_ops)
 
+    batch_total = (total_ops + batch_size - 1) // batch_size
+    failed_batches = 0
+
     for i in range(0, total_ops, batch_size):
         batch = put_ops[i : i + batch_size]
-        await store.abatch(batch)
+        try:
+            await store.abatch(batch)
+        except ChromaBatchWriteError as exc:
+            # Indexing is best-effort: a batch that ChromaDB rejects (an
+            # unreachable embedding provider, a dimension mismatch) must not
+            # stop the remaining batches or the caller's startup. Report it and
+            # keep going — what must never happen is claiming success below.
+            failed_batches += 1
+            log.error(
+                f"{LogTag.CHROMA} Processed batch failed",
+                batch_index=i // batch_size + 1,
+                batch_total=batch_total,
+                error=str(exc),
+            )
+            continue
         log.info(
             f"{LogTag.CHROMA} Processed batch",
             batch_index=i // batch_size + 1,
-            batch_total=(total_ops + batch_size - 1) // batch_size,
+            batch_total=batch_total,
         )
+
+    if failed_batches:
+        log.error(
+            f"{LogTag.CHROMA} tools indexing finished with failed batches",
+            total_ops=total_ops,
+            batch_total=batch_total,
+            failed_batches=failed_batches,
+        )
+        return
 
     log.info(f"{LogTag.CHROMA} Successfully updated tools in ChromaDB", total_ops=total_ops)
 

--- a/apps/api/app/db/chroma/chroma_tools_store.py
+++ b/apps/api/app/db/chroma/chroma_tools_store.py
@@ -12,6 +12,7 @@ from langgraph.store.base import PutOp
 
 from app.agents.core.subagents.registry import all_subagents
 from app.agents.tools.core.registry import ToolRegistry, get_tool_registry
+from app.constants.chroma import GEMINI_EMBEDDING_DIM
 from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from app.db.chroma.chromadb import ChromaClient
@@ -536,7 +537,7 @@ async def initialize_chroma_tools_store() -> ChromaStore:
         collection_name="langgraph_tools_store",
         index={
             "embed": embeddings,
-            "dims": 768,
+            "dims": GEMINI_EMBEDDING_DIM,
             "fields": ["description"],
         },
     )

--- a/apps/api/app/db/chroma/chroma_triggers_store.py
+++ b/apps/api/app/db/chroma/chroma_triggers_store.py
@@ -12,6 +12,7 @@ from chromadb.api.models.AsyncCollection import AsyncCollection
 from langgraph.store.base import PutOp
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
+from app.constants.chroma import GEMINI_EMBEDDING_DIM
 from app.constants.log_tags import LogTag
 from app.core.lazy_loader import MissingKeyStrategy, lazy_provider, providers
 from app.db.chroma.chromadb import ChromaClient
@@ -271,7 +272,7 @@ async def initialize_chroma_triggers_store() -> ChromaStore:
         collection_name="langgraph_triggers_store",
         index={
             "embed": embeddings,
-            "dims": 768,
+            "dims": GEMINI_EMBEDDING_DIM,
             "fields": ["rich_description"],
         },
     )

--- a/apps/api/app/db/chroma/chroma_triggers_store.py
+++ b/apps/api/app/db/chroma/chroma_triggers_store.py
@@ -20,7 +20,7 @@ from app.models.oauth_models import OAuthIntegration
 from app.models.trigger_config import TriggerConfig
 from shared.py.wide_events import VectorContext, log
 
-from .chroma_store import ChromaStore
+from .chroma_store import ChromaBatchWriteError, ChromaStore
 
 # Namespace for workflow triggers in the store
 TRIGGERS_NAMESPACE = "workflow_triggers"
@@ -232,14 +232,40 @@ async def _execute_batch_operations(
 
     total_ops = len(put_ops)
 
+    batch_total = (total_ops + batch_size - 1) // batch_size
+    failed_batches = 0
+
     for i in range(0, total_ops, batch_size):
         batch = put_ops[i : i + batch_size]
-        await store.abatch(batch)
+        try:
+            await store.abatch(batch)
+        except ChromaBatchWriteError as exc:
+            # Indexing is best-effort: a batch that ChromaDB rejects (an
+            # unreachable embedding provider, a dimension mismatch) must not
+            # stop the remaining batches or the caller's startup. Report it and
+            # keep going — what must never happen is claiming success below.
+            failed_batches += 1
+            log.error(
+                f"{LogTag.CHROMA} Processed triggers batch failed",
+                batch_index=i // batch_size + 1,
+                batch_total=batch_total,
+                error=str(exc),
+            )
+            continue
         log.info(
             f"{LogTag.CHROMA} Processed triggers batch",
             batch_index=i // batch_size + 1,
-            batch_total=(total_ops + batch_size - 1) // batch_size,
+            batch_total=batch_total,
         )
+
+    if failed_batches:
+        log.error(
+            f"{LogTag.CHROMA} triggers indexing finished with failed batches",
+            total_ops=total_ops,
+            batch_total=batch_total,
+            failed_batches=failed_batches,
+        )
+        return
 
     log.info(f"{LogTag.CHROMA} Successfully updated triggers in ChromaDB", total_ops=total_ops)
 

--- a/apps/api/tests/integration/db/test_chroma_store.py
+++ b/apps/api/tests/integration/db/test_chroma_store.py
@@ -34,7 +34,7 @@ from langgraph.store.base import GetOp, PutOp, SearchOp
 import pytest
 
 from app.constants.chroma import MAX_CONCURRENT_CHROMA_WRITES
-from app.db.chroma.chroma_store import ChromaStore
+from app.db.chroma.chroma_store import ChromaBatchWriteError, ChromaStore
 from app.db.chroma.chroma_tools_store import (
     _build_put_operations,
     _compute_tool_diff,
@@ -461,11 +461,13 @@ class TestChromaStoreSearch:
         # Exactly 2 items should be returned — not 0, not 3.
         assert len(results[0]) == 2
 
-    async def test_partial_failure_in_gather_does_not_block_successful_puts(self, chroma_store):
+    async def test_partial_failure_completes_other_puts_but_still_raises(self, chroma_store):
         """_apply_put_ops uses asyncio.gather(return_exceptions=True).
 
-        If one upsert task raises, the others should still complete and their
-        items should be retrievable afterwards.
+        If one upsert task raises, the others must still complete and their
+        items must be retrievable afterwards — but the batch must NOT report
+        success. It previously returned normally, so callers logged
+        "Successfully updated tools in ChromaDB" over a batch that dropped rows.
 
         ChromaStore uses __slots__, so we patch at the class level to avoid
         the 'read-only attribute' error from patch.object on the instance.
@@ -483,7 +485,10 @@ class TestChromaStoreSearch:
                 raise RuntimeError("Simulated upsert failure")
             return await original_upsert_item(self_arg, doc_id, op, collection)
 
-        with patch.object(type(chroma_store), "_upsert_item", selective_upsert):
+        with (
+            patch.object(type(chroma_store), "_upsert_item", selective_upsert),
+            pytest.raises(ChromaBatchWriteError, match="1 of 2"),
+        ):
             await chroma_store.abatch(
                 [
                     PutOp(

--- a/apps/api/tests/unit/db/test_chroma_tools_store.py
+++ b/apps/api/tests/unit/db/test_chroma_tools_store.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from langgraph.store.base import PutOp
 import pytest
 
+from app.db.chroma.chroma_store import ChromaBatchWriteError
 from app.db.chroma.chroma_tools_store import (
     _build_put_operations,
     _compute_tool_diff,
@@ -316,6 +317,29 @@ class TestExecuteBatchOperations:
         ops = [MagicMock(spec=PutOp) for _ in range(120)]
         await _execute_batch_operations(store, ops, batch_size=50)
         assert store.abatch.await_count == 3  # 50 + 50 + 20
+
+    async def test_failed_batch_does_not_abort_startup_or_claim_success(self):
+        """A rejected batch must not propagate and must not be reported as success.
+
+        Propagating killed the API: initialize_chroma_triggers_store runs inside a
+        lazy provider, so the app exited with
+        "Failed to initialize required services: ['lazy_providers_auto_initializer']"
+        whenever the embedding provider was unreachable. Swallowing it silently was
+        the original bug. The only correct outcome is: keep going, report honestly.
+        """
+        store = AsyncMock()
+        store.abatch.side_effect = [None, ChromaBatchWriteError("50 of 50 failed"), None]
+        ops = [MagicMock(spec=PutOp) for _ in range(120)]
+
+        with patch.object(log, "info") as info, patch.object(log, "error") as error:
+            await _execute_batch_operations(store, ops, batch_size=50)
+
+        # Every batch is still attempted despite the middle one failing.
+        assert store.abatch.await_count == 3
+        # The failure is reported...
+        assert any("failed" in str(c).lower() for c in error.call_args_list)
+        # ...and success is never claimed over it.
+        assert not any("Successfully updated tools" in str(c) for c in info.call_args_list)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two small fixes in the ChromaDB indexing path, found while verifying #1111 against a live stack.

## 1. A failed batch reported success

`ChromaStore._apply_put_ops` gathered per-document results with `return_exceptions=True`, logged up to three failures, and then **returned normally**. Both indexers read that as success:

```
[CHROMA] _apply_put_ops failure        x129
[CHROMA] Successfully updated tools in ChromaDB   x24
```

129 failed batches, 24 success lines, nothing non-zero anywhere. The store told its callers the write worked.

Now it raises `ChromaBatchWriteError` with the failure counts. Resilience is unchanged in both senses that matter:

- Successful puts in a partly-failed batch still land — `gather` completes every task before the raise. The updated test pins this alongside the raise, so neither property can regress silently.
- The tools indexer (`registry.py:536`) and both MCP call sites (`mcp_client.py:1043`, `:1086`) already wrap this in `try/except` and log a verdict, so they behave as before minus the false claim.

**Behaviour change worth a reviewer's eye:** `_index_category_tools` (`registry.py:629`) does *not* catch, so a genuine indexing failure now propagates there instead of being swallowed. That is the intended fail-loud outcome, but it is the one path where this turns a silent degradation into a visible error.

## 2. `"dims": 768` was wrong in both stores

The value matched nothing:

| Number | Source |
|---|---|
| **3072** | what `models/gemini-embedding-001` actually emits (measured) |
| **1024** | `EMBEDDING_DIM` — the *memory* subsystem's separate model |
| **768** | what these two files claimed |

It is inert (ChromaDB derives dimensionality from the vectors themselves), so this fixes no runtime behaviour — but it is a false statement in the source that sent me down the wrong path for a while. Both literals now come from one `GEMINI_EMBEDDING_DIM` constant that records which model owns the number.

## Not in scope

The underlying design issue is that `NoOpEmbeddingFunction` can define a collection's dimensionality when the real embedding provider is unavailable — its 1024-wide zero vector permanently pins the collection, and every real 3072-dim write is rejected forever after. That is what happened on my local machine.

**Production is unaffected** — I checked read-only. Every collection is pinned correctly (`langgraph_tools_store` 1743 docs @ 3072, memory collections @ 1024) and prod logs show 41 successful indexing passes and **zero** failures. Fixing the pinning hazard means changing how collections get created; it deserves its own PR and its own thought.

## Verification

- `test_partial_failure_completes_other_puts_but_still_raises` — observed **red** with the raise removed, **green** with it restored.
- `pytest tests/integration/db/test_chroma_store.py tests/unit/db/test_chroma_tools_store.py tests/unit/db/test_chroma_triggers_store.py tests/unit/db/chroma` → **102 passed**
- `pytest tests/integration/test_tool_registry_retrieval.py` → **28 passed**
- `ruff check` → All checks passed; `mypy` → Success, no issues in 4 source files

Not verified: the new raise has not been exercised against a real failing production batch — prod currently has no failures to trigger it.
