### PR TITLE
feat(api): add updatedAt index on conversations collection

### DIFF
--- a/apps/api/app/db/mongodb/indexes.py
+++ b/apps/api/app/db/mongodb/indexes.py
@@ -181,6 +181,10 @@ async def create_conversation_indexes() -> None:
             conversations_collection.create_index([("user_id", 1), ("messages.message_id", 1)]),
             # For message pinning aggregations
             conversations_collection.create_index([("user_id", 1), ("messages.pinned", 1)]),
+            # For "active since <date>" range queries (e.g. the cost/usage dashboard).
+            # updatedAt is the only activity timestamp stored as a real BSON date —
+            # createdAt is an ISO string and can't be range-queried efficiently.
+            conversations_collection.create_index([("updatedAt", -1)]),
         )
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Adds a MongoDB index on `updatedAt` for the `conversations` collection so range queries like "conversations active since \<date\>" no longer full-scan the collection.

## Why

`conversations` currently has indexes on `(user_id, createdAt)`, `(user_id, conversation_id)`, `(user_id, starred, createdAt)`, `(user_id, messages.message_id)`, and `(user_id, messages.pinned)`, but nothing on `updatedAt`. The cost/usage dashboard runs an "active since \<date\>" range query against `updatedAt`, which today has to full-collection-scan (4,785 docs, ~81 MB — small now, but scans grow linearly with the collection and this query pattern gets worse as conversations accumulate). `updatedAt` is the only activity timestamp on the document that's a real BSON date (bumped via `$currentDate` on every message, per the repository docstring) — `createdAt` is an ISO string and isn't efficiently range-queryable.

## What changed

### API

- `apps/api/app/db/mongodb/indexes.py`: added `conversations_collection.create_index([("updatedAt", -1)])` to the existing `asyncio.gather` list in `create_conversation_indexes()`, with a comment explaining what it serves and why `updatedAt` (not `createdAt`) is the field to index.

## How to verify

Run `db.conversations.find({updatedAt: {$gte: ISODate(...)}}).explain("executionStats")` against a Mongo instance after the index builds — `winningPlan` should show an `IXSCAN` on `updatedAt` instead of `COLLSCAN`.

**Not verified:** did not run this against a live Mongo instance in this change — verified via `ruff check`, `ruff format`, `mypy`, the existing index-creator unit test suite (`tests/unit/db/test_mongodb.py`, 30 passed), and the repo's complexity-ratchet lint.

## Post-merge steps

Indexes are created by `create_all_indexes()` at API startup, so this index builds automatically on the next deploy. It's a background build (MongoDB builds non-blocking by default) against a small collection (4,785 docs), so no downtime is expected.

## Risk

Low — this only adds a new index; it doesn't touch any existing index, query, or write path. The only cost is index-build time (small collection, background build) and marginal extra storage/write overhead per conversation update, which is in line with the collection's existing five indexes.
