### PR TITLE
chore(worktree): copy .claude/settings.local.json into fresh worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -10,3 +10,4 @@ apps/web/.env
 apps/web/.env.local
 apps/mobile/.env
 apps/bots/.env
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.worktreeinclude` so local Claude Code permission/settings state (gitignored, per-developer) carries over into fresh worktrees/workspaces instead of being lost.

## Test plan
- [x] Confirmed `.claude/settings.local.json` is gitignored (`git check-ignore -v`), matching the file's documented rule of only listing gitignored, non-reconstructable files.