### PR TITLE
chore(deps): bump PostHog SDKs to close outdated-version gap

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -190,7 +190,7 @@ backend = [
   "markdown-it-py==3.0.0",
   "mdurl==0.1.2",
   "pyinstrument>=5.1.1",
-  "posthog>=7.4.2",
+  "posthog>=7.44.2",
   "sentry-sdk[langgraph]>=2.44.0",
   "langfuse>=3.7.0",
   "opik>=1.10.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -171,7 +171,7 @@
     "next-llms-txt": "^1.0.2",
     "onnxruntime-web": "^1.27.0",
     "postcss": "^8.5.16",
-    "posthog-js": "^1.399.2",
+    "posthog-js": "^1.422.5",
     "react": "19.1.0",
     "react-best-gradient-color-picker": "^3.0.14",
     "react-day-picker": "^9.14.0",

--- a/libs/pyproject.toml
+++ b/libs/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pydantic-settings>=2.8.1",
   "python-dotenv>=1.0.0",
   "infisicalsdk>=1.0.7",
-  "posthog>=7.4.2",
+  "posthog>=7.44.2",
 ]
 
 [dependency-groups]

--- a/libs/shared/ts/package.json
+++ b/libs/shared/ts/package.json
@@ -54,7 +54,7 @@
     "axios": "^1.18.1",
     "dotenv": "^16.6.1",
     "hono": "^4.12.29",
-    "posthog-node": "^5.41.0",
+    "posthog-node": "^5.51.4",
     "slackify-markdown": "^5.0.0",
     "string-similarity": "^4.0.4",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,8 +962,8 @@ importers:
         specifier: ^8.5.16
         version: 8.5.16
       posthog-js:
-        specifier: ^1.399.2
-        version: 1.399.2
+        specifier: ^1.422.5
+        version: 1.422.5(@types/react@19.2.17)(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1140,8 +1140,8 @@ importers:
         specifier: ^4.12.29
         version: 4.12.29
       posthog-node:
-        specifier: ^5.41.0
-        version: 5.41.0(rxjs@7.8.2)
+        specifier: ^5.51.4
+        version: 5.51.4(rxjs@7.8.2)
       slackify-markdown:
         specifier: ^5.0.0
         version: 5.0.0
@@ -6308,11 +6308,14 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@posthog/core@1.40.2':
-    resolution: {integrity: sha512-H12j7O9iHGvpK9t2ko8W4pvfbV1pBDxrsWC1LA6yp2RhzwvC4T3sWhu+AekDQJSRSrJEWlB0t/Ueq9QhPSq7FQ==}
+  '@posthog/browser-common@0.7.0':
+    resolution: {integrity: sha512-Kr6j9sH7NisT3fC3w7jZlonYeCFjPXZrDwHl3usFpjNEdgbHUrxPAmekEkTt+zRAa2huldFPIAmibZ3KC4hXoQ==}
 
-  '@posthog/types@1.393.0':
-    resolution: {integrity: sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==}
+  '@posthog/core@1.49.2':
+    resolution: {integrity: sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg==}
+
+  '@posthog/types@1.407.1':
+    resolution: {integrity: sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -12378,6 +12381,9 @@ packages:
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -16637,11 +16643,19 @@ packages:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.399.2:
-    resolution: {integrity: sha512-xcvrGEgUYtIVcWPRlVfc/NkMo0IP9nwnM/dzJIAzjDOSewkdDk/9T4Vz1+gooEhXdQCPfG44jSK95mVJsoySqA==}
+  posthog-js@1.422.5:
+    resolution: {integrity: sha512-p1CLXsGoHwNkdElxXtd1KzNP/df8sIrp8CRII+lAPRhaHdpi1HfNxrybqLSzWvJLw2w5Nou5vpXfGABUI5BVwA==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: 19.1.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
-  posthog-node@5.41.0:
-    resolution: {integrity: sha512-jOkX6THOr5WD+FGUEaTxekas8c7NOC3TqJ2Byfe2KMimQdL/F/osz17uSbkNzR4V9WFZoe8YaGP3Xp0EUpPKGg==}
+  posthog-node@5.51.4:
+    resolution: {integrity: sha512-gI6JMBnU3vjDNclUBWonw3y7k8Y0UPIAVO4AQ2zu9eyW+7sY8UQRofx4JIA7IGYLMEbs4gykfogOmXp16+oUdg==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -19327,6 +19341,9 @@ packages:
 
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -26454,11 +26471,16 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@posthog/core@1.40.2':
+  '@posthog/browser-common@0.7.0':
     dependencies:
-      '@posthog/types': 1.393.0
+      '@posthog/core': 1.49.2
+      '@posthog/types': 1.407.1
 
-  '@posthog/types@1.393.0': {}
+  '@posthog/core@1.49.2':
+    dependencies:
+      '@posthog/types': 1.407.1
+
+  '@posthog/types@1.407.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -33743,6 +33765,10 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dompurify@3.4.14:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -39176,22 +39202,27 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.399.2:
+  posthog-js@1.422.5(@types/react@19.2.17)(react@19.1.0):
     dependencies:
-      '@posthog/core': 1.40.2
-      '@posthog/types': 1.393.0
+      '@posthog/browser-common': 0.7.0
+      '@posthog/core': 1.49.2
+      '@posthog/types': 1.407.1
       core-js: 3.49.0
-      dompurify: 3.4.11
+      dompurify: 3.4.14
       fflate: 0.4.8
       preact: 10.29.7
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.1.0
     transitivePeerDependencies:
       - preact-render-to-string
 
-  posthog-node@5.41.0(rxjs@7.8.2):
+  posthog-node@5.51.4(rxjs@7.8.2):
     dependencies:
-      '@posthog/core': 1.40.2
+      '@posthog/core': 1.49.2
     optionalDependencies:
       rxjs: 7.8.2
 
@@ -42418,6 +42449,8 @@ snapshots:
   web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -2203,7 +2203,7 @@ backend = [
     { name = "opik", specifier = ">=1.10.0" },
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "pillow", specifier = "==12.3.0" },
-    { name = "posthog", specifier = ">=7.4.2" },
+    { name = "posthog", specifier = ">=7.44.2" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "protobuf", specifier = "==5.29.6" },
@@ -2301,7 +2301,7 @@ dev = [
 requires-dist = [
     { name = "infisicalsdk", specifier = ">=1.0.7" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "posthog", specifier = ">=7.4.2" },
+    { name = "posthog", specifier = ">=7.44.2" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -5478,19 +5478,17 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.6.0"
+version = "7.44.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
-    { name = "python-dateutil" },
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/10/dcbe5d12ba5e62b2a9c9004a80117765468198c44ffef16d2b54f938bddf/posthog-7.6.0.tar.gz", hash = "sha256:941dfd278ee427c9b14640f09b35b5bb52a71bdf028d7dbb7307e1838fd3002e", size = 146194, upload-time = "2026-01-19T16:23:04.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/04/7aef5b358b5627086ba9643b32f7616aab8c07d6be829a1dcfc4424d317a/posthog-7.44.2.tar.gz", hash = "sha256:e375172bfaad5c7cfa25c027bc3b9db2794cd94f3845d13b0b51108bdfe80a3b", size = 480055, upload-time = "2026-08-27T08:06:51.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/f6/8d4a2d1b67368fec425f32911e2f3638d5ac9e8abfebc698ac426fcf65db/posthog-7.6.0-py3-none-any.whl", hash = "sha256:c4dd78cf77c4fecceb965f86066e5ac37886ef867d68ffe75a1db5d681d7d9ad", size = 168426, upload-time = "2026-01-19T16:23:02.71Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ce/17f7050afd08facdede145321be581425999b1e067c3cde7147fb7a8b89c/posthog-7.44.2-py3-none-any.whl", hash = "sha256:4a3d4b7c994d0b2d43a05b03293ce9a652900a5143d79fbeedb2f2fa78048ad3", size = 567692, upload-time = "2026-08-27T08:06:49.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- PostHog flagged all three SDKs as outdated: `posthog-node` 5.41.0 (>10% of last-week events), `posthog` (Python) 7.6.0 (>10%), and `posthog-js` 1.399.2/1.364.7 (>20% each).
- Bumped `posthog` 7.6.0 → 7.44.2, `posthog-node` 5.41.0 → 5.51.4, `posthog-js` 1.399.2 → 1.422.5, and regenerated `uv.lock` / `pnpm-lock.yaml`.
- Verified the larger Python jump (7.6 → 7.44) against the actual API surface this repo calls: `Posthog(token, host=, enable_exception_autocapture=)`, `.capture(event=, distinct_id=, properties=)`, `.shutdown()`, and the context API (`new_context` / `identify_context` used in `apps/api/app/api/v1/middleware/auth.py`) all still work unchanged.

Not a fix for missing events — those are flowing normally (51k Python events in the last 7 days). Separately confirmed `chat:message_sent` was intentionally replaced by the server-side `chat:message_submitted` event in #1007; that's a dashboard re-point in PostHog, not a code change.

## Test plan
- [x] `uv lock` — resolved `posthog` 7.6.0 → 7.44.2 cleanly
- [x] `pnpm install --lockfile-only` — resolved `posthog-js` → 1.422.5, `posthog-node` → 5.51.4 cleanly (pre-existing peer warnings on expo/react-native and hono are unrelated)
- [x] Installed 7.44.2 into the API's venv and exercised every PostHog call this codebase makes (construct client, `capture`, `shutdown`, `new_context`/`identify_context`) — all succeed
- [ ] Could not run the API pytest suite in this worktree due to an unrelated `uv run` cross-checkout resolution issue (imports the main checkout, which is on a different, currently-broken branch) — not caused by this change
- [ ] Did not run a full web build/type-check for the `posthog-js` bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)