### PR TITLE
fix(api): carry the workflow execution id into the executor's boundary

### DIFF
--- a/apps/api/app/agents/core/background/executor_queue.py
+++ b/apps/api/app/agents/core/background/executor_queue.py
@@ -284,11 +284,8 @@ async def enqueue_collection_run(
         build_run_item(
             task=EXECUTOR_COLLECTION_TASK,
             configurable=configurable,
-            # The stream is minted at dequeue; a collection turn is a queued run.
             identity=RunIdentity(
-                stream_id="",
                 conversation_id=conversation_id,
-                kind=RunKind.QUEUED,
                 task_id=str(uuid4()),
                 user_message_id=None,
             ),

--- a/apps/api/app/agents/core/background/executor_queue.py
+++ b/apps/api/app/agents/core/background/executor_queue.py
@@ -44,7 +44,7 @@ from app.core.websocket_manager import websocket_manager
 from app.db.redis import redis_cache
 from app.models.agent_models import AgentConfigurable
 from app.utils.general_utils import is_json_safe
-from shared.py.wide_events import log
+from shared.py.wide_events import current_workflow_execution_id, log
 
 # Cosmetic prefix for queued stream ids — kept for log greppability only.
 # The run kind is carried explicitly on ExecutorRun, never parsed from the id.
@@ -71,6 +71,12 @@ class ExecutorRunItem(TypedDict, total=False):
     #: written by a HIL pause (``_record_pause``) — a plain queue enqueue never
     #: sets it. Read back by ``prepare_run_from_item`` into ``ExecutorRun``.
     bot_message_id: str | None
+    #: The workflow execution the run belongs to. It exists only on the workflow
+    #: task's wide event, and a queue pop or HIL resume rebuilds the run in some
+    #: other context (the previous run's finalize, the approval request), so the
+    #: item is the only thing that can carry it across. Read back into
+    #: ``ExecutorRun`` so the resumed run's model calls stay attributable.
+    workflow_execution_id: str | None
 
 
 @dataclass(frozen=True)
@@ -239,6 +245,7 @@ async def enqueue_task(
     configurable: AgentConfigurable,
     conversation_id: str,
     user_message_id: str | None,
+    workflow_execution_id: str | None = None,
 ) -> None:
     """Push a task to the executor queue for deferred execution."""
     queue_item = json.dumps(
@@ -248,6 +255,7 @@ async def enqueue_task(
             configurable=configurable,
             conversation_id=conversation_id,
             user_message_id=user_message_id,
+            workflow_execution_id=workflow_execution_id,
         )
     )
     if redis_cache.client:
@@ -256,7 +264,9 @@ async def enqueue_task(
 
 
 async def enqueue_collection_run(
-    conversation_id: str, base_configurable: AgentConfigurable
+    conversation_id: str,
+    base_configurable: AgentConfigurable,
+    workflow_execution_id: str | None = None,
 ) -> bool:
     """Queue a wake-up turn to collect landed background-subagent work.
 
@@ -289,6 +299,7 @@ async def enqueue_collection_run(
         configurable=configurable,
         conversation_id=conversation_id,
         user_message_id=None,
+        workflow_execution_id=workflow_execution_id,
     )
     log.info(
         f"{LogTag.AGENT} Queued background-subagent collection turn",
@@ -357,10 +368,15 @@ def build_run_item(
     conversation_id: str,
     user_message_id: str | None,
     bot_message_id: str | None = None,
+    workflow_execution_id: str | None = None,
 ) -> ExecutorRunItem:
     """The one serialized run-context shape: written by the queue and the HIL
     resume store, read back by ``prepare_run_from_item``. Add fields here, not
-    at the write sites, or a resumed run silently drops what a queued run keeps."""
+    at the write sites, or a resumed run silently drops what a queued run keeps.
+
+    ``workflow_execution_id`` defaults to the execution in flight on the caller's
+    wide event — a run that already knows its own passes it explicitly, since a
+    pause is recorded from inside the run's boundary, not the workflow task's."""
     return {
         "task": task,
         "task_id": task_id,
@@ -368,6 +384,7 @@ def build_run_item(
         "conversation_id": conversation_id,
         "user_message_id": user_message_id,
         "bot_message_id": bot_message_id,
+        "workflow_execution_id": workflow_execution_id or current_workflow_execution_id(),
     }
 
 
@@ -463,5 +480,6 @@ async def prepare_run_from_item(
             user_message_id=queued_user_message_id,
             bot_message_id=queued_bot_message_id,
         ),
+        workflow_execution_id=item.get("workflow_execution_id"),
     )
     return PreparedQueuedTask(run=run, task=task, configurable=configurable)

--- a/apps/api/app/agents/core/background/executor_queue.py
+++ b/apps/api/app/agents/core/background/executor_queue.py
@@ -238,26 +238,13 @@ async def reclaim_stranded_task(conversation_id: str) -> PreparedQueuedTask | No
 # ── Enqueue ──────────────────────────────────────────────────────────
 
 
-async def enqueue_task(
-    queue_key: str,
-    task: str,
-    task_id: str,
-    configurable: AgentConfigurable,
-    conversation_id: str,
-    user_message_id: str | None,
-    workflow_execution_id: str | None = None,
-) -> None:
-    """Push a task to the executor queue for deferred execution."""
-    queue_item = json.dumps(
-        build_run_item(
-            task=task,
-            task_id=task_id,
-            configurable=configurable,
-            conversation_id=conversation_id,
-            user_message_id=user_message_id,
-            workflow_execution_id=workflow_execution_id,
-        )
-    )
+async def enqueue_task(queue_key: str, item: ExecutorRunItem) -> None:
+    """Push a run item (see :func:`build_run_item`) to the executor queue.
+
+    Takes the built item rather than its fields: the item is the one shape a
+    queued run is rebuilt from, so the fields it carries belong in one place.
+    """
+    queue_item = json.dumps(item)
     if redis_cache.client:
         await redis_cache.client.rpush(queue_key, queue_item)
         await redis_cache.client.expire(queue_key, EXECUTOR_QUEUE_TTL)
@@ -293,13 +280,20 @@ async def enqueue_collection_run(
     }
     configurable.pop("subagent_id", None)
     await enqueue_task(
-        queue_key=f"{EXECUTOR_QUEUE_PREFIX}{conversation_id}",
-        task=EXECUTOR_COLLECTION_TASK,
-        task_id=str(uuid4()),
-        configurable=configurable,
-        conversation_id=conversation_id,
-        user_message_id=None,
-        workflow_execution_id=workflow_execution_id,
+        f"{EXECUTOR_QUEUE_PREFIX}{conversation_id}",
+        build_run_item(
+            task=EXECUTOR_COLLECTION_TASK,
+            configurable=configurable,
+            # The stream is minted at dequeue; a collection turn is a queued run.
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id=conversation_id,
+                kind=RunKind.QUEUED,
+                task_id=str(uuid4()),
+                user_message_id=None,
+            ),
+            workflow_execution_id=workflow_execution_id,
+        ),
     )
     log.info(
         f"{LogTag.AGENT} Queued background-subagent collection turn",
@@ -363,11 +357,8 @@ async def pop_next_queued_run(conversation_id: str) -> PreparedQueuedTask | None
 def build_run_item(
     *,
     task: str,
-    task_id: str | None,
     configurable: AgentConfigurable,
-    conversation_id: str,
-    user_message_id: str | None,
-    bot_message_id: str | None = None,
+    identity: RunIdentity,
     workflow_execution_id: str | None = None,
 ) -> ExecutorRunItem:
     """The one serialized run-context shape: written by the queue and the HIL
@@ -379,11 +370,11 @@ def build_run_item(
     pause is recorded from inside the run's boundary, not the workflow task's."""
     return {
         "task": task,
-        "task_id": task_id,
+        "task_id": identity.task_id,
         "configurable": safe_configurable(configurable),
-        "conversation_id": conversation_id,
-        "user_message_id": user_message_id,
-        "bot_message_id": bot_message_id,
+        "conversation_id": identity.conversation_id,
+        "user_message_id": identity.user_message_id,
+        "bot_message_id": identity.bot_message_id,
         "workflow_execution_id": workflow_execution_id or current_workflow_execution_id(),
     }
 

--- a/apps/api/app/agents/core/background/executor_runner.py
+++ b/apps/api/app/agents/core/background/executor_runner.py
@@ -65,7 +65,7 @@ from app.services.hil.approvals_store import (
 from app.services.hil.resume_slot import release_resume_dispatch
 from app.utils.agent_utils import format_sse_data
 from app.utils.background_tasks import spawn_background_task
-from shared.py.wide_events import get_trace_id, log, wide_task
+from shared.py.wide_events import WorkflowContext, get_trace_id, log, wide_task
 
 #: Task name for a queued executor run. Tests drain by this name to wait out
 #: exactly the runs a turn handed off, not every background task in the process.
@@ -113,6 +113,20 @@ async def run_executor_background(
         # and executor turns are the expensive ones, so the under-count lands
         # exactly where COGS-by-channel matters most.
         conversation_source=configurable.get("conversation_source"),
+        # The workflow run this executor is part of. The workflow task stamped
+        # it on ITS boundary; this one is fresh, so without carrying it over
+        # every model call the executor makes lands in the ledger with the
+        # workflow but no execution — and "what did this run cost" reads only
+        # the comms shell, a few percent of the real figure.
+        **(
+            {
+                "workflow": WorkflowContext(
+                    id=run.workflow_id, execution_id=run.workflow_execution_id
+                )
+            }
+            if run.workflow_id and run.workflow_execution_id
+            else {}
+        ),
     ):
         result_text = ""
         result_type = "final"

--- a/apps/api/app/agents/core/background/executor_runner.py
+++ b/apps/api/app/agents/core/background/executor_runner.py
@@ -194,6 +194,7 @@ async def _record_pause(
             conversation_id=run.conversation_id,
             user_message_id=run.user_message_id,
             bot_message_id=run.bot_message_id,
+            workflow_execution_id=run.workflow_execution_id,
         )
         for approval_id in approval_ids:
             await set_resume_item(approval_id, item)
@@ -397,6 +398,7 @@ async def _queue_collection_if_uncollected(run: ExecutorRun, task: str) -> None:
                     "user_name": run.user.get("name", ""),
                     "user_timezone": run.user.get("timezone"),
                 },
+                workflow_execution_id=run.workflow_execution_id,
             )
     except Exception as e:  # a failed wake must not strand the queue handoff
         log.error(

--- a/apps/api/app/agents/core/background/executor_runner.py
+++ b/apps/api/app/agents/core/background/executor_runner.py
@@ -189,11 +189,8 @@ async def _record_pause(
     try:
         item = build_run_item(
             task=task,
-            task_id=run.task_id,
             configurable=configurable,
-            conversation_id=run.conversation_id,
-            user_message_id=run.user_message_id,
-            bot_message_id=run.bot_message_id,
+            identity=run.identity,
             workflow_execution_id=run.workflow_execution_id,
         )
         for approval_id in approval_ids:

--- a/apps/api/app/agents/core/background/session.py
+++ b/apps/api/app/agents/core/background/session.py
@@ -93,11 +93,14 @@ class RunIdentity:
     object beside the LangGraph ``configurable`` it reads the rest from.
     """
 
-    stream_id: str
     conversation_id: str
-    kind: RunKind
     task_id: str | None
     user_message_id: str | None
+    #: Empty until the run is dispatched: a queued item is written before its
+    #: stream exists (``prepare_run_from_item`` mints one at dequeue), and a
+    #: run with no stream yet is by definition a queued one.
+    stream_id: str = ""
+    kind: RunKind = RunKind.QUEUED
     #: The ORIGINAL live turn's bot message id — see ``ExecutorRun.bot_message_id``.
     bot_message_id: str | None = None
 

--- a/apps/api/app/agents/core/background/session.py
+++ b/apps/api/app/agents/core/background/session.py
@@ -172,6 +172,18 @@ class ExecutorRun:
         )
 
     @property
+    def identity(self) -> RunIdentity:
+        """This run's identity, in the shape a stored run item is written from."""
+        return RunIdentity(
+            stream_id=self.stream_id,
+            conversation_id=self.conversation_id,
+            kind=self.kind,
+            task_id=self.task_id,
+            user_message_id=self.user_message_id,
+            bot_message_id=self.bot_message_id,
+        )
+
+    @property
     def is_queued(self) -> bool:
         return self.kind is RunKind.QUEUED
 

--- a/apps/api/app/agents/core/background/session.py
+++ b/apps/api/app/agents/core/background/session.py
@@ -136,8 +136,15 @@ class ExecutorRun:
         configurable: AgentConfigurable,
         *,
         identity: RunIdentity,
+        workflow_execution_id: str | None = None,
     ) -> "ExecutorRun":
-        """Build the run context from a LangGraph ``configurable`` dict."""
+        """Build the run context from a LangGraph ``configurable`` dict.
+
+        ``workflow_execution_id`` is the stored one when rebuilding from a queue
+        item or HIL resume record (those rebuild in a context with no workflow
+        boundary); a live dispatch leaves it unset and reads the execution in
+        flight off the boundary it is being built in.
+        """
         return cls(
             stream_id=identity.stream_id,
             conversation_id=identity.conversation_id,
@@ -155,7 +162,7 @@ class ExecutorRun:
             user_message_id=identity.user_message_id,
             bot_message_id=identity.bot_message_id,
             workflow_id=configurable.get("workflow_id"),
-            workflow_execution_id=current_workflow_execution_id(),
+            workflow_execution_id=workflow_execution_id or current_workflow_execution_id(),
             workflow_title=configurable.get("workflow_title", ""),
             workflow_notify_on_completion=configurable.get("workflow_notify_on_completion", True),
             active_todo_id=configurable.get("active_todo_id"),

--- a/apps/api/app/agents/core/background/session.py
+++ b/apps/api/app/agents/core/background/session.py
@@ -26,7 +26,7 @@ from app.constants.log_tags import LogTag
 from app.models.agent_models import AgentConfigurable
 from app.models.chat_models import SourceCategory
 from app.models.user_models import AuthenticatedUser
-from shared.py.wide_events import log
+from shared.py.wide_events import current_workflow_execution_id, log
 
 
 class RunKind(StrEnum):
@@ -118,6 +118,10 @@ class ExecutorRun:
     #: mints a fresh message keyed on ``task_id``.
     bot_message_id: str | None = None
     workflow_id: str | None = None
+    #: The workflow execution this run belongs to. Read off the workflow task's
+    #: wide event at construction (it exists nowhere else), so the executor's
+    #: own boundary can carry it and the ledger can attribute its calls to the run.
+    workflow_execution_id: str | None = None
     workflow_title: str = ""
     workflow_notify_on_completion: bool = True
     active_todo_id: str | None = None
@@ -151,6 +155,7 @@ class ExecutorRun:
             user_message_id=identity.user_message_id,
             bot_message_id=identity.bot_message_id,
             workflow_id=configurable.get("workflow_id"),
+            workflow_execution_id=current_workflow_execution_id(),
             workflow_title=configurable.get("workflow_title", ""),
             workflow_notify_on_completion=configurable.get("workflow_notify_on_completion", True),
             active_todo_id=configurable.get("active_todo_id"),

--- a/apps/api/app/agents/tools/executor_tool.py
+++ b/apps/api/app/agents/tools/executor_tool.py
@@ -260,9 +260,7 @@ async def _dispatch_executor(
                     task=task,
                     configurable=configurable,
                     identity=RunIdentity(
-                        stream_id=stream_id or "",
                         conversation_id=conversation_id,
-                        kind=RunKind.QUEUED,
                         task_id=task_id,
                         user_message_id=user_message_id,
                     ),

--- a/apps/api/app/agents/tools/executor_tool.py
+++ b/apps/api/app/agents/tools/executor_tool.py
@@ -16,6 +16,7 @@ from langchain_core.tools import tool
 
 from app.agents.core.background.executor_queue import (
     build_lock_value,
+    build_run_item,
     decode_raw_item,
     enqueue_task,
     parse_lock_value,
@@ -254,12 +255,18 @@ async def _dispatch_executor(
             # Executor is busy with a different turn — queue for later execution
             queue_key = f"{EXECUTOR_QUEUE_PREFIX}{conversation_id}"
             await enqueue_task(
-                queue_key=queue_key,
-                task=task,
-                task_id=task_id,
-                configurable=configurable,
-                conversation_id=conversation_id,
-                user_message_id=user_message_id,
+                queue_key,
+                build_run_item(
+                    task=task,
+                    configurable=configurable,
+                    identity=RunIdentity(
+                        stream_id=stream_id or "",
+                        conversation_id=conversation_id,
+                        kind=RunKind.QUEUED,
+                        task_id=task_id,
+                        user_message_id=user_message_id,
+                    ),
+                ),
             )
             # The only record that this dispatch deferred rather than ran. The
             # returned prose below is written for the comms model, so a caller

--- a/apps/api/app/services/llm_metering.py
+++ b/apps/api/app/services/llm_metering.py
@@ -65,7 +65,7 @@ from app.db.repositories.llm_calls import (
 from app.db.repositories.usage_daily import UsageDailyIncrement
 from app.services.cost_budget import record_model_call_usage
 from app.utils.background_tasks import spawn_background_task
-from shared.py.wide_events import log
+from shared.py.wide_events import current_workflow_execution_id, log
 
 # Exception types per :func:`classify_error_family`. Curated tuples rather than
 # message matching, and ordered most-specific-first at the call site.
@@ -194,10 +194,8 @@ def _ambient_worker_context() -> dict[str, str | None]:
     request, a test), which reads back as ``None`` rather than a fabricated id.
     """
     fields = log.get()
-    workflow = fields.get("workflow")
-    execution_id = workflow.get("execution_id") if isinstance(workflow, dict) else None
     return {
-        "workflow_execution_id": str(execution_id) if execution_id else None,
+        "workflow_execution_id": current_workflow_execution_id(),
         "job_id": str(fields["job_id"]) if fields.get("job_id") else None,
         "task_name": str(fields["task"]) if fields.get("task") else None,
     }

--- a/apps/api/tests/integration/agents/test_executor_queue_roundtrip.py
+++ b/apps/api/tests/integration/agents/test_executor_queue_roundtrip.py
@@ -18,6 +18,7 @@ import json
 import pytest
 
 from app.agents.core.background.executor_queue import build_run_item
+from app.agents.core.background.session import RunIdentity, RunKind
 from app.agents.llm.lane import ModelLane
 from app.helpers.agent_helpers import AgentIdentity, AgentThread, build_agent_config
 from app.models.agent_models import AgentConfigurable, agent_configurable
@@ -55,10 +56,14 @@ def _redis_roundtrip(configurable: AgentConfigurable) -> AgentConfigurable:
     """Exactly what the queue does: serialize the item, store it, read it back."""
     item = build_run_item(
         task="send the email",
-        task_id="task-1",
         configurable=configurable,
-        conversation_id="conv-1",
-        user_message_id="msg-1",
+        identity=RunIdentity(
+            stream_id="",
+            conversation_id="conv-1",
+            kind=RunKind.QUEUED,
+            task_id="task-1",
+            user_message_id="msg-1",
+        ),
     )
     return json.loads(json.dumps(item))["configurable"]
 

--- a/apps/api/tests/unit/agents/test_executor_finalize.py
+++ b/apps/api/tests/unit/agents/test_executor_finalize.py
@@ -651,11 +651,15 @@ class TestBuildRunItem:
     def test_every_field_survives_the_round_trip_shape(self) -> None:
         item = build_run_item(
             task="triage my inbox",
-            task_id="task-1",
             configurable={"user_id": "user-1", "thread_id": "conv-1"},
-            conversation_id="conv-1",
-            user_message_id="user-msg-1",
-            bot_message_id="bot-msg-1",
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id="user-msg-1",
+                bot_message_id="bot-msg-1",
+            ),
         )
 
         assert item["task"] == "triage my inbox"
@@ -669,10 +673,14 @@ class TestBuildRunItem:
         ``prepare_run_from_item`` reads it unconditionally."""
         item = build_run_item(
             task="t",
-            task_id=None,
             configurable={"user_id": "user-1"},
-            conversation_id="conv-1",
-            user_message_id=None,
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id=None,
+                user_message_id=None,
+            ),
         )
 
         assert item["bot_message_id"] is None

--- a/apps/api/tests/unit/agents/test_executor_queue.py
+++ b/apps/api/tests/unit/agents/test_executor_queue.py
@@ -25,7 +25,7 @@ from app.agents.core.background.executor_queue import (
     release_lock_if_owned,
     safe_configurable,
 )
-from app.agents.core.background.session import RunKind, get_session
+from app.agents.core.background.session import RunIdentity, RunKind, get_session
 from app.constants.cache import EXECUTOR_BUSY_TTL, EXECUTOR_QUEUE_TTL
 from app.models.agent_models import AgentConfigurable
 
@@ -257,20 +257,26 @@ class TestEnqueueTask:
             redis.client.expire = AsyncMock()
 
             await enqueue_task(
-                queue_key="executor:queue:conv-1",
-                task="do it",
-                task_id="task-1",
-                configurable={
-                    "user_id": "u1",
-                    "workflow_id": "wf-1",
-                    # Not declared on AgentConfigurable — LangGraph's own runtime
-                    # keys look like this and must never reach the queue item.
-                    "not_owned": "dropped",
-                    # Declared, but holding something JSON cannot carry.
-                    "model_kwargs": {"provider": object()},
-                },
-                conversation_id="conv-1",
-                user_message_id="msg-1",
+                "executor:queue:conv-1",
+                build_run_item(
+                    task="do it",
+                    configurable={
+                        "user_id": "u1",
+                        "workflow_id": "wf-1",
+                        # Not declared on AgentConfigurable — LangGraph's own runtime
+                        # keys look like this and must never reach the queue item.
+                        "not_owned": "dropped",
+                        # Declared, but holding something JSON cannot carry.
+                        "model_kwargs": {"provider": object()},
+                    },
+                    identity=RunIdentity(
+                        stream_id="",
+                        conversation_id="conv-1",
+                        kind=RunKind.QUEUED,
+                        task_id="task-1",
+                        user_message_id="msg-1",
+                    ),
+                ),
             )
 
             payload = json.loads(redis.client.rpush.await_args.args[1])
@@ -290,21 +296,29 @@ class TestBuildRunItem:
     def test_omits_bot_message_id_by_default(self) -> None:
         item = build_run_item(
             task="do it",
-            task_id="task-1",
             configurable={"user_id": "u1"},
-            conversation_id="conv-1",
-            user_message_id="msg-1",
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id="msg-1",
+            ),
         )
         assert item["bot_message_id"] is None
 
     def test_carries_bot_message_id_when_a_pause_supplies_it(self) -> None:
         item = build_run_item(
             task="do it",
-            task_id="task-1",
             configurable={"user_id": "u1"},
-            conversation_id="conv-1",
-            user_message_id="msg-1",
-            bot_message_id="orig-msg-1",
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id="msg-1",
+                bot_message_id="orig-msg-1",
+            ),
         )
         assert item["bot_message_id"] == "orig-msg-1"
 
@@ -317,11 +331,15 @@ class TestPrepareRunFromItemResumeIdentity:
     async def test_bot_message_id_threads_into_the_resumed_run(self) -> None:
         item = build_run_item(
             task="continue the task",
-            task_id="task-1",
             configurable={"user_id": "u1"},
-            conversation_id="conv-1",
-            user_message_id="msg-1",
-            bot_message_id="orig-msg-1",
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id="msg-1",
+                bot_message_id="orig-msg-1",
+            ),
         )
         with (
             patch.object(eq, "redis_cache") as redis,
@@ -347,10 +365,14 @@ class TestPrepareRunFromItemResumeIdentity:
     async def test_plain_queued_item_has_no_bot_message_id(self) -> None:
         item = build_run_item(
             task="do it",
-            task_id="task-1",
             configurable={"user_id": "u1"},
-            conversation_id="conv-1",
-            user_message_id="msg-1",
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id="msg-1",
+            ),
         )
         with (
             patch.object(eq, "redis_cache") as redis,
@@ -452,10 +474,14 @@ class TestRunItemCarriesWorkflowExecution:
             log.set(workflow=WorkflowContext(id="wf-9", execution_id="exec-42"))
             item = build_run_item(
                 task="do it",
-                task_id="task-1",
                 configurable={"user_id": "u1", "workflow_id": "wf-9"},
-                conversation_id="conv-1",
-                user_message_id=None,
+                identity=RunIdentity(
+                    stream_id="",
+                    conversation_id="conv-1",
+                    kind=RunKind.QUEUED,
+                    task_id="task-1",
+                    user_message_id=None,
+                ),
             )
 
         assert item["workflow_execution_id"] == "exec-42"
@@ -463,10 +489,14 @@ class TestRunItemCarriesWorkflowExecution:
     def test_a_run_supplies_its_own_execution_id_when_pausing(self) -> None:
         item = build_run_item(
             task="do it",
-            task_id="task-1",
             configurable={"user_id": "u1", "workflow_id": "wf-9"},
-            conversation_id="conv-1",
-            user_message_id=None,
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id=None,
+            ),
             workflow_execution_id="exec-42",
         )
 
@@ -475,10 +505,14 @@ class TestRunItemCarriesWorkflowExecution:
     async def test_a_resume_outside_any_boundary_still_knows_its_execution(self) -> None:
         item = build_run_item(
             task="continue the task",
-            task_id="task-1",
             configurable={"user_id": "u1", "workflow_id": "wf-9"},
-            conversation_id="conv-1",
-            user_message_id=None,
+            identity=RunIdentity(
+                stream_id="",
+                conversation_id="conv-1",
+                kind=RunKind.QUEUED,
+                task_id="task-1",
+                user_message_id=None,
+            ),
             workflow_execution_id="exec-42",
         )
         with (

--- a/apps/api/tests/unit/agents/test_executor_queue.py
+++ b/apps/api/tests/unit/agents/test_executor_queue.py
@@ -436,3 +436,64 @@ class TestSafeConfigurable:
         assert kept == {"thread_id": "t"}
         assert warn.call_count == 1
         assert warn.call_args.kwargs["configurable_key"] == "model_kwargs"
+
+
+@pytest.mark.regression
+class TestRunItemCarriesWorkflowExecution:
+    """The execution id exists only on the workflow task's wide event. A HIL
+    resume and a queue pop both rebuild the run in some OTHER context (the
+    approval request, the previous run's finalize), so the stored item has to
+    carry it or the resumed run's calls are unattributable to the run."""
+
+    async def test_the_item_records_the_execution_in_flight(self) -> None:
+        from shared.py.wide_events import WorkflowContext, log, wide_task
+
+        async with wide_task("workflow_execution"):
+            log.set(workflow=WorkflowContext(id="wf-9", execution_id="exec-42"))
+            item = build_run_item(
+                task="do it",
+                task_id="task-1",
+                configurable={"user_id": "u1", "workflow_id": "wf-9"},
+                conversation_id="conv-1",
+                user_message_id=None,
+            )
+
+        assert item["workflow_execution_id"] == "exec-42"
+
+    def test_a_run_supplies_its_own_execution_id_when_pausing(self) -> None:
+        item = build_run_item(
+            task="do it",
+            task_id="task-1",
+            configurable={"user_id": "u1", "workflow_id": "wf-9"},
+            conversation_id="conv-1",
+            user_message_id=None,
+            workflow_execution_id="exec-42",
+        )
+
+        assert item["workflow_execution_id"] == "exec-42"
+
+    async def test_a_resume_outside_any_boundary_still_knows_its_execution(self) -> None:
+        item = build_run_item(
+            task="continue the task",
+            task_id="task-1",
+            configurable={"user_id": "u1", "workflow_id": "wf-9"},
+            conversation_id="conv-1",
+            user_message_id=None,
+            workflow_execution_id="exec-42",
+        )
+        with (
+            patch.object(eq, "redis_cache") as redis,
+            patch.object(eq, "StreamManager") as sm,
+            patch.object(eq, "websocket_manager") as ws,
+        ):
+            redis.client.set = AsyncMock()
+            sm.start_stream = AsyncMock()
+            ws.broadcast_to_user = AsyncMock()
+
+            # No wide-event boundary here on purpose: this is the approval
+            # request's context, where the workflow task's stamp never existed.
+            prepared = await prepare_run_from_item("conv-1", item)
+
+        assert prepared is not None
+        assert prepared.run.workflow_id == "wf-9"
+        assert prepared.run.workflow_execution_id == "exec-42"

--- a/apps/api/tests/unit/agents/test_executor_runner_delivery.py
+++ b/apps/api/tests/unit/agents/test_executor_runner_delivery.py
@@ -2118,3 +2118,42 @@ class TestRunBoundaryCarriesWorkflowExecution:
             )
 
         assert seen["workflow"] == {"id": "wf-9", "execution_id": "exec-42"}
+
+    @pytest.mark.parametrize(
+        ("workflow_id", "execution_id"),
+        [("wf-9", None), (None, "exec-42"), (None, None)],
+        ids=["workflow-without-execution", "execution-without-workflow", "plain-run"],
+    )
+    async def test_a_run_missing_either_id_stamps_no_workflow(
+        self, workflow_id: str | None, execution_id: str | None
+    ) -> None:
+        """Half an identity is worse than none: a boundary stamped with only a
+        workflow id would attribute the run's calls to a workflow's *unknown*
+        execution, which is the very gap this fix closes."""
+        from app.agents.core.background.executor_runner import _ExecutorResult
+        from shared.py.wide_events import log
+
+        run = ExecutorRun(
+            stream_id="stream-1",
+            conversation_id="conv-1",
+            user={"user_id": "user-1"},
+            kind=RunKind.LIVE,
+            task_id="task-1",
+            user_message_id=None,
+            workflow_id=workflow_id,
+            workflow_execution_id=execution_id,
+        )
+        seen: dict[str, object] = {}
+
+        async def capture(*_args: object, **_kwargs: object) -> _ExecutorResult:
+            seen["workflow"] = log.get().get("workflow")
+            return _ExecutorResult("done", "final")
+
+        with (
+            patch("app.agents.core.background.executor_runner.capture_event"),
+            patch.object(er, "_execute_executor", side_effect=capture),
+            patch.object(er, "_finalize_executor_run", new_callable=AsyncMock),
+        ):
+            await er.run_executor_background(run, "do things", {"user_id": "user-1"})
+
+        assert seen["workflow"] is None

--- a/apps/api/tests/unit/agents/test_executor_runner_delivery.py
+++ b/apps/api/tests/unit/agents/test_executor_runner_delivery.py
@@ -2078,3 +2078,43 @@ class TestRunBoundaryCarriesTheOriginatingSurface:
         fields = await self._boundary_fields({"user_id": "u1"})
 
         assert fields["conversation_source"] is None
+
+
+@pytest.mark.regression
+class TestRunBoundaryCarriesWorkflowExecution:
+    """``run_executor_background`` opens its own wide-event boundary. The
+    workflow task stamped ``workflow.execution_id`` on ITS boundary, so unless
+    the run carries it across, every model call inside the executor lands in
+    the ledger with a workflow but no execution — which is exactly what
+    happened: $8 of a $10 workflow day was attributed to no run at all."""
+
+    async def test_executor_calls_see_the_workflow_execution(self) -> None:
+        from app.agents.core.background.executor_runner import _ExecutorResult
+        from shared.py.wide_events import log
+
+        run = ExecutorRun(
+            stream_id="stream-1",
+            conversation_id="conv-1",
+            user={"user_id": "user-1"},
+            kind=RunKind.LIVE,
+            task_id="task-1",
+            user_message_id=None,
+            workflow_id="wf-9",
+            workflow_execution_id="exec-42",
+        )
+        seen: dict[str, object] = {}
+
+        async def capture(*_args: object, **_kwargs: object) -> _ExecutorResult:
+            seen["workflow"] = log.get().get("workflow")
+            return _ExecutorResult("done", "final")
+
+        with (
+            patch("app.agents.core.background.executor_runner.capture_event"),
+            patch.object(er, "_execute_executor", side_effect=capture),
+            patch.object(er, "_finalize_executor_run", new_callable=AsyncMock),
+        ):
+            await er.run_executor_background(
+                run, "do things", {"user_id": "user-1", "workflow_id": "wf-9"}
+            )
+
+        assert seen["workflow"] == {"id": "wf-9", "execution_id": "exec-42"}

--- a/apps/api/tests/unit/agents/test_stream_session.py
+++ b/apps/api/tests/unit/agents/test_stream_session.py
@@ -283,3 +283,42 @@ class TestToolOutputOwnership:
     def test_ownership_for_missing_session_is_safe(self) -> None:
         note_tool_output_owner("missing", "tc_fetch", "row-1")  # must not raise
         assert claim_tool_output("missing", "tc_fetch", None) is True
+
+
+@pytest.mark.regression
+class TestExecutorRunCarriesWorkflowExecution:
+    """The execution id lives only on the workflow task's wide event, never in
+    ``configurable``; the run built inside that boundary has to pick it up or
+    every executor call it makes is unattributable to the run in the ledger."""
+
+    async def test_from_configurable_reads_the_execution_id_off_the_boundary(self) -> None:
+        from shared.py.wide_events import WorkflowContext, log, wide_task
+
+        async with wide_task("workflow_execution"):
+            log.set(workflow=WorkflowContext(id="wf-9", execution_id="exec-42"))
+            run = ExecutorRun.from_configurable(
+                {"workflow_id": "wf-9"},
+                identity=RunIdentity(
+                    stream_id="s1",
+                    conversation_id="conv-1",
+                    kind=RunKind.LIVE,
+                    task_id=None,
+                    user_message_id=None,
+                ),
+            )
+
+        assert run.workflow_execution_id == "exec-42"
+
+    def test_no_boundary_means_no_execution_id(self) -> None:
+        run = ExecutorRun.from_configurable(
+            {},
+            identity=RunIdentity(
+                stream_id="s1",
+                conversation_id="conv-1",
+                kind=RunKind.LIVE,
+                task_id=None,
+                user_message_id=None,
+            ),
+        )
+
+        assert run.workflow_execution_id is None

--- a/apps/api/tests/unit/tools/test_executor_tool.py
+++ b/apps/api/tests/unit/tools/test_executor_tool.py
@@ -517,7 +517,7 @@ class TestCallExecutorFailures:
         """An unconditional release here let a second executor run concurrently."""
         await fake_redis.set(LOCK_KEY, "stream-1:live-task", ex=EXECUTOR_BUSY_TTL)
 
-        async def explode(**kwargs: Any) -> None:
+        async def explode(*args: Any, **kwargs: Any) -> None:
             raise RuntimeError("redis write failed")
 
         monkeypatch.setattr(executor_tool, "enqueue_task", explode)

--- a/libs/shared/py/wide_events.py
+++ b/libs/shared/py/wide_events.py
@@ -848,6 +848,21 @@ async def _wide_event_boundary(
         _trace_id.set(outer_trace_id)
 
 
+def current_workflow_execution_id() -> str | None:
+    """The workflow execution the code in flight belongs to, if any.
+
+    The workflow task stamps ``workflow.execution_id`` on its boundary and
+    nothing else carries it — it is not in ``config.configurable``. Anything
+    that needs to attribute work to a run (the ledger, a run spawned from
+    inside the workflow) reads it from here, so the two can never disagree.
+    """
+    workflow = log.get().get("workflow")
+    if not isinstance(workflow, dict):
+        return None
+    execution_id = workflow.get("execution_id")
+    return str(execution_id) if execution_id else None
+
+
 def wide_task(
     task_name: str, *, trace_id: str | None = None, **initial_context: Any
 ) -> contextlib.AbstractAsyncContextManager[WideEventLogger]:


### PR DESCRIPTION
## What

Executor (and subagent) model calls made inside a workflow run land in `llm_calls` with a `workflow_id` but **no `workflow_execution_id`**. Per-workflow attribution is correct; per-*run* cost is understated ~6× because only the comms shell call carries the execution id.

Measured on prod, 2026-09-01: **$8.05 of $10.08** of workflow spend (5,594 calls) had no execution id; the 618 recorded runs read a median of $0.0025 when the real figure is ~$0.016.

## Why

`workflow_tasks.py` stamps `workflow.execution_id` on the ARQ task's wide-event boundary — the only place it exists (never in `config.configurable`). `llm_metering._ambient_worker_context` reads it from there. The executor runs in `run_executor_background`, which opens a **fresh** `wide_task("executor_run", …)` seeded with trace/conversation/stream/task/`conversation_source` — not the workflow namespace — so inside it the metering seam finds nothing. (`workflow_id` survives only because it travels separately via `configurable`.)

## How

- `ExecutorRun.workflow_execution_id`: read off the boundary the run is built in (`from_configurable`), exactly how `conversation_source` already travels. Queued/resumed runs are rebuilt inside the previous run's boundary, so it propagates.
- `run_executor_background` seeds its boundary with `workflow=WorkflowContext(id, execution_id)` when the run has one.
- `current_workflow_execution_id()` in `shared.py.wide_events` is the one reader; the metering seam's inline extraction now uses it, so ledger and run can't disagree.

## Verified

- Regression tests, **red before the fix** (`AttributeError: 'ExecutorRun' object has no attribute 'workflow_execution_id'` / boundary assertion), green after: `uv run pytest tests/unit/agents/test_stream_session.py tests/unit/agents/test_executor_runner_delivery.py -k WorkflowExecution` → 3 passed; wider run of the touched areas → 125 passed.
- `ruff` + `mypy` clean on all touched files.
- NOT verified: a live workflow run against prod after deploy — will confirm via the ledger (executor rows carrying `workflow_execution_id`) once this ships.