### PR TITLE
fix(api): workflow instructions carry the task, not the workflow's own config

### DIFF
--- a/apps/api/app/agents/prompts/subagent_prompts.py
+++ b/apps/api/app/agents/prompts/subagent_prompts.py
@@ -5,6 +5,8 @@ This module contains domain-specific system prompts that give each sub-agent
 the expertise and context needed to effectively use their tool sets.
 """
 
+from app.agents.prompts.workflow_prompts import WORKFLOW_INSTRUCTIONS_CONTRACT
+
 # Base Sub-Agent Prompt Template
 BASE_SUBAGENT_PROMPT = """
 You are a specialized {provider_name} agent with deep expertise in {domain_expertise}.
@@ -1863,8 +1865,9 @@ discovery, and only when the task needs no integration at all (see step 2).
 4. WRITE THE EXECUTION PROMPT (detailed, capability-level)
    - Numbered steps in plain language: which integration and WHAT to do with it ("use Gmail to fetch unread emails from today", "post the summary to Slack #eng").
    - Do NOT put exact tool names or slugs (GMAIL_FETCH_EMAILS, SLACK_SEND_MESSAGE) in the prompt. The workflow runs on the full executor, which finds the right tool at run time; naming one specific tool over-constrains it and breaks the run if that tool cannot do the job. Name the integration and the action, and let the executor choose the tool.
-   - Use trigger data when the trigger is an event ("using the PR from the trigger data..."). Never repeat the trigger as a step.
+   - Use trigger data when the trigger is an event ("using the PR from the trigger data...").
    - State the expected output and any conditions or edge cases.
+   - Obey the prompt contract below: no schedule, no trigger, no mechanics.
 
 5. FINALIZE OR ASK
    - If it is clear, emit the finalized JSON (with integration_ids).
@@ -1882,10 +1885,10 @@ Always produce the workflow. A disconnected integration is something you RECORD,
 
 Do not turn a config detail (which Slack channel, which Gmail label) into a blocker either: leave it for the draft UI and finalize. Ask a clarifying question ONLY when the workflow's INTENT is genuinely ambiguous, never about connection or trigger config.
 
-## TRIGGERS vs STEPS
-- The trigger happens BEFORE the workflow runs. Never write it as a step.
-  WRONG: "1. Use the GitHub PR event to trigger  2. Analyze the PR  3. Post a comment"
-  RIGHT: "1. Analyze the PR changes from the trigger data  2. Generate the review  3. Post the comment"
+## WHAT THE PROMPT MAY CONTAIN
+"""  # noqa: S608 # nosec B608 - natural-language prompt; splicing the contract in is what makes the SQL heuristic scan this text, and it matches "update ... set" in the prose. There is no SQL here.
+    + WORKFLOW_INSTRUCTIONS_CONTRACT
+    + """
 
 ## STRUCTURED OUTPUT FORMAT
 You MUST include a JSON block in EVERY response. Two types:
@@ -1914,7 +1917,7 @@ You MUST include a JSON block in EVERY response. Two types:
 ```
 
 Fields:
-- description: SHORT (1-2 sentences) - displayed in cards/UI only
+- description: SHORT (1-2 sentences) saying what the workflow does, displayed on cards/UI only. The card renders the schedule and trigger next to it, so do NOT restate when it runs ("Daily Gmail summary", not "Daily Gmail summary at 9am").
 - prompt: DETAILED and COMPREHENSIVE - this is what the AI uses to execute the workflow. Include:
   • The full workflow logic in natural language with numbered steps (1, 2, 3...)
   • Which integration to use for each step and WHAT to do with it - NOT exact tool names or slugs (the executor finds the tool at run time; a hard-coded tool name over-constrains it and breaks the run if that tool cannot do the job)
@@ -1922,6 +1925,7 @@ Fields:
   • Expected format of outputs
   • Any conditions or edge cases to handle
   • Context about the user's intent
+  Everything the prompt contract above forbids stays out, however detailed the rest is.
 - integration_ids: the integration ids this workflow depends on, e.g. ["gmail", "slack"], INCLUDING the trigger integration, connected or not
 - cron_expression: Required for scheduled, omit for others (USE USER'S LOCAL TIME, NOT UTC)
 - trigger_slug: Required for integration, omit for others
@@ -2018,8 +2022,8 @@ I'll create that workflow for you.
 {
     "type": "finalized",
     "title": "Morning Email Summary",
-    "description": "Daily Gmail summary at 9am",
-    "prompt": "Every morning at 9am:\\n\\n1. Use Gmail to fetch all unread emails from my inbox\\n2. For each, note the sender, subject, and a brief preview\\n3. Group them by importance (urgent, normal, low) from the sender and subject\\n4. Build a concise digest: total unread count, the most important first with sender and subject, and a short overview of what needs attention\\n\\nExpected output: a readable, priority-ordered digest I can scan quickly.",
+    "description": "Priority-ordered digest of my unread Gmail",
+    "prompt": "1. Use Gmail to fetch all unread emails from my inbox\\n2. Group them by how much they need my attention (urgent, normal, low), judging from the sender and subject\\n3. Build a concise digest: total unread count, the most important first with sender and subject, and a short overview of what needs attention\\n\\nExpected output: a readable, priority-ordered digest I can scan quickly.",
     "trigger_type": "scheduled",
     "cron_expression": "0 9 * * *",
     "integration_ids": ["gmail"],
@@ -2051,8 +2055,8 @@ I'll update that workflow.
 {
     "type": "finalized",
     "title": "Morning Email Summary",
-    "description": "Daily Gmail summary at 8am, sent on WhatsApp",
-    "prompt": "Every morning at 8am:\\n\\n1. Use Gmail to fetch unread emails from my inbox\\n2. Summarize them by priority with sender, subject, and a short preview\\n3. Send the summary to me on WhatsApp\\n\\nExpected output: a concise WhatsApp message with the prioritized summary.",
+    "description": "Gmail summary sent to me on WhatsApp",
+    "prompt": "1. Use Gmail to fetch unread emails from my inbox\\n2. Summarize them by priority with sender, subject, and a short preview\\n3. Send the summary to me on WhatsApp\\n\\nExpected output: a concise WhatsApp message with the prioritized summary.",
     "trigger_type": "scheduled",
     "cron_expression": "0 8 * * *",
     "integration_ids": ["gmail"],
@@ -2071,8 +2075,8 @@ I found the Gmail "New Email" trigger. You can fine-tune which Slack channel in 
 {
     "type": "finalized",
     "title": "Daily Calendar to Slack on New Email",
-    "description": "On a new email, post today's calendar to Slack",
-    "prompt": "When a new email arrives in Gmail:\\n\\n1. Use Google Calendar to get my events for today\\n2. Summarize them with meeting times, attendees, and locations\\n3. Flag any conflicts or back-to-back meetings\\n4. Post the summary to my Slack channel, split into morning and afternoon\\n\\nExpected output: a formatted Slack message with today's calendar overview.",
+    "description": "Posts today's calendar to Slack",
+    "prompt": "1. Use Google Calendar to get my events for today\\n2. Summarize them with meeting times, attendees, and locations\\n3. Flag any conflicts or back-to-back meetings\\n4. Post the summary to my Slack channel, split into morning and afternoon\\n\\nExpected output: a formatted Slack message with today's calendar overview.",
     "trigger_type": "integration",
     "trigger_slug": "GMAIL_NEW_GMAIL_MESSAGE",
     "integration_ids": ["gmail", "googlecalendar", "slack"],

--- a/apps/api/app/agents/prompts/subagent_prompts.py
+++ b/apps/api/app/agents/prompts/subagent_prompts.py
@@ -1867,7 +1867,6 @@ discovery, and only when the task needs no integration at all (see step 2).
    - Do NOT put exact tool names or slugs (GMAIL_FETCH_EMAILS, SLACK_SEND_MESSAGE) in the prompt. The workflow runs on the full executor, which finds the right tool at run time; naming one specific tool over-constrains it and breaks the run if that tool cannot do the job. Name the integration and the action, and let the executor choose the tool.
    - Use trigger data when the trigger is an event ("using the PR from the trigger data...").
    - State the expected output and any conditions or edge cases.
-   - Obey the prompt contract below: no schedule, no trigger, no mechanics.
 
 5. FINALIZE OR ASK
    - If it is clear, emit the finalized JSON (with integration_ids).
@@ -1917,7 +1916,7 @@ You MUST include a JSON block in EVERY response. Two types:
 ```
 
 Fields:
-- description: SHORT (1-2 sentences) saying what the workflow does, displayed on cards/UI only. The card renders the schedule and trigger next to it, so do NOT restate when it runs ("Daily Gmail summary", not "Daily Gmail summary at 9am").
+- description: SHORT (1-2 sentences) saying what the workflow does, displayed in cards/UI only. The card shows the schedule beside it, so do not restate it.
 - prompt: DETAILED and COMPREHENSIVE - this is what the AI uses to execute the workflow. Include:
   • The full workflow logic in natural language with numbered steps (1, 2, 3...)
   • Which integration to use for each step and WHAT to do with it - NOT exact tool names or slugs (the executor finds the tool at run time; a hard-coded tool name over-constrains it and breaks the run if that tool cannot do the job)
@@ -1925,7 +1924,6 @@ Fields:
   • Expected format of outputs
   • Any conditions or edge cases to handle
   • Context about the user's intent
-  Everything the prompt contract above forbids stays out, however detailed the rest is.
 - integration_ids: the integration ids this workflow depends on, e.g. ["gmail", "slack"], INCLUDING the trigger integration, connected or not
 - cron_expression: Required for scheduled, omit for others (USE USER'S LOCAL TIME, NOT UTC)
 - trigger_slug: Required for integration, omit for others

--- a/apps/api/app/agents/prompts/workflow_prompts.py
+++ b/apps/api/app/agents/prompts/workflow_prompts.py
@@ -13,9 +13,10 @@ Workflow generation prompts for GAIA workflow system.
 WORKFLOW_INSTRUCTIONS_CONTRACT = """The executor reads these instructions after the trigger has
 already fired and handed over its data, so they say only WHAT TO DO. Leave out when the run
 happens (cron, clock times, "every morning"), what started it ("when a new email arrives"), and
-mechanics the executor handles itself (field extraction, storage format, retries, error logging).
-A time window the work needs ("emails from the last 24 hours") stays; a statement of when the run
-happens does not.
+mechanics nobody asked for (field extraction, storage format, retries, error logging).
+What the user did ask for is the deliverable, not a mechanic: keep the fields, columns and format
+they named. A time window the work needs ("emails from the last 24 hours") stays too; a statement
+of when the run happens does not.
 
   WRONG: "Every morning at 9am: 1. Fetch unread Gmail and summarize it"
   RIGHT: "1. Fetch unread Gmail and summarize it\""""

--- a/apps/api/app/agents/prompts/workflow_prompts.py
+++ b/apps/api/app/agents/prompts/workflow_prompts.py
@@ -6,32 +6,19 @@ Workflow generation prompts for GAIA workflow system.
 # WHAT A WORKFLOW'S EXECUTION PROMPT MAY CONTAIN
 # =============================================================================
 
-# The single contract every author of a workflow `prompt` follows: the chat
-# workflow assistant (WORKFLOW_AGENT_SYSTEM_PROMPT) and the editor's
-# generate-instructions button (WORKFLOW_PROMPT_GENERATION_SYSTEM). Keeping one
-# copy is what stops the two from drifting: the generator forbade trigger and
-# schedule text while the assistant's own worked examples opened prompts with
-# "Every morning at 9am:", and that text is what the executor reads as its goal.
-WORKFLOW_INSTRUCTIONS_CONTRACT = """The instructions are read by the executor at run time, after
-the trigger has already fired and handed over its data. They say only WHAT TO DO.
+# Stated once, spliced into both authors of a workflow `prompt`: the chat
+# assistant (WORKFLOW_AGENT_SYSTEM_PROMPT) and the editor's generate-instructions
+# button (WORKFLOW_PROMPT_GENERATION_SYSTEM). One copy is what stops the two from
+# drifting, which is how the assistant ended up with no rule at all.
+WORKFLOW_INSTRUCTIONS_CONTRACT = """The executor reads these instructions after the trigger has
+already fired and handed over its data, so they say only WHAT TO DO. Leave out when the run
+happens (cron, clock times, "every morning"), what started it ("when a new email arrives"), and
+mechanics the executor handles itself (field extraction, storage format, retries, error logging).
+A time window the work needs ("emails from the last 24 hours") stays; a statement of when the run
+happens does not.
 
-Never include:
-- WHEN it runs: cron, clock times, cadences, "every morning", "daily at 9am", "10 minutes before".
-  The schedule is stored on the workflow and the scheduler has already fired this run.
-- WHAT STARTED IT: "when a new email arrives", "before each meeting", "when this workflow is
-  triggered". The trigger is stored on the workflow and the executor is told why it was invoked.
-- Implementation details: "store in JSON", "extract fields", "parse the response", "log the error".
-- Data handling: "for each email extract X, Y, Z", "create an object", "build an array".
-- Retry and error logic: the executor handles failures itself.
-
-The trigger is never step 1. Open on the first real action.
   WRONG: "Every morning at 9am: 1. Fetch unread Gmail and summarize it"
-  RIGHT: "1. Fetch unread Gmail and summarize it"
-  WRONG: "When a PR is opened, review the diff and post a comment"
-  RIGHT: "Review the diff of the PR in the trigger data and post the review as a comment"
-
-Keep a time window the work itself needs ("emails from the last 24 hours", "events in the next
-hour"): that is part of what to do. Drop any statement of when the run happens."""
+  RIGHT: "1. Fetch unread Gmail and summarize it\""""
 
 
 # =============================================================================

--- a/apps/api/app/agents/prompts/workflow_prompts.py
+++ b/apps/api/app/agents/prompts/workflow_prompts.py
@@ -293,7 +293,7 @@ Also leave out step-by-step procedures: the system generates the steps separatel
 The user's description is raw input: distill it to intent. Strip away the WHEN (trigger) and focus on the WHAT (action). Examples:
 - "10 mins before every meeting check my inbox" → intent is "show me relevant emails for an upcoming meeting", NOT "check calendar then fetch emails"
 - "when I get an email, summarize it" → intent is "summarize the incoming email"
-- "extract sender, subject, first 200 chars, store as JSON" → intent is "summarize new emails"
+- "extract sender, subject, first 200 chars, store as JSON" → intent is "record each new email as JSON with its sender, subject and first 200 characters" (the fields and the format are the deliverable, so they stay; only the WHEN is stripped)
 
 Write 80-150 words of plain prose. No bullets, no headers, no code fences. Name the integrations and describe what the user should receive. One sentence for fallback behavior.
 

--- a/apps/api/app/agents/prompts/workflow_prompts.py
+++ b/apps/api/app/agents/prompts/workflow_prompts.py
@@ -3,102 +3,49 @@ Workflow generation prompts for GAIA workflow system.
 """
 
 # =============================================================================
-# WORKFLOW CREATION SUBAGENT TASK TEMPLATES
+# WHAT A WORKFLOW'S EXECUTION PROMPT MAY CONTAIN
 # =============================================================================
 
-WORKFLOW_CREATION_NEW_TASK_TEMPLATE = """Create a workflow based on this request:
+# The single contract every author of a workflow `prompt` follows: the chat
+# workflow assistant (WORKFLOW_AGENT_SYSTEM_PROMPT) and the editor's
+# generate-instructions button (WORKFLOW_PROMPT_GENERATION_SYSTEM). Keeping one
+# copy is what stops the two from drifting: the generator forbade trigger and
+# schedule text while the assistant's own worked examples opened prompts with
+# "Every morning at 9am:", and that text is what the executor reads as its goal.
+WORKFLOW_INSTRUCTIONS_CONTRACT = """The instructions are read by the executor at run time, after
+the trigger has already fired and handed over its data. They say only WHAT TO DO.
 
-"{workflow_request}"
-{hints_section}
-Process this request:
-1. If the request is clear and unambiguous, finalize immediately
-2. If anything is unclear (what it should do, when to run), ask ONE clarifying question
-3. For integration triggers, use search_triggers to find appropriate triggers
-4. For scheduled triggers, convert natural language to cron expression
+Never include:
+- WHEN it runs: cron, clock times, cadences, "every morning", "daily at 9am", "10 minutes before".
+  The schedule is stored on the workflow and the scheduler has already fired this run.
+- WHAT STARTED IT: "when a new email arrives", "before each meeting", "when this workflow is
+  triggered". The trigger is stored on the workflow and the executor is told why it was invoked.
+- Implementation details: "store in JSON", "extract fields", "parse the response", "log the error".
+- Data handling: "for each email extract X, Y, Z", "create an object", "build an array".
+- Retry and error logic: the executor handles failures itself.
 
-Always include a JSON block in your response (either clarifying or finalized type).
-"""
+The trigger is never step 1. Open on the first real action.
+  WRONG: "Every morning at 9am: 1. Fetch unread Gmail and summarize it"
+  RIGHT: "1. Fetch unread Gmail and summarize it"
+  WRONG: "When a PR is opened, review the diff and post a comment"
+  RIGHT: "Review the diff of the PR in the trigger data and post the review as a comment"
 
-WORKFLOW_CREATION_HINTS_TEMPLATE = """
-The executor provided these hints (use as suggestions, override based on user input):
-{hints}
-"""
-
-WORKFLOW_CREATION_FROM_CONVERSATION_TASK_TEMPLATE = """Create a workflow from this conversation context:
-
-Title suggestion: {suggested_title}
-Summary: {summary}
-
-Steps identified from conversation:
-{steps_text}
-
-Integrations used: {integrations_used}
-{user_request_section}
-{hints_section}
-Process this context:
-1. Summarize what was accomplished and confirm saving as workflow
-2. Determine trigger type - ask if not obvious from context
-3. For integration triggers, use search_triggers
-4. For scheduled triggers, convert natural language to cron
-5. Once confirmed, output finalized JSON
-
-Always include a JSON block in your response (either clarifying or finalized type).
-"""
-
-WORKFLOW_CREATION_USER_REQUEST_TEMPLATE = """
-User's additional request: "{workflow_request}"
-"""
-
-WORKFLOW_CREATION_RETRY_TEMPLATE = """Your previous response had an invalid JSON output. Error: {error}
-
-Please respond again with a VALID JSON block. Required format:
-
-For clarifying questions:
-```json
-{{"type": "clarifying", "message": "Your question here"}}
-```
-
-For finalized workflow:
-```json
-{{
-    "type": "finalized",
-    "title": "Workflow Title",
-    "description": "1-2 sentence summary for UI cards",
-    "prompt": "Detailed step-by-step instructions. Include numbered steps, specific integrations, data sources, and expected outputs.",
-    "trigger_type": "manual|scheduled|integration",
-    "cron_expression": "0 9 * * *",
-    "trigger_slug": "TRIGGER_SLUG_HERE",
-    "direct_create": true
-}}
-```
-
-Note: cron_expression required for scheduled, trigger_slug required for integration.
-Set direct_create: true only for simple, unambiguous workflows.
-
-Original request:
-{original_task}
-"""
+Keep a time window the work itself needs ("emails from the last 24 hours", "events in the next
+hour"): that is part of what to do. Drop any statement of when the run happens."""
 
 
 # =============================================================================
 # WORKFLOW GENERATION PROMPTS (existing)
 # =============================================================================
 
-# Template for generating detailed todo execution prompt
-TODO_WORKFLOW_PROMPT_TEMPLATE = """This workflow was automatically generated from a todo item to help the user accomplish their task.
+# Execution prompt for a workflow generated from a todo. Everything the executor
+# needs is the task itself: how the workflow got created and when the user runs
+# it are config, and this string is read as the run's goal.
+TODO_WORKFLOW_PROMPT_TEMPLATE = """Complete this task for the user, using external tools for
+every concrete action it needs:
 
-**Purpose:** Break down this todo into actionable automated steps. The user will click "Run Workflow" when they're ready to execute it, and the AI assistant will carry out each step in sequence.
-
-**Important Context:**
-- This is a todo-driven workflow - focus on practical steps to complete the user's task
-- Each step should use external tools to accomplish concrete actions
-- Keep steps minimal and efficient - only include what's necessary to complete the todo
-- The user expects this workflow to help them finish their todo item faster
-
-**Todo Task:** {title}
+**Task:** {title}
 {details_section}
-
-Generate practical, executable steps that will help the user complete: "{title}"
 """
 
 # Short display description for todo workflows
@@ -345,19 +292,15 @@ If this workflow only fetches, reads, lists, or summarizes data, do NOT create a
 # MAGIC PROMPT GENERATOR: system prompt & user template
 # =============================================================================
 
-WORKFLOW_PROMPT_GENERATION_SYSTEM = """You are writing execution instructions for GAIA, an AI workflow agent.
+WORKFLOW_PROMPT_GENERATION_SYSTEM = f"""You are writing execution instructions for GAIA, an AI workflow agent.
 
-The instructions are read by the agent at execution time. Write directly to it in imperative second-person ("Fetch...", "Search...", "Send..."). Never third-person.
+Write directly to the agent in imperative second-person ("Fetch...", "Search...", "Send..."). Never third-person.
 
 The agent is intelligent: it decides how to call tools, process data, format output, handle retries, and structure results on its own. Your job is to describe the GOAL and the desired OUTCOME, not the mechanics.
 
-NEVER include in instructions:
-- Implementation details: "store in JSON", "extract fields", "parse response", "retry once", "log the error"
-- Data handling: "for each email extract X, Y, Z", "create an object", "build an array"
-- Trigger context: what triggers the workflow, when it fires, what event starts it, "when a new email arrives", "before each meeting", "check calendar for upcoming events" (the trigger system handles this separately and the agent already knows WHY it was invoked)
-- Scheduling language: cron, times, "every morning", "10 minutes before"
-- Retry/error logic: the agent handles failures automatically
-- Step-by-step procedures: the system generates steps separately
+{WORKFLOW_INSTRUCTIONS_CONTRACT}
+
+Also leave out step-by-step procedures: the system generates the steps separately.
 
 The user's description is raw input: distill it to intent. Strip away the WHEN (trigger) and focus on the WHAT (action). Examples:
 - "10 mins before every meeting check my inbox" → intent is "show me relevant emails for an upcoming meeting", NOT "check calendar then fetch emails"

--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -252,7 +252,11 @@ class _FocusTodoList(BaseModel):
 class _WorkflowSpec(BaseModel):
     title: str = Field(description="Workflow title — under 60 chars, starts with a verb or noun")
     description: str = Field(
-        description="1-2 sentences: what triggers it, what it does, what output it produces"
+        description=(
+            "1-2 sentences: what it does and what output it produces. Never say when it runs "
+            "or what triggers it: the card shows the schedule, and this text also seeds the "
+            "execution instructions the agent reads after the trigger has already fired."
+        )
     )
     categories: list[str] = Field(
         description=(
@@ -1832,12 +1836,19 @@ async def _create_fallback_workflow(
     integration_ids: list[str] | None = None,
 ) -> list[OnboardingWorkflowSummary]:
     title = "Daily Briefing"
-    description = (
-        f"Every morning, summarize unread emails by priority, today's meetings, and open todos. "
-        f"Focus: {focus[:100]}."
-        if focus
-        else "Every morning at 9am, summarize unread emails by priority, today's meetings, and open todos."
+    description = "Summarizes unread emails by priority, today's meetings, and open todos."
+    if focus:
+        description += f" Focus: {focus[:100]}."
+    # The schedule lives on trigger_config and the card renders it, so neither the
+    # card copy nor the executor's instructions restate when this runs.
+    prompt = (
+        "1. Summarize my unread emails, most in need of attention first\n"
+        "2. List today's meetings with their times\n"
+        "3. List my open todos\n\n"
+        "Expected output: one short briefing I can read in under a minute."
     )
+    if focus:
+        prompt += f"\n\nWeight everything toward what matters for: {focus[:100]}."
     try:
         trigger_config = TriggerConfig(
             type=TriggerType.SCHEDULE, cron_expression=_DEFAULT_WORKFLOW_CRON
@@ -1845,7 +1856,7 @@ async def _create_fallback_workflow(
         request = CreateWorkflowRequest(
             title=title,
             description=description,
-            prompt=description,
+            prompt=prompt,
             trigger_config=trigger_config,
             generate_immediately=True,
             integration_ids=integration_ids,

--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -253,9 +253,8 @@ class _WorkflowSpec(BaseModel):
     title: str = Field(description="Workflow title — under 60 chars, starts with a verb or noun")
     description: str = Field(
         description=(
-            "1-2 sentences: what it does and what output it produces. Never say when it runs "
-            "or what triggers it: the card shows the schedule, and this text also seeds the "
-            "execution instructions the agent reads after the trigger has already fired."
+            "1-2 sentences: what it does and what output it produces, not when it runs "
+            "or what triggers it"
         )
     )
     categories: list[str] = Field(

--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -1838,8 +1838,6 @@ async def _create_fallback_workflow(
     description = "Summarizes unread emails by priority, today's meetings, and open todos."
     if focus:
         description += f" Focus: {focus[:100]}."
-    # The schedule lives on trigger_config and the card renders it, so neither the
-    # card copy nor the executor's instructions restate when this runs.
     prompt = (
         "1. Summarize my unread emails, most in need of attention first\n"
         "2. List today's meetings with their times\n"

--- a/apps/api/app/utils/workflow_utils.py
+++ b/apps/api/app/utils/workflow_utils.py
@@ -217,12 +217,13 @@ async def create_workflow_directly(
             timezone=user_timezone,
         )
 
-        workflow_description = draft.prompt or draft.description
-
+        # The two fields are not interchangeable: description is the one-line card
+        # copy, prompt is what the executor reads as the run's goal. Collapsing
+        # them put the whole numbered instruction blob on the card.
         request = CreateWorkflowRequest(
             title=draft.title,
-            description=workflow_description,
-            prompt=workflow_description or draft.title,
+            description=draft.description or draft.title,
+            prompt=draft.prompt or draft.description or draft.title,
             trigger_config=trigger_config,
             steps=None,
             generate_immediately=True,

--- a/apps/api/tests/unit/agents/context/__snapshots__/tier_workflow_authoring.txt
+++ b/apps/api/tests/unit/agents/context/__snapshots__/tier_workflow_authoring.txt
@@ -162,8 +162,9 @@
     4. WRITE THE EXECUTION PROMPT (detailed, capability-level)
        - Numbered steps in plain language: which integration and WHAT to do with it ("use Gmail to fetch unread emails from today", "post the summary to Slack #eng").
        - Do NOT put exact tool names or slugs (GMAIL_FETCH_EMAILS, SLACK_SEND_MESSAGE) in the prompt. The workflow runs on the full executor, which finds the right tool at run time; naming one specific tool over-constrains it and breaks the run if that tool cannot do the job. Name the integration and the action, and let the executor choose the tool.
-       - Use trigger data when the trigger is an event ("using the PR from the trigger data..."). Never repeat the trigger as a step.
+       - Use trigger data when the trigger is an event ("using the PR from the trigger data...").
        - State the expected output and any conditions or edge cases.
+       - Obey the prompt contract below: no schedule, no trigger, no mechanics.
     
     5. FINALIZE OR ASK
        - If it is clear, emit the finalized JSON (with integration_ids).
@@ -181,10 +182,27 @@
     
     Do not turn a config detail (which Slack channel, which Gmail label) into a blocker either: leave it for the draft UI and finalize. Ask a clarifying question ONLY when the workflow's INTENT is genuinely ambiguous, never about connection or trigger config.
     
-    ## TRIGGERS vs STEPS
-    - The trigger happens BEFORE the workflow runs. Never write it as a step.
-      WRONG: "1. Use the GitHub PR event to trigger  2. Analyze the PR  3. Post a comment"
-      RIGHT: "1. Analyze the PR changes from the trigger data  2. Generate the review  3. Post the comment"
+    ## WHAT THE PROMPT MAY CONTAIN
+    The instructions are read by the executor at run time, after
+    the trigger has already fired and handed over its data. They say only WHAT TO DO.
+    
+    Never include:
+    - WHEN it runs: cron, clock times, cadences, "every morning", "daily at 9am", "10 minutes before".
+      The schedule is stored on the workflow and the scheduler has already fired this run.
+    - WHAT STARTED IT: "when a new email arrives", "before each meeting", "when this workflow is
+      triggered". The trigger is stored on the workflow and the executor is told why it was invoked.
+    - Implementation details: "store in JSON", "extract fields", "parse the response", "log the error".
+    - Data handling: "for each email extract X, Y, Z", "create an object", "build an array".
+    - Retry and error logic: the executor handles failures itself.
+    
+    The trigger is never step 1. Open on the first real action.
+      WRONG: "Every morning at 9am: 1. Fetch unread Gmail and summarize it"
+      RIGHT: "1. Fetch unread Gmail and summarize it"
+      WRONG: "When a PR is opened, review the diff and post a comment"
+      RIGHT: "Review the diff of the PR in the trigger data and post the review as a comment"
+    
+    Keep a time window the work itself needs ("emails from the last 24 hours", "events in the next
+    hour"): that is part of what to do. Drop any statement of when the run happens.
     
     ## STRUCTURED OUTPUT FORMAT
     You MUST include a JSON block in EVERY response. Two types:
@@ -213,7 +231,7 @@
     ```
     
     Fields:
-    - description: SHORT (1-2 sentences) - displayed in cards/UI only
+    - description: SHORT (1-2 sentences) saying what the workflow does, displayed on cards/UI only. The card renders the schedule and trigger next to it, so do NOT restate when it runs ("Daily Gmail summary", not "Daily Gmail summary at 9am").
     - prompt: DETAILED and COMPREHENSIVE - this is what the AI uses to execute the workflow. Include:
       • The full workflow logic in natural language with numbered steps (1, 2, 3...)
       • Which integration to use for each step and WHAT to do with it - NOT exact tool names or slugs (the executor finds the tool at run time; a hard-coded tool name over-constrains it and breaks the run if that tool cannot do the job)
@@ -221,6 +239,7 @@
       • Expected format of outputs
       • Any conditions or edge cases to handle
       • Context about the user's intent
+      Everything the prompt contract above forbids stays out, however detailed the rest is.
     - integration_ids: the integration ids this workflow depends on, e.g. ["gmail", "slack"], INCLUDING the trigger integration, connected or not
     - cron_expression: Required for scheduled, omit for others (USE USER'S LOCAL TIME, NOT UTC)
     - trigger_slug: Required for integration, omit for others
@@ -317,8 +336,8 @@
     {
         "type": "finalized",
         "title": "Morning Email Summary",
-        "description": "Daily Gmail summary at 9am",
-        "prompt": "Every morning at 9am:\n\n1. Use Gmail to fetch all unread emails from my inbox\n2. For each, note the sender, subject, and a brief preview\n3. Group them by importance (urgent, normal, low) from the sender and subject\n4. Build a concise digest: total unread count, the most important first with sender and subject, and a short overview of what needs attention\n\nExpected output: a readable, priority-ordered digest I can scan quickly.",
+        "description": "Priority-ordered digest of my unread Gmail",
+        "prompt": "1. Use Gmail to fetch all unread emails from my inbox\n2. Group them by how much they need my attention (urgent, normal, low), judging from the sender and subject\n3. Build a concise digest: total unread count, the most important first with sender and subject, and a short overview of what needs attention\n\nExpected output: a readable, priority-ordered digest I can scan quickly.",
         "trigger_type": "scheduled",
         "cron_expression": "0 9 * * *",
         "integration_ids": ["gmail"],
@@ -350,8 +369,8 @@
     {
         "type": "finalized",
         "title": "Morning Email Summary",
-        "description": "Daily Gmail summary at 8am, sent on WhatsApp",
-        "prompt": "Every morning at 8am:\n\n1. Use Gmail to fetch unread emails from my inbox\n2. Summarize them by priority with sender, subject, and a short preview\n3. Send the summary to me on WhatsApp\n\nExpected output: a concise WhatsApp message with the prioritized summary.",
+        "description": "Gmail summary sent to me on WhatsApp",
+        "prompt": "1. Use Gmail to fetch unread emails from my inbox\n2. Summarize them by priority with sender, subject, and a short preview\n3. Send the summary to me on WhatsApp\n\nExpected output: a concise WhatsApp message with the prioritized summary.",
         "trigger_type": "scheduled",
         "cron_expression": "0 8 * * *",
         "integration_ids": ["gmail"],
@@ -370,8 +389,8 @@
     {
         "type": "finalized",
         "title": "Daily Calendar to Slack on New Email",
-        "description": "On a new email, post today's calendar to Slack",
-        "prompt": "When a new email arrives in Gmail:\n\n1. Use Google Calendar to get my events for today\n2. Summarize them with meeting times, attendees, and locations\n3. Flag any conflicts or back-to-back meetings\n4. Post the summary to my Slack channel, split into morning and afternoon\n\nExpected output: a formatted Slack message with today's calendar overview.",
+        "description": "Posts today's calendar to Slack",
+        "prompt": "1. Use Google Calendar to get my events for today\n2. Summarize them with meeting times, attendees, and locations\n3. Flag any conflicts or back-to-back meetings\n4. Post the summary to my Slack channel, split into morning and afternoon\n\nExpected output: a formatted Slack message with today's calendar overview.",
         "trigger_type": "integration",
         "trigger_slug": "GMAIL_NEW_GMAIL_MESSAGE",
         "integration_ids": ["gmail", "googlecalendar", "slack"],

--- a/apps/api/tests/unit/agents/context/__snapshots__/tier_workflow_authoring.txt
+++ b/apps/api/tests/unit/agents/context/__snapshots__/tier_workflow_authoring.txt
@@ -185,9 +185,10 @@
     The executor reads these instructions after the trigger has
     already fired and handed over its data, so they say only WHAT TO DO. Leave out when the run
     happens (cron, clock times, "every morning"), what started it ("when a new email arrives"), and
-    mechanics the executor handles itself (field extraction, storage format, retries, error logging).
-    A time window the work needs ("emails from the last 24 hours") stays; a statement of when the run
-    happens does not.
+    mechanics nobody asked for (field extraction, storage format, retries, error logging).
+    What the user did ask for is the deliverable, not a mechanic: keep the fields, columns and format
+    they named. A time window the work needs ("emails from the last 24 hours") stays too; a statement
+    of when the run happens does not.
     
       WRONG: "Every morning at 9am: 1. Fetch unread Gmail and summarize it"
       RIGHT: "1. Fetch unread Gmail and summarize it"

--- a/apps/api/tests/unit/agents/context/__snapshots__/tier_workflow_authoring.txt
+++ b/apps/api/tests/unit/agents/context/__snapshots__/tier_workflow_authoring.txt
@@ -164,7 +164,6 @@
        - Do NOT put exact tool names or slugs (GMAIL_FETCH_EMAILS, SLACK_SEND_MESSAGE) in the prompt. The workflow runs on the full executor, which finds the right tool at run time; naming one specific tool over-constrains it and breaks the run if that tool cannot do the job. Name the integration and the action, and let the executor choose the tool.
        - Use trigger data when the trigger is an event ("using the PR from the trigger data...").
        - State the expected output and any conditions or edge cases.
-       - Obey the prompt contract below: no schedule, no trigger, no mechanics.
     
     5. FINALIZE OR ASK
        - If it is clear, emit the finalized JSON (with integration_ids).
@@ -183,26 +182,15 @@
     Do not turn a config detail (which Slack channel, which Gmail label) into a blocker either: leave it for the draft UI and finalize. Ask a clarifying question ONLY when the workflow's INTENT is genuinely ambiguous, never about connection or trigger config.
     
     ## WHAT THE PROMPT MAY CONTAIN
-    The instructions are read by the executor at run time, after
-    the trigger has already fired and handed over its data. They say only WHAT TO DO.
+    The executor reads these instructions after the trigger has
+    already fired and handed over its data, so they say only WHAT TO DO. Leave out when the run
+    happens (cron, clock times, "every morning"), what started it ("when a new email arrives"), and
+    mechanics the executor handles itself (field extraction, storage format, retries, error logging).
+    A time window the work needs ("emails from the last 24 hours") stays; a statement of when the run
+    happens does not.
     
-    Never include:
-    - WHEN it runs: cron, clock times, cadences, "every morning", "daily at 9am", "10 minutes before".
-      The schedule is stored on the workflow and the scheduler has already fired this run.
-    - WHAT STARTED IT: "when a new email arrives", "before each meeting", "when this workflow is
-      triggered". The trigger is stored on the workflow and the executor is told why it was invoked.
-    - Implementation details: "store in JSON", "extract fields", "parse the response", "log the error".
-    - Data handling: "for each email extract X, Y, Z", "create an object", "build an array".
-    - Retry and error logic: the executor handles failures itself.
-    
-    The trigger is never step 1. Open on the first real action.
       WRONG: "Every morning at 9am: 1. Fetch unread Gmail and summarize it"
       RIGHT: "1. Fetch unread Gmail and summarize it"
-      WRONG: "When a PR is opened, review the diff and post a comment"
-      RIGHT: "Review the diff of the PR in the trigger data and post the review as a comment"
-    
-    Keep a time window the work itself needs ("emails from the last 24 hours", "events in the next
-    hour"): that is part of what to do. Drop any statement of when the run happens.
     
     ## STRUCTURED OUTPUT FORMAT
     You MUST include a JSON block in EVERY response. Two types:
@@ -231,7 +219,7 @@
     ```
     
     Fields:
-    - description: SHORT (1-2 sentences) saying what the workflow does, displayed on cards/UI only. The card renders the schedule and trigger next to it, so do NOT restate when it runs ("Daily Gmail summary", not "Daily Gmail summary at 9am").
+    - description: SHORT (1-2 sentences) saying what the workflow does, displayed in cards/UI only. The card shows the schedule beside it, so do not restate it.
     - prompt: DETAILED and COMPREHENSIVE - this is what the AI uses to execute the workflow. Include:
       • The full workflow logic in natural language with numbered steps (1, 2, 3...)
       • Which integration to use for each step and WHAT to do with it - NOT exact tool names or slugs (the executor finds the tool at run time; a hard-coded tool name over-constrains it and breaks the run if that tool cannot do the job)
@@ -239,7 +227,6 @@
       • Expected format of outputs
       • Any conditions or edge cases to handle
       • Context about the user's intent
-      Everything the prompt contract above forbids stays out, however detailed the rest is.
     - integration_ids: the integration ids this workflow depends on, e.g. ["gmail", "slack"], INCLUDING the trigger integration, connected or not
     - cron_expression: Required for scheduled, omit for others (USE USER'S LOCAL TIME, NOT UTC)
     - trigger_slug: Required for integration, omit for others

--- a/apps/api/tests/unit/agents/prompts/test_workflow_prompt_hygiene.py
+++ b/apps/api/tests/unit/agents/prompts/test_workflow_prompt_hygiene.py
@@ -1,0 +1,111 @@
+"""A workflow's `prompt` is instructions, not a copy of its own config.
+
+The scheduler has already fired the run and the trigger data is already handed
+over by the time the executor reads `prompt`, so "Every morning at 9am:" and
+"When a new email arrives in Gmail:" are inert text the run cannot act on. Two
+separate LLMs write that field, and they had drifted: the editor's generator
+banned schedule and trigger language outright while the chat assistant said
+nothing about it and demonstrated the opposite in all three of its worked
+examples. The examples are the stronger signal, so that is what shipped.
+
+These tests pin both halves: one contract, spliced into both authors, and no
+worked example that contradicts it.
+"""
+
+import json
+import re
+
+import pytest
+
+from app.agents.prompts.subagent_prompts import WORKFLOW_AGENT_SYSTEM_PROMPT
+from app.agents.prompts.workflow_prompts import (
+    TODO_WORKFLOW_PROMPT_TEMPLATE,
+    WORKFLOW_INSTRUCTIONS_CONTRACT,
+    WORKFLOW_PROMPT_GENERATION_SYSTEM,
+)
+
+#: Every LLM that authors a workflow's `prompt`. Both must carry the contract,
+#: or the one that doesn't drifts back to writing config into the field.
+PROMPT_AUTHORS = {
+    "workflow assistant (chat)": WORKFLOW_AGENT_SYSTEM_PROMPT,
+    "instructions generator (editor)": WORKFLOW_PROMPT_GENERATION_SYSTEM,
+}
+
+#: Config text that says WHEN a run happens. The value it carries is already on
+#: the workflow's trigger_config, so in the instructions it is pure noise.
+SCHEDULE_TELLS = (
+    re.compile(r"\bevery (morning|day|night|week|month|hour|monday|weekday)", re.I),
+    re.compile(r"\bat \d{1,2}\s*(am|pm|:\d{2})", re.I),
+    re.compile(r"\b\d{1,2}\s*(am|pm)\b", re.I),
+    re.compile(r"\b(daily|weekly|hourly|cron)\b", re.I),
+)
+
+#: Config text that says WHAT STARTED the run. Same story: it lives on the
+#: trigger, and the executor is told why it was invoked.
+TRIGGER_TELLS = (
+    re.compile(r"^\s*when\b", re.I),
+    re.compile(r"^\s*before (each|every)\b", re.I),
+    re.compile(r"\bwhen (a|an|the) .{0,40}(arrives|is opened|is created|fires)", re.I),
+)
+
+
+def _finalized_example_prompts(system_prompt: str) -> list[str]:
+    """The `prompt` value of every finalized workflow the prompt demonstrates."""
+    prompts: list[str] = []
+    for block in re.findall(r"```json\s*(.*?)```", system_prompt, re.DOTALL):
+        try:
+            payload = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("type") == "finalized":
+            prompts.append(str(payload.get("prompt", "")))
+    return prompts
+
+
+@pytest.mark.unit
+class TestWorkflowInstructionsContract:
+    def test_every_prompt_author_carries_the_same_contract(self) -> None:
+        """One copy, spliced into both. Two hand-maintained copies is how the
+        assistant ended up with no rule at all while the generator had one."""
+        for name, prompt in PROMPT_AUTHORS.items():
+            assert WORKFLOW_INSTRUCTIONS_CONTRACT in prompt, (
+                f"{name} does not carry WORKFLOW_INSTRUCTIONS_CONTRACT"
+            )
+
+    def test_the_assistant_demonstrates_at_least_one_finalized_workflow(self) -> None:
+        """Guards the two tests below: if the examples stop parsing, those pass
+        vacuously and stop protecting anything."""
+        assert len(_finalized_example_prompts(WORKFLOW_AGENT_SYSTEM_PROMPT)) >= 3
+
+
+@pytest.mark.unit
+class TestWorkedExamplesMatchTheContract:
+    def test_no_example_prompt_states_when_the_run_happens(self) -> None:
+        for prompt in _finalized_example_prompts(WORKFLOW_AGENT_SYSTEM_PROMPT):
+            for tell in SCHEDULE_TELLS:
+                assert not tell.search(prompt), (
+                    f"example prompt states its own schedule ({tell.pattern!r}): {prompt[:120]!r}"
+                )
+
+    def test_no_example_prompt_restates_its_trigger(self) -> None:
+        for prompt in _finalized_example_prompts(WORKFLOW_AGENT_SYSTEM_PROMPT):
+            for tell in TRIGGER_TELLS:
+                assert not tell.search(prompt), (
+                    f"example prompt restates its trigger ({tell.pattern!r}): {prompt[:120]!r}"
+                )
+
+
+@pytest.mark.unit
+class TestTodoWorkflowPrompt:
+    def test_it_carries_the_task_and_not_how_the_workflow_was_made(self) -> None:
+        """This template IS the stored prompt for a todo-generated workflow, so
+        every word about where the workflow came from and when the user runs it
+        is config the executor reads as its goal."""
+        rendered = TODO_WORKFLOW_PROMPT_TEMPLATE.format(
+            title="Book the venue for the offsite",
+            details_section="**Details:** capacity 40, budget 2k",
+        )
+        assert "Book the venue for the offsite" in rendered
+        assert "capacity 40, budget 2k" in rendered
+        for config_text in ("automatically generated", "Run Workflow", "todo-driven"):
+            assert config_text not in rendered, f"prompt narrates its own config: {config_text!r}"

--- a/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
+++ b/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
@@ -643,6 +643,16 @@ class TestCreateOnboardingWorkflows:
 # _create_fallback_workflow
 # ---------------------------------------------------------------------------
 
+#: The fallback's two fields, verbatim. They are fixed templates, so the tests
+#: below pin them exactly rather than sampling a substring.
+_FALLBACK_DESCRIPTION = "Summarizes unread emails by priority, today's meetings, and open todos."
+_FALLBACK_PROMPT = (
+    "1. Summarize my unread emails, most in need of attention first\n"
+    "2. List today's meetings with their times\n"
+    "3. List my open todos\n\n"
+    "Expected output: one short briefing I can read in under a minute."
+)
+
 
 class TestCreateFallbackWorkflow:
     async def test_creates_a_daily_briefing(self) -> None:
@@ -670,6 +680,32 @@ class TestCreateFallbackWorkflow:
             result = await _create_fallback_workflow(USER, "")
 
         assert "Focus:" not in result[0].description
+
+    async def test_the_prompt_is_instructions_not_the_card_copy(self) -> None:
+        """This prompt is what the executor reads as the run's goal. It used to be
+        the description, which opened "Every morning at 9am" — config the scheduler
+        has already acted on by the time the agent sees it. Asserted in full: it is
+        a fixed template, so anything less lets a reworded step through."""
+        with patch(f"{MODULE}.WorkflowService") as service:
+            service.create_workflow = AsyncMock(return_value=_workflow())
+            await _create_fallback_workflow(USER)
+
+        request = service.create_workflow.await_args.args[0]
+        assert request.prompt == _FALLBACK_PROMPT
+        assert request.description == _FALLBACK_DESCRIPTION
+        assert request.prompt != request.description
+
+    async def test_a_long_focus_is_truncated_into_both_fields(self) -> None:
+        focus = "shipping the billing rewrite " * 8  # comfortably over the 100-char cap
+        with patch(f"{MODULE}.WorkflowService") as service:
+            service.create_workflow = AsyncMock(return_value=_workflow())
+            await _create_fallback_workflow(USER, focus)
+
+        request = service.create_workflow.await_args.args[0]
+        assert request.description == f"{_FALLBACK_DESCRIPTION} Focus: {focus[:100]}."
+        assert request.prompt == (
+            f"{_FALLBACK_PROMPT}\n\nWeight everything toward what matters for: {focus[:100]}."
+        )
 
     async def test_integration_ids_are_forwarded(self) -> None:
         with patch(f"{MODULE}.WorkflowService") as service:

--- a/apps/api/tests/unit/utils/test_workflow_utils.py
+++ b/apps/api/tests/unit/utils/test_workflow_utils.py
@@ -330,3 +330,18 @@ class TestCreateWorkflowDirectly:
         request = mock_create.await_args.kwargs["request"]
         assert request.description == "Morning digest"
         assert request.prompt == "Summarize my inbox"
+
+    async def test_a_draft_with_no_prompt_falls_back_to_the_description(self) -> None:
+        """The description is the closest thing to instructions the assistant
+        produced, so it beats the title. Only a draft missing both lands on the
+        title."""
+        draft = _draft(description="Summarize my unread Gmail", prompt="")
+        writer = MagicMock()
+
+        with patch(f"{SERVICE}.create_workflow", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _workflow(TriggerConfig(type=TriggerType.MANUAL))
+            await create_workflow_directly(draft=draft, user_id=USER_ID, writer=writer)
+
+        request = mock_create.await_args.kwargs["request"]
+        assert request.prompt == "Summarize my unread Gmail"
+        assert request.description == "Summarize my unread Gmail"

--- a/apps/api/tests/unit/utils/test_workflow_utils.py
+++ b/apps/api/tests/unit/utils/test_workflow_utils.py
@@ -17,6 +17,7 @@ from app.utils.workflow_utils import (
     _edited_trigger,
     _regenerated_after_prompt_edit,
     apply_workflow_edit,
+    create_workflow_directly,
     get_user_id,
     get_workflow_id,
 )
@@ -288,3 +289,44 @@ class TestApplyWorkflowEdit:
                 "the user to adjust the trigger there."
             ),
         }
+
+
+@pytest.mark.unit
+class TestCreateWorkflowDirectly:
+    async def test_the_card_description_is_not_the_execution_prompt(self) -> None:
+        """description is card copy, prompt is the executor's goal. Writing the
+        prompt into both put the whole numbered instruction blob, schedule
+        preamble and all, on every chat-created workflow card."""
+        draft = _draft(
+            description="Priority-ordered digest of my unread Gmail",
+            prompt=(
+                "1. Use Gmail to fetch all unread emails\n"
+                "2. Group them by how much they need my attention\n\n"
+                "Expected output: a digest I can scan quickly."
+            ),
+            cron_expression="0 9 * * *",
+        )
+        writer = MagicMock()
+
+        with patch(f"{SERVICE}.create_workflow", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _workflow(
+                TriggerConfig(type=TriggerType.SCHEDULE, cron_expression="0 9 * * *")
+            )
+            await create_workflow_directly(draft=draft, user_id=USER_ID, writer=writer)
+
+        request = mock_create.await_args.kwargs["request"]
+        assert request.description == "Priority-ordered digest of my unread Gmail"
+        assert request.prompt == draft.prompt
+        assert request.description != request.prompt
+
+    async def test_a_draft_with_no_description_falls_back_to_the_title(self) -> None:
+        draft = _draft(description="", prompt="Summarize my inbox")
+        writer = MagicMock()
+
+        with patch(f"{SERVICE}.create_workflow", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _workflow(TriggerConfig(type=TriggerType.MANUAL))
+            await create_workflow_directly(draft=draft, user_id=USER_ID, writer=writer)
+
+        request = mock_create.await_args.kwargs["request"]
+        assert request.description == "Morning digest"
+        assert request.prompt == "Summarize my inbox"


### PR DESCRIPTION
## Summary

A workflow that GAIA creates for you no longer opens its own instructions with a copy of its
schedule. Before this, asking for "check my email every morning at 9am" produced a workflow
whose instructions began `Every morning at 9am:` — text the agent reads at run time, when the
scheduler has already fired the run and the timing is settled. The instructions now start at
the first real action. Chat-created workflow cards also stop showing the full numbered
instruction blob as their description.

## Why

Measured on the real workflow-authoring agent against a live model: **5 out of 5** generated
workflows put their trigger or schedule into the `prompt` field. That field is spliced into the
run as the agent's goal (`app/helpers/message_helpers.py:160` reads `workflow.effective_prompt`),
so every run started by reading configuration it cannot act on.

Two separate models write that field and they had drifted apart. The workflow editor's
"generate instructions" prompt banned schedule and trigger language outright. The chat
assistant said nothing about it, and demonstrated the opposite in all three of its worked
examples. A worked example beats a rule the prompt never states, so the boilerplate shipped.

## What changed

### API

- One `WORKFLOW_INSTRUCTIONS_CONTRACT` in `app/agents/prompts/workflow_prompts.py`, spliced into
  both authors of a workflow's `prompt`, so they cannot diverge again.
- Rewrote the chat assistant's three finalized worked examples, which were the actual cause.
- `create_workflow_directly` wrote the execution prompt into `description` as well as `prompt`,
  so every chat-created workflow card rendered the whole instruction blob. The two fields are
  now written from their own sources.
- `TODO_WORKFLOW_PROMPT_TEMPLATE` is stored verbatim as a todo-generated workflow's prompt and
  was almost entirely narration about how the workflow got created and when the user would run
  it. Reduced to the task.
- Onboarding (four workflows per new user): the spec no longer asks the model for "what triggers
  it" in the description, and the fallback Daily Briefing stops using its card copy
  (`"Every morning at 9am, ..."`) as its execution prompt.
- Deleted five unreferenced `WORKFLOW_CREATION_*` prompt constants.

---

## The bug

**Symptom** — a workflow created from chat stores instructions like:

```
Every morning at 9am:

1. Use Gmail to fetch all unread emails from my inbox
2. ...
```

and, on the direct-create path, stores that same block as the workflow's `description`, so the
card in the workflows list shows the full numbered text instead of a one-line summary.

**Reproduce** — on master, ask GAIA in chat: *"create a workflow that checks my email every
morning at 9am and summarizes unread ones"*. Open the workflow in the editor: the instructions
box opens with `Every morning at 9am:`, and the card description is that whole block.

**Root cause** — two independent causes, both reproduced:

1. `app/agents/prompts/subagent_prompts.py` — the chat workflow assistant's prompt had no rule
   against schedule or trigger text, and its three worked `finalized` examples all modelled it
   (`"prompt": "Every morning at 9am:\n\n1. Use Gmail..."`,
   `"When a new email arrives in Gmail:\n\n1. ..."`). The model copied the examples.
2. `app/utils/workflow_utils.py:220` — `workflow_description = draft.prompt or draft.description`
   was then passed to **both** `description=` and `prompt=` on the create request, so the card
   copy the assistant had written was thrown away.

**The fix** — the contract is stated once and shared by both prompt authors rather than
maintained in two hand-written copies, since the divergence is what produced the bug. The
worked examples now obey it. The two workflow fields are written from their own sources.

**Regression test** — `tests/unit/agents/prompts/test_workflow_prompt_hygiene.py` parses every
fenced `finalized` example out of the assistant's assembled prompt and asserts none states its
schedule or restates its trigger, plus that both authors carry the same contract.
`tests/unit/utils/test_workflow_utils.py::TestCreateWorkflowDirectly` covers the field collapse.
Both were watched failing against the pre-fix code first, and each assertion was mutation-checked
by reintroducing the exact boilerplate it bans.

**Why the suite missed it** — nothing asserted anything about the *content* of the prompts, only
that the agent plumbing around them worked. The `create_workflow_directly` field mapping had no
test at all; its only coverage was through mocks that never looked at the request it built.

---

## How to verify

Run the workflow-authoring agent against a real model and look at the `prompt` it emits:

1. Point the dev LLM at any OpenAI-compatible endpoint (`DEV_LLM_BASE_URL`, `DEV_LLM_API_KEY`,
   `DEV_LLM_MODEL`) and start the stack with `mise dev --agent`.
2. In chat: *"create a workflow that checks my email every morning at 9am and summarizes unread
   ones"*.
3. Open it in the workflow editor. The instructions must start at step 1, not with the schedule,
   and the schedule chip must still read 9:00 AM (`cron 0 9 * * *`).
4. Repeat with an event trigger — *"when I get a new email, post my calendar for the day to
   Slack"* — and confirm the instructions do not begin `When a new email arrives`.

To check the stored document rather than the UI:

```
db.getSiblingDB("GAIA").workflows.findOne({title: "..."}, {description: 1, prompt: 1})
```

`description` must be the one-line card copy and `prompt` the numbered instructions; on master
they are the same string.

**Not verified:** the onboarding path was not driven end to end — it needs a fresh user through
the full onboarding pipeline. Its two changes (the spec's description field and the fallback
Daily Briefing) were checked by reading the code and by unit tests, not by running onboarding.

## Metrics

Measured by running `WorkflowSubagentRunner.execute`, the same function `create_workflow` calls,
over five workflow requests, once with this branch's prompt and once with `origin/master`'s
patched in. Same model and endpoint for both runs. The harness was a throwaway script and is not
committed, so these numbers are reported rather than reproducible from this diff.

| Metric | Before | After | How measured |
| --- | --- | --- | --- |
| `prompt` containing schedule or trigger config | 5/5 | 0/5 | regex for cadences, clock times and "when X arrives" over the emitted `prompt` |
| `description` containing it | 5/5 | 2/5 | same patterns over the emitted `description` |

Cron expressions and trigger selection were unchanged between the two runs (`0 9 * * *`,
`0 8 * * 1`, `0 18 * * 1-5`, and the Gmail trigger for the event case), so the timing moved to
configuration only rather than being lost.

The remaining two descriptions still mention the trigger ("Posts today's calendar overview to
Slack when a new email arrives"). That is card copy shown next to a chip that already displays
the trigger, so it is redundant rather than wrong, and it does not reach the agent.

## Risk

Prompt changes affect every workflow created from chat and every workflow created during
onboarding, from the moment this deploys. The plausible failure is the authoring model dropping
a detail it used to carry, producing thinner instructions; that shows up immediately as a
worse-quality workflow on the next creation, and reverting this PR restores the previous prompt
with no data migration.

Workflows already in the database keep the text they were created with — this only changes new
creation. Cleaning up existing rows would need a backfill, in the shape of
`app/scripts/backfill_public_workflow_descriptions.py`.
