### PR TITLE
fix(web): drop .npmrc from the Dockerfile COPY (#1132 removed it)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,12 +20,10 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 # Copy all package manifests first for better cache signal.
-# .npmrc rides along: node-linker=hoisted must not arrive only via
-# `COPY . .` after the install (it changes module layout used by next build).
 # patches/ too: root package.json's pnpm.patchedDependencies references
 # these files — install fails with ENOENT without them (proved in CI:
 # "pnpm: ENOENT ... /app/patches/dmg-builder.patch").
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches ./patches/
 COPY apps/web/package.json         ./apps/web/
 COPY apps/desktop/package.json     ./apps/desktop/


### PR DESCRIPTION
## Summary
The web Docker image build fails on every `master` push with `ERROR: "/.npmrc": not found`. #1132 deleted `.npmrc` (the hoisted linker is gone — pnpm's isolated linker is the default now), but `apps/web/Dockerfile` still copied it in the manifest `COPY`.

Only surfaced on `master`: on PRs the web image is skipped when `web` is unaffected, so the broken COPY was never exercised there.

## Fix
Remove `.npmrc` from the `COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./` line and the now-stale comment about `node-linker=hoisted`. No `.npmrc` exists in the repo any more.

## Verify
`docker build -f apps/web/Dockerfile .` gets past the manifest COPY; the `docker-web` lane on this PR builds green.