### PR TITLE
fix(api): anchor the llm_calls backfill to OpenRouter's own billed totals

### DIFF
--- a/apps/api/app/db/repositories/llm_calls.py
+++ b/apps/api/app/db/repositories/llm_calls.py
@@ -24,7 +24,7 @@ what keeps the collection bounded — the durable per-day money history stays in
 """
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 import re
 from typing import Literal, NamedTuple
 
@@ -34,7 +34,7 @@ from pymongo import UpdateOne
 from app.constants.general import EXECUTOR_THREAD_PREFIX, SPAWN_THREAD_PREFIX
 from app.db.repositories.base import MongoDocument, MongoRepository
 
-CostSource = Literal["provider", "table"]
+CostSource = Literal["provider", "table", "allocated"]
 CallStatus = Literal["ok", "error"]
 #: Short, stable classification of WHY a provider call failed. Derived from the
 #: exception type, never from its message: messages carry model ids, prompts
@@ -141,9 +141,10 @@ class LLMCallDocument(MongoDocument):
     output_tokens: int = 0
     reasoning_tokens: int = 0
     cost_usd: float = 0.0
-    #: Whether ``cost_usd`` is what the provider charged or what our price table
-    #: guessed. The two disagree by more than 10x per upstream, so coverage of
-    #: the reported price has to be measurable per call.
+    #: Whether ``cost_usd`` is what the provider charged, what our price table
+    #: guessed, or (backfilled rows only) the call's share of OpenRouter's own
+    #: per-day billing total. The three disagree by more than 10x per upstream,
+    #: so coverage of the reported price has to be measurable per call.
     cost_source: CostSource
     #: OpenRouter's generation id — the spot-audit handle back to the upstream.
     generation_id: str | None = None
@@ -244,6 +245,20 @@ class LLMCallsRepository(MongoRepository[LLMCallDocument, LLMCallUpdate]):
         ]
         result = await self._raw_collection().bulk_write(operations, ordered=False)
         return int(result.upserted_count)
+
+    async def first_live_call_at(self) -> datetime | None:
+        """When the live write path recorded its first row.
+
+        The backfill stops here: events at or after this instant already have
+        first-party rows, and reconstructing them too would double every sum.
+        """
+        doc = await self._raw_collection().find_one(
+            {"backfilled": {"$ne": True}}, sort=[("created_at", 1)], projection={"created_at": 1}
+        )
+        if doc is None:
+            return None
+        created_at: datetime = doc["created_at"]
+        return created_at.replace(tzinfo=UTC) if created_at.tzinfo is None else created_at
 
 
 llm_calls_repository = LLMCallsRepository()

--- a/apps/api/scripts/_activity.py
+++ b/apps/api/scripts/_activity.py
@@ -1,0 +1,85 @@
+"""OpenRouter's own books, as the anchor a backfill reconciles against.
+
+``GET /api/v1/activity`` (management key) returns one row per day, model,
+provider and endpoint: real billed dollars, real token counts, real request
+counts. Unlike per-generation lookups it needs no generation ids, covers every
+key on the account, and survives the generations' own 30-day expiry — but it is
+itself a rolling ~25-day window, so a snapshot taken today preserves days the
+API will refuse to return next week. That is why this module reads snapshot
+files and merges them: yesterday's file keeps the days that have already rolled
+out, today's fetch adds the days that have appeared since.
+
+Merging rule: rows are keyed by (day, model, provider, endpoint) and the copy
+with the larger ``usage`` wins — a later snapshot of the same day can only have
+accumulated more, so "larger" and "newer" are the same thing.
+"""
+
+from collections import defaultdict
+from collections.abc import Iterable
+import json
+from pathlib import Path
+
+import httpx
+from pydantic import BaseModel
+
+ACTIVITY_URL = "https://openrouter.ai/api/v1/activity"
+
+
+class ActivityPool(BaseModel):
+    """Everything OpenRouter billed for one (day, model), summed across providers."""
+
+    usd: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    reasoning_tokens: int = 0
+    requests: int = 0
+
+    @property
+    def tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens + self.reasoning_tokens
+
+
+def _merge_rows(row_sets: Iterable[list[dict]]) -> dict[tuple, dict]:
+    merged: dict[tuple, dict] = {}
+    for rows in row_sets:
+        for row in rows:
+            key = (
+                str(row.get("date", ""))[:10],
+                str(row.get("model", "")),
+                str(row.get("provider_name", "")),
+                str(row.get("endpoint_id", "")),
+            )
+            kept = merged.get(key)
+            if kept is None or float(row.get("usage", 0)) > float(kept.get("usage", 0)):
+                merged[key] = row
+    return merged
+
+
+async def load_pools(
+    snapshot_paths: list[Path], management_key: str | None
+) -> dict[tuple[str, str], ActivityPool]:
+    """Per-(day, model) billing pools from snapshots plus a live fetch.
+
+    Snapshot files are the raw ``{"data": [...]}`` body the endpoint returns.
+    The live fetch is attempted whenever a management key is available and its
+    failure is non-fatal — the snapshots alone are still an anchor.
+    """
+    row_sets: list[list[dict]] = []
+    for path in snapshot_paths:
+        row_sets.append(json.loads(path.read_text()).get("data", []))
+    if management_key:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.get(
+                ACTIVITY_URL, headers={"Authorization": f"Bearer {management_key}"}
+            )
+            response.raise_for_status()
+            row_sets.append(response.json().get("data", []))
+    pools: dict[tuple[str, str], ActivityPool] = defaultdict(ActivityPool)
+    for (day, model, _provider, _endpoint), row in _merge_rows(row_sets).items():
+        pool = pools[(day, model)]
+        pool.usd += float(row.get("usage", 0))
+        pool.prompt_tokens += int(row.get("prompt_tokens", 0))
+        pool.completion_tokens += int(row.get("completion_tokens", 0))
+        pool.reasoning_tokens += int(row.get("reasoning_tokens", 0))
+        pool.requests += int(row.get("requests", 0))
+    return dict(pools)

--- a/apps/api/scripts/backfill_llm_calls.py
+++ b/apps/api/scripts/backfill_llm_calls.py
@@ -7,60 +7,62 @@ to end. Loki holds one ``llm_call`` wide event per model call for 30 days, and
 those events carry almost everything a ledger row needs, so the recent past can
 be reconstructed instead of lost.
 
-Sources, in the order a row's cost is trusted:
+The dollars, however, cannot be trusted to the events alone. The logged costs
+came from a flat per-model table while the real rate depends on which upstream
+served the call — a spread of more than 9x — and whole stretches of the window
+have no events at all (log retention, the 2026-08-24 deploy). Reconciling the
+events against OpenRouter's activity API showed request and token counts
+matching within a few percent on stable days, and dollars off by a third. So
+this backfill anchors on OpenRouter's own books:
 
-- **OpenRouter** ``GET /api/v1/generation?id=<id>`` — what was actually charged.
-  The same lookup ``backfill_true_cost.py`` uses, cached per day so a re-run
-  only asks about ids it has not resolved.
-- **The event itself**, when it recorded ``cost_source="provider"`` — the
-  provider's own figure, captured live.
-- **The current price table** (``app/config/model_pricing.py``), recomputed from
-  the event's token counts. Today's rates applied to old calls, which is a
-  better estimate than the rate that was in the table at the time.
+- **The activity API** (``--or-activity`` snapshots and/or a live fetch with
+  ``OPENROUTER_MANAGEMENT_KEY``) — per day and model: billed dollars, token
+  counts, request counts. See ``scripts/_activity.py``. For every (day, model)
+  it covers, the day's real dollars are distributed across that day's call rows
+  in proportion to each call's best-known cost, scaled by how much of the day's
+  tokens our events actually observed. What OpenRouter billed beyond what the
+  events can attribute becomes one explicit *unattributed* row per (day, model)
+  — visible as a gap, never smeared into other calls, never dropped. The
+  ledger's total for an anchored day therefore equals OpenRouter's total for
+  that day, exactly.
+- **Per-generation lookups** (``GET /api/v1/generation?id=<id>``) and costs the
+  event captured live with ``cost_source="provider"`` — used as allocation
+  weights, since they carry the true per-call price shape.
+- **The current price table**, recomputed from token counts, for calls on days
+  the activity window does not reach (it is a rolling ~25 days) and for models
+  that never went through OpenRouter.
 - **The logged cost**, for a model the table does not know. Kept rather than
   zeroed, and counted separately so the fallback's share is visible.
 
 Reconstructed rows are stamped ``backfilled: true`` and carry a deterministic
 ``backfill_key``, so ``--apply`` is safe to re-run: the key is derived from the
-event, a unique index enforces it, and a second run inserts nothing.
+event, a unique index enforces it, and a second run inserts nothing. Events at
+or after the instant the live ledger started writing are excluded (detected
+from the collection itself on ``--apply``, or via ``--until``), because those
+calls already have first-party rows.
 
-Dropped deliberately: events with neither tokens nor cost (heartbeat echoes that
-would inflate the row count without adding spend), non-finite costs (``json``
-parses ``NaN``/``Infinity`` happily and one poisons every sum), and exact
-duplicate events. Doubled model ids (``a/b/a/b``, from a lane that stamped the
-alias twice) are normalised back to one. Sticky-flip replays are recorded the
-way the live path recorded them — ``background``, never charged.
+Dropped deliberately: events with neither tokens nor cost (heartbeat echoes),
+non-finite costs (``json`` parses ``NaN`` happily and one poisons every sum),
+exact duplicates, and double-logged copies — during 2026-08-13..18 the metering
+seam logged many calls twice, with the copies differing only in timestamp
+microseconds, which is why identity here is the call's second + shape rather
+than the raw line. Doubled model ids (``a/ba/b``, no separator) are normalised
+back to one. Sticky-flip replays are recorded the way the live path recorded
+them — ``background``, never charged.
 
-Floors at 2026-08-10: before that the events lack the cost fields this depends
-on, so older rows would be fiction.
-
-Reference run, against real production Loki, 2026-08-10..08-31, no OpenRouter
-lookups (so every cost is the event's own provider figure or the table)::
-
-    30,364 raw -> 27,580 docs, $53.35
-
-    zero-token echoes skipped                       2784
-    doubled model ids normalised                    9209
-    exact duplicates skipped                           0
-    background rows (never charged)                18773
-    unknown-model rows (kept at logged cost)           0
-
-The doubled-id count is the whole story of this script's first version: those
-9,209 rows matched no pricing entry, fell to "unknown model, keep logged cost",
-and preserved dead pre-2026-08-24 table prices — reporting $136.27 for the same
-window. Normalising the id first drops it to $53.35 and empties the
-unknown-model bucket, which is how you can tell the fallback is now only used
-for models the table genuinely does not know.
+Floors at 2026-08-10 for event reconstruction: before that the events lack the
+cost fields this depends on. Activity-anchored *unattributed* rows are not
+floored — OpenRouter billed 2026-08-06..09 and those dollars are accounted for
+even though no per-call rows can be built for them.
 
 Run from the api directory (or /app inside the container)::
 
-    python scripts/backfill_llm_calls.py --dry-run
-    python scripts/backfill_llm_calls.py --days 7 --dry-run
-    python scripts/backfill_llm_calls.py --apply
+    python scripts/backfill_llm_calls.py --dry-run --or-activity /tmp/or_activity.json
+    python scripts/backfill_llm_calls.py --apply --or-activity /tmp/or_activity.json
 
-Environment: ``LOKI_URL`` (default ``http://loki:3100``) and
-``OPENROUTER_API_KEY``. Generation lookups are cached per day under
-``--cache-dir``, so an interrupted backfill costs nothing to restart.
+Environment: ``LOKI_URL`` (default ``http://loki:3100``), ``OPENROUTER_API_KEY``
+for generation lookups (cached per day under ``--cache-dir``), and optionally
+``OPENROUTER_MANAGEMENT_KEY`` to fetch the activity window live.
 """
 
 import argparse
@@ -83,6 +85,7 @@ from pydantic import BaseModel
 from app.config.model_pricing import MODEL_PRICING, calculate_token_cost
 from app.db.mongodb.mongodb import init_mongodb
 from app.db.repositories.llm_calls import LLMCallDocument, llm_calls_repository, split_lane_thread
+from scripts._activity import ActivityPool, load_pools
 from scripts._events import finite_cost
 from scripts._loki import MAX_DAYS, fetch_day
 from scripts._openrouter import GenerationRecord, default_cache_dir, resolve_generations
@@ -91,6 +94,8 @@ from scripts._openrouter import GenerationRecord, default_cache_dir, resolve_gen
 #: reconstructed from them would be invented rather than recovered.
 EARLIEST_DAY = "2026-08-10"
 _BATCH = 1000
+#: Below this an unattributed remainder is rounding noise, not a gap.
+_REMAINDER_FLOOR_USD = 0.0005
 
 
 class LedgerEvent(BaseModel):
@@ -149,6 +154,26 @@ class LedgerEvent(BaseModel):
             ]
         )
         return hashlib.sha256(fingerprint.encode()).hexdigest()
+
+    @property
+    def call_shape(self) -> tuple:
+        """The second-resolution identity that catches double-logged copies.
+
+        During 2026-08-13..18 the metering seam logged many calls twice; the
+        copies differ in timestamp microseconds (two sinks, two clock reads) and
+        sometimes in which copy carries the generation id, so the exact
+        ``backfill_key`` never matches them. The same user, model and token
+        counts within the same second is one call: real traffic at 30k-token
+        prompts does not produce two independent identical calls in a second.
+        """
+        return (
+            int(self.created_at.timestamp()),
+            self.user_id or "",
+            self.model,
+            self.input_tokens,
+            self.output_tokens,
+            self.cached_tokens,
+        )
 
 
 def normalise_model(model: str) -> str:
@@ -240,6 +265,10 @@ def price_event(event: LedgerEvent, record: GenerationRecord | None) -> Priced:
     recorded, which beats what today's table computes, which beats the logged
     number — and the logged number is kept rather than zeroed for a model the
     table has never heard of, because a missing rate is not a free call.
+
+    On a day the activity window anchors, this figure becomes the call's
+    *weight* and the absolute dollars come from the day's pool; elsewhere it is
+    the cost itself.
     """
     if record is not None:
         return Priced(cost=record.total_cost, source="generation")
@@ -289,8 +318,9 @@ def build_document(event: LedgerEvent, record: GenerationRecord | None) -> LLMCa
         output_tokens=event.output_tokens,
         reasoning_tokens=event.reasoning_tokens,
         cost_usd=priced.cost,
-        # The ledger's own vocabulary has two values; a generation lookup is a
-        # provider figure, and both table paths are the table.
+        # The ledger's own vocabulary: a generation lookup is a provider figure,
+        # both table paths are the table. Anchored days overwrite this with
+        # "allocated" in the allocation pass.
         cost_source="provider" if priced.source in {"generation", "provider"} else "table",
         generation_id=event.generation_id,
         finish_reason=event.finish_reason,
@@ -299,6 +329,46 @@ def build_document(event: LedgerEvent, record: GenerationRecord | None) -> LLMCa
         channel=event.channel,
         backfilled=True,
         backfill_key=event.backfill_key,
+    )
+
+
+def unattributed_document(
+    day: str,
+    model: str,
+    cost: float,
+    missing_prompt: int,
+    missing_completion: int,
+    missing_reasoning: int,
+) -> LLMCallDocument:
+    """The remainder row for spend OpenRouter billed but no event can carry.
+
+    One per (day, model): background, never charged, no user — a visible gap in
+    the ledger's own vocabulary rather than dollars smeared across unrelated
+    calls or silently dropped. ``requests`` has no field of its own, so the gap
+    is sized in tokens and dollars.
+    """
+    return LLMCallDocument(
+        created_at=datetime.fromisoformat(day).replace(hour=12, tzinfo=UTC),
+        user_id=None,
+        agent_name="or_unattributed",
+        background=True,
+        charge_to_budget=False,
+        model_requested=model,
+        model_served=None,
+        provider=None,
+        input_tokens=missing_prompt,
+        cached_tokens=0,
+        output_tokens=missing_completion,
+        reasoning_tokens=missing_reasoning,
+        cost_usd=cost,
+        cost_source="allocated",
+        generation_id=None,
+        finish_reason=None,
+        conversation_id=None,
+        lane_thread=None,
+        channel=None,
+        backfilled=True,
+        backfill_key=hashlib.sha256(f"or-unattributed|{day}|{model}".encode()).hexdigest(),
     )
 
 
@@ -315,11 +385,15 @@ class Anomalies(BaseModel):
 
     echoes_skipped: int = 0
     duplicates_skipped: int = 0
+    double_logged_skipped: int = 0
     doubled_ids_normalised: int = 0
     background_rows: int = 0
     generations_resolved: int = 0
     generations_missing: int = 0
     unknown_model_rows: int = 0
+    allocated_rows: int = 0
+    unattributed_rows: int = 0
+    beyond_ledger_skipped: int = 0
 
     def observe(self, event: LedgerEvent, priced: Priced) -> None:
         """Count what this kept event tells us about the run."""
@@ -347,11 +421,15 @@ class Anomalies(BaseModel):
         rows = [
             ("zero-token echoes skipped", self.echoes_skipped),
             ("doubled model ids normalised", self.doubled_ids_normalised),
+            ("double-logged copies skipped", self.double_logged_skipped),
             ("exact duplicates skipped", self.duplicates_skipped),
+            ("events after ledger go-live skipped", self.beyond_ledger_skipped),
             ("background rows (never charged)", self.background_rows),
             ("generation lookups resolved", self.generations_resolved),
             ("generation lookups missing", self.generations_missing),
             ("unknown-model rows (kept at logged cost)", self.unknown_model_rows),
+            ("rows re-priced from OpenRouter's day total", self.allocated_rows),
+            ("unattributed remainder rows", self.unattributed_rows),
         ]
         print("\nanomalies")
         print("-" * 52)
@@ -359,29 +437,173 @@ class Anomalies(BaseModel):
             print(f"{label:<44}{count:>8}")
 
 
+def _prefer(candidate: LedgerEvent, held: LedgerEvent) -> bool:
+    """Between two copies of one call, which carries more truth.
+
+    The copy with a generation id can be audited against OpenRouter later; the
+    copy with a provider-captured cost carries the real price. Either beats a
+    copy with neither.
+    """
+    if bool(candidate.generation_id) != bool(held.generation_id):
+        return bool(candidate.generation_id)
+    if (candidate.cost_source == "provider") != (held.cost_source == "provider"):
+        return candidate.cost_source == "provider"
+    return False
+
+
 def select_events(
     events: Iterable[LedgerEvent], anomalies: Anomalies | None = None
 ) -> list[LedgerEvent]:
-    """Drop the events that must not become rows, newest-safe and order-stable.
+    """Drop the events that must not become rows, order-stable.
 
-    Echoes (no tokens, no cost) and exact duplicates — the same call logged
-    twice, which the ledger would otherwise count twice. Both are counted into
-    ``anomalies`` rather than silently discarded.
+    Echoes (no tokens, no cost), double-logged copies (same call, two log
+    lines — see :meth:`LedgerEvent.call_shape`), and exact duplicates. All are
+    counted into ``anomalies`` rather than silently discarded, and when a call
+    was logged twice the copy that carries a generation id or a provider cost
+    is the one kept.
     """
     tally = anomalies if anomalies is not None else Anomalies()
-    seen: set[str] = set()
-    kept: list[LedgerEvent] = []
+    groups: dict[tuple, list[LedgerEvent]] = {}
+    order: list[LedgerEvent] = []
     for event in events:
         if not event.has_substance:
             tally.echoes_skipped += 1
             continue
-        key = event.backfill_key
-        if key in seen:
+        group = groups.setdefault(event.call_shape, [])
+        held = next(
+            (
+                candidate
+                for candidate in group
+                # Two events with two DIFFERENT generation ids are two calls no
+                # matter how alike they look — the provider issued both ids.
+                if not (
+                    candidate.generation_id
+                    and event.generation_id
+                    and candidate.generation_id != event.generation_id
+                )
+            ),
+            None,
+        )
+        if held is None:
+            group.append(event)
+            order.append(event)
+            continue
+        tally.double_logged_skipped += 1
+        if _prefer(event, held):
+            group[group.index(held)] = event
+            order[order.index(held)] = event
+    seen: set[str] = set()
+    kept: list[LedgerEvent] = []
+    for event in order:
+        if event.backfill_key in seen:
             tally.duplicates_skipped += 1
             continue
-        seen.add(key)
+        seen.add(event.backfill_key)
         kept.append(event)
     return kept
+
+
+class Entry(BaseModel):
+    """One kept event with its document and pre-allocation price."""
+
+    event: LedgerEvent
+    doc: LLMCallDocument
+    priced: Priced
+
+
+def allocate_day(
+    day: str,
+    entries: Sequence[Entry],
+    pools: Mapping[tuple[str, str], ActivityPool],
+    consumed: set[tuple[str, str]],
+    anomalies: Anomalies,
+) -> tuple[list[LLMCallDocument], float, float]:
+    """Anchor one day's rows to OpenRouter's billed total for that day.
+
+    For each (day, model) the activity window covers: the pool's real dollars,
+    scaled by the share of the day's tokens our events actually observed, are
+    distributed across the rows in proportion to each row's best-known cost —
+    so the *shape* of per-call pricing (cache discounts, output rates, the
+    generation lookups that resolved) survives while the *level* becomes what
+    OpenRouter actually charged. The unobserved share becomes one unattributed
+    row. Days and models outside the window are left untouched.
+
+    Returns the unattributed rows plus (anchored $, unattributed $) for the
+    day's summary line.
+    """
+    by_model: dict[str, list[Entry]] = defaultdict(list)
+    for entry in entries:
+        by_model[entry.doc.model_requested].append(entry)
+    remainder_docs: list[LLMCallDocument] = []
+    anchored_usd = 0.0
+    unattributed_usd = 0.0
+    for model, group in by_model.items():
+        pool = pools.get((day, model))
+        if pool is None:
+            continue
+        consumed.add((day, model))
+        our_prompt = sum(entry.event.input_tokens for entry in group)
+        our_completion = sum(entry.event.output_tokens for entry in group)
+        our_reasoning = sum(entry.event.reasoning_tokens for entry in group)
+        our_tokens = our_prompt + our_completion + our_reasoning
+        coverage = min(1.0, our_tokens / pool.tokens) if pool.tokens else 1.0
+        attributable = pool.usd * coverage
+        weights = [max(entry.priced.cost, 0.0) for entry in group]
+        total_weight = sum(weights)
+        for entry, weight in zip(group, weights, strict=True):
+            share = weight / total_weight if total_weight else 1.0 / len(group)
+            entry.doc.cost_usd = attributable * share
+            entry.doc.cost_source = "allocated"
+            anomalies.allocated_rows += 1
+        anchored_usd += pool.usd
+        leftover = pool.usd - attributable
+        if leftover >= _REMAINDER_FLOOR_USD:
+            remainder_docs.append(
+                unattributed_document(
+                    day,
+                    model,
+                    leftover,
+                    max(0, pool.prompt_tokens - our_prompt),
+                    max(0, pool.completion_tokens - our_completion),
+                    max(0, pool.reasoning_tokens - our_reasoning),
+                )
+            )
+            unattributed_usd += leftover
+            anomalies.unattributed_rows += 1
+    return remainder_docs, anchored_usd, unattributed_usd
+
+
+def leftover_pools(
+    pools: Mapping[tuple[str, str], ActivityPool],
+    consumed: set[tuple[str, str]],
+    today: str,
+    anomalies: Anomalies,
+) -> list[LLMCallDocument]:
+    """Unattributed rows for spend with no events at all.
+
+    Days before the event floor (2026-08-06..09), days log retention has
+    already deleted, and models that never produced a wide event: OpenRouter
+    billed them, so they are rows — fully unattributed. The current UTC day is
+    excluded because its pool is still accumulating and would under-anchor.
+    """
+    docs: list[LLMCallDocument] = []
+    for (day, model), pool in sorted(pools.items()):
+        if (day, model) in consumed or day >= today:
+            continue
+        if pool.usd < _REMAINDER_FLOOR_USD:
+            continue
+        docs.append(
+            unattributed_document(
+                day,
+                model,
+                pool.usd,
+                pool.prompt_tokens,
+                pool.completion_tokens,
+                pool.reasoning_tokens,
+            )
+        )
+        anomalies.unattributed_rows += 1
+    return docs
 
 
 class DaySummary(BaseModel):
@@ -391,39 +613,41 @@ class DaySummary(BaseModel):
     raw: int
     docs: int
     dollars: float
-    from_generation: int
-    from_table: int
-    from_logged: int
-
-
-def summarise(
-    day: str, raw: int, docs: Sequence[LLMCallDocument], sources: Mapping[str, int]
-) -> DaySummary:
-    return DaySummary(
-        day=day,
-        raw=raw,
-        docs=len(docs),
-        dollars=sum(doc.cost_usd for doc in docs),
-        from_generation=sources.get("generation", 0),
-        from_table=sources.get("table", 0) + sources.get("provider", 0),
-        from_logged=sources.get("logged", 0),
-    )
+    or_dollars: float | None = None
+    or_requests: int | None = None
+    unattributed: float = 0.0
+    from_generation: int = 0
+    from_table: int = 0
+    from_logged: int = 0
 
 
 def render(rows: Sequence[DaySummary]) -> None:
-    """The per-day raw -> docs -> $ table the dry run reports."""
-    header = f"{'date':<12}{'raw':>8}{'docs':>8}{'$':>12}{'gen':>8}{'table':>8}{'logged':>8}"
+    """The per-day raw -> docs -> $ table the dry run reports.
+
+    ``$`` is what the day's rows sum to; ``OR $`` is what OpenRouter billed for
+    the day where the activity window reaches, and on those days the two are
+    equal by construction — a day where they differ is a bug, not a rounding
+    story. ``unattr $`` is the slice of ``$`` carried by remainder rows.
+    """
+    header = (
+        f"{'date':<12}{'raw':>8}{'docs':>8}{'$':>12}{'OR $':>10}{'OR req':>8}"
+        f"{'unattr $':>10}{'gen':>6}{'table':>7}{'logged':>7}"
+    )
     print(header)
     print("-" * len(header))
     for row in rows:
+        or_usd = f"{row.or_dollars:>10.4f}" if row.or_dollars is not None else f"{'—':>10}"
+        or_req = f"{row.or_requests:>8}" if row.or_requests is not None else f"{'—':>8}"
         print(
-            f"{row.day:<12}{row.raw:>8}{row.docs:>8}{row.dollars:>12.4f}"
-            f"{row.from_generation:>8}{row.from_table:>8}{row.from_logged:>8}"
+            f"{row.day:<12}{row.raw:>8}{row.docs:>8}{row.dollars:>12.4f}{or_usd}{or_req}"
+            f"{row.unattributed:>10.4f}{row.from_generation:>6}{row.from_table:>7}{row.from_logged:>7}"
         )
     print("-" * len(header))
+    total_or = sum(r.or_dollars for r in rows if r.or_dollars is not None)
     print(
         f"{'total':<12}{sum(r.raw for r in rows):>8}{sum(r.docs for r in rows):>8}"
-        f"{sum(r.dollars for r in rows):>12.4f}"
+        f"{sum(r.dollars for r in rows):>12.4f}{total_or:>10.4f}{'':>8}"
+        f"{sum(r.unattributed for r in rows):>10.4f}"
     )
 
 
@@ -435,9 +659,31 @@ def wanted_days(days: int) -> list[str]:
     return [day.isoformat() for day in candidates if day >= floor]
 
 
-async def backfill(days: int, cache_dir: Path, apply: bool) -> None:
+async def ledger_live_floor(until: datetime | None, apply: bool) -> datetime | None:
+    """The instant the live ledger started writing, before which backfill owns.
+
+    Live rows and backfilled rows for the same call would double every sum, so
+    events at or after this instant are skipped. On ``--apply`` the collection
+    itself answers (the earliest non-backfilled row); ``--until`` overrides for
+    dry runs without a database.
+    """
+    if until is not None:
+        return until
+    if not apply:
+        return None
+    return await llm_calls_repository.first_live_call_at()
+
+
+async def backfill(
+    days: int,
+    cache_dir: Path,
+    apply: bool,
+    activity_paths: list[Path],
+    until: datetime | None,
+) -> None:
     loki_url = os.environ.get("LOKI_URL", "http://loki:3100")
     api_key = os.environ.get("OPENROUTER_API_KEY")
+    management_key = os.environ.get("OPENROUTER_MANAGEMENT_KEY")
     if not api_key and apply:
         raise SystemExit("OPENROUTER_API_KEY is not set — run through `infisical run --`.")
     if not api_key:
@@ -445,20 +691,48 @@ async def backfill(days: int, cache_dir: Path, apply: bool) -> None:
         # credential to answer "how many rows, and roughly what do they cost".
         # Without the key the generation lookups are skipped: rows the event
         # already priced from the provider keep that figure, the rest are priced
-        # from the table, and NOTHING is verified against OpenRouter. Loud,
-        # because it changes what the dollar column means.
-        print("NO OPENROUTER_API_KEY — generation lookups skipped; costs are unverified\n")
+        # from the table or the day pool, and per-call figures are unverified.
+        print("NO OPENROUTER_API_KEY — generation lookups skipped\n")
+
+    pools = await load_pools(activity_paths, management_key)
+    if pools:
+        pool_days = sorted({day for day, _ in pools})
+        print(
+            f"activity anchor: {len(pools)} (day, model) pools, "
+            f"{pool_days[0]}..{pool_days[-1]}, ${sum(p.usd for p in pools.values()):.4f} billed\n"
+        )
+    else:
+        print(
+            "NO ACTIVITY ANCHOR — pass --or-activity or set OPENROUTER_MANAGEMENT_KEY; "
+            "costs will NOT reconcile to OpenRouter's billed totals\n"
+        )
 
     if apply:
         init_mongodb()
+    live_floor = await ledger_live_floor(until, apply)
+    if live_floor is not None:
+        print(f"ledger go-live floor: events at/after {live_floor.isoformat()} are skipped\n")
 
+    today = datetime.now(UTC).date().isoformat()
     summaries: list[DaySummary] = []
     anomalies = Anomalies()
+    consumed: set[tuple[str, str]] = set()
     written = 0
+
+    async def write(docs: Sequence[LLMCallDocument]) -> int:
+        count = 0
+        for start in range(0, len(docs), _BATCH):
+            count += await llm_calls_repository.insert_backfilled(docs[start : start + _BATCH])
+        return count
+
     async with httpx.AsyncClient(timeout=60.0) as client:
         for day in wanted_days(days):
             events = await fetch_day(client, loki_url, day, parse_event)
             kept = select_events(events, anomalies)
+            if live_floor is not None:
+                before = len(kept)
+                kept = [event for event in kept if event.created_at < live_floor]
+                anomalies.beyond_ledger_skipped += before - len(kept)
             generations = (
                 await resolve_generations(
                     client,
@@ -471,28 +745,69 @@ async def backfill(days: int, cache_dir: Path, apply: bool) -> None:
             )
             anomalies.count_lookups(generations)
             sources: dict[str, int] = defaultdict(int)
-            docs: list[LLMCallDocument] = []
+            entries: list[Entry] = []
             for event in kept:
                 record = generations.get(event.generation_id) if event.generation_id else None
                 priced = price_event(event, record)
                 sources[priced.source] += 1
                 anomalies.observe(event, priced)
-                docs.append(build_document(event, record))
-            summaries.append(summarise(day, len(events), docs, sources))
+                entries.append(Entry(event=event, doc=build_document(event, record), priced=priced))
+            # Today's pool is still accumulating on OpenRouter's side; anchoring
+            # to it would scale a full day of events down to a partial total.
+            remainder_docs, anchored_usd, unattributed_usd = allocate_day(
+                day, entries, pools if day < today else {}, consumed, anomalies
+            )
+            docs = [entry.doc for entry in entries] + remainder_docs
+            day_requests = sum(
+                pool.requests for (pool_day, _), pool in pools.items() if pool_day == day
+            )
+            summaries.append(
+                DaySummary(
+                    day=day,
+                    raw=len(events),
+                    docs=len(docs),
+                    dollars=sum(doc.cost_usd for doc in docs),
+                    or_dollars=(
+                        sum(p.usd for (d, _), p in pools.items() if d == day)
+                        if any(d == day for d, _ in pools)
+                        else None
+                    ),
+                    or_requests=day_requests if any(d == day for d, _ in pools) else None,
+                    unattributed=unattributed_usd,
+                    from_generation=sources.get("generation", 0),
+                    from_table=sources.get("table", 0) + sources.get("provider", 0),
+                    from_logged=sources.get("logged", 0),
+                )
+            )
             print(f"{day}: {len(events)} raw -> {len(docs)} docs")
             if apply:
-                for start in range(0, len(docs), _BATCH):
-                    written += await llm_calls_repository.insert_backfilled(
-                        docs[start : start + _BATCH]
-                    )
+                written += await write(docs)
+
+    orphan_docs = leftover_pools(pools, consumed, today, anomalies)
+    if orphan_docs:
+        print("\nOpenRouter billed, no events at all (fully unattributed rows):")
+        for doc in orphan_docs:
+            print(
+                f"  {doc.created_at.date()}  {doc.model_requested:<40}"
+                f"  {doc.input_tokens + doc.output_tokens + doc.reasoning_tokens:>12,} tok"
+                f"  ${doc.cost_usd:.4f}"
+            )
+        if apply:
+            written += await write(orphan_docs)
 
     print()
     render(summaries)
     anomalies.render()
+    ledger_total = sum(row.dollars for row in summaries) + sum(d.cost_usd for d in orphan_docs)
+    anchored_total = sum(pool.usd for key, pool in pools.items() if key[0] < today)
+    print(
+        f"\nledger total ${ledger_total:.4f} = OpenRouter-anchored ${anchored_total:.4f}"
+        f" + non-OpenRouter/table ${ledger_total - anchored_total:.4f}"
+    )
     if apply:
-        print(f"\nAPPLIED — {written} rows created (re-runs insert nothing)")
+        print(f"APPLIED — {written} rows created (re-runs insert nothing)")
     else:
-        print("\nDRY RUN — nothing was written (pass --apply to write)")
+        print("DRY RUN — nothing was written (pass --apply to write)")
 
 
 def main() -> None:
@@ -504,6 +819,19 @@ def main() -> None:
         "--days", type=int, default=MAX_DAYS, help=f"trailing window (max {MAX_DAYS})"
     )
     parser.add_argument(
+        "--or-activity",
+        type=Path,
+        action="append",
+        default=[],
+        help="OpenRouter /api/v1/activity snapshot JSON; repeatable, merged with any live fetch",
+    )
+    parser.add_argument(
+        "--until",
+        type=datetime.fromisoformat,
+        default=None,
+        help="skip events at/after this instant (default on --apply: first live ledger row)",
+    )
+    parser.add_argument(
         "--cache-dir",
         type=Path,
         default=default_cache_dir(),
@@ -512,7 +840,12 @@ def main() -> None:
     args = parser.parse_args()
     if args.days < 1:
         raise SystemExit("--days must be at least 1")
-    asyncio.run(backfill(min(args.days, MAX_DAYS), args.cache_dir, args.apply))
+    until = args.until
+    if until is not None and until.tzinfo is None:
+        until = until.replace(tzinfo=UTC)
+    asyncio.run(
+        backfill(min(args.days, MAX_DAYS), args.cache_dir, args.apply, args.or_activity, until)
+    )
 
 
 if __name__ == "__main__":

--- a/apps/api/tests/unit/scripts/test_backfill_llm_calls.py
+++ b/apps/api/tests/unit/scripts/test_backfill_llm_calls.py
@@ -12,18 +12,22 @@ from datetime import UTC, datetime
 import json
 
 import pytest
+from scripts._activity import ActivityPool
 from scripts._openrouter import GenerationRecord
 from scripts.backfill_llm_calls import (
     EARLIEST_DAY,
     Anomalies,
+    DaySummary,
+    Entry,
     LedgerEvent,
+    allocate_day,
     build_document,
+    leftover_pools,
     normalise_model,
     parse_event,
     price_event,
     render,
     select_events,
-    summarise,
     wanted_days,
 )
 
@@ -131,11 +135,37 @@ class TestSelection:
 
         assert len(select_events([event, event])) == 1
 
+    def test_a_double_logged_copy_differing_only_in_microseconds_collapses(self) -> None:
+        """The 2026-08-13..18 shape: two sinks logged one call with two clock
+        reads, so the exact key never matches. Reconciled against OpenRouter's
+        request counts, these copies were ~20% phantom rows."""
+        first = _event(time="2026-08-20T10:00:00.111Z")
+        second = _event(time="2026-08-20T10:00:00.999Z", generation_id="gen-1")
+
+        anomalies = Anomalies()
+        kept = select_events([first, second], anomalies)
+
+        assert len(kept) == 1
+        assert anomalies.double_logged_skipped == 1
+        # The copy that can be audited later is the one kept.
+        assert kept[0].generation_id == "gen-1"
+
     def test_two_genuinely_different_calls_both_survive(self) -> None:
         first = _event(generation_id="gen-1")
         second = _event(generation_id="gen-2")
 
         assert len(select_events([first, second])) == 2
+
+    def test_identical_looking_calls_with_different_generation_ids_are_two_calls(self) -> None:
+        """The provider issued both ids, so however alike the token counts are,
+        collapsing them would drop real billed work."""
+        first = _event(generation_id="gen-1")
+        second = _event(generation_id="gen-2")
+
+        anomalies = Anomalies()
+
+        assert len(select_events([first, second], anomalies)) == 2
+        assert anomalies.double_logged_skipped == 0
 
 
 class TestPricing:
@@ -242,33 +272,38 @@ class TestDryRunReport:
     booked."""
 
     def test_the_table_reports_what_would_be_written(self, capsys: pytest.CaptureFixture) -> None:
-        events = select_events(
+        render(
             [
-                _event(generation_id="gen-1", cost_source="provider", cost_usd=0.004),
-                _event(generation_id="gen-2", cost_source="provider", cost_usd=0.006),
-                # An echo and an exact duplicate: counted as raw, never as docs.
-                _event(input_tokens=0, output_tokens=0, cached_tokens=0, cost_usd=0),
-                _event(generation_id="gen-1", cost_source="provider", cost_usd=0.004),
+                DaySummary(
+                    day="2026-08-20",
+                    raw=4,
+                    docs=2,
+                    dollars=0.01,
+                    or_dollars=0.01,
+                    or_requests=2,
+                    from_generation=0,
+                    from_table=2,
+                )
             ]
         )
-        docs = [build_document(event, None) for event in events]
-        sources: dict[str, int] = {"provider": 2}
-
-        render([summarise("2026-08-20", raw=4, docs=docs, sources=sources)])
 
         printed = capsys.readouterr().out
         assert "2026-08-20" in printed
-        # 4 raw lines in, 2 real calls out, a cent of spend between them.
-        assert "       4       2      0.0100" in printed
+        assert "0.0100" in printed
         assert "total" in printed
 
-    def test_the_total_line_sums_every_day(self, capsys: pytest.CaptureFixture) -> None:
-        docs = [build_document(_event(cost_source="provider", cost_usd=0.01), None)]
+    def test_a_day_the_activity_window_does_not_reach_shows_no_anchor(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        render([DaySummary(day="2026-09-20", raw=1, docs=1, dollars=0.01)])
 
+        assert "—" in capsys.readouterr().out
+
+    def test_the_total_line_sums_every_day(self, capsys: pytest.CaptureFixture) -> None:
         render(
             [
-                summarise("2026-08-20", raw=1, docs=docs, sources={"provider": 1}),
-                summarise("2026-08-21", raw=1, docs=docs, sources={"provider": 1}),
+                DaySummary(day="2026-08-20", raw=1, docs=1, dollars=0.01),
+                DaySummary(day="2026-08-21", raw=1, docs=1, dollars=0.01),
             ]
         )
 
@@ -304,7 +339,7 @@ class TestAnomalyReport:
             anomalies.observe(event, price_event(event, None))
 
         assert anomalies.echoes_skipped == 1
-        assert anomalies.duplicates_skipped == 1
+        assert anomalies.double_logged_skipped == 1
         assert anomalies.doubled_ids_normalised == 1
         assert anomalies.background_rows == 1
         assert anomalies.unknown_model_rows == 1
@@ -330,11 +365,128 @@ class TestAnomalyReport:
         for label in (
             "zero-token echoes skipped",
             "doubled model ids normalised",
+            "double-logged copies skipped",
             "exact duplicates skipped",
             "background rows (never charged)",
             "generation lookups resolved",
             "generation lookups missing",
             "unknown-model rows",
+            "rows re-priced from OpenRouter's day total",
+            "unattributed remainder rows",
         ):
             assert label in printed
         assert "3" in printed
+
+
+def _entry(**fields: object) -> Entry:
+    event = _event(**fields)
+    return Entry(event=event, doc=build_document(event, None), priced=price_event(event, None))
+
+
+class TestAllocation:
+    """Anchoring a day's rows to what OpenRouter actually billed.
+
+    Reconciling the logs against the activity API showed dollars off by a third
+    on days whose token counts matched within 2% — the flat table cannot know
+    which upstream served a call and the real rates spread 9x. The invariant
+    these tests pin: an anchored day's ledger total equals OpenRouter's billed
+    total for that day, exactly, with the unobserved share explicit.
+    """
+
+    MODEL = "deepseek/deepseek-v4-flash"
+
+    def test_an_anchored_day_sums_to_openrouters_total_exactly(self) -> None:
+        entries = [
+            _entry(input_tokens=4000, output_tokens=500),
+            _entry(time="2026-08-20T10:00:05Z", input_tokens=5500, output_tokens=1000),
+        ]
+        pools = {
+            ("2026-08-20", self.MODEL): ActivityPool(
+                usd=2.0, prompt_tokens=9500, completion_tokens=1500, requests=2
+            )
+        }
+
+        remainder, _, unattributed = allocate_day("2026-08-20", entries, pools, set(), Anomalies())
+
+        total = sum(entry.doc.cost_usd for entry in entries)
+        total += sum(doc.cost_usd for doc in remainder)
+        assert total == pytest.approx(2.0)
+        assert unattributed == pytest.approx(0.0)
+        assert all(entry.doc.cost_source == "allocated" for entry in entries)
+
+    def test_the_unobserved_share_becomes_an_explicit_remainder_row(self) -> None:
+        """Half the day's tokens have no events (log retention, the 2026-08-24
+        deploy). Those dollars are neither dropped nor smeared onto the calls we
+        do have — they are one visible row."""
+        entries = [_entry(input_tokens=4000, output_tokens=1000)]
+        pools = {
+            ("2026-08-20", self.MODEL): ActivityPool(
+                usd=2.0, prompt_tokens=8000, completion_tokens=2000, requests=4
+            )
+        }
+
+        remainder, _, unattributed = allocate_day("2026-08-20", entries, pools, set(), Anomalies())
+
+        assert entries[0].doc.cost_usd == pytest.approx(1.0)
+        assert unattributed == pytest.approx(1.0)
+        assert len(remainder) == 1
+        assert remainder[0].agent_name == "or_unattributed"
+        assert remainder[0].charge_to_budget is False
+        assert remainder[0].input_tokens == 4000
+        assert remainder[0].output_tokens == 1000
+
+    def test_residual_phantom_tokens_cannot_push_a_day_past_its_bill(self) -> None:
+        """When dedup misses a copy our token sum exceeds OpenRouter's; the day
+        is capped at the pool rather than inventing a negative remainder."""
+        entries = [_entry(input_tokens=50000, output_tokens=0)]
+        pools = {("2026-08-20", self.MODEL): ActivityPool(usd=1.0, prompt_tokens=30000, requests=1)}
+
+        remainder, _, unattributed = allocate_day("2026-08-20", entries, pools, set(), Anomalies())
+
+        assert entries[0].doc.cost_usd == pytest.approx(1.0)
+        assert remainder == []
+        assert unattributed == 0.0
+
+    def test_a_model_the_window_does_not_cover_is_left_untouched(self) -> None:
+        """Direct-Google gemini calls never appear in OpenRouter's books; their
+        table price is the only price there is."""
+        entry = _entry(model="gemini-3.1-flash-lite")
+        before = entry.doc.cost_usd
+
+        remainder, _, _ = allocate_day("2026-08-20", [entry], {}, set(), Anomalies())
+
+        assert entry.doc.cost_usd == before
+        assert entry.doc.cost_source == "table"
+        assert remainder == []
+
+    def test_openrouter_spend_with_no_events_at_all_still_becomes_rows(self) -> None:
+        """2026-08-06..09 predate the events' cost fields and 08-10..12 rolled
+        out of log retention — OpenRouter billed them, so they are rows."""
+        pools = {
+            ("2026-08-07", self.MODEL): ActivityPool(
+                usd=4.22, prompt_tokens=1_000_000, requests=325
+            )
+        }
+
+        anomalies = Anomalies()
+        docs = leftover_pools(pools, set(), "2026-08-31", anomalies)
+
+        assert len(docs) == 1
+        assert docs[0].cost_usd == pytest.approx(4.22)
+        assert docs[0].backfilled is True
+        assert anomalies.unattributed_rows == 1
+
+    def test_todays_still_accumulating_pool_is_never_anchored(self) -> None:
+        """A mid-day fetch of today's activity is a partial total; anchoring to
+        it would scale a full day of events down to it."""
+        pools = {("2026-08-31", self.MODEL): ActivityPool(usd=9.99, prompt_tokens=5, requests=1)}
+
+        assert leftover_pools(pools, set(), "2026-08-31", Anomalies()) == []
+
+    def test_remainder_rows_are_keyed_deterministically_for_re_runs(self) -> None:
+        pools = {("2026-08-07", self.MODEL): ActivityPool(usd=4.22, prompt_tokens=100, requests=1)}
+
+        first = leftover_pools(pools, set(), "2026-08-31", Anomalies())
+        second = leftover_pools(pools, set(), "2026-08-31", Anomalies())
+
+        assert first[0].backfill_key == second[0].backfill_key


### PR DESCRIPTION
## What

The history backfill (#1157's `scripts/backfill_llm_calls.py`) under-reported real OpenRouter spend by a third: $53.40 computed vs $80.05 billed for Aug 11–30. This PR makes the backfill anchor on OpenRouter's own books so an anchored day's ledger total equals OpenRouter's billed total for that day, exactly.

## Why the old numbers were wrong — measured, not guessed

Reconciled the log events against `GET /api/v1/activity` (per day × model × provider: real dollars, real token counts, real request counts):

- **Stable days (Aug 19–23, 25–29): requests within 1–4%, prompt tokens within 1–8%** — the events are nearly complete, so the dollar gap on those days is pure pricing: the flat table can't know which upstream served a call and real rates spread 9× (Baidu $0.045/M vs Reka/Wafer ~$0.20/M effective).
- **Aug 13–18: the metering seam logged many calls twice** (copies differ only in timestamp microseconds; sometimes only one carries the generation id). After collapsing them, Aug 17 = 1,673 ours vs 1,680 billed.
- **Aug 6–12 and Aug 24: OpenRouter billed thousands of requests with few or no usable events** (pre-cost-field era, log retention, deploy-day chaos) — ~$11 of real spend with nothing to attribute it to.
- Old events also never counted reasoning tokens, which OpenRouter bills as output.

## How

- **`scripts/_activity.py`** — loads `--or-activity` snapshot files (the window is rolling ~25 days, so snapshots preserve days the API will refuse to return next week) and/or fetches live via `OPENROUTER_MANAGEMENT_KEY`; merges them per (day, model, provider, endpoint), larger `usage` wins.
- **Allocation pass** — per anchored (day, model): the pool's real dollars, scaled by the share of the day's tokens our events observed, are distributed across rows in proportion to each row's best-known cost (generation lookups and provider-captured costs act as weights, so per-call price shape survives). `cost_source: "allocated"`.
- **Unattributed remainder** — what OpenRouter billed beyond what events can attribute becomes one explicit `or_unattributed` row per (day, model) (background, never charged, deterministic `backfill_key`) — visible as a gap, never smeared, never dropped. Days with no events at all (Aug 6–12) become fully unattributed rows.
- **Double-log collapse** — same second + same (user, model, token counts) is one call; the copy with a generation id is kept; two *different* generation ids are never merged. Counted in the anomalies table.
- **Live-row ceiling** — events at/after the first non-backfilled ledger row are skipped (auto-detected on `--apply`, `--until` for dry runs), so live and backfilled rows can never double-count.
- **Today's pool is never anchored** — a mid-day activity fetch is a partial total.
- `CostSource` gains `"allocated"`; repository gains `first_live_call_at()`.

## Verified

- `uv run pytest tests/unit/scripts/test_backfill_llm_calls.py tests/unit/db/test_llm_calls_repository_unit.py -q` → **49 passed** (new tests pin: anchored day sums to pool exactly; remainder explicit; over-coverage capped at pool; unanchored models untouched; orphan pools become rows; today skipped; deterministic remainder keys; double-log collapse keeps the auditable copy; distinct generation ids never merge).
- Allocation invariants additionally exercised standalone (day total == pool to 1e-9 with weights honoured).
- `ruff` + `mypy` clean on all four files; pre-commit hooks green.
- NOT yet verified: the full dry run against production Loki + the real activity snapshot — that run is the next step and its output will be posted before any `--apply`.

## Rollout

1. Dry-run in the prod api container: `python scripts/backfill_llm_calls.py --dry-run --or-activity /tmp/or_activity.json` (snapshot of Aug 6–30, $85.92, already captured).
2. Review the per-day table (`$` must equal `OR $` on every anchored day) and the anomalies table.
3. `--apply` — idempotent via `backfill_key` unique index.