### PR TITLE
fix(web): COPY libs/wake-word/package.json in the Docker build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -33,6 +33,7 @@ COPY apps/bots/slack/package.json  ./apps/bots/slack/
 COPY apps/bots/telegram/package.json ./apps/bots/telegram/
 COPY packages/cli/package.json     ./packages/cli/
 COPY libs/shared/ts/package.json   ./libs/shared/ts/
+COPY libs/wake-word/package.json   ./libs/wake-word/
 
 # Install BEFORE copying source. Consider the two layouts on a fresh
 # GitHub-hosted runner (BuildKit cache mounts start EMPTY every job):


### PR DESCRIPTION
## Summary
The web Docker image build (`build-images / docker-web`) has failed on every `master` push since the CI/linker work landed, with:
```
Error: Module not found: Can't resolve 'onnxruntime-web/wasm'
error TS2307: Cannot find module 'onnxruntime-web' / 'react' — libs/wake-word
```
This blocks the deploy pipeline (docker-web is in `quality-gate.needs`).

## Root cause
The Dockerfile stages each workspace `package.json` **before** `COPY . .` so pnpm can resolve the workspace and cache the install layer. That enumerated list never included `libs/wake-word` (the lib was added after the list was written). pnpm installed an incomplete workspace, and with the isolated linker from #1132 (no hoisting to mask it), `libs/wake-word`'s optional peers — `react` and `onnxruntime-web`, provided by `apps/web` — were unresolvable when `next build` type-checked the lib's source.

It only surfaced on `master` because the web image is skipped on PRs where `web` is unaffected, and it built green before #1132 because hoisting made the peers globally visible.

## Fix
One line: `COPY libs/wake-word/package.json ./libs/wake-word/` in the pre-install list. No stub or dependency change is needed — once the workspace is complete, pnpm materialises the peers and tsc resolves them.

## Verify (done locally with the exact Dockerfile)
Reproduced the failure on a clean `node:24-alpine` `docker build --target builder` off current master, applied the one line, rebuilt: **compiled, type-checked, generated all 4798 static pages, and exported the image.** The only build-log noise is the expected offline SSG fetches to the `preview.placeholder.buildtime` URL (non-fatal).

## Note
The pre-install COPY list is inherently drift-prone — `apps/bots/{harness,imessage,whatsapp}` are also absent from it (harmless for the web image, which does not import them). A follow-up could replace the enumeration with a glob so a new workspace package cannot silently break this again.