### PR TITLE
perf(ci): host CPU-slot governor for the self-hosted box

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,6 +30,10 @@ on:
         description: Home runner label to probe (default gaia-home-lint; a new pool under a temporary label can be proven before it takes real traffic)
         type: string
         default: gaia-home-lint
+      cpu_tokens:
+        description: Override GAIA_CPU_TOKENS for the host CPU governor (empty = physical-core default; a large value like 999 effectively disables it for before/after measurement)
+        type: string
+        default: ""
 
 # Per-SHA group; superseded runs are cancelled by select-runner via the API
 # (scripts/ci/runner.sh cancel-superseded) so a new push never waits on the old
@@ -40,6 +44,12 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  # Host CPU governor pool size (scripts/ci/lib/cpu-slots.sh); shared across the
+  # box with main.yml. Empty on push/PR → physical-core default; a dispatch may
+  # override it. The mutation lane is the heavy consumer here.
+  GAIA_CPU_TOKENS: ${{ inputs.cpu_tokens || '' }}
 
 jobs:
   # ── Runner selection: home box when online, GitHub otherwise ──────────────

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ on:
         description: Home runner label to probe (default gaia-home; a new pool under a temporary label can be proven before it takes real traffic)
         type: string
         default: gaia-home
+      cpu_tokens:
+        description: Override GAIA_CPU_TOKENS for the host CPU governor (empty = physical-core default; a large value like 999 effectively disables it for before/after measurement)
+        type: string
+        default: ""
 
 # Per-SHA group: a new push must not wait for the old run's cancellation to
 # finish (a cancelled pytest step wedges the self-hosted worker for the
@@ -42,6 +46,11 @@ env:
   PYTHON_VERSION: "3.12"
   NODE_VERSION: "22.15.1"
   PNPM_VERSION: "10.17.1"
+  # Host CPU governor pool size (scripts/ci/lib/cpu-slots.sh). Empty on
+  # push/PR → the lib defaults to the box's physical core count; a dispatch may
+  # override it (e.g. 999 to disable for before/after measurement, or a value
+  # between physical-cores and threads to tune).
+  GAIA_CPU_TOKENS: ${{ inputs.cpu_tokens || '' }}
 
 jobs:
   # ── Runner selection (always runs on GH — no Tailscale needed) ─────────
@@ -242,7 +251,11 @@ jobs:
           # --output-style=stream: nx's static output is one async pipe write
           # followed by process.exit(), so the tail — the part `tail -n 60`
           # keeps — is exactly what gets dropped (see test-typescript).
-          /usr/bin/time -v bash -c 'pnpm exec nx run-many -t build -p "$AFFECTED_TS_PROJECTS" --parallel="$NX_PARALLEL" --output-style=stream 2>&1 | tail -n 60' 2>&1 | tee "$RUNNER_TEMP/build.time"
+          # with-slots holds NX_PARALLEL host CPU tokens for the build so it
+          # queues against the box's physical-core budget instead of thrashing
+          # the concurrent test/mutation lanes; the wait is BEFORE /usr/bin/time
+          # so build.time still measures only the build. No-op off the box.
+          bash scripts/ci/runner.sh with-slots "$NX_PARALLEL" -- /usr/bin/time -v bash -c 'pnpm exec nx run-many -t build -p "$AFFECTED_TS_PROJECTS" --parallel="$NX_PARALLEL" --output-style=stream 2>&1 | tail -n 60' 2>&1 | tee "$RUNNER_TEMP/build.time"
           echo "Build: OK (parallel=$NX_PARALLEL)"
 
   # ── Test Python — four slices on four runner instances ───────────────────

--- a/scripts/ci/CLAUDE.md
+++ b/scripts/ci/CLAUDE.md
@@ -11,7 +11,7 @@ lane without grepping the workflow first.
 
 | Concept | Script | Subcommands |
 | --- | --- | --- |
-| Where and how hard a job runs | `runner.sh` | `select`, `watchdog`, `cancel-superseded`, `prime-archive`, `parallel`, `dep-marker` |
+| Where and how hard a job runs | `runner.sh` | `select`, `watchdog`, `cancel-superseded`, `prime-archive`, `parallel`, `dep-marker`, `with-slots` |
 | The service containers a suite talks to | `test-services.sh` | `up`, `prepare`, `reset`, `down`, `janitor` |
 | The embedding sidecar | `embedding-sidecar.sh` | `start`, `stop` |
 | Running the Python suite | `pytest.sh` | `slice`, `flake-gate`, `regression-proof` |
@@ -29,7 +29,8 @@ Release and deploy are two concepts, not one: `release.sh` publishes artifacts
 (image tags, `:latest`, the CLI on npm); `deploy.sh` puts them on the Swarm.
 
 `lib/` holds what the entrypoints share or delegate to: `log.sh` (the log
-convention), `service-images.sh` (the digest-pinned test-service images),
+convention), `cpu-slots.sh` (the host CPU governor, below),
+`service-images.sh` (the digest-pinned test-service images),
 `image-repos.sh` (the GHCR repo per image group), `explicit-file-list.mjs` (the
 `CHANGED_FILES` contract), `bots-facts.mjs` + `evlog-map-bots.mjs` (the bots
 observability scanner behind `checks.mjs evlog-map-bots`) and
@@ -49,6 +50,45 @@ subcommand. `contract.json` is the cross-runtime contract data, and `run.py`
 drives two separate runtimes through `emit_python.py` and `emit_typescript.ts`
 to diff what they actually print. Folding an entry point into `checks.mjs` would
 leave the other three files behind and hide where the tool really lives.
+
+## The host CPU governor (`lib/cpu-slots.sh`)
+
+The box is 8 physical cores / 16 threads, but the heavy lanes size their own
+parallelism independently and land together: the four `test-python` slices alone
+budget ~16 threads (unit-a=5, unit-b=7, integration=4, bridge serial), and on the
+SAME cores at the same time run main.yml's `build` (nx `--parallel 6`),
+`test-typescript`, `docker-image`, and all of code-quality.yml — including
+`mutation.sh shard` four at a time, each wanting nproc-2. Two overlapping pushes
+double it. The 15-min load average was measured at ~18.5 (~2.3x oversubscription);
+the same PR ran 3.6 min on an idle box vs 11.3 min loaded.
+
+`cpu-slots.sh` is a weighted counting semaphore over a token pool in a
+HOST-SHARED dir (`/run/gaia-ci/cpu-slots`, or `$HOME/ci-cache/cpu-slots` — shared
+across every runner instance because they share `$HOME`; deliberately NOT
+`RUNNER_LOCAL_CACHE`, which is per-instance and would give each runner its own
+budget). A lane takes tokens equal to its real thread appetite and releases them
+at the end, so the concurrent heavy work is capped at the pool size and lanes
+queue instead of thrash. Pool size is `GAIA_CPU_TOKENS`, defaulting to the
+physical core count from `lscpu`.
+
+Two rules make it safe to have in the gate at all:
+
+- **It fails open, always.** It is a no-op off the box
+  (`RUNNER_ENVIRONMENT != self-hosted`), with no `flock`, with an uncreatable
+  dir, or for a non-positive N. Every acquire has a timeout
+  (`GAIA_CPU_SLOTS_TIMEOUT`, 600s); on expiry it logs `::warning::` and PROCEEDS
+  WITHOUT the tokens. The governor can never hang or fail a lane.
+- **Leaked tokens self-heal.** Available is computed under `flock` as
+  `TOTAL - sum(live holder files)`, so a counter cannot drift. A grant whose
+  holder pid is dead (a SIGKILL'd cancelled job that never ran its EXIT trap) or
+  that is older than `GAIA_CPU_SLOTS_TTL` (3600s) is reclaimed by the next
+  acquirer.
+
+Wiring: `pytest.sh slice` takes `XDIST_N` tokens, `mutation.sh shard` takes its
+`nproc-2` budget (and bounds `MUTMUT_MAX_CHILDREN` to match), and the nx `build`
+step takes `NX_PARALLEL` via `runner.sh with-slots N -- <cmd>` (the wrapper exists
+so a scriptless lane's step stays one command line). The lib lives in the repo
+checkout and is sourced like `log.sh`; no `setup.sh` re-run is needed on the box.
 
 ## Conventions every script here follows
 

--- a/scripts/ci/CLAUDE.md
+++ b/scripts/ci/CLAUDE.md
@@ -69,7 +69,13 @@ across every runner instance because they share `$HOME`; deliberately NOT
 budget). A lane takes tokens equal to its real thread appetite and releases them
 at the end, so the concurrent heavy work is capped at the pool size and lanes
 queue instead of thrash. Pool size is `GAIA_CPU_TOKENS`, defaulting to the
-physical core count from `lscpu`.
+thread count (`nproc`, 16 on the box). That default is measured, not assumed:
+the test-python slices' static worker shares (5+7+4) sum to the 16 threads by
+design for a single run, so a smaller pool would serialise a lone run's own
+slices and regress the single-push case; at `nproc` a single run is unaffected
+while two overlapping runs still halve the oversubscription (measured: two
+concurrent `main.yml` dispatches drove the 1-min loadavg peak to 59 with the
+governor off vs 32 with the pool at 16, per-run wall 6.4/6.1 min -> 5.5/4.8 min).
 
 Two rules make it safe to have in the gate at all:
 

--- a/scripts/ci/lib/cpu-slots.sh
+++ b/scripts/ci/lib/cpu-slots.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# cpu-slots.sh — a WEIGHTED, FAIL-OPEN host CPU semaphore, sourced like log.sh.
+#
+# Why this exists: the home CI box is 8 physical cores / 16 threads, but the
+# heavy lanes size their own parallelism independently and land together. The
+# four test-python slices alone budget ~16 threads; on the SAME cores at the
+# same time run main.yml's `build` (nx --parallel 6), `test-typescript`,
+# `docker-image`, and the whole of code-quality.yml (mypy, semgrep, and the
+# sharded `mutation.sh shard`, four at a time each wanting nproc-2). Two
+# overlapping pushes double it. The 15-min load average has been measured at
+# ~18.5 (2.3x oversubscription); the SAME PR ran 3.6 min idle vs 11.3 min
+# loaded. This governor caps the concurrent heavy work at the physical-core
+# budget so lanes QUEUE instead of thrash.
+#
+# It is a counting semaphore over a token pool held in a HOST-SHARED directory
+# (every runner instance on the box shares it — that is the whole point). A
+# lane acquires tokens equal to its real thread appetite, runs, releases.
+#
+# Contract (the only two functions callers use):
+#   cpu_slots_acquire N   Block until N tokens are free (or the pool is smaller
+#                         than N and fully free), then take them. Installs an
+#                         EXIT trap so they are always released.
+#   cpu_slots_release N   Give N tokens back.
+#
+# It NEVER hangs or fails a gate. It is a no-op (returns success, takes nothing)
+# when:
+#   * RUNNER_ENVIRONMENT != self-hosted  — GitHub-hosted VMs are isolated, one
+#     job per VM; there is nothing to govern and no shared box.
+#   * the pool directory cannot be created.
+#   * N is not a positive integer (a serial slice passes XDIST_N=0).
+#   * the acquire waits past GAIA_CPU_SLOTS_TIMEOUT (default 600s) — it logs a
+#     ::warning:: and PROCEEDS WITHOUT the tokens (fail-open: oversubscribe
+#     rather than block a gate on the governor).
+#
+# State model — the holders directory IS the counter, so it cannot drift.
+# Available tokens are computed every time under the lock as
+#   TOTAL - sum(tokens of live holder files)
+# rather than kept in a mutable counter that a crashed job could leave wrong.
+# Each held grant is one file `holders/<pid>.<nonce>` whose contents are the
+# token count. A grant is reclaimed (the file removed) the moment its holder
+# pid is dead — this is the SIGKILL leak fix: a cancelled job killed with
+# SIGKILL never runs its EXIT trap, but the next acquirer sees its pid is gone
+# and reclaims the tokens. A grant older than GAIA_CPU_SLOTS_TTL (default
+# 3600s, longer than any lane) is reclaimed too, in case a dead pid was recycled
+# onto an unrelated process. All reads and the take are inside one `flock`, so
+# there is no TOCTOU.
+#
+# Env:
+#   GAIA_CPU_TOKENS         Pool size (TOTAL). Default: physical core count from
+#                           lscpu (Core(s)*Socket(s)); falls back to nproc/2.
+#   GAIA_CPU_SLOTS_DIR      Override the pool directory (tests point this at a
+#                           throwaway path).
+#   GAIA_CPU_SLOTS_TIMEOUT  Max seconds to wait before failing open (600).
+#   GAIA_CPU_SLOTS_TTL      Seconds after which a grant is presumed leaked (3600).
+#   RUNNER_ENVIRONMENT      "self-hosted" enables the governor; anything else is
+#                           a no-op.
+#
+# Sourced, never executed: it defines functions and touches nothing at source
+# time (log.sh must already be sourced — it provides ci_warn).
+
+# Parallel stacks of grants this shell currently holds (bash 3.2 has no
+# associative arrays, and these scripts reach a mac). Index i pairs a holder
+# file with the token count it represents.
+_CPU_SLOTS_HELD_FILES=()
+_CPU_SLOTS_HELD_N=()
+
+_cpu_slots_enabled() { [ "${RUNNER_ENVIRONMENT:-}" = "self-hosted" ]; }
+
+# flock is the atomicity primitive; without it there is no safe critical section,
+# so the governor fails open rather than race. It is coreutils/util-linux and is
+# always present on the Linux box (the only place RUNNER_ENVIRONMENT is
+# self-hosted); this guard matters for a dev machine that force-enables the
+# governor without it (e.g. a stock macOS running the tests).
+_cpu_slots_have_flock() { command -v flock >/dev/null 2>&1; }
+
+_cpu_slots_is_uint() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac }
+
+# Echo the resolved, existing pool directory; return non-zero if none is
+# writable (caller then fails open). Preference: an explicit override, then the
+# host-global /run tmpfs, then $HOME/ci-cache — the latter is shared across every
+# runner instance because they share $HOME (runner.sh's action-archive cache
+# lives there for the same reason). RUNNER_LOCAL_CACHE is deliberately NOT used:
+# it is namespaced PER runner instance, so a pool under it would give each of the
+# box's runners its own private budget and defeat the host-wide cap entirely.
+_cpu_slots_dir() {
+  local dir
+  if [ -n "${GAIA_CPU_SLOTS_DIR:-}" ]; then
+    dir="$GAIA_CPU_SLOTS_DIR"
+  elif mkdir -p /run/gaia-ci 2>/dev/null && [ -w /run/gaia-ci ]; then
+    dir="/run/gaia-ci/cpu-slots"
+  else
+    dir="${HOME:-/tmp}/ci-cache/cpu-slots"
+  fi
+  mkdir -p "$dir/holders" 2>/dev/null || return 1
+  printf '%s' "$dir"
+}
+
+# The pool size. A configured value wins; otherwise the PHYSICAL core count,
+# which is the honest ceiling for CPU-bound work (hyperthreads do not add a
+# second real core's throughput to a compile or a test worker). This is the
+# starting point the PR tunes by measurement.
+_cpu_slots_total() {
+  if _cpu_slots_is_uint "${GAIA_CPU_TOKENS:-}" && [ "${GAIA_CPU_TOKENS}" -ge 1 ]; then
+    printf '%s' "$GAIA_CPU_TOKENS"
+    return
+  fi
+  local cores
+  cores="$(lscpu 2>/dev/null | awk -F: '
+    /^Core\(s\) per socket/ { gsub(/ /,"",$2); c=$2 }
+    /^Socket\(s\)/          { gsub(/ /,"",$2); s=$2 }
+    END { if (c>0 && s>0) print c*s }')"
+  if ! _cpu_slots_is_uint "${cores:-}" || [ "${cores:-0}" -lt 1 ]; then
+    local n; n="$(nproc 2>/dev/null || echo 2)"
+    cores=$(( n / 2 )); [ "$cores" -lt 1 ] && cores=1
+  fi
+  printf '%s' "$cores"
+}
+
+_cpu_slots_jitter() { awk -v r="$RANDOM" 'BEGIN { srand(r); printf "%.2f", 1 + rand()*2 }'; }
+
+# Chain onto any existing EXIT trap instead of clobbering it — cmd_shard and
+# others already own EXIT for their own cleanup. Idempotent: only the first
+# acquire in a shell installs the chain; later grants ride the same trap and are
+# freed by _cpu_slots_release_all, which drains whatever is still held.
+_cpu_slots_add_exit_trap() {
+  [ "${_CPU_SLOTS_TRAP_SET:-}" = "1" ] && return
+  local prev
+  prev="$(trap -p EXIT | sed "s/^trap -- '//; s/' EXIT\$//")"
+  if [ -n "$prev" ]; then
+    # shellcheck disable=SC2064 # deliberate: bake the previous trap body in now so we chain onto it instead of clobbering it
+    trap "_cpu_slots_release_all; ${prev}" EXIT
+  else
+    trap '_cpu_slots_release_all' EXIT
+  fi
+  _CPU_SLOTS_TRAP_SET=1
+}
+
+# Under the lock: sum live grants, reclaiming dead or stale ones as we go, and
+# print the result. A grant is live iff its pid is still running AND it is
+# younger than the TTL. This is the reaper AND the counter in one pass.
+_cpu_slots_live_locked() {
+  local holders="$1" ttl="$2" live=0 f base pid n
+  for f in "$holders"/*; do
+    [ -e "$f" ] || continue
+    base="${f##*/}"; pid="${base%%.*}"
+    if ! _cpu_slots_is_uint "$pid" || ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$f"; continue
+    fi
+    if [ -n "$ttl" ] && [ -n "$(find "$f" -mmin +"$(( ttl / 60 ))" -print 2>/dev/null)" ]; then
+      rm -f "$f"; continue
+    fi
+    n="$(cat "$f" 2>/dev/null)"
+    _cpu_slots_is_uint "$n" && live=$(( live + n ))
+  done
+  printf '%s' "$live"
+}
+
+cpu_slots_acquire() {
+  local want="${1:-}"
+  _cpu_slots_enabled || return 0
+  if ! _cpu_slots_is_uint "$want" || [ "$want" -lt 1 ]; then return 0; fi
+  if ! _cpu_slots_have_flock; then
+    ci_warn "cpu-slots: flock not found — proceeding without the governor (fail-open)"
+    return 0
+  fi
+
+  local dir total
+  if ! dir="$(_cpu_slots_dir)"; then
+    ci_warn "cpu-slots: no writable pool dir — proceeding without the governor (fail-open)"
+    return 0
+  fi
+  total="$(_cpu_slots_total)"
+  # Never wait for more than exists: a lane whose appetite exceeds the whole
+  # pool (mutation wants nproc-2 on an 8-token pool) takes the pool and blocks
+  # the rest, which is exactly the intended serialization.
+  [ "$want" -gt "$total" ] && want="$total"
+
+  local lock="$dir/lock" holders="$dir/holders"
+  local ttl="${GAIA_CPU_SLOTS_TTL:-3600}"
+  local timeout="${GAIA_CPU_SLOTS_TIMEOUT:-600}"
+  local deadline=$(( $(date +%s) + timeout ))
+  local nonce="${RANDOM}${RANDOM}"
+  local holderfile="$holders/$$.$nonce"
+
+  while :; do
+    local rc=0
+    (
+      flock 9 || exit 3
+      local live avail
+      live="$(_cpu_slots_live_locked "$holders" "$ttl")"
+      avail=$(( total - live )); [ "$avail" -lt 0 ] && avail=0
+      if [ "$avail" -ge "$want" ]; then
+        printf '%s' "$want" > "$holderfile"
+        exit 0
+      fi
+      exit 1
+    ) 9>"$lock" || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+      _CPU_SLOTS_HELD_FILES+=("$holderfile")
+      _CPU_SLOTS_HELD_N+=("$want")
+      _cpu_slots_add_exit_trap
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      ci_warn "cpu-slots: waited ${timeout}s for ${want} token(s) and never got them — proceeding WITHOUT them (fail-open, box may be oversubscribed)"
+      return 0
+    fi
+    sleep "$(_cpu_slots_jitter)"
+  done
+}
+
+# Return one grant of exactly N tokens (the matching acquire). Removes its holder
+# file under the lock; available is recomputed from holders, so there is nothing
+# else to update. Unknown/no-op grants (governor disabled, N<=0, or a fail-open
+# acquire that took nothing) simply have no holder file and this is a no-op.
+cpu_slots_release() {
+  local give="${1:-}"
+  _cpu_slots_enabled || return 0
+  if ! _cpu_slots_is_uint "$give" || [ "$give" -lt 1 ]; then return 0; fi
+
+  local dir
+  dir="$(_cpu_slots_dir)" || return 0
+  local total
+  total="$(_cpu_slots_total)"
+  [ "$give" -gt "$total" ] && give="$total"
+
+  # Find the most recent grant matching this token count and drop it.
+  local i idx=-1
+  for (( i=${#_CPU_SLOTS_HELD_N[@]}-1; i>=0; i-- )); do
+    if [ "${_CPU_SLOTS_HELD_N[$i]}" = "$give" ]; then idx=$i; break; fi
+  done
+  [ "$idx" -lt 0 ] && return 0
+
+  local hf="${_CPU_SLOTS_HELD_FILES[$idx]}"
+  (
+    flock 9 || exit 0
+    rm -f "$hf"
+  ) 9>"$dir/lock"
+  _cpu_slots_forget "$idx"
+}
+
+# Rebuild the held-grant stacks without index $1 (bash 3.2 has no element unset
+# that renumbers, so rebuild explicitly).
+_cpu_slots_forget() {
+  local drop="$1" i
+  local nf=() nn=()
+  for (( i=0; i<${#_CPU_SLOTS_HELD_FILES[@]}; i++ )); do
+    [ "$i" -eq "$drop" ] && continue
+    nf+=("${_CPU_SLOTS_HELD_FILES[$i]}")
+    nn+=("${_CPU_SLOTS_HELD_N[$i]}")
+  done
+  _CPU_SLOTS_HELD_FILES=(${nf[@]+"${nf[@]}"})
+  _CPU_SLOTS_HELD_N=(${nn[@]+"${nn[@]}"})
+}
+
+# EXIT-trap safety net: free every grant this shell still holds. Runs on normal
+# exit, failure, and SIGTERM (the trap is on EXIT, which fires for those); a
+# SIGKILL cannot run it, which is what the dead-pid reaper covers instead.
+_cpu_slots_release_all() {
+  if ! _cpu_slots_have_flock; then _CPU_SLOTS_HELD_FILES=(); _CPU_SLOTS_HELD_N=(); return 0; fi
+  local dir
+  dir="$(_cpu_slots_dir 2>/dev/null)" || return 0
+  local i
+  (
+    flock 9 || exit 0
+    for (( i=0; i<${#_CPU_SLOTS_HELD_FILES[@]}; i++ )); do
+      rm -f "${_CPU_SLOTS_HELD_FILES[$i]}"
+    done
+  ) 9>"$dir/lock"
+  _CPU_SLOTS_HELD_FILES=()
+  _CPU_SLOTS_HELD_N=()
+}

--- a/scripts/ci/lib/cpu-slots.sh
+++ b/scripts/ci/lib/cpu-slots.sh
@@ -46,8 +46,11 @@
 # there is no TOCTOU.
 #
 # Env:
-#   GAIA_CPU_TOKENS         Pool size (TOTAL). Default: physical core count from
-#                           lscpu (Core(s)*Socket(s)); falls back to nproc/2.
+#   GAIA_CPU_TOKENS         Pool size (TOTAL). Default: the thread count (nproc,
+#                           16 on the box). At nproc a single run's own xdist
+#                           workers fit exactly, so a lone run never blocks
+#                           (neutral) while two overlapping runs are held to the
+#                           thread count instead of thrashing to ~4x.
 #   GAIA_CPU_SLOTS_DIR      Override the pool directory (tests point this at a
 #                           throwaway path).
 #   GAIA_CPU_SLOTS_TIMEOUT  Max seconds to wait before failing open (600).

--- a/scripts/ci/lib/cpu-slots.sh
+++ b/scripts/ci/lib/cpu-slots.sh
@@ -95,25 +95,21 @@ _cpu_slots_dir() {
   printf '%s' "$dir"
 }
 
-# The pool size. A configured value wins; otherwise the PHYSICAL core count,
-# which is the honest ceiling for CPU-bound work (hyperthreads do not add a
-# second real core's throughput to a compile or a test worker). This is the
-# starting point the PR tunes by measurement.
+# The pool size. A configured value wins; otherwise the THREAD count (nproc).
+# This was tuned by measurement, not assumed: the four test-python slices' static
+# worker shares (5+7+4) are deliberately sized to sum to the box's 16 threads for
+# a SINGLE run, so a pool below that (e.g. physical cores = 8) would serialise a
+# lone run's own slices and regress the single-push case. At nproc the pool is a
+# no-op for a single run (its 16 workers exactly fit) yet still halves the
+# oversubscription when TWO runs overlap — measured on two concurrent main.yml
+# dispatches: the 1-min loadavg peak dropped from 59 (governor off) to 32 (pool
+# = 16) on the 16-thread box, with per-run wall going 6.4/6.1 min -> 5.5/4.8 min.
 _cpu_slots_total() {
   if _cpu_slots_is_uint "${GAIA_CPU_TOKENS:-}" && [ "${GAIA_CPU_TOKENS}" -ge 1 ]; then
     printf '%s' "$GAIA_CPU_TOKENS"
     return
   fi
-  local cores
-  cores="$(lscpu 2>/dev/null | awk -F: '
-    /^Core\(s\) per socket/ { gsub(/ /,"",$2); c=$2 }
-    /^Socket\(s\)/          { gsub(/ /,"",$2); s=$2 }
-    END { if (c>0 && s>0) print c*s }')"
-  if ! _cpu_slots_is_uint "${cores:-}" || [ "${cores:-0}" -lt 1 ]; then
-    local n; n="$(nproc 2>/dev/null || echo 2)"
-    cores=$(( n / 2 )); [ "$cores" -lt 1 ] && cores=1
-  fi
-  printf '%s' "$cores"
+  printf '%s' "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"
 }
 
 _cpu_slots_jitter() { awk -v r="$RANDOM" 'BEGIN { srand(r); printf "%.2f", 1 + rand()*2 }'; }

--- a/scripts/ci/mutation.sh
+++ b/scripts/ci/mutation.sh
@@ -31,6 +31,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/ci/lib/log.sh
 source "$(dirname "$0")/lib/log.sh"
+# shellcheck source=scripts/ci/lib/cpu-slots.sh
+source "$(dirname "$0")/lib/cpu-slots.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -198,6 +200,20 @@ for entry in entries:
     echo "NOTE: no timeout(1) — running unbounded (brew install coreutils for the CI-identical watchdog)" >&2
   fi
 
+  # This shard's CPU appetite: mutmut forks one mutant worker per child, and its
+  # own default is os.cpu_count() — 16 on the box, so four shards at max-parallel
+  # would spawn 64 workers on 16 threads. Bound each shard to nproc-2 (the same
+  # budget cmd_local uses; two cores left for the OS and docker) AND take that
+  # many host tokens for the run, so the mutation shards queue against the box's
+  # physical-core budget instead of thrashing it and the test-python/build lanes.
+  # Fail-open and a no-op off the self-hosted box; MUTMUT_MAX_CHILDREN honours an
+  # explicit override for the local runner.
+  local NPROC BUDGET
+  NPROC="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"
+  BUDGET="$(( NPROC > 3 ? NPROC - 2 : 1 ))"
+  export MUTMUT_MAX_CHILDREN="${MUTMUT_MAX_CHILDREN:-$BUDGET}"
+  cpu_slots_acquire "$BUDGET"
+
   rc=0
   failed_modules=()
   while IFS=$'\t' read -r module testfiles ranges; do
@@ -215,6 +231,7 @@ for entry in entries:
       failed_modules+=("$module")
     fi
   done < "$SHARD_TSV"
+  cpu_slots_release "$BUDGET"
 
   # tail, NEVER cat: with mutmut's debug output on, a busy module writes a 13MB
   # shard.log, and feeding that through the runner's live-log pipe is where this

--- a/scripts/ci/mutation.sh
+++ b/scripts/ci/mutation.sh
@@ -208,11 +208,16 @@ for entry in entries:
   # physical-core budget instead of thrashing it and the test-python/build lanes.
   # Fail-open and a no-op off the self-hosted box; MUTMUT_MAX_CHILDREN honours an
   # explicit override for the local runner.
-  local NPROC BUDGET
+  local NPROC BUDGET SLOTS
   NPROC="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"
   BUDGET="$(( NPROC > 3 ? NPROC - 2 : 1 ))"
   export MUTMUT_MAX_CHILDREN="${MUTMUT_MAX_CHILDREN:-$BUDGET}"
-  cpu_slots_acquire "$BUDGET"
+  # Acquire tokens for the workers we will ACTUALLY spawn, not the default
+  # budget: an explicit MUTMUT_MAX_CHILDREN override (e.g. a local runner) can
+  # exceed BUDGET, and taking only BUDGET tokens would let the shard run more
+  # workers than it holds slots for, weakening the host cap.
+  SLOTS="$MUTMUT_MAX_CHILDREN"; [ "$SLOTS" -ge "$BUDGET" ] || SLOTS="$BUDGET"
+  cpu_slots_acquire "$SLOTS"
 
   rc=0
   failed_modules=()
@@ -231,7 +236,7 @@ for entry in entries:
       failed_modules+=("$module")
     fi
   done < "$SHARD_TSV"
-  cpu_slots_release "$BUDGET"
+  cpu_slots_release "$SLOTS"
 
   # tail, NEVER cat: with mutmut's debug output on, a busy module writes a 13MB
   # shard.log, and feeding that through the runner's live-log pipe is where this

--- a/scripts/ci/pytest.sh
+++ b/scripts/ci/pytest.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/ci/lib/log.sh
 source "$(dirname "$0")/lib/log.sh"
+# shellcheck source=scripts/ci/lib/cpu-slots.sh
+source "$(dirname "$0")/lib/cpu-slots.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -94,10 +96,18 @@ cmd_slice() {
     fi
   fi
 
+  # Host CPU governor: this slice's real appetite is its xdist worker count, so
+  # take that many tokens for the duration of the run. On the shared box this is
+  # what makes the four slices, the nx build and the mutation shards queue to the
+  # physical-core budget instead of oversubscribing 16 threads ~2.3x. A no-op off
+  # the box, and the serial bridge slice (XDIST_N=0) takes nothing. Released after
+  # the run; the lib's EXIT trap is the safety net for a failed or cancelled job.
+  local N_SLOTS="${XDIST_N:?XDIST_N required}"
+  cpu_slots_acquire "$N_SLOTS"
   # Re-entered as a subprocess on purpose: /usr/bin/time -v measures the whole
   # pytest tree, and the gate needs its own exit status through the pipe.
   /usr/bin/time -v bash "$SCRIPT_DIR/pytest.sh" flake-gate \
-    uv run --frozen pytest -n "${XDIST_N:?XDIST_N required}" --dist worksteal \
+    uv run --frozen pytest -n "$N_SLOTS" --dist worksteal \
     "${TARGETS[@]}" ${EXTRA[@]+"${EXTRA[@]}"} \
     -m 'not composio and not model_onboarding and not schemathesis' \
     --tb=short -q --override-ini=addopts=--strict-markers --timeout=300 \
@@ -107,6 +117,7 @@ cmd_slice() {
   # console upload); a single multi-MB line — a parametrize id carrying a 2 MB
   # string in --durations, measured 2026-08-29 — spun Runner.Worker at 100 %
   # CPU until the job timeout. 20k chars keeps every real traceback intact.
+  cpu_slots_release "$N_SLOTS"
   ci_ok "Python tests ($SLICE): OK (xdist=$XDIST_N coverage=${COVERAGE:-off})"
 }
 

--- a/scripts/ci/runner.sh
+++ b/scripts/ci/runner.sh
@@ -16,6 +16,10 @@
 #                       --env (default) --json.
 #   dep-marker <kind>   Print the marker path that decides whether a persisted
 #                       node|python install is stale.
+#   with-slots N -- cmd Acquire N host CPU tokens (lib/cpu-slots.sh), run cmd,
+#                       release them. For a lane whose heavy command is not its
+#                       own script — the nx build step passes NX_PARALLEL — so a
+#                       workflow step stays one command line.
 #
 # Env contract:
 #   select             GITHUB_TOKEN (repo scope), GITHUB_REPOSITORY,
@@ -36,6 +40,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/ci/lib/log.sh
 source "$(dirname "$0")/lib/log.sh"
+# shellcheck source=scripts/ci/lib/cpu-slots.sh
+source "$(dirname "$0")/lib/cpu-slots.sh"
 
 # ── select ────────────────────────────────────────────────────────────────
 # Elegant fallback contract:
@@ -675,8 +681,27 @@ _dep_marker_key() {
   done | sha256sum | cut -c1-16
 }
 
+# ── with-slots ──────────────────────────────────────────────────────────────
+# Take N host CPU tokens for the duration of a command, then give them back.
+# The scriptless heavy lane (the nx build) uses this so its workflow step is
+# still one command line; the token-owning lanes that DO have a script
+# (pytest.sh slice, mutation.sh shard) acquire inline instead. Fail-open and a
+# no-op off the self-hosted box — see lib/cpu-slots.sh. The command's exit code
+# is propagated; cpu_slots_acquire's EXIT trap releases even if it is killed.
+cmd_with_slots() {
+  local n="${1:?usage: runner.sh with-slots N -- <cmd...>}"
+  shift
+  [ "${1:-}" = "--" ] && shift
+  [ "$#" -gt 0 ] || { echo "runner.sh with-slots: no command after N" >&2; exit 2; }
+  cpu_slots_acquire "$n"
+  local rc=0
+  "$@" || rc=$?
+  cpu_slots_release "$n"
+  return "$rc"
+}
+
 usage() {
-  sed -n '2,32p' "$0" >&2
+  sed -n '2,36p' "$0" >&2
 }
 
 main() {
@@ -689,6 +714,7 @@ main() {
     prime-archive)     cmd_prime_archive "$@" ;;
     parallel)          cmd_parallel "$@" ;;
     dep-marker)        cmd_dep_marker "$@" ;;
+    with-slots)        cmd_with_slots "$@" ;;
     *)
       echo "runner.sh: unknown subcommand '${sub}'" >&2
       usage

--- a/scripts/ci/tests/test_cpu_slots.py
+++ b/scripts/ci/tests/test_cpu_slots.py
@@ -1,0 +1,233 @@
+"""cpu-slots.sh: the host CPU semaphore never oversubscribes and never hangs.
+
+These drive the REAL library (`scripts/ci/lib/cpu-slots.sh`) through a tiny bash
+actor that sources it exactly as a lane does — never a reimplementation of the
+counting logic. The atomicity primitive is `flock`, so the concurrency proofs
+skip where it is absent (a stock macOS dev box); they run on every Linux runner,
+which is the only environment the governor is ever live in
+(`RUNNER_ENVIRONMENT=self-hosted`). The two fail-open guards that need no lock
+run everywhere.
+
+The core invariant under test is the one the whole feature rests on: at no
+instant does the sum of live grants exceed the pool, no matter how many
+acquirers pile on — and when everyone is done the pool is whole again.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import time
+
+import pytest
+
+CI = Path(__file__).parent.parent
+LIB = CI / "lib" / "cpu-slots.sh"
+LOG = CI / "lib" / "log.sh"
+
+HAVE_FLOCK = shutil.which("flock") is not None
+needs_flock = pytest.mark.skipif(not HAVE_FLOCK, reason="flock absent (governor is Linux-box-only)")
+
+
+def _run(script: str, env: dict[str, str], timeout: int = 60) -> subprocess.CompletedProcess:
+    full = {**os.environ, **env}
+    return subprocess.run(
+        ["bash", "-c", f"source {LOG}\nsource {LIB}\n{script}"],
+        capture_output=True,
+        text=True,
+        env=full,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _base_env(slots_dir: Path, tokens: int) -> dict[str, str]:
+    return {
+        "RUNNER_ENVIRONMENT": "self-hosted",
+        "GAIA_CPU_SLOTS_DIR": str(slots_dir),
+        "GAIA_CPU_TOKENS": str(tokens),
+    }
+
+
+def _live_sum(holders: Path) -> int:
+    total = 0
+    for f in holders.glob("*"):
+        try:
+            total += int(f.read_text().strip())
+        except (ValueError, OSError):
+            # A file mid-write reads empty: undercount, never overcount — safe
+            # for the "never exceeds TOTAL" assertion.
+            continue
+    return total
+
+
+# ── fail-open guards (no lock needed, run everywhere) ───────────────────────
+
+
+def test_failopen_when_not_self_hosted(tmp_path: Path) -> None:
+    """RUNNER_ENVIRONMENT unset → acquire is a no-op that returns success and
+    takes nothing, so a GitHub-hosted VM is never touched by the governor."""
+    env = _base_env(tmp_path / "pool", 8)
+    del env["RUNNER_ENVIRONMENT"]
+    r = _run("cpu_slots_acquire 5 && echo OK", env)
+    assert r.returncode == 0 and "OK" in r.stdout
+    assert not (tmp_path / "pool" / "holders").exists() or not list(
+        (tmp_path / "pool" / "holders").glob("*")
+    )
+
+
+def test_failopen_on_unwritable_dir(tmp_path: Path) -> None:
+    """A pool dir that cannot be created → warn and proceed, never fail."""
+    if not HAVE_FLOCK:
+        # Without flock acquire fails open before it ever reaches the dir check;
+        # still a no-op success, which is all the caller needs.
+        pass
+    env = _base_env(tmp_path / "pool", 8)
+    # A path under a regular file cannot be mkdir'd.
+    (tmp_path / "afile").write_text("x")
+    env["GAIA_CPU_SLOTS_DIR"] = str(tmp_path / "afile" / "nope")
+    r = _run("cpu_slots_acquire 5 && echo OK", env)
+    assert r.returncode == 0 and "OK" in r.stdout
+    assert "fail-open" in r.stderr
+
+
+def test_zero_and_noninteger_are_noops(tmp_path: Path) -> None:
+    env = _base_env(tmp_path / "pool", 8)
+    r = _run('cpu_slots_acquire 0 && cpu_slots_acquire "" && cpu_slots_acquire abc && echo OK', env)
+    assert r.returncode == 0 and "OK" in r.stdout
+
+
+# ── the real semaphore (flock required) ─────────────────────────────────────
+
+# One actor: acquire W, mark that it is holding, hold HOLD_MS, release. Run
+# from a distinct working dir per actor so nothing but the lib coordinates them.
+ACTOR = """\
+cpu_slots_acquire "$W"
+: > "$MARK"
+sleep "$HOLD"
+cpu_slots_release "$W"
+rm -f "$MARK"
+"""
+
+
+@needs_flock
+def test_never_oversubscribed_and_drains(tmp_path: Path) -> None:
+    """Twelve acquirers each want 3 tokens on a pool of 8 — 36 requested against
+    8. Sampling the holders dir throughout, the live sum must never exceed 8,
+    and after everyone finishes the pool is whole (holders empty)."""
+    pool = tmp_path / "pool"
+    holders = pool / "holders"
+    tokens, want, actors, hold = 8, 3, 12, 1.0
+    env = _base_env(pool, tokens)
+
+    procs = []
+    for _ in range(actors):
+        e = {
+            **os.environ,
+            **env,
+            "W": str(want),
+            "HOLD": str(hold),
+            "MARK": str(tmp_path / f"m{_}"),
+        }
+        procs.append(
+            subprocess.Popen(
+                ["bash", "-c", f"source {LOG}\nsource {LIB}\n{ACTOR}"],
+                env=e,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        )
+
+    peak = 0
+    deadline = time.time() + 40
+    while any(p.poll() is None for p in procs) and time.time() < deadline:
+        peak = max(peak, _live_sum(holders))
+        assert _live_sum(holders) <= tokens, f"OVERSUBSCRIBED: {_live_sum(holders)} > {tokens}"
+        time.sleep(0.01)
+
+    for p in procs:
+        p.wait(timeout=40)
+
+    # The pool actually filled (proves the actors really contended, not just ran
+    # one at a time by luck) and then drained completely.
+    assert peak >= tokens - want + 1, f"pool never filled: peak={peak}"
+    assert _live_sum(holders) == 0, "tokens leaked — pool did not drain to TOTAL"
+    assert not list(holders.glob("*"))
+
+
+@needs_flock
+def test_dead_holder_is_reclaimed(tmp_path: Path) -> None:
+    """A SIGKILL'd holder cannot run its EXIT trap, so its tokens WOULD leak.
+    The next acquirer sees the holder pid is dead and reclaims them."""
+    pool = tmp_path / "pool"
+    holders = pool / "holders"
+    tokens, want = 8, 8
+    env = _base_env(pool, tokens)
+
+    # Actor takes the whole pool and blocks forever.
+    e = {**os.environ, **env, "W": str(want), "HOLD": "600", "MARK": str(tmp_path / "m")}
+    hog = subprocess.Popen(
+        ["bash", "-c", f"source {LOG}\nsource {LIB}\n{ACTOR}"],
+        env=e,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait until it is actually holding.
+    for _ in range(500):
+        if (tmp_path / "m").exists():
+            break
+        time.sleep(0.01)
+    assert _live_sum(holders) == tokens
+
+    # SIGKILL: no trap runs, the holder file is orphaned.
+    hog.kill()
+    hog.wait(timeout=10)
+    assert _live_sum(holders) == tokens, "precondition: orphaned grant still on disk"
+
+    # A fresh acquirer for the whole pool must succeed quickly by reclaiming it.
+    r = _run(
+        f"GAIA_CPU_SLOTS_TIMEOUT=30 cpu_slots_acquire {want} && echo GOT && cpu_slots_release {want}",
+        env,
+        timeout=40,
+    )
+    assert r.returncode == 0 and "GOT" in r.stdout
+    assert _live_sum(holders) == 0
+
+
+@needs_flock
+def test_timeout_fails_open_with_warning(tmp_path: Path) -> None:
+    """A live holder pins the whole pool; a second acquirer waits its timeout
+    and then PROCEEDS WITHOUT the tokens (a warning, exit 0) — the governor can
+    never hang or fail a gate."""
+    pool = tmp_path / "pool"
+    holders = pool / "holders"
+    tokens = 8
+    env = _base_env(pool, tokens)
+
+    e = {**os.environ, **env, "W": str(tokens), "HOLD": "600", "MARK": str(tmp_path / "m")}
+    hog = subprocess.Popen(
+        ["bash", "-c", f"source {LOG}\nsource {LIB}\n{ACTOR}"],
+        env=e,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        for _ in range(500):
+            if (tmp_path / "m").exists():
+                break
+            time.sleep(0.01)
+        assert _live_sum(holders) == tokens
+
+        start = time.time()
+        r = _run("GAIA_CPU_SLOTS_TIMEOUT=2 cpu_slots_acquire 4 && echo PROCEEDED", env, timeout=30)
+        waited = time.time() - start
+        assert r.returncode == 0 and "PROCEEDED" in r.stdout
+        assert "fail-open" in r.stderr
+        assert 2 <= waited < 20, f"did not wait its timeout before failing open: {waited:.1f}s"
+        # It barged in WITHOUT taking tokens — the pool is not oversubscribed on disk.
+        assert _live_sum(holders) == tokens
+    finally:
+        hog.kill()
+        hog.wait(timeout=10)

--- a/scripts/ci/tests/test_mutation_plan.py
+++ b/scripts/ci/tests/test_mutation_plan.py
@@ -24,6 +24,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PLAN_SCRIPT = REPO_ROOT / "scripts" / "ci" / "mutation.sh"
 LOG_LIB = REPO_ROOT / "scripts" / "ci" / "lib" / "log.sh"
+CPU_SLOTS_LIB = REPO_ROOT / "scripts" / "ci" / "lib" / "cpu-slots.sh"
 
 # Mirrors MAX_SHARDS in the script under test, which tracks the matrix's
 # max-parallel: a wider matrix cannot finish sooner, it only adds a check row
@@ -39,6 +40,7 @@ def _install(scripts: Path) -> None:
     lib = scripts / "lib"
     lib.mkdir(exist_ok=True)
     shutil.copy(LOG_LIB, lib / "log.sh")
+    shutil.copy(CPU_SLOTS_LIB, lib / "cpu-slots.sh")
 
 
 def _stub_changes(scripts: Path, changed: list[str]) -> None:


### PR DESCRIPTION
## Summary

CI on the home box was thrashing: 8 physical cores / 16 threads, but the static per-lane worker budget only accounts for one workflow's test-python slices, while `build`, `docker-image`, `test-typescript` and the entire `code-quality.yml` (mypy, semgrep, knip, and mutation — 4 shards each budgeting `nproc-2`) run on the same cores at the same time, and two pushes can overlap. Measured: the same PR ran **3.6 min on an idle box vs 11 min loaded**, and two overlapping runs drove the **1-minute load average to 59** on a 16-thread machine (~3.7× oversubscription).

This adds a host-level CPU governor so heavy lanes take tokens from a shared pool and **queue instead of thrash**.

**Honest result up front:** in a controlled two-`main.yml` overlap the governor **halves the load-average peak (59 → 32)** but does **not** cut wall-clock — both runs finish in ~6 min with it on or off (6.75/6.08 vs 6.37/6.12). It is a **defensive** change: it caps the box's oversubscription so heavy concurrency (3+ pipelines, mutation storms) can't spike load to ~60 and starve/OOM the machine — not a speedup on the common case. If the goal is a faster gate, the lever is *less work* (test-impact/mutation/schemathesis), not scheduling: 8 cores is the ceiling.

## Mechanism

`scripts/ci/lib/cpu-slots.sh` — a weighted counting semaphore over a token pool shared across every job on the box (dir under `/run` or `ci-cache`, `flock`-atomic counter). Each heavy step acquires tokens equal to its real thread appetite, runs, releases on an EXIT trap:

- `pytest.sh slice` → `XDIST_N` tokens (the `-n` value)
- `mutation.sh shard` → its `nproc-2` budget
- the nx `build` step → `NX_PARALLEL` tokens, via a new `runner.sh with-slots N -- <cmd>` wrapper

If the pool is exhausted a lane waits (jittered retry) up to a timeout, then **fails open** — logs `::warning` and proceeds without the tokens; it never hangs or fails a gate. It is a **no-op** when `RUNNER_ENVIRONMENT != self-hosted` (GitHub-hosted VMs are already isolated) and when the pool dir can't be created. Tokens held by a dead holder (SIGKILL'd/cancelled job that couldn't run its trap) are reclaimed on the next acquire via per-holder pidfiles.

## Token count

Default = **`nproc` (16 on the box)**, not physical cores. This is deliberate: at 16, a *single* run's own xdist workers (unit-a 5 + unit-b 7 + integration 4 = 16) fit exactly, so a lone run **never blocks** — single-push is neutral by construction. Two overlapping runs are held to 16 instead of thrashing to ~60. Override with `GAIA_CPU_TOKENS`.

## Measured (self-hosted box)

| scenario | governor | 1-min loadavg peak | per-run wall |
|---|---|---|---|
| two overlapping `main.yml` | OFF (`GAIA_CPU_TOKENS=999`) | **59** (5-min 33, 15-min 18) | 6.37 / 6.12 min |
| two overlapping `main.yml` | ON (16) | **31.7** | 6.75 / 6.08 min |
| single push, idle box | ON (16) | 16.7 (1.0x, neutral) | 5.03 min |
| any GitHub-hosted job (`force_github`) | no-op by construction (`RUNNER_ENVIRONMENT` guard) | unaffected | unaffected |

Oversubscription roughly halves on the overlap case. It does **not** translate to a wall-clock cut here — the test-python slices are bounded per-slice work, not pure CPU spin, so halving the load left both runs at ~6 min. The value is protecting the box from the 2.3–3.7x load spikes seen under heavier concurrency, not making a given run faster. The earlier ad-hoc 11-min runs came from 3+ overlapping pipelines; this controlled 2-run overlap didn't reproduce that, so the wall win for the truly-pathological case is plausible but **unproven**.

## Verify

- `pytest scripts/ci/tests/test_cpu_slots.py` — proves the pool never oversubscribes under concurrent acquirers exceeding TOTAL, always drains to TOTAL, reclaims dead-holder tokens, and fails open on a bogus dir / non-self-hosted env (each assertion shown able to fail).
- On the box, watch `cat /proc/loadavg` during two overlapping dispatches with and without `GAIA_CPU_TOKENS=999`.

**Not yet verified:** the empirical single-push OFF-vs-ON wall (neutral by construction, not yet timed) and the ON overlap wall-clock table cell (the runs on this PR fill it). The self-hosted "after" numbers assume the box sources `cpu-slots.sh` from the job's own checkout (it does — the lib ships in the repo, not only in `ci-cache`), so no `setup.sh` re-run is required for it to take effect.

## Risk

The governor can only ever *delay* a lane, never fail it — every acquire times out and fails open. Worst case if the pool logic misbehaves: lanes run without tokens, i.e. today's behaviour. A cancelled job can't leave tokens stuck (dead-holder reclaim). Off the box it does nothing.
