### PR TITLE
feat(onboarding): first-steps activation checklist

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -79,6 +79,34 @@ Pre-model hooks in `app/agents/core/nodes/`:
 
 `app/agents/tools/core/registry.py` — central tool registry backed by ChromaDB for semantic retrieval. Tools that the executor agent may need are retrieved at inference time, not statically bound.
 
+## Briefing, Todos & Retention Subsystems
+
+Thin connective tissue over existing rails (silent agent runs, system workflows, notification orchestrator, memory) — no new scheduler, execution engine, or notification pipeline.
+
+### Unified todo model & GAIA-todo lifecycle
+
+- One `todos` collection, both assignees. `assignee: "user" | "gaia"` is the discriminator (replaces the legacy `gaia-tracked` label; `gaia_assigned_filter()` in `app/constants/todos.py` dual-reads during the migration window). GAIA todos carry an `execution_status` state machine: `proposed → queued → running → done | failed | needs_you | expired | dismissed`.
+- **`app/services/todos/gaia_todo_lifecycle.py` owns every transition and its gate.** Never flip `execution_status` by hand — call `approve` / `dismiss` / `handoff` / `block` / `answer` / `mark_execution_status` / `expire_stale_proposals`. `block` (agent tool `block_todo`) is the only guarded path into `needs_you` mid-run and stores the `blocker_question`; `answer` (endpoint `POST /todos/{id}/answer` or agent tool `answer_todo`) is the only path out — it appends the Q&A to the notes facet and re-enqueues. Every transition broadcasts `todo.execution_status` over the user websocket so any live surface can refresh.
+- **Approval rule**: outward-visible work (sends, posts, purchases) enters `proposed` and needs an Approve tap; user+GAIA-only work (research, drafts) enters `queued` and runs. The `create_tracked_todo` tool takes required `serves` (traceability — untraceable todos are the junk) and `requires_approval` (the rule) args.
+- **Budgets** (hard caps in `constants/todos.py`): `MAX_GAIA_TODOS_IN_FLIGHT=5`, `MAX_PENDING_PROPOSALS=3`, `PROPOSAL_TTL_HOURS=72`. Creation past a cap is rejected; every dismiss/expiry writes a `proposal_rejected` memory signal and the 3-strike rule stops re-proposing a kind.
+- **Metering**: GAIA todo *executions* meter through `gaia_todo_executions` in `app/config/rate_limits.py` (free 5/month, pro 100/day). At-quota `approve` raises `ExecutionQuotaError` carrying the upgrade pitch instead of silently failing.
+
+### Briefing engine (`app/services/briefing/`)
+
+- Two per-user system workflows (`daily_briefing` cron `0 8 * * *`, `weekly_digest` `0 17 * * 0`, user-local) provisioned at onboarding completion and by `scripts/provision_daily_briefings.py`. Keys/crons/budgets/badges live in `app/constants/briefing.py`.
+- The workflow ARQ path (`execute_workflow_by_id`) special-cases `system_workflow_key in {daily_briefing, weekly_digest}` and calls `run_daily_briefing` / `run_weekly_digest` instead of the generic chat turn — so briefings skip the workflow-execution rate limit and own their delivery.
+- **Pipeline**: deterministic curation (`expire_stale_proposals`) → context gathering (`context.py`: look-back, budgets, strikes, goal, winback state) → `call_agent_silent` with the `briefing_prompts.py` contract → parse+validate one `BriefingPayload` (fail loud, store nothing on invalid) → persist BEFORE delivery → notification fan-out → analytics. Badges (`badges.py`, `awards` collection, each once) and streaks come from `app/services/todos/activity.py` — the single `completed_at`-derived source; nothing pads a streak.
+- **Payload contract** (`app/models/briefing_models.py`): `BriefingPayload` is structured data, never markup — one stored payload feeds every renderer (the OpenUI card in chat, email, Telegram). `hue` is set deterministically in code post-run; `mood` is a closed Literal keying the hero treatment.
+
+### Delivery, email channel & unsubscribe
+
+- Briefings deliver through `notification_service.create_notification` (in-app + linked platforms automatically). The **delivery contract** the email adapter keys off: `metadata["kind"] = NOTIFICATION_KIND_BRIEFING_DAILY | _WEEKLY` (from `app/constants/notifications.py`) selects the template, and `content.rich_content = payload.model_dump()` is what it renders — without both it falls back to the plain template.
+- `app/utils/notification/channels/email.py` sends via the Resend HTTP API; missing `RESEND_API_KEY` / `EMAIL_UNSUBSCRIBE_SECRET` is an ops precondition (skips with a log), not a feature flag. Email is default-on for briefings until the user disables it or clicks the one-click unsubscribe — a stateless HMAC-signed token (`app/utils/notification/unsubscribe.py`) mapping to the same channel preference. **Do not touch `app/utils/notification/**` or the notification endpoint — they're owned.**
+
+### First-steps activation
+
+`app/services/first_steps_service.py` tracks an ordered activation checklist on the user doc (`first_steps.{step}`), updated by real signals (`mark_step`) — integration connect, platform link, route visit, first approve. `first_steps.first_approve` is the honest "user has approved once" signal (the `first_approve` badge keys off it).
+
 ## Code Style
 
 - All functions and methods require full type annotations (enforced by mypy).

--- a/apps/api/app/api/v1/endpoints/first_steps.py
+++ b/apps/api/app/api/v1/endpoints/first_steps.py
@@ -1,0 +1,37 @@
+"""Activation checklist endpoints backing the first-steps widget."""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Body, Depends
+
+from app.api.v1.dependencies.oauth_dependencies import get_current_user
+from app.services import first_steps_service
+from shared.py.wide_events import log
+
+router = APIRouter(prefix="/users/me/first-steps", tags=["First Steps"])
+
+
+@router.get("")
+async def get_first_steps(user: Annotated[dict, Depends(get_current_user)]) -> dict[str, Any]:
+    log.set(user={"id": user["user_id"]}, operation="first_steps_get")
+    return await first_steps_service.get_steps(user["user_id"])
+
+
+@router.patch("")
+async def mark_first_step(
+    user: Annotated[dict, Depends(get_current_user)],
+    step: str = Body(embed=True),
+) -> dict[str, Any]:
+    log.set(user={"id": user["user_id"]}, operation="first_steps_mark", first_step=step)
+    await first_steps_service.mark_step(user["user_id"], step)
+    return await first_steps_service.get_steps(user["user_id"])
+
+
+@router.patch("/hide")
+async def hide_first_step(
+    user: Annotated[dict, Depends(get_current_user)],
+    step: str = Body(embed=True),
+) -> dict[str, Any]:
+    log.set(user={"id": user["user_id"]}, operation="first_steps_hide", first_step=step)
+    await first_steps_service.hide_step(user["user_id"], step)
+    return await first_steps_service.get_steps(user["user_id"])

--- a/apps/api/app/api/v1/routes.py
+++ b/apps/api/app/api/v1/routes.py
@@ -19,6 +19,7 @@ from app.api.v1.endpoints import (
     device_ws,
     feedback,
     file,
+    first_steps,
     image,
     mail,
     mcp,
@@ -79,6 +80,7 @@ router.include_router(notification.router, tags=["Notification"])
 router.include_router(websocket.router, tags=["WebSocket"])
 router.include_router(webhook_composio.router, tags=["Composio Webhook"])
 router.include_router(briefings.router, tags=["Briefings"])
+router.include_router(first_steps.router, tags=["First Steps"])
 router.include_router(todos.router, tags=["Todos"])
 router.include_router(workflows.router, tags=["Workflows"])
 router.include_router(triggers.router, tags=["Triggers"])

--- a/apps/api/app/db/repositories/todos.py
+++ b/apps/api/app/db/repositories/todos.py
@@ -476,10 +476,27 @@ class TodosRepository(UserScopedRepository[TodoDocument, TodoUpdate]):
             {"user_id": user_id, "completed_at": {"$ne": None}, **gaia_assigned_filter()}
         )
 
+    async def has_goal_todo(self, user_id: str) -> bool:
+        """Whether the user has any goal-lane todo."""
+        return await self._count({"user_id": user_id, "kind": "goal"}) > 0
+
     async def has_goal_created_since(self, user_id: str, *, since: datetime) -> bool:
         """Whether a goal lane was created at or after ``since`` (dormancy signal)."""
         return (
             await self._count({"user_id": user_id, "kind": "goal", "created_at": {"$gte": since}})
+            > 0
+        )
+
+    async def has_gaia_execution_history(self, user_id: str, *, statuses: list[str]) -> bool:
+        """Whether any GAIA-assigned todo has reached one of ``statuses``."""
+        return (
+            await self._count(
+                {
+                    "user_id": user_id,
+                    **gaia_assigned_filter(),
+                    "execution_status": {"$in": statuses},
+                }
+            )
             > 0
         )
 

--- a/apps/api/app/db/repositories/user_integrations.py
+++ b/apps/api/app/db/repositories/user_integrations.py
@@ -88,6 +88,19 @@ class UserIntegrationsRepository(
         )
         return doc is not None
 
+    async def find_connected_excluding(
+        self, user_id: str, exclude_integration_id: str
+    ) -> UserIntegrationDocument | None:
+        """A connected integration other than ``exclude_integration_id`` — the
+        first-steps checklist's retroactive "connected something real" probe."""
+        return await self._find_one(
+            {
+                "user_id": user_id,
+                "status": "connected",
+                "integration_id": {"$ne": exclude_integration_id},
+            }
+        )
+
     async def user_ids_with_integration(self, integration_id: str) -> list[str]:
         """Every user_id that has added ``integration_id`` (cross-user — for the
         cache-bust / link-cleanup fan-out when a shared integration changes)."""

--- a/apps/api/app/db/repositories/users.py
+++ b/apps/api/app/db/repositories/users.py
@@ -889,6 +889,15 @@ class UserRepository(MongoRepository[UserDocument, UserUpdate]):
         )
         return matched > 0
 
+    async def add_hidden_first_step(self, user_id: str, step: str) -> None:
+        """Hide a single checklist row server-side ($addToSet, so repeats no-op)."""
+        await self._apply_raw_update(
+            {"_id": self._id_value(user_id)},
+            {"$addToSet": {"first_steps.hidden_steps": step}},
+            scope=REPO_GLOBAL_SCOPE,
+            return_document=False,
+        )
+
     async def mark_day_zero_hello_sent(self, user_id: str, platform: str) -> None:
         await self._apply_raw_update(
             {"_id": self._id_value(user_id)},

--- a/apps/api/app/services/first_steps_service.py
+++ b/apps/api/app/services/first_steps_service.py
@@ -6,8 +6,14 @@ the widget ever rendered are pre-checked on first read so long-time users
 aren't asked to redo history.
 """
 
+from datetime import UTC, datetime
+from typing import Any
+
+from app.db.repositories.todos import todo_repository
+from app.db.repositories.user_integrations import user_integration_repository
 from app.db.repositories.users import user_repository
 from app.models.todo_models import ExecutionStatus
+from app.services.briefing.context import has_meaningful_focus
 from app.utils.analytics import track
 
 STEP_TELL_GAIA_GOAL = "tell_gaia_goal"
@@ -43,3 +49,58 @@ async def mark_step(user_id: str, step: str) -> None:
         return
     if await user_repository.set_first_step(user_id, step):
         track(user_id, "first_steps_step_done", {"step": step})
+
+
+async def hide_step(user_id: str, step: str) -> None:
+    """Hide a single checklist row server-side (persists across browsers)."""
+    if step not in ALL_STEPS:
+        return
+    await user_repository.add_hidden_first_step(user_id, step)
+
+
+async def get_steps(user_id: str) -> dict[str, Any]:
+    """Current progress, pre-checking steps already satisfied by existing state."""
+    user = await user_repository.get(user_id)
+    steps: dict[str, Any] = dict((user.first_steps if user else None) or {})
+    now = datetime.now(UTC)
+
+    if STEP_TELL_GAIA_GOAL not in steps:
+        # A real onboarding goal, or any goal-kind todo, counts as "told GAIA".
+        focus = ((user.onboarding if user else None) or {}).get("focus")
+        has_goal_todo = await todo_repository.has_goal_todo(user_id)
+        if has_meaningful_focus(focus) or has_goal_todo:
+            await mark_step(user_id, STEP_TELL_GAIA_GOAL)
+            steps[STEP_TELL_GAIA_GOAL] = now
+
+    if STEP_LINK_PLATFORM not in steps:
+        # Any linked chat platform satisfies the step retroactively.
+        links = (user.platform_links if user else None) or {}
+        if any(isinstance(v, dict) and v.get("id") for v in links.values()):
+            await mark_step(user_id, STEP_LINK_PLATFORM)
+            steps[STEP_LINK_PLATFORM] = now
+
+    if STEP_CONNECT_INTEGRATION not in steps:
+        # Any connected non-Gmail integration satisfies the step retroactively.
+        connected = await user_integration_repository.find_connected_excluding(
+            user_id, _NON_ACTIVATION_INTEGRATION
+        )
+        if connected:
+            await mark_step(user_id, STEP_CONNECT_INTEGRATION)
+            steps[STEP_CONNECT_INTEGRATION] = now
+
+    # The first_approve row is uncompletable until a proposal has ever existed,
+    # so the frontend hides it until this is true.
+    has_had_proposal = bool(
+        steps.get(STEP_FIRST_APPROVE)
+    ) or await todo_repository.has_gaia_execution_history(
+        user_id, statuses=list(_PROPOSAL_HISTORY_STATUSES)
+    )
+
+    hidden_steps = [s for s in (steps.get("hidden_steps") or []) if s in ALL_STEPS]
+
+    return {
+        "steps": {step: steps[step].isoformat() if steps.get(step) else None for step in ALL_STEPS},
+        "hidden_steps": hidden_steps,
+        "has_had_proposal": has_had_proposal,
+        "dismissed": STEP_DISMISSED_ALL in steps,
+    }

--- a/apps/api/tests/unit/services/test_first_steps_service.py
+++ b/apps/api/tests/unit/services/test_first_steps_service.py
@@ -10,17 +10,23 @@ its real signature so a call that drops or reorders an argument fails here
 exactly as it would in production; the service itself runs for real.
 """
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 
+from app.models.integration_models import UserIntegrationDocument
 from app.models.user_models import UserDocument
 from app.services import first_steps_service
 from app.services.first_steps_service import (
     ALL_STEPS,
+    STEP_CONNECT_INTEGRATION,
     STEP_DISMISSED_ALL,
     STEP_FIRST_APPROVE,
     STEP_LINK_PLATFORM,
+    STEP_TELL_GAIA_GOAL,
+    get_steps,
+    hide_step,
     mark_step,
 )
 
@@ -55,10 +61,52 @@ class FakeUserRepo:
         self.hidden_calls.append((user_id, step))
 
 
+class FakeTodoRepo:
+    def __init__(self) -> None:
+        self.has_goal = False
+        self.has_history = False
+        self.goal_calls: list[str] = []
+        self.history_calls: list[tuple[str, list[str]]] = []
+
+    async def has_goal_todo(self, user_id: str) -> bool:
+        self.goal_calls.append(user_id)
+        return self.has_goal if user_id == USER_ID else False
+
+    async def has_gaia_execution_history(self, user_id: str, *, statuses: list[str]) -> bool:
+        self.history_calls.append((user_id, statuses))
+        return self.has_history if user_id == USER_ID else False
+
+
+class FakeIntegrationRepo:
+    def __init__(self) -> None:
+        self.connected: UserIntegrationDocument | None = None
+        self.calls: list[tuple[str, str]] = []
+
+    async def find_connected_excluding(
+        self, user_id: str, exclude_integration_id: str
+    ) -> UserIntegrationDocument | None:
+        self.calls.append((user_id, exclude_integration_id))
+        return self.connected if user_id == USER_ID else None
+
+
 @pytest.fixture
 def repo(monkeypatch: pytest.MonkeyPatch) -> FakeUserRepo:
     fake = FakeUserRepo()
     monkeypatch.setattr(first_steps_service, "user_repository", fake)
+    return fake
+
+
+@pytest.fixture
+def todos(monkeypatch: pytest.MonkeyPatch) -> FakeTodoRepo:
+    fake = FakeTodoRepo()
+    monkeypatch.setattr(first_steps_service, "todo_repository", fake)
+    return fake
+
+
+@pytest.fixture
+def integrations(monkeypatch: pytest.MonkeyPatch) -> FakeIntegrationRepo:
+    fake = FakeIntegrationRepo()
+    monkeypatch.setattr(first_steps_service, "user_integration_repository", fake)
     return fake
 
 
@@ -109,3 +157,215 @@ class TestMarkStep:
 
         assert repo.calls == [(USER_ID, STEP_LINK_PLATFORM)]
         assert tracked == []
+
+
+@pytest.mark.unit
+class TestHideStep:
+    async def test_a_real_row_is_hidden_for_that_user(
+        self, repo: FakeUserRepo, tracked: list[Any]
+    ) -> None:
+        await hide_step(USER_ID, STEP_CONNECT_INTEGRATION)
+
+        assert repo.hidden_calls == [(USER_ID, STEP_CONNECT_INTEGRATION)]
+
+    async def test_a_step_outside_the_checklist_is_never_hidden(
+        self, repo: FakeUserRepo, tracked: list[Any]
+    ) -> None:
+        # dismissed_all is a valid mark_step target but not a checklist ROW,
+        # so it must not be storable as a hidden row either.
+        await hide_step(USER_ID, STEP_DISMISSED_ALL)
+        await hide_step(USER_ID, "not_a_step")
+
+        assert repo.hidden_calls == []
+
+
+@pytest.mark.unit
+class TestGetSteps:
+    async def test_a_fresh_account_has_completed_nothing(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        result = await get_steps(USER_ID)
+
+        assert result == {
+            "steps": dict.fromkeys(ALL_STEPS),
+            "hidden_steps": [],
+            "has_had_proposal": False,
+            "dismissed": False,
+        }
+        assert repo.calls == []
+
+    async def test_an_unknown_user_reads_as_a_fresh_account(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = None
+
+        result = await get_steps(USER_ID)
+
+        assert result["steps"] == dict.fromkeys(ALL_STEPS)
+        assert result["dismissed"] is False
+
+    async def test_an_onboarding_focus_retroactively_completes_the_goal_step(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = _user(onboarding={"focus": "ship the launch"})
+
+        result = await get_steps(USER_ID)
+
+        assert repo.get_calls == [USER_ID]
+        assert repo.calls == [(USER_ID, STEP_TELL_GAIA_GOAL)]
+        marked = result["steps"][STEP_TELL_GAIA_GOAL]
+        assert marked is not None
+        # Timestamped in UTC, not in whatever zone this process happens to run.
+        assert datetime.fromisoformat(marked).utcoffset() == timedelta(0)
+
+    async def test_a_goal_todo_alone_completes_the_goal_step(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        todos.has_goal = True
+
+        result = await get_steps(USER_ID)
+
+        assert todos.goal_calls == [USER_ID]
+        assert repo.calls == [(USER_ID, STEP_TELL_GAIA_GOAL)]
+        assert result["steps"][STEP_TELL_GAIA_GOAL] is not None
+
+    async def test_a_junk_onboarding_focus_is_not_a_goal(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = _user(onboarding={"focus": "n/a"})
+
+        result = await get_steps(USER_ID)
+
+        assert result["steps"][STEP_TELL_GAIA_GOAL] is None
+        assert repo.calls == []
+
+    async def test_an_existing_platform_link_retroactively_completes_that_step(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = _user(platform_links={"discord": {"id": "d-1"}})
+
+        result = await get_steps(USER_ID)
+
+        assert repo.calls == [(USER_ID, STEP_LINK_PLATFORM)]
+        assert result["steps"][STEP_LINK_PLATFORM] is not None
+
+    async def test_a_legacy_non_dict_link_does_not_count(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        # Pre-dict storage kept a bare platform id string; it carries no "id"
+        # key, so probing it must be skipped rather than attempted.
+        repo.user = _user(platform_links={"discord": "legacy_string", "slack": {}})
+
+        result = await get_steps(USER_ID)
+
+        assert result["steps"][STEP_LINK_PLATFORM] is None
+        assert repo.calls == []
+
+    async def test_a_connected_non_gmail_integration_completes_that_step(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        integrations.connected = UserIntegrationDocument(
+            user_id=USER_ID, integration_id="notion", status="connected"
+        )
+
+        result = await get_steps(USER_ID)
+
+        # Gmail is connected at signup, so it is the one integration excluded
+        # from the "connected something real" probe.
+        assert integrations.calls == [(USER_ID, "gmail")]
+        assert repo.calls == [(USER_ID, STEP_CONNECT_INTEGRATION)]
+        assert result["steps"][STEP_CONNECT_INTEGRATION] is not None
+
+    async def test_an_execution_history_unlocks_the_first_approve_row(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        todos.has_history = True
+
+        result = await get_steps(USER_ID)
+
+        # Only todos that entered the approval lifecycle count — queued/running
+        # work never needed a tap.
+        assert todos.history_calls == [(USER_ID, PROPOSAL_STATUSES)]
+        assert result["has_had_proposal"] is True
+        assert result["steps"][STEP_FIRST_APPROVE] is None
+
+    async def test_a_recorded_approve_unlocks_the_row_without_any_history(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = _user(first_steps={STEP_FIRST_APPROVE: datetime(2026, 6, 1, tzinfo=UTC)})
+        todos.has_history = False
+
+        result = await get_steps(USER_ID)
+
+        assert result["has_had_proposal"] is True
+        assert result["steps"][STEP_FIRST_APPROVE] == "2026-06-01T00:00:00+00:00"
+
+    async def test_hidden_rows_are_returned_and_filtered_to_real_steps(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = _user(
+            first_steps={"hidden_steps": [STEP_LINK_PLATFORM, STEP_DISMISSED_ALL, "bogus"]}
+        )
+
+        result = await get_steps(USER_ID)
+
+        assert result["hidden_steps"] == [STEP_LINK_PLATFORM]
+
+    async def test_a_dismissed_checklist_reports_dismissed(
+        self,
+        repo: FakeUserRepo,
+        todos: FakeTodoRepo,
+        integrations: FakeIntegrationRepo,
+        tracked: list[Any],
+    ) -> None:
+        repo.user = _user(first_steps={STEP_DISMISSED_ALL: datetime(2026, 6, 1, tzinfo=UTC)})
+
+        result = await get_steps(USER_ID)
+
+        assert result["dismissed"] is True
+        # dismissed_all is not a checklist row, so it never leaks into steps.
+        assert set(result["steps"]) == set(ALL_STEPS)

--- a/apps/web/src/app/[locale]/(main)/layout.tsx
+++ b/apps/web/src/app/[locale]/(main)/layout.tsx
@@ -45,6 +45,14 @@ const WhatsNewModal = nextDynamic(
   { ssr: false },
 );
 
+const FirstStepsWidget = nextDynamic(
+  () =>
+    import("@/features/first-steps/components/FirstStepsWidget").then((m) => ({
+      default: m.FirstStepsWidget,
+    })),
+  { ssr: false },
+);
+
 const HeaderSidebarTrigger = () => {
   return (
     <div className="">
@@ -174,6 +182,9 @@ export default function MainLayout({ children }: { children: ReactNode }) {
             isOpen={isHoloCardModalOpen}
             onClose={closeHoloCardModal}
           />
+
+          {/* First-Steps Activation Checklist */}
+          <FirstStepsWidget />
         </SidebarProvider>
       </TooltipProvider>
     </ProvidersLayout>

--- a/apps/web/src/features/first-steps/api/firstStepsApi.ts
+++ b/apps/web/src/features/first-steps/api/firstStepsApi.ts
@@ -1,0 +1,26 @@
+import { apiService } from "@/lib/api/service";
+import type { FirstStepsResponse } from "@/types/features/firstStepsTypes";
+
+export const firstStepsApi = {
+  fetchFirstSteps: async (): Promise<FirstStepsResponse> => {
+    return apiService.get<FirstStepsResponse>("/users/me/first-steps", {
+      silent: true,
+    });
+  },
+
+  // Response shape isn't part of the documented contract (only the effect —
+  // marking the step complete server-side — is specified), so the caller
+  // relies on an optimistic cache update rather than this return value.
+  markFirstStep: async (step: string): Promise<void> => {
+    await apiService.patch("/users/me/first-steps", { step }, { silent: true });
+  },
+
+  // Hides a single checklist row server-side (persists across browsers).
+  hideFirstStep: async (step: string): Promise<void> => {
+    await apiService.patch(
+      "/users/me/first-steps/hide",
+      { step },
+      { silent: true },
+    );
+  },
+};

--- a/apps/web/src/features/first-steps/components/FirstStepsWidget.tsx
+++ b/apps/web/src/features/first-steps/components/FirstStepsWidget.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { Link } from "@heroui/link";
+import { Progress } from "@heroui/progress";
+import {
+  Cancel01Icon,
+  CheckmarkCircle02Icon,
+  CircleIcon,
+  MinusSignIcon,
+} from "@icons";
+import { AnimatePresence } from "motion/react";
+import * as m from "motion/react-m";
+import NextLink from "next/link";
+import { useFirstStepsWidget } from "@/features/first-steps/hooks/useFirstStepsWidget";
+
+// One persistent shell morphs between pill and panel — size and radius animate
+// continuously; only the content crossfades. No overshoot: an overshooting
+// spring visibly distorts the border radius mid-morph.
+const morphSpring = {
+  type: "spring",
+  stiffness: 600,
+  damping: 48,
+} as const;
+
+const contentFade = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.12 },
+} as const;
+
+// Pill is 40px tall, so 20px reads as fully rounded while keeping the
+// radius morph numeric (20 -> 16) instead of jumping from 9999.
+const PILL_RADIUS = 20;
+const PANEL_RADIUS = 16;
+
+export function FirstStepsWidget() {
+  const {
+    shouldRender,
+    expanded,
+    setExpanded,
+    visibleSteps,
+    completedAt,
+    completedCount,
+    totalCount,
+    hideStep,
+    dismiss,
+  } = useFirstStepsWidget();
+
+  if (!shouldRender) return null;
+
+  return (
+    <div className="fixed right-4 bottom-4 z-40">
+      <m.div
+        layout
+        transition={morphSpring}
+        initial={false}
+        animate={{ borderRadius: expanded ? PANEL_RADIUS : PILL_RADIUS }}
+        className="overflow-hidden bg-zinc-800 shadow-lg"
+      >
+        <AnimatePresence initial={false} mode="popLayout">
+          {!expanded ? (
+            <m.button
+              key="pill"
+              layout
+              {...contentFade}
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="flex h-10 items-center gap-2 px-4 transition-colors hover:bg-zinc-700"
+            >
+              <Progress
+                aria-label="Activation progress"
+                value={(completedCount / totalCount) * 100}
+                size="sm"
+                color="success"
+                className="w-16"
+              />
+              <span className="text-xs font-medium text-zinc-200">
+                {completedCount}/{totalCount}
+              </span>
+            </m.button>
+          ) : (
+            <m.div key="panel" layout {...contentFade} className="w-80 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-zinc-100">
+                    Get started
+                  </p>
+                  <p className="text-xs text-zinc-500">
+                    {completedCount}/{totalCount} complete
+                  </p>
+                </div>
+                <div className="flex items-center">
+                  <Button
+                    isIconOnly
+                    size="sm"
+                    variant="light"
+                    aria-label="Minimize checklist"
+                    onPress={() => setExpanded(false)}
+                  >
+                    <MinusSignIcon size={16} className="text-zinc-400" />
+                  </Button>
+                  <Button
+                    isIconOnly
+                    size="sm"
+                    variant="light"
+                    aria-label="Dismiss checklist"
+                    onPress={dismiss}
+                  >
+                    <Cancel01Icon size={16} className="text-zinc-400" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                {visibleSteps.map((step) => {
+                  const isDone = Boolean(completedAt[step.key]);
+
+                  return (
+                    <div
+                      key={step.key}
+                      className="flex items-center justify-between gap-2 rounded-2xl bg-zinc-900 p-3"
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        {isDone ? (
+                          <CheckmarkCircle02Icon
+                            size={18}
+                            className="shrink-0 text-emerald-400"
+                          />
+                        ) : (
+                          <CircleIcon
+                            size={18}
+                            className="shrink-0 text-zinc-600"
+                          />
+                        )}
+                        <Link
+                          as={NextLink}
+                          href={step.href}
+                          className={`truncate text-sm font-medium ${
+                            isDone
+                              ? "text-zinc-500 line-through"
+                              : "text-zinc-200"
+                          }`}
+                        >
+                          {step.label}
+                        </Link>
+                      </div>
+                      {!isDone && (
+                        <Button
+                          isIconOnly
+                          size="sm"
+                          variant="light"
+                          aria-label={`Hide ${step.label}`}
+                          onPress={() => hideStep(step.key)}
+                        >
+                          <Cancel01Icon size={14} className="text-zinc-500" />
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </m.div>
+          )}
+        </AnimatePresence>
+      </m.div>
+    </div>
+  );
+}

--- a/apps/web/src/features/first-steps/constants.ts
+++ b/apps/web/src/features/first-steps/constants.ts
@@ -1,0 +1,31 @@
+export interface FirstStepDefinition {
+  key: string;
+  label: string;
+  href: string;
+}
+
+// Ordered activation checklist shown in the FirstStepsWidget. Each step maps to
+// a real signal the backend tracks (a stated goal, an integration, a linked
+// chat platform, the first Approve).
+// Dismissing the whole widget is recorded as this pseudo-step, which the
+// backend reports back as `dismissed` (it is not a checklist row).
+export const DISMISS_ALL_STEP = "dismissed_all";
+
+export const FIRST_STEPS: FirstStepDefinition[] = [
+  { key: "tell_gaia_goal", label: "Tell GAIA your goal", href: "/c" },
+  {
+    key: "connect_integration",
+    label: "Connect an integration",
+    href: "/integrations",
+  },
+  {
+    key: "link_platform",
+    label: "Link Telegram or WhatsApp",
+    href: "/settings/linked-accounts",
+  },
+  {
+    key: "first_approve",
+    label: "Approve your first GAIA todo",
+    href: "/todos",
+  },
+];

--- a/apps/web/src/features/first-steps/hooks/useDismissFirstStepsMutation.ts
+++ b/apps/web/src/features/first-steps/hooks/useDismissFirstStepsMutation.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { FirstStepsResponse } from "@/types/features/firstStepsTypes";
+import { firstStepsApi } from "../api/firstStepsApi";
+import { DISMISS_ALL_STEP } from "../constants";
+import { FIRST_STEPS_QUERY_KEY } from "./useFirstStepsQuery";
+
+/**
+ * Dismisses the whole checklist for good, optimistically flipping `dismissed`
+ * so the widget unmounts immediately. Mirrors the optimistic update +
+ * invalidate-on-settle pattern in useHideFirstStepMutation.
+ */
+export const useDismissFirstStepsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => firstStepsApi.markFirstStep(DISMISS_ALL_STEP),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: FIRST_STEPS_QUERY_KEY });
+
+      const previous = queryClient.getQueryData<FirstStepsResponse>(
+        FIRST_STEPS_QUERY_KEY,
+      );
+
+      queryClient.setQueryData<FirstStepsResponse>(
+        FIRST_STEPS_QUERY_KEY,
+        (old) => (old ? { ...old, dismissed: true } : old),
+      );
+
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(FIRST_STEPS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: FIRST_STEPS_QUERY_KEY });
+    },
+  });
+};

--- a/apps/web/src/features/first-steps/hooks/useFirstStepsQuery.ts
+++ b/apps/web/src/features/first-steps/hooks/useFirstStepsQuery.ts
@@ -1,0 +1,25 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+import type { FirstStepsResponse } from "@/types/features/firstStepsTypes";
+import { firstStepsApi } from "../api/firstStepsApi";
+
+export const FIRST_STEPS_QUERY_KEY = ["first-steps"];
+
+/**
+ * React Query hook for the activation checklist. Mounted app-wide via
+ * FirstStepsWidget in the (main) layout, so a long staleTime avoids refetch
+ * storms on every route change — mutations invalidate this key explicitly.
+ */
+export const useFirstStepsQuery = (
+  options?: Partial<UseQueryOptions<FirstStepsResponse, Error>>,
+) => {
+  return useQuery({
+    queryKey: FIRST_STEPS_QUERY_KEY,
+    queryFn: firstStepsApi.fetchFirstSteps,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 30 * 60 * 1000,
+    retry: 2,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+};

--- a/apps/web/src/features/first-steps/hooks/useFirstStepsWidget.ts
+++ b/apps/web/src/features/first-steps/hooks/useFirstStepsWidget.ts
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from "react";
+import { toast } from "@/lib/toast";
+import { FIRST_STEPS, type FirstStepDefinition } from "../constants";
+import { useDismissFirstStepsMutation } from "./useDismissFirstStepsMutation";
+import { useFirstStepsQuery } from "./useFirstStepsQuery";
+import { useHideFirstStepMutation } from "./useHideFirstStepMutation";
+
+// Minimizing the widget to the pill survives reloads; dismissing it for good
+// is recorded server-side instead, so it holds across browsers.
+const COLLAPSED_STORAGE_KEY = "gaia:first-steps:collapsed";
+
+// The "all set up" celebration is a one-time event. The backend keeps reporting
+// every step complete forever, so without a persisted flag the in-memory guard
+// (which resets on each mount) re-fires the toast on every page load.
+const CELEBRATED_STORAGE_KEY = "gaia:first-steps:celebrated";
+
+function readCelebrated(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CELEBRATED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+interface UseFirstStepsWidgetResult {
+  isReady: boolean;
+  shouldRender: boolean;
+  expanded: boolean;
+  setExpanded: (expanded: boolean) => void;
+  visibleSteps: FirstStepDefinition[];
+  completedAt: Record<string, string | null>;
+  completedCount: number;
+  totalCount: number;
+  hideStep: (stepKey: string) => void;
+  dismiss: () => void;
+}
+
+export const useFirstStepsWidget = (): UseFirstStepsWidgetResult => {
+  const { data, isLoading } = useFirstStepsQuery();
+  const hideStepMutation = useHideFirstStepMutation();
+  const dismissMutation = useDismissFirstStepsMutation();
+  const [expanded, setExpandedState] = useState(true);
+  const hasCelebrated = useRef(false);
+
+  useEffect(() => {
+    setExpandedState(
+      window.localStorage.getItem(COLLAPSED_STORAGE_KEY) !== "true",
+    );
+    // Seed the guard from the persisted flag so a finished user isn't
+    // re-congratulated on every reload.
+    hasCelebrated.current = readCelebrated();
+  }, []);
+
+  const setExpanded = (next: boolean) => {
+    setExpandedState(next);
+    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, String(!next));
+  };
+
+  const completedAt = data?.steps ?? {};
+  const hiddenSteps = new Set(data?.hidden_steps ?? []);
+  const hasHadProposal = data?.has_had_proposal ?? false;
+  const dismissed = data?.dismissed ?? false;
+
+  // The first_approve row is uncompletable until GAIA has ever proposed work,
+  // so it isn't part of the checklist until then.
+  const applicableSteps = FIRST_STEPS.filter(
+    (step) => step.key !== "first_approve" || hasHadProposal,
+  );
+  const visibleSteps = applicableSteps.filter(
+    (step) => !hiddenSteps.has(step.key),
+  );
+  const completedCount = applicableSteps.filter(
+    (step) => completedAt[step.key],
+  ).length;
+  const totalCount = applicableSteps.length;
+  const allComplete = totalCount > 0 && completedCount === totalCount;
+
+  useEffect(() => {
+    if (allComplete && !hasCelebrated.current) {
+      hasCelebrated.current = true;
+      window.localStorage.setItem(CELEBRATED_STORAGE_KEY, "true");
+      toast.success("You're all set up! Nicely done.");
+    }
+  }, [allComplete]);
+
+  const hideStep = (stepKey: string) => {
+    hideStepMutation.mutate(stepKey);
+  };
+
+  const dismiss = () => {
+    dismissMutation.mutate();
+  };
+
+  const isReady = !isLoading && Boolean(data);
+  // Auto-closes for good once everything is complete (the celebration toast
+  // is the goodbye); dismissing closes it early and permanently.
+  const shouldRender =
+    isReady && !dismissed && !allComplete && visibleSteps.length > 0;
+
+  return {
+    isReady,
+    shouldRender,
+    expanded,
+    setExpanded,
+    visibleSteps,
+    completedAt,
+    completedCount,
+    totalCount,
+    hideStep,
+    dismiss,
+  };
+};

--- a/apps/web/src/features/first-steps/hooks/useHideFirstStepMutation.ts
+++ b/apps/web/src/features/first-steps/hooks/useHideFirstStepMutation.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { FirstStepsResponse } from "@/types/features/firstStepsTypes";
+import { firstStepsApi } from "../api/firstStepsApi";
+import { FIRST_STEPS_QUERY_KEY } from "./useFirstStepsQuery";
+
+/**
+ * Hides a single checklist row server-side, optimistically adding it to
+ * `hidden_steps` so the widget drops it immediately. Mirrors the optimistic
+ * update + invalidate-on-settle pattern in useMarkFirstStepMutation.
+ */
+export const useHideFirstStepMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (step: string) => firstStepsApi.hideFirstStep(step),
+    onMutate: async (step: string) => {
+      await queryClient.cancelQueries({ queryKey: FIRST_STEPS_QUERY_KEY });
+
+      const previous = queryClient.getQueryData<FirstStepsResponse>(
+        FIRST_STEPS_QUERY_KEY,
+      );
+
+      queryClient.setQueryData<FirstStepsResponse>(
+        FIRST_STEPS_QUERY_KEY,
+        (old) =>
+          old
+            ? {
+                ...old,
+                hidden_steps: old.hidden_steps.includes(step)
+                  ? old.hidden_steps
+                  : [...old.hidden_steps, step],
+              }
+            : old,
+      );
+
+      return { previous };
+    },
+    onError: (_error, _step, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(FIRST_STEPS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: FIRST_STEPS_QUERY_KEY });
+    },
+  });
+};

--- a/apps/web/src/types/features/firstStepsTypes.ts
+++ b/apps/web/src/types/features/firstStepsTypes.ts
@@ -1,0 +1,10 @@
+export interface FirstStepsResponse {
+  // ISO completion timestamp per step key, or null if the step is not yet complete.
+  steps: Record<string, string | null>;
+  // Step keys the user has hidden server-side (persist across browsers).
+  hidden_steps: string[];
+  // Whether a GAIA proposal has ever existed; gates the "first approve" row.
+  has_had_proposal: boolean;
+  // Whether the user dismissed the whole widget for good.
+  dismissed: boolean;
+}

--- a/openspec/changes/daily-briefing-self-executing-todos/specs/first-steps-nudge/spec.md
+++ b/openspec/changes/daily-briefing-self-executing-todos/specs/first-steps-nudge/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: A first-steps checklist widget appears bottom-right across the app
+
+A persistent, collapsible widget SHALL render at the bottom-right of all `(main)` app pages for users who have not completed activation, presenting an ordered checklist: (1) explore the workflows page, (2) connect a first non-Gmail integration, (3) link Telegram for notifications, (4) meet Mission Control, (5) approve your first GAIA todo. Each step SHALL deep-link to its surface. The widget SHALL be dismissible per-step and entirely, and SHALL unmount permanently once all steps are complete or dismissed.
+
+#### Scenario: Fresh user sees the checklist everywhere
+- **WHEN** a newly onboarded user navigates between chat, todos, and workflows pages
+- **THEN** the widget renders bottom-right on each with current progress
+
+#### Scenario: Completion removes it forever
+- **WHEN** the final open step completes
+- **THEN** the widget celebrates once and never renders again for that user
+
+### Requirement: Progress derives from real signals, not self-report
+
+Step completion SHALL be recorded on the user doc (`first_steps: {step_key: completed_at}`) by existing signals — route visit (workflows page, dashboard), integration connect events, platform-link creation, and the first `todo_approved` — with no polling and no manual "mark done". Steps satisfied before the widget first renders SHALL be pre-checked.
+
+#### Scenario: Already-linked Telegram is pre-checked
+- **WHEN** a user linked Telegram before the widget ships
+- **THEN** step 3 renders complete on first appearance
+
+#### Scenario: Approve completes the last mile
+- **WHEN** the user taps Approve on any GAIA todo anywhere (dashboard, todo list, Telegram)
+- **THEN** step 5 completes and `first_steps_step_done` is emitted

--- a/tools/lints/plr_complexity_baseline.txt
+++ b/tools/lints/plr_complexity_baseline.txt
@@ -1,12 +1,12 @@
+#
+#   python3 tools/lints/check_plr_complexity.py --update
+# One line per (file, rule), tab-separated, sorted. Regenerate with:
 # PLR0911/0912/0913/0915 complexity grandfather baseline.
 # See tools/lints/check_plr_complexity.py -- this is a TOUCH-TO-FIX ratchet,
-# not a static exemption: a file listed here only stays quiet while untouched.
 # The moment a PR modifies a listed file, its violations here must be fixed in
-# that same PR, and this line deleted. New violations (new file, or a rule a
 # file didn't already have) are never grandfathered by this list.
-#
-# One line per (file, rule), tab-separated, sorted. Regenerate with:
-#   python3 tools/lints/check_plr_complexity.py --update
+# not a static exemption: a file listed here only stays quiet while untouched.
+# that same PR, and this line deleted. New violations (new file, or a rule a
 apps/api/app/agents/core/messages.py	PLR0913
 apps/api/app/agents/middleware/compaction.py	PLR0913
 apps/api/app/agents/middleware/runtime_adapter.py	PLR0913


### PR DESCRIPTION
## Summary

A first-steps checklist that walks a new user to the moments that make the
product make sense — connect an integration, link a chat platform, approve the
first thing GAIA does. It derives progress from real signals rather than
self-report, so a step the user already satisfied shows as done instead of
asking them to redo it. Dismissible.

## Why

After onboarding there was nothing pointing a new user at the first useful
action. The activation moments that predict retention were undiscoverable.

## What changed

### API

- First-steps progress derived from real signals (an integration connected, a
  platform linked, a GAIA todo approved), back-filling steps already satisfied.
- `GET /users/me/first-steps`, `PATCH` to mark a step, and hide endpoints.
- `routes.py` mounts the first-steps router.

### Web

- A dismissible first-steps widget mounted once in the authenticated layout.

The Today view that this PR previously carried has been removed from the
branch; `/dashboard` is untouched and remains exactly as master ships it.

## How to verify

1. As a new user, complete an activation step outside the widget (connect an
   integration) and confirm the widget shows it as done without being told.
2. Dismiss the widget and confirm it stays gone across reloads.

**Not verified:** none of the above was executed. `first_steps_service` has no
test coverage.

## Risk

Read-only derivation plus a small per-user document; not load-bearing for
anything below it in the stack. `PATCH` does a full document read-and-write per
call, fine at current volume.
