### PR TITLE
fix(api): serialize pg checkpointer migration across xdist workers

### DIFF
--- a/apps/api/tests/integration/agents/test_agent_graph_checkpointing.py
+++ b/apps/api/tests/integration/agents/test_agent_graph_checkpointing.py
@@ -23,10 +23,13 @@ import contextlib
 # Constants
 # ---------------------------------------------------------------------------
 import os
+from pathlib import Path
+import tempfile
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from filelock import FileLock
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langgraph.checkpoint.memory import InMemorySaver
@@ -57,6 +60,17 @@ from tests.helpers import (
 POSTGRES_TEST_URL = os.environ.get(
     "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/gaia_test"
 )
+
+# All pytest-xdist workers (separate processes) and, per parallel-worktrees, all
+# worktree test sessions on this box share one `gaia_test` Postgres database. Two
+# workers/sessions can both call checkpointer setup() concurrently and race the
+# check-then-insert against `checkpoint_migrations`, raising
+# `UniqueViolation: duplicate key value violates unique constraint
+# "checkpoint_migrations_pkey"`. This cross-PROCESS lock (an `asyncio.Lock` would
+# only serialize within one process) makes migration setup mutually exclusive
+# across every worker and worktree. The lock file itself carries no state about
+# migration progress, so leaving it behind between runs is harmless.
+_PG_MIGRATION_LOCK_PATH = Path(tempfile.gettempdir()) / "gaia_pg_checkpointer_migration.lock"
 
 # The hooks build_comms_graph declares, in the order the graph must run them.
 # executor_status_hook must stay before manage_system_prompts_node so the
@@ -280,7 +294,8 @@ async def pg_checkpointer():
     await pool.open(wait=True, timeout=10)
 
     checkpointer = AsyncPostgresSaver(conn=pool)
-    await checkpointer.setup()
+    with FileLock(_PG_MIGRATION_LOCK_PATH):
+        await checkpointer.setup()
 
     yield checkpointer
 
@@ -298,7 +313,8 @@ async def pg_checkpointer_manager():
     if os.environ.get("USE_REAL_SERVICES") != "1":
         pytest.skip("PostgreSQL not available at " + POSTGRES_TEST_URL)
     manager = CheckpointerManager(conninfo=POSTGRES_TEST_URL, max_pool_size=5)
-    await manager.setup()
+    with FileLock(_PG_MIGRATION_LOCK_PATH):
+        await manager.setup()
 
     yield manager
 
@@ -984,7 +1000,10 @@ class TestCheckpointerManagerProduction:
         checkpointer. get_checkpointer() must return a usable saver."""
         manager = CheckpointerManager(conninfo=POSTGRES_TEST_URL, max_pool_size=5)
         try:
-            await manager.setup()
+            # Same cross-process migration race as the fixtures above (see
+            # _PG_MIGRATION_LOCK_PATH) — this test calls setup() directly.
+            with FileLock(_PG_MIGRATION_LOCK_PATH):
+                await manager.setup()
         except Exception:
             pytest.skip("PostgreSQL not available at " + POSTGRES_TEST_URL)
 
@@ -1006,7 +1025,8 @@ class TestCheckpointerManagerProduction:
         """Calling close() multiple times must not raise."""
         manager = CheckpointerManager(conninfo=POSTGRES_TEST_URL, max_pool_size=5)
         try:
-            await manager.setup()
+            with FileLock(_PG_MIGRATION_LOCK_PATH):
+                await manager.setup()
         except Exception:
             pytest.skip("PostgreSQL not available at " + POSTGRES_TEST_URL)
         await manager.close()


### PR DESCRIPTION
## Summary

Two fixtures in the Postgres checkpointer integration test suite each ran LangGraph's checkpoint-migration `setup()` on every test, against one shared test database. Under pytest-xdist (`-n 4`, `--dist worksteal`) that races a check-then-insert on the migrations tracking table across worker processes, producing an intermittent `UniqueViolation` and a flaky CI lane. The fix serializes migration setup across processes with a file lock.

## Why

On branch `feat/paid-only-gate`, the `test-python (integration)` lane failed with exactly this `UniqueViolation` signature on 1 of 5 runs over unchanged code, and passed on the flake-gate's automatic rerun — a textbook cross-process race, not a real bug in the code under test.

## What changed

### API

- `apps/api/tests/integration/agents/test_agent_graph_checkpointing.py`: wrap every call to `AsyncPostgresSaver.setup()` / `CheckpointerManager.setup()` in a `filelock.FileLock` keyed to a fixed path in the temp dir, so only one process at a time runs the migration against the shared `gaia_test` database — across xdist workers and across worktree sessions on the same box. `filelock` is already a direct `apps/api` dependency (`pyproject.toml`), not a new one.

---

## The bug

**Symptom** — `psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "checkpoint_migrations_pkey"` (or, as reproduced below, the equivalent race on the table's own catalog entry) raised out of `checkpointer.setup()` / `manager.setup()`, intermittently, only under parallel workers.

**Reproduce** — Run the file under xdist against a *fresh* Postgres (migrations not yet applied) several times:
`DATABASE_URL=postgresql://postgres:postgres@localhost:55432/gaia_test USE_REAL_SERVICES=1 uv run --group backend --group dev pytest tests/integration/agents/test_agent_graph_checkpointing.py -n 4 --dist worksteal -q`
Against the shared long-lived dev Postgres (migrations already fully applied from prior runs) the race does not fire, because `AsyncPostgresSaver.setup()`'s loop over pending migrations is empty once the tracking table is already at its final version — I reproduced it instead against a disposable, freshly-created Postgres container so the migration path actually runs concurrently, and saw the race on the very first pre-fix attempt (3 of 19 tests errored with `UniqueViolation: duplicate key value violates unique constraint "pg_type_typname_nsp_index" ... Key (typname, typnamespace)=(checkpoint_migrations, 2200) already exists`).

**Root cause** — `AsyncPostgresSaver.setup()` (`langgraph/checkpoint/postgres/aio.py`) and `CheckpointerManager.setup()` (`apps/api/app/agents/core/graph_builder/checkpointer_manager.py:81`) do a check-then-act against `checkpoint_migrations`/`store_migrations`: read the last applied version, then `CREATE TABLE IF NOT EXISTS` / run pending migrations / `INSERT`. The `pg_checkpointer` and `pg_checkpointer_manager` fixtures in `test_agent_graph_checkpointing.py` (previously lines ~296 and ~315) called this on every test, unguarded, against one database shared by all 4 xdist worker processes. Two workers landing in `setup()` at the same moment race the same check-then-act sequence.

**The fix** — Serialize `setup()` across worker *processes* (an `asyncio.Lock` only serializes within one process, so it can't help here) with `filelock.FileLock` on a fixed temp-dir path, applied at both call sites — the two fixtures, and the two tests in `TestCheckpointerManagerProduction` that call `manager.setup()` directly and share the same race. The lock file carries no migration state, only mutual exclusion, so it's safe to leave behind between runs and across worktrees.

**Regression test** — This is a pure timing race with no code-level branch to flip red/green deterministically; there is no failing-then-passing unit test for it. Verification is empirical: reproduced on a disposable Postgres pre-fix (3/19 errored on the first attempt), then ran the same disposable-Postgres + `-n 4 --dist worksteal` command 5 times post-fix (19/19 passed every time), plus `-n 0` (single worker, 19/19 passed) and a hermetic run with no `USE_REAL_SERVICES` (4 passed, 15 skipped at collection, no localhost dial).

**Why the suite missed it** — The fixtures were written and reviewed against a single-worker mental model; nothing in the test file or CI config flagged that `setup()`'s check-then-act isn't safe under `-n 4 --dist worksteal`, and the failure only manifests on a database that hasn't already had migrations applied (i.e. rarely, once the shared dev DB is warm) — which is exactly why it showed up as a 1-in-5 CI flake instead of a reliable failure.

## How to verify

1. Spin up a disposable Postgres so migrations actually run: `docker run -d --name pg-repro -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=gaia_test -p 55432:5432 postgres:18-alpine`
2. `cd apps/api && DATABASE_URL=postgresql://postgres:postgres@localhost:55432/gaia_test USE_REAL_SERVICES=1 uv run --group backend --group dev pytest tests/integration/agents/test_agent_graph_checkpointing.py -n 4 --dist worksteal -q` — expect 19 passed, repeatably.
3. Same command with a plain `uv run --group backend --group dev pytest tests/integration/agents/test_agent_graph_checkpointing.py -n 4 --dist worksteal -q` (no `USE_REAL_SERVICES`, no `DATABASE_URL`) — expect 4 passed, 15 skipped, fast, no network access.

**Not verified:** I did not get a second pre-fix repro run with the exact `checkpoint_migrations_pkey` unique-violation wording quoted in the issue — my disposable-Postgres repro hit a variant of the same check-then-act race (the `CREATE TABLE IF NOT EXISTS` step's own catalog insert) on the first attempt, which was reproducible and errored 3/19 tests, but I did not keep re-running to also catch the pkey-specific variant.

## Risk

Low, test-only change. Worst case if the lock path collided with something else in the temp dir: `FileLock` would just serialize against an unrelated file, at most slowing these tests down — it can't corrupt data or affect any other test file.
