### PR TITLE
fix(web): point Tailwind @source globs at the app's node_modules, not the root

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -2,7 +2,7 @@
 @import "uniwind";
 @import "heroui-native/styles";
 
-@source "./../../node_modules/heroui-native/lib";
+@source "./node_modules/heroui-native/lib";
 
 @theme {
   --radius: 0.5rem;

--- a/apps/web/src/__tests__/tailwind-source-globs.test.ts
+++ b/apps/web/src/__tests__/tailwind-source-globs.test.ts
@@ -1,0 +1,41 @@
+import { globSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tailwind v4 resolves `@source` globs relative to the CSS file and silently
+ * emits nothing when one matches no files. A path that goes stale — as every
+ * `../../../../../node_modules/...` glob did when pnpm's hoisted linker was
+ * dropped (#1132) — costs hundreds of HeroUI utilities with no build error.
+ */
+const STYLESHEETS = [
+  "src/app/styles/globals.css",
+  "../mobile/global.css",
+] as const;
+
+const SOURCE_PATH = /@source\s+(?:not\s+)?"([^"]+)"/g;
+
+function declaredSources(stylesheet: string): string[] {
+  const file = path.resolve(__dirname, "../..", stylesheet);
+  const css = readFileSync(file, "utf8");
+  return [...css.matchAll(SOURCE_PATH)]
+    .map(([, glob]) => glob)
+    .filter((glob) => !glob.startsWith("inline("))
+    .map((glob) => path.resolve(path.dirname(file), glob));
+}
+
+describe("Tailwind @source globs", () => {
+  for (const stylesheet of STYLESHEETS) {
+    it(`${stylesheet}: every declared source matches at least one file`, () => {
+      const sources = declaredSources(stylesheet);
+      expect(sources.length).toBeGreaterThan(0);
+
+      for (const source of sources) {
+        expect(
+          globSync(source),
+          `no files match @source "${source}"`,
+        ).not.toHaveLength(0);
+      }
+    });
+  }
+});

--- a/apps/web/src/app/styles/globals.css
+++ b/apps/web/src/app/styles/globals.css
@@ -17,10 +17,10 @@
 @source inline("grid-rows-3 grid-rows-4 grid-cols-3 grid-cols-4");
 
 /* HeroUI */
-@source "../../../../../node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}";
+@source "../../../node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}";
 
 /* Streamdown — markdown renderer; scan its dist so Tailwind emits the utilities its components use */
-@source "../../../../../node_modules/streamdown/dist/*.js";
+@source "../../../node_modules/streamdown/dist/*.js";
 
 @custom-variant dark (&:is(.dark *));
 @plugin "./hero.ts";


### PR DESCRIPTION
## Summary

Production lost most of its HeroUI styling: buttons, the sidebar, follow-up actions and dropdowns rendered with no border radius, dropdown and modal backgrounds disappeared, sidebar hover states stopped changing colour, and switches and flat/danger buttons rendered unstyled. The cause was three Tailwind `@source` globs still pointing at the repo-root `node_modules/`, which pnpm stopped populating. Repointing them at each app's own `node_modules/` restores 598 CSS selectors (245KB) that had silently stopped being generated.

## Why

#1132 dropped `node-linker=hoisted` and switched pnpm to its default isolated linker. Under the isolated linker, packages no longer exist at the repo-root `node_modules/` — they live in the depending app's `node_modules/` as symlinks into `.pnpm`. That PR correctly fixed the one hardcoded root path it knew about, in `hero.ts`, but three identical hardcoded paths in the stylesheets were missed. Tailwind resolves `@source` relative to the CSS file and emits nothing — with no error and no warning — when a glob matches no files, so the breakage shipped silently.

## What changed

### Web

- `apps/web/src/app/styles/globals.css` — the `@heroui/theme` and `streamdown` `@source` globs now resolve to `apps/web/node_modules/` instead of the repo root.
- New `apps/web/src/__tests__/tailwind-source-globs.test.ts` — parses the `@source` globs out of both stylesheets and asserts each one matches at least one file.

### Bots / Mobile

- `apps/mobile/global.css` — the `heroui-native` `@source` glob now resolves to `apps/mobile/node_modules/`. Same bug, same cause; not yet reported as a mobile symptom, but the glob is equally dead.

---

## The bug

**Symptom** — On production: no border radius on buttons, sidebar items, or follow-up actions; the "What's new" modal and HeroUI dropdowns render with no background; sidebar chat rows no longer change background on hover; HeroUI switches, and flat and danger buttons, render unstyled.

**Reproduce** — On `master`:

1. `pnpm install --frozen-lockfile`
2. `ls node_modules/@heroui/theme` → does not exist (it is at `apps/web/node_modules/@heroui/theme`)
3. Compile `apps/web/src/app/styles/globals.css` through Tailwind with and without the fix → the stylesheet is ~245KB smaller without it

Live production CSS is missing the same HeroUI utilities, which is what the reported symptoms are.

**Root cause** — `apps/web/src/app/styles/globals.css:20` and `:23`, and `apps/mobile/global.css:5`, contained `@source` globs pointing at the repo-root `node_modules/`. Introduced as a latent bug by ccd9256da6 (#1132), which removed the `node-linker=hoisted` setting those paths depended on. Reproduced, not inferred.

**The fix** — Point each glob at the `node_modules/` of the app that declares the dependency, which is where the isolated linker actually places it. This is the root fix rather than a workaround: it removes the assumption about hoisting entirely instead of restoring the hoisting, and it matches how #1132 already fixed the equivalent path in `hero.ts` (which resolves `@heroui/theme` by name through normal module resolution).

**Regression test** — `apps/web/src/__tests__/tailwind-source-globs.test.ts`. Confirmed failing before the fix: with the pre-fix paths restored, both cases fail with `no files match @source ".../node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}"` and the equivalent for `heroui-native`. Green after.

**Why the suite missed it** — Nothing tested the build's CSS output or the resolvability of its inputs. The failure mode is a glob that matches nothing, which Tailwind treats as valid, so type-check, lint and the unit suite were all green while the stylesheet silently shrank by a quarter of a megabyte. The new test closes the gap at its cheapest point — the declared inputs — rather than by snapshotting compiled CSS, which would be brittle across HeroUI upgrades.

## How to verify

1. `pnpm install --frozen-lockfile`
2. `pnpm --dir apps/web exec vitest run src/__tests__/tailwind-source-globs.test.ts` → 2 passed.
3. To see it fail: revert the two stylesheets (`git checkout master -- apps/web/src/app/styles/globals.css apps/mobile/global.css`) and re-run → 2 failed, each naming the unmatched glob.
4. In the running app, confirm buttons and sidebar items have rounded corners, HeroUI dropdowns and the "What's new" modal have a background, sidebar chat rows change background on hover, and switches and danger/flat buttons are styled.

**Not verified:** I compiled the stylesheet through the Tailwind/PostCSS pipeline rather than running a full `nx build web`, and I did not load the built production bundle in a browser. Step 4 above has not been driven manually.

## Metrics

Compiled `apps/web/src/app/styles/globals.css` through `@tailwindcss/postcss` against a real `pnpm install --frozen-lockfile` of the current lockfile, once with the current paths and once with the fixed paths, in a single process with the working directory set to `apps/web` (what Next does).

| Metric | Before | After | How measured |
| --- | --- | --- | --- |
| Emitted CSS | 608,616 B | 853,281 B | `result.css.length` |
| Distinct selector strings absent before | — | 1,550 | set difference over `/\.[^\s{,]+/` matches |
| …of those, `hover:` / `data-*` stateful | — | 830 | substring filter over the same set |

The absent selectors cover the surfaces in the symptom list: `rounded-large` / `rounded-t-*` / `rounded-b-*`, `bg-content1` / `bg-content3`, `bg-sidebar`, `bg-default-500` / `-800`, `shadow-small` / `-medium` / `-large`, `border-medium` / `-small`, and the full `danger-*` / `success-*` / `warning-*` background and border families.

Caveat on precision: the byte delta reproduces consistently, but exact per-class presence shifts between runners, because Tailwind's automatic content detection scans a different file set under vitest than under plain node (608,459 B vs 608,616 B for the same input). Treat the ~245KB delta and the surface list as the reliable figures and any single-class count as environment-dependent.

## Risk

The change is three path strings. If a path were wrong the new test fails immediately and loudly, and CI would catch it before merge. The realistic residual risk is the opposite direction: some HeroUI utilities are now generated that were absent from production for the last few deploys, so any styling that was tuned against the broken CSS will shift back to its intended appearance — a correction, but a visible one.

## Related

Fixes the styling regression introduced by #1132.
