### PR TITLE
fix(web): reset canvas.md cache when the selected todo changes

### DIFF
--- a/apps/web/src/__tests__/todo-canvas-stale-switch.test.tsx
+++ b/apps/web/src/__tests__/todo-canvas-stale-switch.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TodoSidebar } from "@/components/layout/sidebar/right-variants/TodoSidebar";
+import { getTodoCanvas } from "@/features/todo/api/todoApi";
+import { Priority, type Todo } from "@/types/features/todoTypes";
+
+/**
+ * Regression test: switching the selected todo must show the newly selected
+ * todo's canvas.md, not the previously opened one.
+ *
+ * The sidebar reuses one CanvasViewer instance across todo selections (only the
+ * props change). CanvasViewer previously cached the fetched markdown and guarded
+ * the fetch with `if (content !== null) return`, so todo A's cached content
+ * survived a switch to todo B — the guard short-circuited the refetch and B's
+ * viewer showed A's canvas until a full page refresh. CanvasViewer now fetches
+ * on every open; reintroduce the cache guard and this fails.
+ */
+
+vi.mock("@/features/auth/hooks/useUser", () => ({
+  useUser: () => undefined,
+}));
+
+// Siblings pull in workflow fetches / selects that are irrelevant here.
+vi.mock("@/features/todo/components/WorkflowSection", () => ({
+  default: () => null,
+}));
+vi.mock("@/features/todo/components/shared/SubtaskManager", () => ({
+  default: () => null,
+}));
+vi.mock("@/features/todo/components/shared/TodoFieldsRow", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/features/todo/api/todoApi", () => ({
+  getTodoCanvas: vi.fn(async (todoId: string) => ({
+    content: `# canvas for ${todoId}`,
+  })),
+}));
+
+// Surface the content prop CanvasViewer computes without HeroUI's portal.
+vi.mock("@/components/common/MarkdownViewerModal", () => ({
+  default: ({
+    isOpen,
+    content,
+    onClose,
+  }: {
+    isOpen: boolean;
+    content: string | null;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="canvas-modal">
+        <span data-testid="canvas-content">{content}</span>
+        <button type="button" data-testid="canvas-close" onClick={onClose}>
+          close
+        </button>
+      </div>
+    ) : null,
+}));
+
+function makeTodo(id: string): Todo {
+  return {
+    id,
+    user_id: "user-1",
+    title: `Todo ${id}`,
+    labels: [],
+    priority: Priority.NONE,
+    project_id: "project-1",
+    completed: false,
+    subtasks: [],
+    vfs_path: `/todos/${id}/canvas.md`,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const noop = vi.fn();
+
+describe("TodoSidebar canvas.md across todo switches", () => {
+  beforeEach(() => {
+    vi.mocked(getTodoCanvas).mockClear();
+  });
+
+  it("shows the newly selected todo's canvas after opening, closing, and switching", async () => {
+    const todoA = makeTodo("todo-a");
+    const todoB = makeTodo("todo-b");
+
+    const { rerender } = render(
+      <TodoSidebar
+        todo={todoA}
+        onUpdate={noop}
+        onDelete={noop}
+        projects={[]}
+      />,
+    );
+
+    // Open todo A's canvas.
+    fireEvent.click(screen.getByText("canvas.md"));
+    await waitFor(() =>
+      expect(screen.getByTestId("canvas-content").textContent).toBe(
+        "# canvas for todo-a",
+      ),
+    );
+
+    // Close it, then switch the selected todo to B.
+    fireEvent.click(screen.getByTestId("canvas-close"));
+    rerender(
+      <TodoSidebar
+        todo={todoB}
+        onUpdate={noop}
+        onDelete={noop}
+        projects={[]}
+      />,
+    );
+
+    // Open B's canvas — it must fetch and show B, not the cached A.
+    fireEvent.click(screen.getByText("canvas.md"));
+    await waitFor(() =>
+      expect(screen.getByTestId("canvas-content").textContent).toBe(
+        "# canvas for todo-b",
+      ),
+    );
+    expect(getTodoCanvas).toHaveBeenLastCalledWith("todo-b");
+  });
+});

--- a/apps/web/src/features/todo/components/CanvasViewer.tsx
+++ b/apps/web/src/features/todo/components/CanvasViewer.tsx
@@ -19,10 +19,10 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ todoId, todoTitle }) => {
   const [hasError, setHasError] = useState(false);
 
   const handleOpen = async () => {
+    // Fetch on every open: the sidebar reuses this instance across todo
+    // selections, so re-reading the current todo's canvas keeps a previously
+    // opened todo's content from leaking through and lets a failed read retry.
     setIsOpen(true);
-    // Re-fetch if we have neither content nor a prior successful load, so a
-    // failed read can be retried simply by reopening the viewer.
-    if (content !== null) return;
     setIsLoading(true);
     setHasError(false);
     try {

--- a/apps/web/src/features/todo/components/CanvasViewer.tsx
+++ b/apps/web/src/features/todo/components/CanvasViewer.tsx
@@ -19,9 +19,6 @@ const CanvasViewer: React.FC<CanvasViewerProps> = ({ todoId, todoTitle }) => {
   const [hasError, setHasError] = useState(false);
 
   const handleOpen = async () => {
-    // Fetch on every open: the sidebar reuses this instance across todo
-    // selections, so re-reading the current todo's canvas keeps a previously
-    // opened todo's content from leaking through and lets a failed read retry.
     setIsOpen(true);
     setIsLoading(true);
     setHasError(false);


### PR DESCRIPTION
## Summary

Opening a tracked todo's `canvas.md`, closing it, then opening a different todo's canvas showed the **previous** todo's canvas — and it stayed wrong until a full page refresh. This fixes the viewer so it always shows the currently selected todo's canvas.

## Why

A user selecting todo B after viewing todo A's `canvas.md` saw A's working memory in B's viewer, silently reading the wrong file's contents.

## What changed

### Web

- `CanvasViewer` now fetches the canvas on every open instead of caching it per instance, so a reused instance can't serve a previous todo's canvas.

---

## The bug

**Symptom** — After opening one tracked todo's `canvas.md`, closing it, and opening another todo's canvas, the viewer renders the first todo's canvas instead of the second's. Only a page refresh corrects it.

**Reproduce** —
1. Open a gaia-tracked todo in the sidebar and click `canvas.md` — its canvas loads.
2. Close the viewer.
3. Select a different tracked todo and click its `canvas.md`.
4. The first todo's canvas is shown, not the second's.

**Root cause** — `CanvasViewer` (`apps/web/src/features/todo/components/CanvasViewer.tsx`) cached the fetched markdown in per-instance `useState` and guarded the fetch with `if (content !== null) return`. The sidebar renders a single `CanvasViewer` and only swaps its `todoId`/`todoTitle` props when the selected todo changes, so React reuses the same instance. Todo A's cached `content` survived the switch, the guard short-circuited the refetch, and B's viewer showed A's canvas. A refresh destroys the instance, which is why refresh appeared to "fix" it.

**The fix** — Drop the cache guard and fetch on every open. The canvas is GAIA's live working memory, so re-reading it on open is more correct regardless, and the `isLoading` gate in `MarkdownViewerModal` masks the previous content while the new read is in flight. Two alternatives were rejected: keying `CanvasViewer` at the call site collides with its sibling `WorkflowSection`, which already uses `key={todo.id}` in the same parent (React `Encountered two children with the same key`, leaving the stale instance mounted); resetting state in a `todoId` effect is the `no-adjust-state-on-prop-change` anti-pattern React Doctor flags. Fetching on open is the simplest correct option.

**Regression test** — `apps/web/src/__tests__/todo-canvas-stale-switch.test.tsx` renders the real `TodoSidebar` + `CanvasViewer`, opens todo A's canvas, closes it, switches to todo B, and asserts B's canvas loads (and that the fetch was made for B). Confirmed failing before the fix (`# canvas for todo-a` served for todo B) and passing after; reintroducing the cache guard turns it red again.

**Why the suite missed it** — The only existing canvas test (`todo-canvas-url.test.ts`) asserted the request URL of `getTodoCanvas` in isolation. No test exercised the component across a todo switch, so the instance-scoped cache was never observed leaking between todos.

## How to verify

1. `cd apps/web && pnpm vitest run src/__tests__/todo-canvas-stale-switch.test.tsx` — passes.
2. In the running app: open todo A's `canvas.md`, close it, select todo B, open its `canvas.md` — B's canvas loads without a refresh.

## Risk

Scoped to `CanvasViewer`. The only behavioral change is that opening the viewer always refetches (a silent GET) instead of serving a cached copy, so switching todos no longer reuses stale canvas content and reopening the same todo reflects the latest canvas.
