### PR TITLE
feat(integrations): run vendor CLIs as a first-party integration transport

### DIFF
--- a/apps/api/.pre-commit-config.yaml
+++ b/apps/api/.pre-commit-config.yaml
@@ -90,5 +90,11 @@ repos:
         # apps/api-relative: this nested config runs with cwd=apps/api, so
         # ^apps/api/app/ can never match and the hook would always skip.
         files: ^app/
+        # `files` alone matches every file under app/, including the non-Python
+        # ones that live there (skill SKILL.md bodies, bundled resources).
+        # Handing mypy a Markdown file makes it fail as a syntax error on the
+        # first non-ASCII character, blocking a commit for a reason that has
+        # nothing to do with types.
+        types: [python]
         pass_filenames: true
         priority: 0

--- a/apps/api/app/agents/core/subagents/handoff_tools.py
+++ b/apps/api/app/agents/core/subagents/handoff_tools.py
@@ -38,6 +38,7 @@ from app.agents.core.subagents.call_record import append_call_record
 from app.agents.core.subagents.provider_subagents import (
     SubagentUnavailableError,
     create_subagent_for_user,
+    custom_subagent_name,
 )
 from app.agents.core.subagents.registry import (
     all_subagents,
@@ -226,7 +227,10 @@ async def _get_subagent_by_id(subagent_id: str) -> Subagent | dict[str, Any] | N
             "id": doc.get("integration_id"),
             "name": doc.get("name"),
             "source": resolved.source,
-            "managed_by": "mcp",
+            # The document's own transport, not an assumed one: a CLI-backed
+            # integration reaching this fallback would otherwise be labelled and
+            # named as an MCP for the rest of the handoff.
+            "managed_by": resolved.managed_by,
             "mcp_config": doc.get("mcp_config"),
             "icon_url": doc.get("icon_url"),
             "subagent_config": None,
@@ -300,7 +304,7 @@ async def _resolve_custom_mcp_subagent(
     resolved: dict[str, Any],
     user_id: str | None,
 ) -> tuple[CompiledAgentGraph | None, str | None, str | None, bool]:
-    """Resolve a custom MCP (a MongoDB dict) into the `_resolve_subagent` tuple."""
+    """Resolve a custom integration (a MongoDB dict) into the `_resolve_subagent` tuple."""
     integration_id = str(resolved.get("id", ""))
     integration_name = str(resolved.get("name", integration_id))
 
@@ -315,7 +319,6 @@ async def _resolve_custom_mcp_subagent(
             False,
         )
 
-    # Create subagent for custom MCP
     try:
         subagent_graph = await create_subagent_for_user(integration_id, user_id)
     except SubagentUnavailableError as e:
@@ -326,7 +329,7 @@ async def _resolve_custom_mcp_subagent(
             False,
         )
 
-    agent_name = f"custom_mcp_{integration_id}"
+    agent_name = custom_subagent_name(integration_id, is_cli=resolved.get("managed_by") == "cli")
     return subagent_graph, agent_name, integration_id, True
 
 

--- a/apps/api/app/agents/core/subagents/provider_subagents.py
+++ b/apps/api/app/agents/core/subagents/provider_subagents.py
@@ -99,7 +99,14 @@ async def register_cli_subagent_tools(subagent: Subagent, tool_registry: ToolReg
         )
     await register_cli_tools(
         tool_registry,
-        CliIntegration(id=subagent.id, name=integration.name, config=integration.cli_config),
+        CliIntegration(
+            id=subagent.id,
+            name=integration.name,
+            config=integration.cli_config,
+            # Reached only via the OAUTH_INTEGRATIONS lookup above, so this is
+            # by definition a curated platform entry.
+            is_platform=True,
+        ),
         tool_space=subagent.config.tool_space,
     )
 
@@ -128,7 +135,12 @@ async def register_cli_tools(
     if integration.id in tool_registry._categories:
         return
 
-    tool = build_cli_tool(integration.id, integration.name, integration.config)
+    tool = build_cli_tool(
+        integration.id,
+        integration.name,
+        integration.config,
+        is_platform=integration.is_platform,
+    )
     tool_registry._add_category(
         name=integration.id,
         tools=[tool],

--- a/apps/api/app/agents/core/subagents/provider_subagents.py
+++ b/apps/api/app/agents/core/subagents/provider_subagents.py
@@ -15,6 +15,7 @@ from langgraph.graph.state import CompiledStateGraph
 
 from app.agents.core.subagents.registry import all_subagents, get_subagent_by_id
 from app.agents.llm.client import init_llm
+from app.agents.tools.cli.cli_tool import build_cli_tool
 from app.agents.tools.core.registry import (
     CategoryOptions,
     CategoryRisk,
@@ -26,8 +27,10 @@ from app.config.oauth_config import get_integration_by_id
 from app.constants.log_tags import LogTag
 from app.core.lazy_loader import providers
 from app.db.repositories.integrations import integration_repository
+from app.db.repositories.user_integrations import user_integration_repository
 from app.helpers.namespace_utils import derive_integration_namespace
 from app.models.subagent_models import Subagent
+from app.services.cli.tools import CliIntegration, resolve_cli_integration
 from app.services.mcp.mcp_client import get_mcp_client
 from shared.py.wide_events import log
 
@@ -76,6 +79,87 @@ async def register_composio_subagent_tools(subagent: Subagent, tool_registry: To
         specific_tools=config.specific_tools,
         exclude_tools=config.exclude_tools,
     )
+
+
+async def register_cli_subagent_tools(subagent: Subagent, tool_registry: ToolRegistry) -> None:
+    """Put a platform CLI integration's single tool in the registry.
+
+    ``Subagent`` does not carry cli_config; the OAuth integration does. The
+    OAuthIntegration validator enforces cli_config when managed_by="cli", so
+    landing here without one means an entry declared that transport and never
+    described the CLI — which would build a tool-less agent that reports
+    healthy. Fail loudly instead, exactly as the Composio path does.
+    """
+    integration = get_integration_by_id(subagent.id)
+    if integration is None or integration.cli_config is None:
+        raise ValueError(
+            f"CLI subagent {subagent.id!r} has no matching OAuth integration "
+            f"with cli_config. managed_by='cli' must correspond to an "
+            f"OAUTH_INTEGRATIONS entry."
+        )
+    await register_cli_tools(
+        tool_registry,
+        CliIntegration(id=subagent.id, name=integration.name, config=integration.cli_config),
+        tool_space=subagent.config.tool_space,
+    )
+
+
+async def register_cli_tools(
+    tool_registry: ToolRegistry, integration: CliIntegration, tool_space: str
+) -> None:
+    """Register, once per process, the one tool that runs this integration's CLI.
+
+    A CLI integration is delegated and integration-gated exactly like a Composio
+    toolkit, so it gets the same category shape: keyed by integration id, spaced
+    by the subagent's tool_space (which is how ``build_scoped_tool_dict`` finds
+    it), delegated so the main executor discovers the subagent rather than the
+    raw shell, and require_integration so the tools catalog reports it locked
+    until the user connects.
+
+    Unlike the per-user MCP tools, this category is process-global on purpose:
+    the tool closes over the integration, never over a user, and resolves the
+    sandbox and the credentials from the run's user at call time.
+
+    Risk stays with ``integration_destructive_tools`` — uncurated means the HIL
+    classifier judges each command at gate time, which is the only workable
+    verdict when one tool name covers ``gh pr list`` and ``gh repo delete``
+    alike.
+    """
+    if integration.id in tool_registry._categories:
+        return
+
+    tool = build_cli_tool(integration.id, integration.name, integration.config)
+    tool_registry._add_category(
+        name=integration.id,
+        tools=[tool],
+        options=CategoryOptions(
+            space=tool_space,
+            require_integration=True,
+            integration_name=integration.id,
+            is_delegated=True,
+        ),
+        risk=CategoryRisk(destructive_tools=integration_destructive_tools(integration.id)),
+    )
+    await tool_registry._index_category_tools(integration.id)
+
+    log.set(cli={"integration_id": integration.id, "command": integration.config.command})
+    log.info(
+        f"{LogTag.AGENT} Registered CLI integration tool",
+        integration_id=integration.id,
+        command=integration.config.command,
+        tool_name=tool.name,
+        tool_space=tool_space,
+    )
+
+
+def custom_subagent_name(integration_id: str, *, is_cli: bool) -> str:
+    """Graph name for a user-created integration's subagent.
+
+    Defined once because the handoff layer derives the same name for its call
+    records: two copies of the convention drift the moment a transport is added
+    — which is exactly what CLI would have done.
+    """
+    return f"custom_{'cli' if is_cli else 'mcp'}_{integration_id}"
 
 
 async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
@@ -137,6 +221,12 @@ async def create_subagent(subagent: Subagent) -> CompiledStateGraph:
     elif subagent.managed_by == "composio":
         await register_composio_subagent_tools(subagent, tool_registry)
 
+    # CLI integrations: one tool, registered here rather than per user. Whether
+    # THIS user may reach it is settled before the graph is asked for — handoff
+    # runs the connection check for every non-MCP, non-internal transport.
+    elif subagent.managed_by == "cli":
+        await register_cli_subagent_tools(subagent, tool_registry)
+
     llm = init_llm()
 
     log.set(subagent={"name": config.agent_name, "provider": subagent.provider})
@@ -185,9 +275,14 @@ async def _build_user_subagent(integration_id: str, user_id: str) -> CompiledSta
     """
     subagent = get_subagent_by_id(integration_id)
 
-    # Custom MCPs from MongoDB (not in static registry) — IDs can be 'custom_'
-    # prefixed or 12-char hex.
+    # Custom integrations from MongoDB (not in static registry) — IDs can be
+    # 'custom_' prefixed or 12-char hex. A CLI-backed one is dispatched on its
+    # spec here rather than inside the MCP builder, so that builder keeps owning
+    # exactly one transport.
     if not subagent:
+        cli_integration = await resolve_cli_integration(integration_id)
+        if cli_integration is not None:
+            return await _create_custom_cli_subagent(cli_integration, user_id)
         return await _create_custom_mcp_subagent(integration_id, user_id)
 
     mcp_config = subagent.mcp_config
@@ -313,7 +408,7 @@ async def _create_custom_mcp_subagent(integration_id: str, user_id: str) -> Comp
         raise SubagentUnavailableError(f"{integration_id} exposed no usable tools")
 
     llm = init_llm()
-    agent_name = f"custom_mcp_{integration_id}"
+    agent_name = custom_subagent_name(integration_id, is_cli=False)
 
     log.set(subagent={"name": agent_name, "provider": integration_id})
 
@@ -346,6 +441,70 @@ async def _create_custom_mcp_subagent(integration_id: str, user_id: str) -> Comp
         f"{LogTag.AGENT} Custom MCP subagent created successfully",
         agent_name=agent_name,
         integration_id=integration_id,
+        user_id=user_id,
+    )
+    return graph
+
+
+async def _create_custom_cli_subagent(
+    integration: CliIntegration, user_id: str
+) -> CompiledStateGraph:
+    """Build a subagent graph for a user-created CLI integration from MongoDB.
+
+    The connection check lives here because this is the only place it can: a
+    platform CLI integration is gated by handoff before its graph is ever asked
+    for, but a custom one is resolved straight out of Mongo and never passes
+    that check. Skipping it would hand the model a CLI that is installed and
+    signed in for nobody, and the failure would surface as vendor auth errors
+    rather than "connect this first".
+
+    The integration's id is its namespace: unlike a custom MCP there is no
+    server URL to derive one from, and the id is already unique per document.
+    """
+    if not await user_integration_repository.is_connected(user_id, integration.id):
+        log.warning(
+            f"{LogTag.AGENT} Custom CLI subagent refused: integration not connected",
+            integration_id=integration.id,
+            user_id=user_id,
+        )
+        # Dash-free: this reason is relayed to the model verbatim by handoff.
+        raise SubagentUnavailableError(
+            f"{integration.name} is not connected. Ask the user to connect it first."
+        )
+
+    tool_registry = await get_tool_registry()
+    await register_cli_tools(tool_registry, integration, tool_space=integration.id)
+
+    llm = init_llm()
+    agent_name = custom_subagent_name(integration.id, is_cli=True)
+
+    log.set(subagent={"name": agent_name, "provider": integration.id})
+    log.info(
+        f"{LogTag.AGENT} Creating custom CLI subagent",
+        agent_name=agent_name,
+        integration_id=integration.id,
+        command=integration.config.command,
+        user_id=user_id,
+    )
+
+    graph = await SubAgentFactory.create_provider_subagent(
+        provider=integration.id,
+        llm=llm,
+        name=agent_name,
+        config=SubAgentToolConfig(
+            tool_space=integration.id,
+            # One tool, so retrieval can only ever return that same tool: bind
+            # it up front and skip the round trip.
+            use_direct_tools=True,
+            disable_retrieve_tools=True,
+            source_label=integration.name,
+        ),
+    )
+
+    log.info(
+        f"{LogTag.AGENT} Custom CLI subagent created successfully",
+        agent_name=agent_name,
+        integration_id=integration.id,
         user_id=user_id,
     )
     return graph

--- a/apps/api/app/agents/prompts/subagent_prompts.py
+++ b/apps/api/app/agents/prompts/subagent_prompts.py
@@ -2521,3 +2521,58 @@ fetched content, OR when you have explored and concluded the docs do not
 contain the answer.
 """,
 )
+
+STRIPE_LINK_AGENT_SYSTEM_PROMPT = BASE_SUBAGENT_PROMPT.format(
+    provider_name="Stripe Link",
+    domain_expertise="making payments on the user's behalf with one-time, approval-gated payment credentials",
+    provider_specific_content="""
+## DOMAIN OVERVIEW
+Stripe Link issues SINGLE-USE payment credentials from the user's own Link wallet.
+Their real card is never exposed, and the user approves every purchase in the Link
+app before a credential exists. You drive the `link-cli` command-line tool through
+the `run_link_cli` tool.
+
+## THE ONE THING TO UNDERSTAND
+A purchase is not a single call. It is:
+1. `link-cli spend-request create`; describe the purchase (merchant, amount, why).
+2. `link-cli spend-request request-approval <id>`; ask the user to approve.
+3. The user approves in the Link app. Only then does a usable credential exist.
+4. `link-cli spend-request retrieve <id>`; read the credential and pay.
+
+You cannot skip step 3 and you cannot approve on the user's behalf. If approval is
+pending, say so and stop; do not poll in a tight loop or re-create the request.
+
+## LEARN THE TOOL, DON'T GUESS IT
+Flags change between releases. Before using a subcommand you have not used in this
+conversation, run its help; `link-cli spend-request create --help`; or
+`link-cli --llms` for the full command list. Guessing a flag wastes a turn; reading
+help costs one cheap call.
+
+## OUTPUT
+Always pass `--format json` when you intend to read a value out of the result.
+Many commands return a `_next` object naming the exact next command to run; prefer
+it over composing one yourself.
+
+## HANDLING CARD DETAILS
+NEVER print a card number. When a command can emit raw card data, use its
+`--output-file` flag so the number goes to a file and stays out of the
+conversation, then use the file. Report the last four digits at most.
+
+## LIMITS THAT WILL BITE YOU
+Per-request and per-day spend caps apply, the approval window is minutes not hours,
+and credentials expire. If a request expires, create a new one rather than retrying
+the old id. Surface the CLI's own error text to the user; it says what the actual
+limit was.
+
+## TESTING
+`--test` yields test-mode credentials (a test card number, no real money). Use it
+whenever the user is trying things out, and say clearly that it was test mode.
+
+## EXECUTION RULES
+- State the merchant and the exact amount back to the user before creating a request.
+- One spend request per purchase. Never reuse an approved credential for a second buy.
+- After a purchase attempt, run `link-cli report` so Stripe sees the outcome.
+- If the user is not authenticated, tell them to connect Stripe Link in Integrations
+ ; do not attempt `auth login` yourself, the connect flow owns that.
+""",
+)

--- a/apps/api/app/agents/skills/builtin/stripe-link-purchase/SKILL.md
+++ b/apps/api/app/agents/skills/builtin/stripe-link-purchase/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: stripe-link-purchase
+description: Buy something on the user's behalf with Stripe Link — create a spend request, get the user's approval, then pay with the one-time credential. Covers test mode and the limits that bite.
+target: stripe_link_agent
+---
+
+# Stripe Link: Paying For Something
+
+## When to Activate
+The user asks you to buy, order, pay for, or subscribe to something, or to pay an
+API/endpoint that returns HTTP 402.
+
+## The Shape of a Purchase
+
+A purchase is four steps and the third one is not yours:
+
+```
+create  ->  request-approval  ->  [USER APPROVES IN LINK APP]  ->  retrieve + pay
+```
+
+You cannot approve for them. If approval is pending, tell the user and stop.
+
+## Step 0: Know What You're Buying
+
+Before touching the CLI, be able to state:
+
+- **merchant name** and **merchant URL** — where the money goes
+- **amount** and currency — exactly
+- **why** — a real description; the CLI requires a substantial `context` string and
+  the user reads it when approving
+
+If you are missing any of these, ask. Do not invent a merchant or round an amount.
+
+## Step 1: Check the Flags Before You Use Them
+
+```
+run_link_cli: link-cli spend-request create --help
+```
+
+Read it. Flags differ between versions, and a wrong guess costs a whole turn. For
+the full command list: `link-cli --llms`.
+
+## Step 2: Create the Spend Request
+
+```
+run_link_cli: link-cli spend-request create \
+  --merchant-name "..." --merchant-url "..." \
+  --amount <minor units or as --help specifies> \
+  --context "..." --format json
+```
+
+Add `--test` when the user is trying things out. Say clearly afterwards that it was
+test mode.
+
+Keep the returned `id`.
+
+## Step 3: Ask For Approval
+
+```
+run_link_cli: link-cli spend-request request-approval <id> --format json
+```
+
+This pushes a notification to the user's Link app. Then:
+
+- Tell the user, in plain words, that a request for `<amount>` at `<merchant>` is
+  waiting for approval in their Link app.
+- If the response carries a `_next` object, prefer its command over composing one.
+- Do NOT loop on retrieve waiting for them. One status check is fine; then report
+  and stop.
+
+## Step 4: Retrieve and Pay
+
+Once approved:
+
+```
+run_link_cli: link-cli spend-request retrieve <id> --format json
+```
+
+**Never print a card number.** When you need the raw card, use the command's
+`--output-file` flag so it lands in a file and stays out of the conversation, then
+read from that file. Tell the user at most the last four digits.
+
+For a 402-gated URL, `link-cli mpp pay <url>` does the whole flow; prefer its
+`_next.pay_argv` over building a shell string yourself.
+
+## Step 5: Report the Outcome
+
+```
+run_link_cli: link-cli report ...
+```
+
+Run this after every purchase attempt, success or failure. Stripe uses it to keep
+checkout working; skipping it degrades the service for everyone.
+
+## Limits That Will Bite You
+
+- There are per-request and per-day spend caps. A rejection tells you the real
+  number — surface that text to the user rather than paraphrasing.
+- The approval window is minutes. An expired request cannot be revived: create a
+  new one, and say why.
+- Credentials are single-use and expire. Never reuse one for a second purchase.
+
+## Failure Handling
+
+- **Not authenticated** — tell the user to connect Stripe Link on the Integrations
+  page. Do not run `auth login` yourself; the connect flow owns that and your
+  invocation would strand a device code nobody sees.
+- **Approval denied** — accept it. Do not create a near-identical request.
+- **Anything else** — surface the CLI's own error text. It is written for a human
+  and is almost always actionable.

--- a/apps/api/app/agents/tools/cli/cli_tool.py
+++ b/apps/api/app/agents/tools/cli/cli_tool.py
@@ -1,0 +1,168 @@
+"""The agent's handle on a connected CLI: one tool per integration.
+
+Deliberately ONE tool that takes a shell command, rather than a generated tool
+per subcommand. A vendor CLI already documents itself; ``--help`` on every
+subcommand, and increasingly a machine-readable ``--schema``; and that
+documentation is always correct for the installed version. Enumerating
+subcommands into fixed tool schemas would freeze a snapshot of it, break on the
+vendor's next release, and throw away the long tail (every flag, every
+subcommand nobody thought to wrap) which is precisely what makes a CLI worth
+integrating.
+
+So the model gets what a developer gets: the command, its own help, and a
+shell. Pipes, redirection and ``&&`` work, because a CLI without them is half a
+CLI; ``gh pr list --json number | jq ...`` is the normal way to use one.
+
+What the model does NOT get is a way out of the integration: the tool's name,
+description and gating are bound to one integration, and only that
+integration's launcher is put on ``PATH``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from langchain_core.runnables.config import RunnableConfig
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import BaseModel, Field
+
+from app.agents.tools.coding._context import get_session_id, get_user_id
+from app.agents.workspace.paths import session_dir
+from app.constants.cli_integrations import (
+    EXEC_DEFAULT_TIMEOUT_SECONDS,
+    EXEC_MAX_TIMEOUT_SECONDS,
+)
+from app.constants.log_tags import LogTag
+from app.models.cli_config import CliConfig
+from app.services.cli import runtime
+from app.services.sandbox import SandboxAcquisitionError, acquire_sandbox
+from app.utils.output_limiter import truncate_head_tail
+from shared.py.wide_events import log
+
+# Metadata key marking a tool as CLI-backed, and naming the integration it
+# belongs to. Read by the HIL gate, which classifies the risk of the *command*
+# rather than of the tool as a whole (every call shares one tool name, so a
+# name-only verdict would gate `gh pr list` exactly as hard as `gh repo delete`).
+CLI_INTEGRATION_METADATA_KEY = "gaia_cli_integration"
+CLI_COMMAND_METADATA_KEY = "gaia_cli_command"
+
+
+class CliToolInput(BaseModel):
+    """Arguments for one CLI invocation."""
+
+    command: str = Field(
+        description=(
+            "Shell command to run. The CLI is already on PATH and authenticated. "
+            "Pipes, redirection and && are supported."
+        )
+    )
+    timeout: int = Field(
+        default=EXEC_DEFAULT_TIMEOUT_SECONDS,
+        description="Seconds before the command is killed.",
+    )
+
+
+def tool_name_for(command: str) -> str:
+    """Stable tool name for a CLI integration's command.
+
+    Derived from the executable rather than the integration id, so the name the
+    model selects and the name it types inside ``command`` are the same word
+    (``run_link_cli`` -> ``link-cli``). The ``run_`` prefix keeps it reading as
+    an action and avoids a bare ``gh``/``vercel`` colliding with a future
+    first-party tool of that name.
+    """
+    return f"run_{command.replace('-', '_').replace('.', '_')}"
+
+
+def _description(config: CliConfig, integration_name: str) -> str:
+    """What the model is told this tool is for.
+
+    Names the executable explicitly and points at ``--help`` as the way to
+    learn the rest, so discovery happens against the installed version instead
+    of against whatever was true when this integration was written.
+    """
+    lines = [
+        f"Run the `{config.command}` command-line tool for {integration_name}. "
+        f"It is installed and signed in as the user.",
+    ]
+    if config.capabilities:
+        lines.append("Use it for: " + ", ".join(config.capabilities) + ".")
+    lines.append(
+        f"You do not know this tool's exact flags; run `{config.command} --help`, "
+        f"or `{config.command} <subcommand> --help`, before guessing. "
+        "Prefer a JSON/machine-readable output flag when the tool offers one."
+    )
+    return " ".join(lines)
+
+
+def build_cli_tool(integration_id: str, integration_name: str, config: CliConfig) -> BaseTool:
+    """Create the LangChain tool that runs one connected CLI."""
+
+    async def _run(
+        command: Annotated[str, "Shell command to run"],
+        timeout: int = EXEC_DEFAULT_TIMEOUT_SECONDS,
+        # Injected by LangChain from the run context (matched on the
+        # RunnableConfig annotation), not supplied by the model — it is absent
+        # from args_schema, which is what the model actually sees.
+        run_config: RunnableConfig | None = None,
+    ) -> str:
+        runnable_config: RunnableConfig = run_config or {}
+        log.set(
+            tool={"name": tool_name_for(config.command), "action": "execute"},
+            integration={"id": integration_id, "managed_by": "cli"},
+        )
+        if not command.strip():
+            return "Error: command cannot be empty"
+
+        try:
+            user_id = get_user_id(runnable_config)
+        except ValueError as e:
+            return f"Error: {e}"
+
+        bounded = max(1, min(timeout, EXEC_MAX_TIMEOUT_SECONDS))
+        session_id = get_session_id(runnable_config)
+        # Run from the session directory so anything the CLI writes (an export,
+        # a downloaded file) lands where the rest of the turn's artifacts do.
+        cwd = session_dir(session_id) if session_id else None
+
+        try:
+            async with acquire_sandbox(user_id) as sbx:
+                result = await runtime.execute(
+                    sbx, integration_id, config, command, timeout=bounded, cwd=cwd
+                )
+        except SandboxAcquisitionError as e:
+            return f"Error: sandbox unavailable ({e})"
+        except Exception as e:
+            log.error(
+                f"{LogTag.INTEGRATION} CLI tool failed",
+                integration_id=integration_id,
+                error_type=type(e).__name__,
+                exc_info=True,
+            )
+            return f"Error running {config.command}: {e}"
+
+        if result.install_failed:
+            return (
+                f"Error: {config.command} is not installed and could not be installed.\n"
+                f"{truncate_head_tail(result.stderr)}"
+            )
+
+        parts = [f"exit_code: {result.exit_code}"]
+        if result.stdout:
+            parts.append("stdout:\n" + truncate_head_tail(result.stdout))
+        if result.stderr:
+            parts.append("stderr:\n" + truncate_head_tail(result.stderr))
+        return "\n\n".join(parts)
+
+    return StructuredTool.from_function(
+        coroutine=_run,
+        name=tool_name_for(config.command),
+        description=_description(config, integration_name),
+        args_schema=CliToolInput,
+        # The gate reads these to classify the command being run, and to tie the
+        # call back to the integration that must be connected for it to work.
+        metadata={
+            CLI_INTEGRATION_METADATA_KEY: integration_id,
+            CLI_COMMAND_METADATA_KEY: config.command,
+        },
+    )

--- a/apps/api/app/agents/tools/cli/cli_tool.py
+++ b/apps/api/app/agents/tools/cli/cli_tool.py
@@ -13,9 +13,13 @@ So the model gets what a developer gets: the command, its own help, and a
 shell. Pipes, redirection and ``&&`` work, because a CLI without them is half a
 CLI; ``gh pr list --json number | jq ...`` is the normal way to use one.
 
-What the model does NOT get is a way out of the integration: the tool's name,
-description and gating are bound to one integration, and only that
-integration's launcher is put on ``PATH``.
+What the tool does bound is attribution, not isolation: its name, description
+and HIL gating belong to one integration, and every command it runs is
+classified against that integration. It is NOT a sandbox within the sandbox --
+``PATH`` carries the shared launcher directory, so every CLI the user has
+connected is reachable from any of them, and they all run as the same sandbox
+user. That is the same trust boundary the bash tool already has: one user's
+own tools, on one user's own machine.
 """
 
 from __future__ import annotations
@@ -29,9 +33,13 @@ from pydantic import BaseModel, Field
 from app.agents.tools.coding._context import get_session_id, get_user_id
 from app.agents.workspace.paths import session_dir
 from app.constants.cli_integrations import (
+    CLI_COMMAND_METADATA_KEY,
+    CLI_INTEGRATION_METADATA_KEY,
     EXEC_DEFAULT_TIMEOUT_SECONDS,
+    EXEC_MAX_COMMAND_LENGTH,
     EXEC_MAX_TIMEOUT_SECONDS,
     INSTALL_TIMEOUT_SECONDS,
+    cli_tool_name,
 )
 from app.constants.log_tags import LogTag
 from app.models.cli_config import CliConfig
@@ -39,13 +47,6 @@ from app.services.cli import runtime
 from app.services.sandbox import SandboxAcquisitionError, acquire_sandbox
 from app.utils.output_limiter import truncate_head_tail
 from shared.py.wide_events import log
-
-# Metadata key marking a tool as CLI-backed, and naming the integration it
-# belongs to. Read by the HIL gate, which classifies the risk of the *command*
-# rather than of the tool as a whole (every call shares one tool name, so a
-# name-only verdict would gate `gh pr list` exactly as hard as `gh repo delete`).
-CLI_INTEGRATION_METADATA_KEY = "gaia_cli_integration"
-CLI_COMMAND_METADATA_KEY = "gaia_cli_command"
 
 
 class CliToolInput(BaseModel):
@@ -61,18 +62,6 @@ class CliToolInput(BaseModel):
         default=EXEC_DEFAULT_TIMEOUT_SECONDS,
         description="Seconds before the command is killed.",
     )
-
-
-def tool_name_for(command: str) -> str:
-    """Stable tool name for a CLI integration's command.
-
-    Derived from the executable rather than the integration id, so the name the
-    model selects and the name it types inside ``command`` are the same word
-    (``run_link_cli`` -> ``link-cli``). The ``run_`` prefix keeps it reading as
-    an action and avoids a bare ``gh``/``vercel`` colliding with a future
-    first-party tool of that name.
-    """
-    return f"run_{command.replace('-', '_').replace('.', '_')}"
 
 
 def _description(config: CliConfig, integration_name: str) -> str:
@@ -96,8 +85,15 @@ def _description(config: CliConfig, integration_name: str) -> str:
     return " ".join(lines)
 
 
-def build_cli_tool(integration_id: str, integration_name: str, config: CliConfig) -> BaseTool:
+def build_cli_tool(
+    integration_id: str,
+    integration_name: str,
+    config: CliConfig,
+    *,
+    is_platform: bool = True,
+) -> BaseTool:
     """Create the LangChain tool that runs one connected CLI."""
+    name = cli_tool_name(config.command, integration_id, is_platform=is_platform)
 
     async def _run(
         command: Annotated[str, "Shell command to run"],
@@ -109,11 +105,13 @@ def build_cli_tool(integration_id: str, integration_name: str, config: CliConfig
     ) -> str:
         runnable_config: RunnableConfig = run_config or {}
         log.set(
-            tool={"name": tool_name_for(config.command), "action": "execute"},
+            tool={"name": name, "action": "execute"},
             integration={"id": integration_id, "managed_by": "cli"},
         )
         if not command.strip():
             return "Error: command cannot be empty"
+        if len(command) > EXEC_MAX_COMMAND_LENGTH:
+            return f"Error: command exceeds {EXEC_MAX_COMMAND_LENGTH} characters"
 
         try:
             user_id = get_user_id(runnable_config)
@@ -167,7 +165,7 @@ def build_cli_tool(integration_id: str, integration_name: str, config: CliConfig
 
     return StructuredTool.from_function(
         coroutine=_run,
-        name=tool_name_for(config.command),
+        name=name,
         description=_description(config, integration_name),
         args_schema=CliToolInput,
         # The gate reads these to classify the command being run, and to tie the

--- a/apps/api/app/agents/tools/cli/cli_tool.py
+++ b/apps/api/app/agents/tools/cli/cli_tool.py
@@ -31,6 +31,7 @@ from app.agents.workspace.paths import session_dir
 from app.constants.cli_integrations import (
     EXEC_DEFAULT_TIMEOUT_SECONDS,
     EXEC_MAX_TIMEOUT_SECONDS,
+    INSTALL_TIMEOUT_SECONDS,
 )
 from app.constants.log_tags import LogTag
 from app.models.cli_config import CliConfig
@@ -128,7 +129,17 @@ def build_cli_tool(integration_id: str, integration_name: str, config: CliConfig
         try:
             async with acquire_sandbox(user_id) as sbx:
                 result = await runtime.execute(
-                    sbx, integration_id, config, command, timeout=bounded, cwd=cwd
+                    sbx,
+                    integration_id,
+                    config,
+                    command,
+                    # `bounded` is the model's budget for ITS command. The
+                    # install guard shares the same shell, and after the hourly
+                    # sandbox recreation the first call pays for it, so the
+                    # sandbox-level deadline has to cover both or a cold call
+                    # dies mid-install with a timeout the model cannot act on.
+                    timeout=bounded + INSTALL_TIMEOUT_SECONDS,
+                    cwd=cwd,
                 )
         except SandboxAcquisitionError as e:
             return f"Error: sandbox unavailable ({e})"

--- a/apps/api/app/agents/tools/core/registry.py
+++ b/apps/api/app/agents/tools/core/registry.py
@@ -362,6 +362,7 @@ class ToolRegistry:
             finish_task_tool,
             flowchart_tool,
             image_tool,
+            integration_authoring_tool,
             integration_instructions_tools,
             integration_tool,
             manual_tool,
@@ -495,8 +496,13 @@ class ToolRegistry:
         )
         self._add_category(
             "integrations",
-            tools=integration_tool.tools,
-            risk=CategoryRisk(destructive_tools={"connect_integration"}),
+            tools=[*integration_tool.tools, *integration_authoring_tool.tools],
+            # Authoring is destructive in the sense the gate cares about: it
+            # stores an install command that will later run in the user's
+            # sandbox, so it is a change to their account, not a lookup.
+            risk=CategoryRisk(
+                destructive_tools={"connect_integration", "create_custom_integration"}
+            ),
         )
         self._add_category(
             "integration_instructions",

--- a/apps/api/app/agents/tools/integration_authoring_tool.py
+++ b/apps/api/app/agents/tools/integration_authoring_tool.py
@@ -57,6 +57,14 @@ class CustomIntegrationSpec(BaseModel):
         default=None,
         description="CLI only: short phrases for what it can do, shown to the user",
     )
+    homepage: str = Field(
+        default="",
+        description=(
+            "CLI only: the vendor's own site, e.g. 'https://cli.github.com'. Used for "
+            "the integration's icon, so give the product's homepage, NOT the download "
+            "or package-registry URL."
+        ),
+    )
     auth_kind: Literal["none", "device", "token"] = Field(
         default="none",
         description=(
@@ -172,6 +180,7 @@ def _build_blueprint(spec: CustomIntegrationSpec) -> McpBlueprint | CliBlueprint
         command=spec.command,
         install_command=spec.install_command,
         capabilities=spec.capabilities or [],
+        homepage=spec.homepage or None,
         auth_kind=spec.auth_kind,
         login_command=spec.login_command or None,
         verify_command=spec.verify_command,

--- a/apps/api/app/agents/tools/integration_authoring_tool.py
+++ b/apps/api/app/agents/tools/integration_authoring_tool.py
@@ -13,11 +13,11 @@ actually runs.
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Literal
 
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import tool
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from app.agents.tools.coding._context import get_user_id
 from app.constants.log_tags import LogTag
@@ -29,50 +29,78 @@ from app.services.integrations.authoring import (
 from shared.py.wide_events import log
 
 
-@tool
-async def create_custom_integration(
-    config: RunnableConfig,
-    kind: Annotated[
-        Literal["mcp", "cli"],
-        "'mcp' for a hosted MCP server URL; 'cli' for a real command-line tool.",
-    ],
-    name: Annotated[str, "Display name, e.g. 'GitHub CLI'"],
-    description: Annotated[str, "One sentence on what it lets the user do"],
-    server_url: Annotated[str, "MCP only: the server's https URL"] = "",
-    command: Annotated[str, "CLI only: the executable name, e.g. 'gh'"] = "",
-    install_command: Annotated[
-        str,
-        'CLI only: shell that installs it, e.g. "npm install -g some-cli" or a '
-        "curl of a release tarball. Runs unprivileged in the user's sandbox.",
-    ] = "",
-    capabilities: Annotated[
-        list[str] | None, "CLI only: short phrases for what it can do, shown to the user"
-    ] = None,
-    auth_kind: Annotated[
-        Literal["none", "device", "token"],
-        "CLI only: 'device' if it prints a URL/code to approve, 'token' if the user "
-        "pastes a secret, 'none' if it needs no credentials.",
-    ] = "none",
-    login_command: Annotated[str, "CLI only: the login command (required for 'device')"] = "",
-    verify_command: Annotated[
-        str, "CLI only: a command that exits 0 only when signed in, e.g. 'gh auth status'"
-    ] = "",
-    logout_command: Annotated[str, "CLI only: the logout command, if it has one"] = "",
-    token_env: Annotated[
-        str, "CLI only, 'token' auth: the env var the tool reads, e.g. 'GH_TOKEN'"
-    ] = "",
-    token_label: Annotated[str, "CLI only, 'token' auth: what to call the secret in the UI"] = "",
-    token_help_url: Annotated[
-        str, "CLI only, 'token' auth: page where the user creates the token"
-    ] = "",
-) -> str:
+class CustomIntegrationSpec(BaseModel):
+    """The model-facing argument schema: one flat field per fact to supply.
+
+    Deliberately flat rather than a discriminated union of an MCP shape and a
+    CLI shape, even though that is what the domain actually is: models fill flat
+    schemas far more reliably than nested ones, and a malformed nested argument
+    costs a whole tool call to discover. The union is reconstructed in
+    ``_build_blueprint``, where it is validated properly.
+    """
+
+    kind: Literal["mcp", "cli"] = Field(
+        description="'mcp' for a hosted MCP server URL; 'cli' for a real command-line tool."
+    )
+    name: str = Field(description="Display name, e.g. 'GitHub CLI'")
+    description: str = Field(description="One sentence on what it lets the user do")
+    server_url: str = Field(default="", description="MCP only: the server's https URL")
+    command: str = Field(default="", description="CLI only: the executable name, e.g. 'gh'")
+    install_command: str = Field(
+        default="",
+        description=(
+            'CLI only: shell that installs it, e.g. "npm install -g some-cli" or a '
+            "curl of a release tarball. Runs unprivileged in the user's sandbox."
+        ),
+    )
+    capabilities: list[str] | None = Field(
+        default=None,
+        description="CLI only: short phrases for what it can do, shown to the user",
+    )
+    auth_kind: Literal["none", "device", "token"] = Field(
+        default="none",
+        description=(
+            "CLI only: 'device' if it prints a URL/code to approve, 'token' if the user "
+            "pastes a secret, 'none' if it needs no credentials."
+        ),
+    )
+    login_command: str = Field(
+        default="", description="CLI only: the login command (required for 'device')"
+    )
+    verify_command: str = Field(
+        default="",
+        description="CLI only: a command that exits 0 only when signed in, e.g. 'gh auth status'",
+    )
+    logout_command: str = Field(
+        default="", description="CLI only: the logout command, if it has one"
+    )
+    token_env: str = Field(
+        default="",
+        description="CLI only, 'token' auth: the env var the tool reads, e.g. 'GH_TOKEN'",
+    )
+    token_label: str = Field(
+        default="", description="CLI only, 'token' auth: what to call the secret in the UI"
+    )
+    token_help_url: str = Field(
+        default="", description="CLI only, 'token' auth: page where the user creates the token"
+    )
+
+
+@tool(args_schema=CustomIntegrationSpec)
+async def create_custom_integration(config: RunnableConfig, **fields: object) -> str:
     """Create a new integration for this user from a description of what backs it.
 
     Research the tool first; read its docs or `--help`; and pass its real
     install and auth commands. Do not guess them.
     """
+    # LangChain hands the tool its arguments flat (the schema above is what the
+    # model sees), and only the keys the model actually supplied. Re-validating
+    # here is what fills the defaults and turns them back into one typed object,
+    # so nothing below this line handles fourteen loose parameters.
+    spec = CustomIntegrationSpec.model_validate(fields)
     log.set(
-        tool={"name": "create_custom_integration", "action": "create"}, integration={"kind": kind}
+        tool={"name": "create_custom_integration", "action": "create"},
+        integration={"kind": spec.kind},
     )
     try:
         user_id = get_user_id(config)
@@ -80,22 +108,7 @@ async def create_custom_integration(
         return f"Error: {e}"
 
     try:
-        blueprint = _build_blueprint(
-            kind=kind,
-            name=name,
-            description=description,
-            server_url=server_url,
-            command=command,
-            install_command=install_command,
-            capabilities=capabilities or [],
-            auth_kind=auth_kind,
-            login_command=login_command,
-            verify_command=verify_command,
-            logout_command=logout_command,
-            token_env=token_env,
-            token_label=token_label,
-            token_help_url=token_help_url,
-        )
+        blueprint = _build_blueprint(spec)
     except (ValidationError, ValueError) as e:
         # Returned rather than raised: the caller is a model that can read the
         # complaint and retry with the field it left out.
@@ -116,7 +129,7 @@ async def create_custom_integration(
 
     lines = [
         f"Created '{authored.integration.name}' "
-        f"(id: {authored.integration.integration_id}, kind: {kind}).",
+        f"(id: {authored.integration.integration_id}, kind: {spec.kind}).",
     ]
     if authored.note:
         lines.append(authored.note)
@@ -127,40 +140,26 @@ async def create_custom_integration(
     return " ".join(lines)
 
 
-def _build_blueprint(
-    *,
-    kind: str,
-    name: str,
-    description: str,
-    server_url: str,
-    command: str,
-    install_command: str,
-    capabilities: list[str],
-    auth_kind: str,
-    login_command: str,
-    verify_command: str,
-    logout_command: str,
-    token_env: str,
-    token_label: str,
-    token_help_url: str,
-) -> McpBlueprint | CliBlueprint:
-    """Turn the tool's flat arguments into the right typed blueprint.
+def _build_blueprint(spec: CustomIntegrationSpec) -> McpBlueprint | CliBlueprint:
+    """Turn the flat tool arguments into the right typed blueprint.
 
-    Flat arguments rather than a nested union because models fill flat schemas
-    far more reliably; the union is reconstructed here where it can be
-    validated properly.
+    The flat schema cannot express "these fields are required for a CLI and
+    meaningless for an MCP server", so the per-transport requirements are
+    checked here, once, before anything is persisted.
     """
-    if kind == "mcp":
-        if not server_url:
+    if spec.kind == "mcp":
+        if not spec.server_url:
             raise ValueError("an MCP integration needs server_url")
-        return McpBlueprint(name=name, description=description, server_url=server_url)
+        return McpBlueprint(
+            name=spec.name, description=spec.description, server_url=spec.server_url
+        )
 
     missing = [
         field
         for field, value in (
-            ("command", command),
-            ("install_command", install_command),
-            ("verify_command", verify_command),
+            ("command", spec.command),
+            ("install_command", spec.install_command),
+            ("verify_command", spec.verify_command),
         )
         if not value
     ]
@@ -168,18 +167,18 @@ def _build_blueprint(
         raise ValueError(f"a CLI integration needs {', '.join(missing)}")
 
     return CliBlueprint(
-        name=name,
-        description=description,
-        command=command,
-        install_command=install_command,
-        capabilities=capabilities,
-        auth_kind=auth_kind,  # type: ignore[arg-type]  # validated by the Literal on the tool arg
-        login_command=login_command or None,
-        verify_command=verify_command,
-        logout_command=logout_command or None,
-        token_env=token_env or None,
-        token_label=token_label or None,
-        token_help_url=token_help_url or None,
+        name=spec.name,
+        description=spec.description,
+        command=spec.command,
+        install_command=spec.install_command,
+        capabilities=spec.capabilities or [],
+        auth_kind=spec.auth_kind,
+        login_command=spec.login_command or None,
+        verify_command=spec.verify_command,
+        logout_command=spec.logout_command or None,
+        token_env=spec.token_env or None,
+        token_label=spec.token_label or None,
+        token_help_url=spec.token_help_url or None,
     )
 
 

--- a/apps/api/app/agents/tools/integration_authoring_tool.py
+++ b/apps/api/app/agents/tools/integration_authoring_tool.py
@@ -1,0 +1,186 @@
+"""Let the agent create an integration the catalog does not have yet.
+
+The UI's "add integration" dialog is deliberately MCP-only: pasting a server URL
+is something a user can reasonably do themselves, while describing a CLI (what
+installs it, what its login command is, how to tell whether it worked) is
+research, not data entry. That research is exactly what an agent is good at -
+read the tool's docs, find its install command and its auth shape; so the
+multi-transport path lives here rather than in a form.
+
+The agent proposes; the user still has to connect it, which is where anything
+actually runs.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from langchain_core.runnables.config import RunnableConfig
+from langchain_core.tools import tool
+from pydantic import ValidationError
+
+from app.agents.tools.coding._context import get_user_id
+from app.constants.log_tags import LogTag
+from app.services.integrations.authoring import (
+    CliBlueprint,
+    McpBlueprint,
+    create_integration,
+)
+from shared.py.wide_events import log
+
+
+@tool
+async def create_custom_integration(
+    config: RunnableConfig,
+    kind: Annotated[
+        Literal["mcp", "cli"],
+        "'mcp' for a hosted MCP server URL; 'cli' for a real command-line tool.",
+    ],
+    name: Annotated[str, "Display name, e.g. 'GitHub CLI'"],
+    description: Annotated[str, "One sentence on what it lets the user do"],
+    server_url: Annotated[str, "MCP only: the server's https URL"] = "",
+    command: Annotated[str, "CLI only: the executable name, e.g. 'gh'"] = "",
+    install_command: Annotated[
+        str,
+        'CLI only: shell that installs it, e.g. "npm install -g some-cli" or a '
+        "curl of a release tarball. Runs unprivileged in the user's sandbox.",
+    ] = "",
+    capabilities: Annotated[
+        list[str] | None, "CLI only: short phrases for what it can do, shown to the user"
+    ] = None,
+    auth_kind: Annotated[
+        Literal["none", "device", "token"],
+        "CLI only: 'device' if it prints a URL/code to approve, 'token' if the user "
+        "pastes a secret, 'none' if it needs no credentials.",
+    ] = "none",
+    login_command: Annotated[str, "CLI only: the login command (required for 'device')"] = "",
+    verify_command: Annotated[
+        str, "CLI only: a command that exits 0 only when signed in, e.g. 'gh auth status'"
+    ] = "",
+    logout_command: Annotated[str, "CLI only: the logout command, if it has one"] = "",
+    token_env: Annotated[
+        str, "CLI only, 'token' auth: the env var the tool reads, e.g. 'GH_TOKEN'"
+    ] = "",
+    token_label: Annotated[str, "CLI only, 'token' auth: what to call the secret in the UI"] = "",
+    token_help_url: Annotated[
+        str, "CLI only, 'token' auth: page where the user creates the token"
+    ] = "",
+) -> str:
+    """Create a new integration for this user from a description of what backs it.
+
+    Research the tool first; read its docs or `--help`; and pass its real
+    install and auth commands. Do not guess them.
+    """
+    log.set(
+        tool={"name": "create_custom_integration", "action": "create"}, integration={"kind": kind}
+    )
+    try:
+        user_id = get_user_id(config)
+    except ValueError as e:
+        return f"Error: {e}"
+
+    try:
+        blueprint = _build_blueprint(
+            kind=kind,
+            name=name,
+            description=description,
+            server_url=server_url,
+            command=command,
+            install_command=install_command,
+            capabilities=capabilities or [],
+            auth_kind=auth_kind,
+            login_command=login_command,
+            verify_command=verify_command,
+            logout_command=logout_command,
+            token_env=token_env,
+            token_label=token_label,
+            token_help_url=token_help_url,
+        )
+    except (ValidationError, ValueError) as e:
+        # Returned rather than raised: the caller is a model that can read the
+        # complaint and retry with the field it left out.
+        return f"Could not create the integration; {e}"
+
+    try:
+        authored = await create_integration(user_id, blueprint)
+    except ValueError as e:
+        return f"Could not create the integration; {e}"
+    except Exception as e:
+        log.error(
+            f"{LogTag.INTEGRATION} Authoring an integration failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            user_id=user_id,
+        )
+        return f"Error creating the integration: {e}"
+
+    lines = [
+        f"Created '{authored.integration.name}' "
+        f"(id: {authored.integration.integration_id}, kind: {kind}).",
+    ]
+    if authored.note:
+        lines.append(authored.note)
+    if authored.needs_connection:
+        lines.append(
+            "Tell the user to open Integrations and click Connect to finish setting it up."
+        )
+    return " ".join(lines)
+
+
+def _build_blueprint(
+    *,
+    kind: str,
+    name: str,
+    description: str,
+    server_url: str,
+    command: str,
+    install_command: str,
+    capabilities: list[str],
+    auth_kind: str,
+    login_command: str,
+    verify_command: str,
+    logout_command: str,
+    token_env: str,
+    token_label: str,
+    token_help_url: str,
+) -> McpBlueprint | CliBlueprint:
+    """Turn the tool's flat arguments into the right typed blueprint.
+
+    Flat arguments rather than a nested union because models fill flat schemas
+    far more reliably; the union is reconstructed here where it can be
+    validated properly.
+    """
+    if kind == "mcp":
+        if not server_url:
+            raise ValueError("an MCP integration needs server_url")
+        return McpBlueprint(name=name, description=description, server_url=server_url)
+
+    missing = [
+        field
+        for field, value in (
+            ("command", command),
+            ("install_command", install_command),
+            ("verify_command", verify_command),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"a CLI integration needs {', '.join(missing)}")
+
+    return CliBlueprint(
+        name=name,
+        description=description,
+        command=command,
+        install_command=install_command,
+        capabilities=capabilities,
+        auth_kind=auth_kind,  # type: ignore[arg-type]  # validated by the Literal on the tool arg
+        login_command=login_command or None,
+        verify_command=verify_command,
+        logout_command=logout_command or None,
+        token_env=token_env or None,
+        token_label=token_label or None,
+        token_help_url=token_help_url or None,
+    )
+
+
+tools = [create_custom_integration]

--- a/apps/api/app/api/v1/endpoints/integrations/config.py
+++ b/apps/api/app/api/v1/endpoints/integrations/config.py
@@ -23,15 +23,11 @@ from app.schemas.integrations.responses import (
 )
 from app.services.analytics_service import AnalyticsEvents, capture_context_event
 from app.services.connect_link_service import resolve_and_consume_connect_code
+from app.services.integrations.connect_dispatch import initiate_integration_connection
 from app.services.integrations.integration_connection_service import (
     build_integrations_config,
-    connect_composio_integration,
-    connect_mcp_integration,
-    connect_self_integration,
     disconnect_integration,
-    initiate_integration_connection,
 )
-from app.services.integrations.integration_resolver import IntegrationResolver
 from app.services.integrations.my_integrations import (
     get_integration_tools,
     get_my_integrations,
@@ -125,7 +121,13 @@ async def connect_integration_endpoint(
     request: ConnectIntegrationRequest,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> ConnectIntegrationResponse:
-    """Connect an integration for the current user, returning the next-step action."""
+    """Connect an integration for the current user, returning the next-step action.
+
+    Transport-agnostic: the shared dispatch picks the provider. For CLI-backed
+    integrations this endpoint is also the poll — it is idempotent and advances
+    the connect state machine one step per call, returning ``pending`` until the
+    install finishes and the user has approved the login.
+    """
     user_id = user.get("user_id")
     if not user_id:
         raise HTTPException(status_code=400, detail="User ID not found")
@@ -136,114 +138,16 @@ async def connect_integration_endpoint(
         user={"id": user_id},
         integration={"id": integration_id},
     )
-    resolved = await IntegrationResolver.resolve(integration_id)
-    if not resolved:
+    result = await initiate_integration_connection(
+        user_id=str(user_id),
+        integration_id=integration_id,
+        user_email=user.get("email", ""),
+        redirect_path=request.redirect_path,
+        bearer_token=request.bearer_token,
+    )
+    if result is None:
         raise HTTPException(status_code=404, detail=f"Integration {integration_id} not found")
-
-    if resolved.source == "platform" and resolved.platform_integration:
-        if not resolved.platform_integration.available:
-            return ConnectIntegrationResponse(
-                status="error",
-                integration_id=integration_id,
-                name=resolved.name,
-                error=f"Integration {integration_id} is not available yet",
-            )
-
-    try:
-        auth_type: str | None = None
-        if resolved.mcp_config:
-            auth_type = "oauth2" if resolved.mcp_config.requires_auth else "none"
-        elif resolved.managed_by in ("composio", "self"):
-            auth_type = "oauth2"
-
-        provider: str | None = (
-            resolved.platform_integration.provider if resolved.platform_integration else None
-        )
-
-        log.set(
-            integration_name=resolved.name,
-            integration={
-                "id": integration_id,
-                "managed_by": resolved.managed_by,
-                "auth_type": auth_type,
-                "provider": provider or integration_id,
-            },
-        )
-        if resolved.managed_by == "mcp":
-            result = await connect_mcp_integration(
-                user_id=str(user_id),
-                integration_id=integration_id,
-                integration_name=resolved.name,
-                requires_auth=resolved.requires_auth,
-                redirect_path=request.redirect_path,
-                server_url=resolved.mcp_config.server_url if resolved.mcp_config else None,
-                is_platform=resolved.source == "platform",
-                bearer_token=request.bearer_token,
-            )
-            log.set(outcome="success")
-            # OAuth-managed connects complete at their callback; only a direct
-            # (no-auth / bearer) connect finishes here.
-            if result.status == "connected":
-                capture_context_event(
-                    AnalyticsEvents.INTEGRATION_CONNECTED,
-                    {
-                        "integration_id": integration_id,
-                        "managed_by": resolved.managed_by,
-                    },
-                )
-            return result
-        if resolved.managed_by == "composio":
-            provider = (
-                resolved.platform_integration.provider if resolved.platform_integration else None
-            )
-            if not provider:
-                raise HTTPException(status_code=400, detail="Provider not configured")
-            result = await connect_composio_integration(
-                user_id=str(user_id),
-                integration_id=integration_id,
-                integration_name=resolved.name,
-                provider=provider,
-                redirect_path=request.redirect_path,
-            )
-            log.set(outcome="success")
-            return result
-        if resolved.managed_by == "self":
-            provider = (
-                resolved.platform_integration.provider if resolved.platform_integration else None
-            )
-            if not provider:
-                raise HTTPException(status_code=400, detail="Provider not configured")
-            result = await connect_self_integration(
-                user_id=str(user_id),
-                user_email=user.get("email", ""),
-                integration_id=integration_id,
-                integration_name=resolved.name,
-                provider=provider,
-                redirect_path=request.redirect_path,
-            )
-            log.set(outcome="success")
-            return result
-        return ConnectIntegrationResponse(
-            status="error",
-            integration_id=integration_id,
-            name=resolved.name,
-            error=f"Unsupported integration type: {resolved.managed_by}",
-        )
-    except Exception as e:
-        log.error(
-            f"{LogTag.INTEGRATION} Failed to connect integration",
-            integration_id=integration_id,
-            user_id=user_id,
-            error_type=type(e).__name__,
-            error=str(e),
-        )
-        log.set(integration={"id": integration_id, "status": "error"})
-        return ConnectIntegrationResponse(
-            status="error",
-            integration_id=integration_id,
-            name=resolved.name,
-            error=str(e),
-        )
+    return result
 
 
 def _connect_link_error(reason: str) -> RedirectResponse:

--- a/apps/api/app/api/v1/endpoints/integrations/config.py
+++ b/apps/api/app/api/v1/endpoints/integrations/config.py
@@ -23,10 +23,12 @@ from app.schemas.integrations.responses import (
 )
 from app.services.analytics_service import AnalyticsEvents, capture_context_event
 from app.services.connect_link_service import resolve_and_consume_connect_code
-from app.services.integrations.connect_dispatch import initiate_integration_connection
+from app.services.integrations.connect_dispatch import (
+    disconnect_integration,
+    initiate_integration_connection,
+)
 from app.services.integrations.integration_connection_service import (
     build_integrations_config,
-    disconnect_integration,
 )
 from app.services.integrations.my_integrations import (
     get_integration_tools,

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -188,7 +188,6 @@ async def add_public_integration(
                 requires_auth=requires_auth,
                 redirect_path=request.redirect_path,
                 server_url=server_url,
-                is_platform=False,
                 bearer_token=request.bearer_token,
             )
         )

--- a/apps/api/app/api/v1/endpoints/integrations/public.py
+++ b/apps/api/app/api/v1/endpoints/integrations/public.py
@@ -27,6 +27,7 @@ from app.schemas.integrations.responses import (
 )
 from app.services.analytics_service import AnalyticsEvents, capture_context_event
 from app.services.integrations.integration_connection_service import (
+    McpConnectRequest,
     connect_mcp_integration,
 )
 from app.services.integrations.user_integrations import add_user_integration
@@ -180,14 +181,16 @@ async def add_public_integration(
             )
 
         connect_result = await connect_mcp_integration(
-            user_id=user_id,
-            integration_id=integration_id,
-            integration_name=integration_name,
-            requires_auth=requires_auth,
-            redirect_path=request.redirect_path,
-            server_url=server_url,
-            is_platform=False,
-            bearer_token=request.bearer_token,
+            McpConnectRequest(
+                user_id=user_id,
+                integration_id=integration_id,
+                integration_name=integration_name,
+                requires_auth=requires_auth,
+                redirect_path=request.redirect_path,
+                server_url=server_url,
+                is_platform=False,
+                bearer_token=request.bearer_token,
+            )
         )
 
         log.set(integration_name=integration_name)

--- a/apps/api/app/config/oauth_config.py
+++ b/apps/api/app/config/oauth_config.py
@@ -117,6 +117,7 @@ from app.config.oauth_content import (
     YELP_CONTENT,
     ZOOM_CONTENT,
 )
+from app.constants.cli_integrations import LOGIN_TIMEOUT_SECONDS
 from app.constants.hil_destructive_tools import (
     AIRTABLE_DESTRUCTIVE_TOOLS,
     ASANA_DESTRUCTIVE_TOOLS,
@@ -2032,9 +2033,14 @@ OAUTH_INTEGRATIONS: list[OAuthIntegration] = [
                 kind="device",
                 # --interval makes the CLI print the approval URL and then keep
                 # polling in the same process, so one detached login covers the
-                # whole flow. --timeout stays under LOGIN_TIMEOUT_SECONDS so the
-                # CLI gives up before GAIA declares the attempt stale.
-                login_command=("link-cli auth login --client-name GAIA --interval 5 --timeout 600"),
+                # whole flow. --timeout is bound to LOGIN_TIMEOUT_SECONDS rather
+                # than repeated as a literal: if the CLI stopped polling first,
+                # the difference would be a window where GAIA still shows a code
+                # that can no longer be redeemed.
+                login_command=(
+                    "link-cli auth login --client-name GAIA --interval 5 "
+                    f"--timeout {LOGIN_TIMEOUT_SECONDS}"
+                ),
                 # `auth status` exits 0 whether or not you are signed in, so the
                 # exit code alone says nothing — the authenticated flag does.
                 verify_command=(

--- a/apps/api/app/config/oauth_config.py
+++ b/apps/api/app/config/oauth_config.py
@@ -117,7 +117,7 @@ from app.config.oauth_content import (
     YELP_CONTENT,
     ZOOM_CONTENT,
 )
-from app.constants.cli_integrations import LOGIN_TIMEOUT_SECONDS
+from app.constants.cli_integrations import LOGIN_TIMEOUT_SECONDS, cli_tool_name
 from app.constants.hil_destructive_tools import (
     AIRTABLE_DESTRUCTIVE_TOOLS,
     ASANA_DESTRUCTIVE_TOOLS,
@@ -2041,11 +2041,16 @@ OAUTH_INTEGRATIONS: list[OAuthIntegration] = [
                     "link-cli auth login --client-name GAIA --interval 5 "
                     f"--timeout {LOGIN_TIMEOUT_SECONDS}"
                 ),
-                # `auth status` exits 0 whether or not you are signed in, so the
-                # exit code alone says nothing — the authenticated flag does.
+                # `auth status` exits 0 whether or not you are signed in, so
+                # the exit code alone says nothing -- the authenticated flag
+                # does. Read with `jq -e` (baked into the sandbox image) rather
+                # than grepped: a grep silently matches nothing if Stripe
+                # renames the field or pretty-prints the value onto its own
+                # line, which would strand the user as permanently
+                # "not connected". `jq -e` exits non-zero on false AND errors
+                # loudly on a shape it cannot read.
                 verify_command=(
-                    "link-cli auth status --format json "
-                    "| grep -qi '\"authenticated\"[[:space:]]*:[[:space:]]*true'"
+                    "link-cli auth status --format json | jq -e '.authenticated == true'"
                 ),
                 logout_command="link-cli auth logout",
             ),
@@ -2070,7 +2075,11 @@ OAUTH_INTEGRATIONS: list[OAuthIntegration] = [
             # there is nothing to retrieve — bind it and go.
             use_direct_tools=True,
             disable_retrieve_tools=True,
-            auto_bind_tools=["run_link_cli"],
+            # Derived, not spelled out: the tool's registry name comes from the
+            # command, so a literal here silently binds nothing the day the
+            # command changes -- and with disable_retrieve_tools that produces a
+            # subagent with no tools that still reports healthy.
+            auto_bind_tools=[cli_tool_name("link-cli", "stripe_link", is_platform=True)],
         ),
         content=STRIPE_LINK_CONTENT,
     ),

--- a/apps/api/app/config/oauth_config.py
+++ b/apps/api/app/config/oauth_config.py
@@ -74,6 +74,7 @@ from app.agents.prompts.subagent_prompts import (
     REMINDER_AGENT_SYSTEM_PROMPT,
     SKILLS_AGENT_SYSTEM_PROMPT,
     SLACK_AGENT_SYSTEM_PROMPT,
+    STRIPE_LINK_AGENT_SYSTEM_PROMPT,
     TODO_AGENT_SYSTEM_PROMPT,
     TODOIST_AGENT_SYSTEM_PROMPT,
     TRELLO_AGENT_SYSTEM_PROMPT,
@@ -109,6 +110,7 @@ from app.config.oauth_content import (
     POSTHOG_CONTENT,
     REDDIT_CONTENT,
     SLACK_CONTENT,
+    STRIPE_LINK_CONTENT,
     TODOIST_CONTENT,
     TRELLO_CONTENT,
     TWITTER_CONTENT,
@@ -143,6 +145,7 @@ from app.constants.hil_destructive_tools import (
 from app.constants.mcp import INSTACART_MCP_SERVER_URL, YELP_MCP_SERVER_URL
 from app.langchain.core.subgraphs.github_subgraph import GITHUB_TOOLS
 from app.langchain.core.subgraphs.slack_subgraph import SLACK_TOOLS
+from app.models.cli_config import CliAuthSpec, CliConfig
 from app.models.mcp_config import (
     ComposioConfig,
     MCPConfig,
@@ -1992,6 +1995,78 @@ OAUTH_INTEGRATIONS: list[OAuthIntegration] = [
             memory_prompt=POSTHOG_MEMORY_PROMPT,
         ),
         content=POSTHOG_CONTENT,
+    ),
+    # Stripe Link — the first CLI-backed integration. GAIA runs Stripe's own
+    # `link-cli` inside the user's sandbox rather than reimplementing the Link
+    # API: Stripe owns the payment flow, the approval UX and the credential
+    # lifecycle, and the CLI is the interface they maintain for agents.
+    OAuthIntegration(
+        id="stripe_link",
+        name="Stripe Link",
+        description=(
+            "Let GAIA pay for things with single-use credentials from your Link wallet. "
+            "Your card is never exposed and you approve every purchase."
+        ),
+        category="business",
+        provider="stripe_link",
+        scopes=[],
+        available=True,
+        is_featured=True,
+        short_name="link",
+        managed_by="cli",
+        cli_config=CliConfig(
+            command="link-cli",
+            # Caret-pinned: 0.x means this tracks patches only, so a flag we
+            # depend on cannot disappear under us in a minor release, while
+            # fixes still land without a redeploy.
+            install_command=(
+                "npm install --no-audit --no-fund --loglevel=error '@stripe/link-cli@^0.16.0'"
+            ),
+            capabilities=[
+                "create a one-time payment credential for a specific purchase",
+                "request the user's approval for a purchase",
+                "list payment methods, shipping addresses and wallet balances",
+                "pay a Machine Payment Protocol (HTTP 402) endpoint",
+            ],
+            auth=CliAuthSpec(
+                kind="device",
+                # --interval makes the CLI print the approval URL and then keep
+                # polling in the same process, so one detached login covers the
+                # whole flow. --timeout stays under LOGIN_TIMEOUT_SECONDS so the
+                # CLI gives up before GAIA declares the attempt stale.
+                login_command=("link-cli auth login --client-name GAIA --interval 5 --timeout 600"),
+                # `auth status` exits 0 whether or not you are signed in, so the
+                # exit code alone says nothing — the authenticated flag does.
+                verify_command=(
+                    "link-cli auth status --format json "
+                    "| grep -qi '\"authenticated\"[[:space:]]*:[[:space:]]*true'"
+                ),
+                logout_command="link-cli auth logout",
+            ),
+        ),
+        subagent_config=SubAgentConfig(
+            has_subagent=True,
+            agent_name="stripe_link_agent",
+            tool_space="stripe_link",
+            handoff_tool_name="call_stripe_link_agent",
+            domain="payments made on the user's behalf",
+            capabilities=(
+                "creating single-use payment credentials, requesting purchase approval, "
+                "listing payment methods and balances, and paying 402-gated endpoints"
+            ),
+            use_cases=(
+                "buying something for the user, paying for an API or service, or "
+                "checking which payment methods and balances are available"
+            ),
+            system_prompt=STRIPE_LINK_AGENT_SYSTEM_PROMPT,
+            # One tool wraps the whole CLI (see app/agents/tools/cli/cli_tool.py
+            # for why the CLI is not exploded into per-subcommand tools), so
+            # there is nothing to retrieve — bind it and go.
+            use_direct_tools=True,
+            disable_retrieve_tools=True,
+            auto_bind_tools=["run_link_cli"],
+        ),
+        content=STRIPE_LINK_CONTENT,
     ),
 ]
 

--- a/apps/api/app/config/oauth_content.py
+++ b/apps/api/app/config/oauth_content.py
@@ -1358,3 +1358,72 @@ POSTHOG_CONTENT = IntegrationContent(
         ),
     ],
 )
+
+STRIPE_LINK_CONTENT = IntegrationContent(
+    use_cases=[
+        "Let GAIA buy something for you without ever handing it your card",
+        "Approve each purchase from your phone before any money moves",
+        "Try agent payments safely in test mode before spending anything real",
+        "Keep a reviewable record of what was bought, from where, and why",
+    ],
+    how_it_works=[
+        IntegrationHowItWorksStep(
+            title="Connect your Link wallet",
+            body=(
+                "GAIA opens a Stripe Link login and shows you a code to approve. "
+                "Your card details stay with Stripe — GAIA never sees or stores them."
+            ),
+        ),
+        IntegrationHowItWorksStep(
+            title="Ask GAIA to buy something",
+            body=(
+                "GAIA describes the purchase — merchant, amount, and reason — and "
+                "creates a spend request for exactly that."
+            ),
+        ),
+        IntegrationHowItWorksStep(
+            title="You approve it",
+            body=(
+                "The request lands in your Link app. Nothing is charged until you "
+                "approve, and the approval window is short by design."
+            ),
+        ),
+        IntegrationHowItWorksStep(
+            title="A single-use credential is issued",
+            body=(
+                "Stripe mints a one-time payment credential scoped to that purchase. "
+                "It cannot be reused for a second one."
+            ),
+        ),
+    ],
+    faqs=[
+        IntegrationFAQ(
+            question="Does GAIA get my card number?",
+            answer=(
+                "No. Stripe issues a one-time credential for each approved purchase. "
+                "Your real card never leaves your Link wallet."
+            ),
+        ),
+        IntegrationFAQ(
+            question="Can GAIA spend money without asking me?",
+            answer=(
+                "No. Every purchase needs your explicit approval in the Link app, and "
+                "per-purchase and daily spend caps apply on top of that."
+            ),
+        ),
+        IntegrationFAQ(
+            question="Can I try it without spending real money?",
+            answer=(
+                "Yes. Ask GAIA to use test mode and Stripe returns test credentials, so "
+                "you can watch the whole flow without a charge."
+            ),
+        ),
+        IntegrationFAQ(
+            question="What happens if I ignore an approval request?",
+            answer=(
+                "It expires and no credential is created. GAIA will tell you the request "
+                "expired rather than retrying silently."
+            ),
+        ),
+    ],
+)

--- a/apps/api/app/constants/cli_integrations.py
+++ b/apps/api/app/constants/cli_integrations.py
@@ -37,7 +37,15 @@ exactly as it would on a laptop — and a CLI we have never seen keeps working
 as long as it respects ``HOME``.
 """
 
+import hashlib
+from typing import Final
+
 from app.agents.workspace.paths import GAIA_RUNTIME_DIRNAME, WORKSPACE_ROOT
+from app.constants.sandbox import (
+    BASH_DEFAULT_TIMEOUT_SECONDS,
+    BASH_MAX_COMMAND_LENGTH,
+    BASH_MAX_TIMEOUT_SECONDS,
+)
 
 # --- Local disk (baked into the image or re-created per sandbox) -------------
 
@@ -115,10 +123,12 @@ def install_marker_path(integration_id: str) -> str:
 # paid once per sandbox, never per call.
 INSTALL_TIMEOUT_SECONDS = 600
 
-# A single CLI invocation on behalf of the agent. Matches the bash tool's
-# default: these are the same class of command.
-EXEC_DEFAULT_TIMEOUT_SECONDS = 300
-EXEC_MAX_TIMEOUT_SECONDS = 1800
+# A single CLI invocation on behalf of the agent. These ARE sandbox shell
+# commands, so they take the sandbox's bounds rather than a second copy of the
+# same two numbers (constants/sandbox.py asks callers to import instead of
+# redefining, and a constant whose comment says "matches X" is a copy of X).
+EXEC_DEFAULT_TIMEOUT_SECONDS: Final[int] = BASH_DEFAULT_TIMEOUT_SECONDS
+EXEC_MAX_TIMEOUT_SECONDS: Final[int] = BASH_MAX_TIMEOUT_SECONDS
 
 # Bound on a "does this CLI consider itself logged in?" probe. Kept short: it
 # runs on every connect poll, and a CLI that cannot answer in this window is
@@ -140,3 +150,41 @@ LOGIN_TIMEOUT_SECONDS = 600
 # response. Login output is instructions for a human ("go to <url>, enter
 # <code>"), never a transcript, so this is ample.
 LOGIN_OUTPUT_MAX_CHARS = 4_000
+
+
+# --- The agent-facing tool ---------------------------------------------------
+
+# Metadata stamped on every CLI-backed tool. Lives here rather than beside the
+# tool factory because the HIL gate reads it, and a service importing an
+# agent-tool module would drag langchain, e2b and the sandbox client into the
+# gate's import graph.
+CLI_INTEGRATION_METADATA_KEY = "gaia_cli_integration"
+CLI_COMMAND_METADATA_KEY = "gaia_cli_command"
+
+# Custom integrations are per-user Mongo documents, but the tool registry is
+# process-global and keyed by name alone ("Tool names are globally unique" --
+# registry.py). Two users each authoring a CLI called `gh` would therefore
+# collide: last writer wins, and the loser's approval cards, Chroma namespace
+# and cached HIL verdict all resolve to the other user's integration. A short
+# digest of the integration id keeps the name readable and unique.
+_CUSTOM_TOOL_NAME_DIGEST_CHARS = 8
+
+
+def cli_tool_name(command: str, integration_id: str, *, is_platform: bool) -> str:
+    """The registry name for one CLI integration's tool.
+
+    Platform integrations keep the clean ``run_<command>`` form: their ids are
+    curated and unique, so there is nothing to disambiguate. Custom ones carry a
+    digest of their integration id.
+    """
+    base = f"run_{command.replace('-', '_').replace('.', '_')}"
+    if is_platform:
+        return base
+    digest = hashlib.sha256(integration_id.encode()).hexdigest()
+    return f"{base}_{digest[:_CUSTOM_TOOL_NAME_DIGEST_CHARS]}"
+
+
+# A CLI invocation is a shell string like any other, so it takes the same length
+# bound the bash tool applies. Without it the CLI tool accepted an unbounded
+# command its sibling refuses.
+EXEC_MAX_COMMAND_LENGTH: Final[int] = BASH_MAX_COMMAND_LENGTH

--- a/apps/api/app/constants/cli_integrations.py
+++ b/apps/api/app/constants/cli_integrations.py
@@ -126,8 +126,15 @@ EXEC_MAX_TIMEOUT_SECONDS = 1800
 VERIFY_TIMEOUT_SECONDS = 60
 
 # How long a device-code login may stay pending before the connect flow gives
-# up. Vendor device codes typically expire in 5–15 minutes.
-LOGIN_TIMEOUT_SECONDS = 900
+# up and starts a fresh one. Vendor device codes typically expire in 5–15
+# minutes; 600s sits inside that for every CLI surveyed.
+#
+# An integration's own login command must not stop polling BEFORE this window
+# elapses. The gap between the two is time in which the CLI has given up but
+# GAIA still believes the login is live, so the user is shown a code that can
+# no longer be redeemed. Keep a polling login command's timeout at or above
+# this value.
+LOGIN_TIMEOUT_SECONDS = 600
 
 # Maximum characters of captured CLI output surfaced in a connect status
 # response. Login output is instructions for a human ("go to <url>, enter

--- a/apps/api/app/constants/cli_integrations.py
+++ b/apps/api/app/constants/cli_integrations.py
@@ -1,0 +1,135 @@
+"""Filesystem layout and tunables for CLI-backed integrations.
+
+A CLI integration runs a real third-party command-line tool (``gh``,
+``link-cli``, ``wrangler``, …) inside the user's E2B sandbox. Three kinds of
+bytes are involved and they must NOT share a filesystem — the split below is
+the single most important decision in this subsystem, and it is measured, not
+assumed:
+
+===================  ====================  ====================================
+What                 Where                 Why
+===================  ====================  ====================================
+Language runtime     ``RUNTIME_DIR``       Baked into the E2B template. Node is
+                     (image, local disk)   188 MB / ~20k files. Extracting it
+                                           onto JuiceFS took >600 s and left
+                                           ``node`` with a 12 s startup; from
+                                           the image it is 0.3 s.
+Installed CLI        ``APPS_DIR``          Local disk, re-created per sandbox.
+packages             (local disk)          ``npm install @stripe/link-cli`` is
+                                           ~20 s here and effectively unbounded
+                                           on JuiceFS (thousands of small
+                                           files). Losing it on sandbox
+                                           recreation is the correct trade: a
+                                           20 s reinstall beats a 10 min mount.
+Credentials +        ``home_dir()``        JuiceFS — durable across pause,
+CLI config           (JuiceFS)             kill, and recreation. This is a
+                                           handful of small files (a token
+                                           JSON, a hosts.yml), which JuiceFS
+                                           serves fine, and it is the ONLY part
+                                           that must survive: losing it would
+                                           log the user out of every CLI.
+===================  ====================  ====================================
+
+The CLI is pointed at its durable config by ``HOME`` (plus the XDG variables
+for tools that honour them), set by the per-app launcher in ``LAUNCHER_DIR``.
+GAIA therefore stores no CLI credential itself — the tool owns its own login,
+exactly as it would on a laptop — and a CLI we have never seen keeps working
+as long as it respects ``HOME``.
+"""
+
+from app.agents.workspace.paths import GAIA_RUNTIME_DIRNAME, WORKSPACE_ROOT
+
+# --- Local disk (baked into the image or re-created per sandbox) -------------
+
+# Language runtime baked into the template, under a root only the build writes.
+# Only Node today: it is what the overwhelming majority of vendor CLIs ship on
+# (npm), and Go/Rust CLIs distribute self-contained binaries that need no
+# toolchain to *run*.
+GAIA_OPT_ROOT = "/opt/gaia"
+RUNTIME_DIR = f"{GAIA_OPT_ROOT}/runtime"
+RUNTIME_BIN_DIR = f"{RUNTIME_DIR}/bin"
+
+# Installs and launchers live under the sandbox user's OWN home, not under
+# /opt, so nothing here depends on the template having pre-created a directory.
+# That is not tidiness: E2B resumes a paused sandbox from its original image, so
+# after a template change a returning user can keep running on the old
+# filesystem for hours. Rooting these at a path the unprivileged user always
+# owns means such a sandbox installs cleanly instead of failing on
+# "mkdir: /opt/gaia: Permission denied". (A missing Node still fails, but with
+# "npm: not found", which says what to do.)
+#
+# Local disk, like /opt: re-created per sandbox by design. Only credentials are
+# durable (see CLI_HOME_ROOT).
+SANDBOX_USER_ROOT = "/home/user/.gaia"
+
+# One directory per installed CLI integration, holding whatever its install
+# command produced (node_modules/, an extracted release tarball, …).
+APPS_DIR = f"{SANDBOX_USER_ROOT}/apps"
+
+# Generated launcher scripts, one per installed CLI, added to PATH for every
+# CLI tool invocation. Each launcher pins its own app's HOME so two CLIs can
+# appear in the same shell pipeline without fighting over ~/.config.
+LAUNCHER_DIR = f"{SANDBOX_USER_ROOT}/bin"
+
+# Node version baked into the template. Pinned rather than "lts" so a rebuild
+# is reproducible and a CLI that breaks on a new major does so when we choose.
+NODE_VERSION = "22.14.0"
+NODE_TARBALL_URL = f"https://nodejs.org/dist/v{NODE_VERSION}/node-v{NODE_VERSION}-linux-x64.tar.xz"
+
+# --- JuiceFS (durable across sandbox recreation) -----------------------------
+
+# Parent of the per-integration HOME directories. Sits under the existing
+# /workspace/.gaia runtime dir so it stays out of the user's own file tree
+# (and out of `ls /workspace`), alongside .gaia/runs.
+CLI_HOME_ROOT = f"{WORKSPACE_ROOT}/{GAIA_RUNTIME_DIRNAME}/apps"
+
+
+def app_dir(integration_id: str) -> str:
+    """Local-disk directory holding this integration's installed CLI."""
+    return f"{APPS_DIR}/{integration_id}"
+
+
+def home_dir(integration_id: str) -> str:
+    """Durable (JuiceFS) HOME for this integration's CLI — where its login lives."""
+    return f"{CLI_HOME_ROOT}/{integration_id}"
+
+
+def launcher_path(command: str) -> str:
+    """Path of the generated launcher that puts ``command`` on PATH."""
+    return f"{LAUNCHER_DIR}/{command}"
+
+
+def install_marker_path(integration_id: str) -> str:
+    """Marker written after a successful install, read to skip reinstalling.
+
+    Lives beside the install on LOCAL disk, so a recreated sandbox correctly
+    reports "not installed" and reinstalls, while a warm one skips the ~20 s.
+    """
+    return f"{app_dir(integration_id)}/.gaia-installed"
+
+
+# --- Tunables ---------------------------------------------------------------
+
+# Install is a one-off cold cost (npm install of a vendor CLI measured at ~20 s;
+# a release-tarball download at ~1 s). The ceiling is generous because it is
+# paid once per sandbox, never per call.
+INSTALL_TIMEOUT_SECONDS = 600
+
+# A single CLI invocation on behalf of the agent. Matches the bash tool's
+# default: these are the same class of command.
+EXEC_DEFAULT_TIMEOUT_SECONDS = 300
+EXEC_MAX_TIMEOUT_SECONDS = 1800
+
+# Bound on a "does this CLI consider itself logged in?" probe. Kept short: it
+# runs on every connect poll, and a CLI that cannot answer in this window is
+# reported as not-yet-authenticated rather than blocking the poll.
+VERIFY_TIMEOUT_SECONDS = 60
+
+# How long a device-code login may stay pending before the connect flow gives
+# up. Vendor device codes typically expire in 5–15 minutes.
+LOGIN_TIMEOUT_SECONDS = 900
+
+# Maximum characters of captured CLI output surfaced in a connect status
+# response. Login output is instructions for a human ("go to <url>, enter
+# <code>"), never a transcript, so this is ample.
+LOGIN_OUTPUT_MAX_CHARS = 4_000

--- a/apps/api/app/constants/hil.py
+++ b/apps/api/app/constants/hil.py
@@ -53,6 +53,14 @@ HIL_JUDGE_MIN_QUOTE_WORDS = 3
 # asks, resolver leaves pending).
 HIL_LLM_TIMEOUT_SECONDS = 30
 
+# --- CLI command shaping ----------------------------------------------------------------
+#
+# How many leading words of one command survive into the shape its risk is classified
+# under (``gh pr list``, ``link-cli spend-request create``). Deep enough for the
+# subcommand paths real CLIs use, and a bound on how many distinct shapes one CLI can
+# mint — each new shape costs one classification.
+HIL_CLI_SHAPE_MAX_WORDS = 4
+
 # --- resume ---------------------------------------------------------------------------
 #
 # The only statuses a ``Command(resume=...)`` payload may carry. Anything else is treated

--- a/apps/api/app/constants/integrations.py
+++ b/apps/api/app/constants/integrations.py
@@ -4,6 +4,8 @@ from typing import Final
 
 from composio.core.models.webhook_events import ConnectionStatusEnum
 
+from app.models.integration_provider import ManagedBy
+
 # Limits for LLM context to prevent overwhelming responses
 MAX_CONNECTED_FOR_LLM = 20
 MAX_AVAILABLE_FOR_LLM = 15
@@ -47,13 +49,17 @@ DEAD_CONNECTION_STATUSES: Final = frozenset(
     }
 )
 
-# Integration managed_by provider identifiers
-MANAGED_BY_MCP = "mcp"
-MANAGED_BY_COMPOSIO = "composio"
-MANAGED_BY_SELF = "self"
+# Integration managed_by provider identifiers. Annotated with the shared
+# ``ManagedBy`` alias so a typo here is a type error rather than a value that
+# silently matches no dispatch branch.
+MANAGED_BY_MCP: Final[ManagedBy] = "mcp"
+MANAGED_BY_COMPOSIO: Final[ManagedBy] = "composio"
+MANAGED_BY_SELF: Final[ManagedBy] = "self"
 # Internal integrations (todos, reminders, skills) are always available and
 # never require the user to connect anything.
-MANAGED_BY_INTERNAL = "internal"
+MANAGED_BY_INTERNAL: Final[ManagedBy] = "internal"
+# A real vendor command-line tool, installed and run in the user's sandbox.
+MANAGED_BY_CLI: Final[ManagedBy] = "cli"
 
 # Known integration IDs
 GMAIL_INTEGRATION_ID = "gmail"

--- a/apps/api/app/models/cli_config.py
+++ b/apps/api/app/models/cli_config.py
@@ -39,6 +39,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from app.utils.url_safety import assert_safe_url_shape
+
 # An executable name, not a path. This becomes a filename in the launcher
 # directory and is interpolated into shell, so it is restricted to characters
 # that are inert in both roles. Vendor CLIs are all named well within this
@@ -47,6 +49,13 @@ COMMAND_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$")
 
 # Environment-variable name, for the token auth shape.
 ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,63}$")
+
+
+# Where a connect attempt stands. Lives beside the config rather than in the
+# service that drives it, because the API schema also needs it and a schema
+# cannot import a service -- which is why it was previously written out twice
+# and would have silently rejected a new phase at serialization time.
+CliConnectPhase = Literal["installing", "needs_token", "awaiting_approval", "connected", "failed"]
 
 
 class CliAuthSpec(BaseModel):
@@ -133,7 +142,38 @@ class CliConfig(BaseModel):
     # card. The agent gets the real detail from the CLI's own --help.
     capabilities: list[str] = Field(default_factory=list)
 
+    # The vendor's own site, used only to fetch the icon shown on the
+    # integration card. Declared rather than derived: the obvious shortcut is to
+    # reuse a URL out of ``install_command``, but that names where the bytes are
+    # hosted, not whose tool this is. A CLI published through GitHub Releases or
+    # npm would take GitHub's or npm's icon, which looks plausible and is wrong.
+    homepage: str | None = None
+
     auth: CliAuthSpec
+
+    @field_validator("homepage")
+    @classmethod
+    def _validate_homepage(cls, v: str | None) -> str | None:
+        """Reject anything the favicon fetcher should not be pointed at.
+
+        This value reaches an outbound HTTP request, and for an agent-authored
+        integration it originates from a model, so it gets the same cheap
+        SSRF shape check the MCP server URL does.
+        """
+        if v is None or not v.strip():
+            return None
+        assert_safe_url_shape(v)
+        return v
+
+    @property
+    def requires_auth(self) -> bool:
+        """Whether connecting this CLI needs a credential step.
+
+        One derived predicate instead of ``auth.kind != "none"`` spelled out at
+        every call site, so adding a fourth auth shape cannot leave one of them
+        behind.
+        """
+        return self.auth.kind != "none"
 
     @field_validator("command")
     @classmethod

--- a/apps/api/app/models/cli_config.py
+++ b/apps/api/app/models/cli_config.py
@@ -61,6 +61,9 @@ class CliAuthSpec(BaseModel):
     # run detached because it blocks for minutes and sandbox commands are
     # serialised per user (a foreground poll would freeze every other tool
     # call for that user).
+    # If it takes its own polling timeout, set that at or above
+    # ``LOGIN_TIMEOUT_SECONDS``: a shorter one leaves a window where the CLI
+    # has stopped polling but GAIA still shows the code as live.
     #
     # For ``token`` it is optional: when set it runs once with the pasted
     # secret available under ``token_env``; when unset, exporting that variable

--- a/apps/api/app/models/cli_config.py
+++ b/apps/api/app/models/cli_config.py
@@ -1,0 +1,150 @@
+"""Configuration for CLI-backed integrations.
+
+A CLI integration is described entirely by data: what to install, what the
+resulting command is called, and how that command logs in. No provider-specific
+behaviour lives in code — the same three fields drive ``gh``, ``link-cli``,
+``wrangler`` and a CLI nobody here has seen, which is the point. Vendor CLIs
+agree on almost nothing (flag spelling, output shape, where config lands), so
+the only durable contract we lean on is the one every one of them honours:
+``HOME`` decides where credentials go, and an exit code says whether the tool
+considers itself logged in.
+
+The three auth shapes below are exhaustive for every CLI surveyed (GitHub,
+Vercel, Cloudflare, Supabase, Stripe, Railway, Stripe Link):
+
+``device``
+    The CLI prints instructions — a URL and usually a short code — and polls
+    the vendor until the human approves. GAIA never parses that output; it is
+    relayed to the user verbatim and ``verify_command`` decides when the login
+    landed. Nothing to keep in sync when a vendor rewords its prompt.
+
+``token``
+    The human pastes a token. It is written into the CLI's own durable HOME as
+    an environment file the launcher sources, so the credential lives exactly
+    where that CLI's config lives and GAIA stores none of it. A CLI that also
+    wants to materialise its own config (``gh auth login --with-token``) sets
+    ``login_command`` too.
+
+``none``
+    No credentials (a formatter, a local-only tool).
+
+Browser logins that require a ``localhost`` callback are deliberately absent:
+the sandbox is a different machine from the user's browser, so that redirect
+can never complete. Such CLIs are configured with ``token`` instead, which
+every one of them also supports.
+"""
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# An executable name, not a path. This becomes a filename in the launcher
+# directory and is interpolated into shell, so it is restricted to characters
+# that are inert in both roles. Vendor CLIs are all named well within this
+# (`gh`, `link-cli`, `wrangler`, `supabase`).
+COMMAND_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$")
+
+# Environment-variable name, for the token auth shape.
+ENV_VAR_RE = re.compile(r"^[A-Z_][A-Z0-9_]{0,63}$")
+
+
+class CliAuthSpec(BaseModel):
+    """How one CLI authenticates."""
+
+    kind: Literal["none", "device", "token"]
+
+    # Shell command that performs the login. Runs through the integration's
+    # launcher, so HOME/PATH/XDG are already pointed at this CLI's own dirs.
+    #
+    # For ``device`` this is the command that prints the URL and polls; it is
+    # run detached because it blocks for minutes and sandbox commands are
+    # serialised per user (a foreground poll would freeze every other tool
+    # call for that user).
+    #
+    # For ``token`` it is optional: when set it runs once with the pasted
+    # secret available under ``token_env``; when unset, exporting that variable
+    # on every invocation IS the authentication.
+    login_command: str | None = None
+
+    # Exits 0 if and only if the CLI considers itself authenticated. This is
+    # the single source of truth for connection state — not a parsed string,
+    # not a file we look for. Every surveyed CLI has one (`gh auth status`,
+    # `link-cli auth status`, `wrangler whoami`).
+    verify_command: str
+
+    # Undoes the login. Optional: when absent, disconnecting falls back to
+    # deleting the CLI's durable HOME, which logs out any CLI by construction.
+    logout_command: str | None = None
+
+    # --- token shape only ---
+    # Variable the pasted secret is exported as. Vendor-native names
+    # (CLOUDFLARE_API_TOKEN, VERCEL_TOKEN) mean many CLIs need no
+    # ``login_command`` at all.
+    token_env: str | None = None
+    # What to call the secret in the UI, and where the user gets one.
+    token_label: str | None = None
+    token_help_url: str | None = None
+
+    @field_validator("token_env")
+    @classmethod
+    def _validate_token_env(cls, v: str | None) -> str | None:
+        if v is not None and not ENV_VAR_RE.match(v):
+            raise ValueError(f"token_env {v!r} is not a valid environment variable name")
+        return v
+
+    @model_validator(mode="after")
+    def _enforce_shape_invariants(self) -> "CliAuthSpec":
+        """Pin each auth shape to the fields it actually needs.
+
+        Without this a ``token`` spec missing ``token_env`` would surface as a
+        connect flow that collects a secret and silently drops it.
+        """
+        if self.kind == "device" and not self.login_command:
+            raise ValueError("auth.kind='device' requires login_command")
+        if self.kind == "token":
+            if not self.token_env:
+                raise ValueError("auth.kind='token' requires token_env")
+            if not self.token_label:
+                raise ValueError("auth.kind='token' requires token_label for the UI prompt")
+        if self.kind == "none" and self.login_command:
+            raise ValueError("auth.kind='none' must not set login_command")
+        return self
+
+
+class CliConfig(BaseModel):
+    """Everything GAIA needs to run one third-party CLI on a user's behalf."""
+
+    # The executable the agent invokes, e.g. "link-cli". A launcher of this
+    # name is generated on PATH; the agent never sees an absolute path.
+    command: str
+
+    # Shell that installs the CLI. Runs unprivileged, in this integration's
+    # own local-disk app directory, with the baked Node runtime on PATH.
+    # Deliberately a free-form command rather than a package name: npm,
+    # a release tarball, and a vendor install script are all one line here,
+    # and a CLI distributed some fourth way needs no code change.
+    install_command: str
+
+    # Human-readable summary of what this CLI is for, shown on the integration
+    # card. The agent gets the real detail from the CLI's own --help.
+    capabilities: list[str] = Field(default_factory=list)
+
+    auth: CliAuthSpec
+
+    @field_validator("command")
+    @classmethod
+    def _validate_command(cls, v: str) -> str:
+        if not COMMAND_NAME_RE.match(v):
+            raise ValueError(
+                f"command {v!r} must be a bare executable name "
+                "(letters, digits, dot, dash, underscore)"
+            )
+        return v
+
+    @field_validator("install_command")
+    @classmethod
+    def _validate_install(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("install_command cannot be empty")
+        return v

--- a/apps/api/app/models/hil_models.py
+++ b/apps/api/app/models/hil_models.py
@@ -66,12 +66,19 @@ class HILToolRiskRecord(MongoDocument):
     ``hil_tool_risk``), for durability across restarts/processes.
 
     Supported/internal tools are never stored here — they resolve straight from
-    the tool registry's ``destructive`` flag.
+    the tool registry's ``destructive`` flag. A CLI-backed tool stores one record
+    per command shape, since its single name covers every command it can run.
     """
 
     tool_name: str
+    # md5 of what was classified: the tool's description, plus the CLI command shape
+    # when the verdict is for one command rather than for the tool as a whole.
     description_hash: str
     is_destructive: bool
+    # The classified command shape, for a CLI-backed tool whose one name covers every
+    # command it can run (empty for every other tool). Stored in the clear because the
+    # hash above is a key, not something a human reading a cached verdict can decode.
+    command_shape: str = ""
     rationale: str = ""
     classified_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/apps/api/app/models/integration_models.py
+++ b/apps/api/app/models/integration_models.py
@@ -81,18 +81,18 @@ class Integration(MongoDocument):
     # Management and source
     managed_by: ManagedBy = Field(..., description="Which system manages the integration")
     source: Literal["platform", "custom"] = Field(
-        "custom", description="Platform (from code) or custom (user-created)"
+        default="custom", description="Platform (from code) or custom (user-created)"
     )
 
     # Visibility and ownership
-    is_public: bool = Field(False, description="Visible in public marketplace")
+    is_public: bool = Field(default=False, description="Visible in public marketplace")
     created_by: str | None = Field(None, description="User ID for custom integrations")
 
     # Publishing metadata
     published_at: datetime | None = Field(
-        None, description="When integration was published to marketplace"
+        default=None, description="When integration was published to marketplace"
     )
-    clone_count: int = Field(0, description="Number of times this integration was cloned")
+    clone_count: int = Field(default=0, description="Number of times this integration was cloned")
     # Human-readable unique slug, written at publish time (and by the slug backfill);
     # absent until published. Creator info (name/picture) is not stored here — it is
     # joined from the users collection at read time (see IntegrationWithCreator).
@@ -115,8 +115,8 @@ class Integration(MongoDocument):
         default_factory=list, description="Tool list for frontend display only"
     )
     icon_url: str | None = Field(None, description="Favicon URL fetched from MCP server subdomain")
-    display_priority: int = Field(0, description="Higher priority shows first")
-    is_featured: bool = Field(False, description="Show in featured section")
+    display_priority: int = Field(default=0, description="Higher priority shows first")
+    is_featured: bool = Field(default=False, description="Show in featured section")
 
     # LLM-generated marketplace detail content (use cases, how-it-works, FAQs).
     # Generated at publish time; absent until then (frontend falls back to generic copy).

--- a/apps/api/app/models/integration_models.py
+++ b/apps/api/app/models/integration_models.py
@@ -15,6 +15,8 @@ from pydantic.alias_generators import to_camel
 
 from app.db.repositories.base import MongoDocument, UserScopedDocument
 from app.helpers.integration_helpers import generate_integration_slug
+from app.models.cli_config import CliConfig
+from app.models.integration_provider import ManagedBy
 from app.models.mcp_config import MCPConfig
 from app.models.oauth_models import IntegrationContent, OAuthIntegration
 
@@ -77,9 +79,7 @@ class Integration(MongoDocument):
     category: str = Field(..., description="e.g., productivity, communication, developer")
 
     # Management and source
-    managed_by: Literal["self", "composio", "mcp", "internal"] = Field(
-        ..., description="Which system manages the integration"
-    )
+    managed_by: ManagedBy = Field(..., description="Which system manages the integration")
     source: Literal["platform", "custom"] = Field(
         "custom", description="Platform (from code) or custom (user-created)"
     )
@@ -101,6 +101,7 @@ class Integration(MongoDocument):
     # Configuration (one of these based on managed_by)
     mcp_config: MCPConfig | None = None
     composio_config: ComposioConfigDoc | None = None
+    cli_config: CliConfig | None = None
 
     # Legacy top-level auth mirror. mcp_config is authoritative; these duplicate
     # its auth flags at the document root for older documents. IntegrationResolver
@@ -255,7 +256,7 @@ class IntegrationResponse(BaseModel):
     name: str
     description: str
     category: str
-    managed_by: Literal["self", "composio", "mcp", "internal"]
+    managed_by: ManagedBy
     source: Literal["platform", "custom"]
     is_featured: bool
     display_priority: int
@@ -296,6 +297,12 @@ class IntegrationResponse(BaseModel):
         if integration.mcp_config:
             requires_auth = integration.mcp_config.requires_auth
             auth_type = integration.mcp_config.auth_type or ("oauth" if requires_auth else "none")
+        elif integration.cli_config:
+            # auth_type stays None for CLI-backed integrations: it names an
+            # HTTP auth scheme, and a CLI's login is neither OAuth nor a bearer
+            # header. Leaving it unset is what keeps the client from opening the
+            # bearer-token dialog instead of the CLI connect flow.
+            requires_auth = integration.cli_config.auth.kind != "none"
 
         # Compute slug at runtime (not stored in DB)
         slug = generate_integration_slug(
@@ -335,6 +342,10 @@ class IntegrationResponse(BaseModel):
         elif oauth_int.composio_config:
             requires_auth = True
             auth_type = "oauth"
+        elif oauth_int.cli_config:
+            # See from_integration: auth_type is an HTTP scheme and does not
+            # describe a CLI login.
+            requires_auth = oauth_int.cli_config.auth.kind != "none"
 
         return cls(
             integration_id=oauth_int.id,
@@ -347,7 +358,14 @@ class IntegrationResponse(BaseModel):
             display_priority=oauth_int.display_priority,
             requires_auth=requires_auth,
             auth_type=cast(AuthType, auth_type) if auth_type else None,
-            tools=[],  # Platform tools are loaded live, not stored
+            # A CLI integration's declared capabilities ARE its user-facing tool
+            # list — one tool wraps the whole CLI, so listing that single tool
+            # would tell the user nothing. Other platform tools load live.
+            tools=(
+                [IntegrationTool(name=c) for c in oauth_int.cli_config.capabilities]
+                if oauth_int.cli_config
+                else []
+            ),
             slug=oauth_int.id,  # Platform integrations use ID as slug
         )
 

--- a/apps/api/app/models/integration_models.py
+++ b/apps/api/app/models/integration_models.py
@@ -232,7 +232,7 @@ class CreateCustomIntegrationRequest(BaseModel):
     server_url: str = Field(..., description="MCP server URL")
     requires_auth: bool = Field(False)
     auth_type: Literal["none", "oauth", "bearer"] | None = Field(None)
-    is_public: bool = Field(False)
+    is_public: bool = Field(default=False)
     bearer_token: str | None = Field(None)
 
 
@@ -302,7 +302,7 @@ class IntegrationResponse(BaseModel):
             # HTTP auth scheme, and a CLI's login is neither OAuth nor a bearer
             # header. Leaving it unset is what keeps the client from opening the
             # bearer-token dialog instead of the CLI connect flow.
-            requires_auth = integration.cli_config.auth.kind != "none"
+            requires_auth = integration.cli_config.requires_auth
 
         # Compute slug at runtime (not stored in DB)
         slug = generate_integration_slug(
@@ -345,7 +345,7 @@ class IntegrationResponse(BaseModel):
         elif oauth_int.cli_config:
             # See from_integration: auth_type is an HTTP scheme and does not
             # describe a CLI login.
-            requires_auth = oauth_int.cli_config.auth.kind != "none"
+            requires_auth = oauth_int.cli_config.requires_auth
 
         return cls(
             integration_id=oauth_int.id,

--- a/apps/api/app/models/integration_provider.py
+++ b/apps/api/app/models/integration_provider.py
@@ -1,0 +1,17 @@
+"""The transports an integration can be backed by.
+
+One closed set, referenced from the catalog models, the API schemas, the
+subagent models and the connect dispatch. It lived as a repeated
+``Literal[...]`` in six places, which is exactly the shape that drifts: adding
+a transport meant finding every copy, and missing one produced a validation
+error far from the change.
+"""
+
+from typing import Literal
+
+# ``self``      — GAIA runs the OAuth dance itself (Google).
+# ``composio``  — Composio brokers the connection and hosts the tools.
+# ``mcp``       — an MCP server, platform-configured or user-supplied.
+# ``internal``  — built into GAIA; nothing to connect (todos, reminders).
+# ``cli``       — a real vendor command-line tool run in the user's sandbox.
+ManagedBy = Literal["self", "composio", "mcp", "internal", "cli"]

--- a/apps/api/app/models/oauth_models.py
+++ b/apps/api/app/models/oauth_models.py
@@ -5,6 +5,8 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.alias_generators import to_camel
 
+from app.models.cli_config import CliConfig
+from app.models.integration_provider import ManagedBy
 from app.models.mcp_config import (
     ComposioConfig,
     MCPConfig,
@@ -61,9 +63,10 @@ class OAuthIntegration(BaseModel):
     included_integrations: list[str] = []
     is_featured: bool = False
     short_name: str | None = None
-    managed_by: Literal["self", "composio", "mcp", "internal"]
+    managed_by: ManagedBy
     composio_config: ComposioConfig | None = None
     mcp_config: MCPConfig | None = None
+    cli_config: CliConfig | None = None
     # Tool names/slugs this integration's HIL gate must treat as destructive
     # (e.g. GMAIL_SEND_EMAIL). Integration-agnostic — applies to Composio and
     # built-in MCP configs alike. ``None`` = uncurated: the HIL LLM classifier
@@ -90,6 +93,17 @@ class OAuthIntegration(BaseModel):
             raise ValueError(
                 f"Integration {self.id!r} has managed_by='composio' but no composio_config."
             )
+        # Same bidirectional invariant for the CLI transport: the connect
+        # dispatch and the tool factory both select on managed_by == "cli" and
+        # then require cli_config, so a mismatch would surface as a connect
+        # that resolves to nothing rather than a config error at import.
+        if self.cli_config is not None and self.managed_by != "cli":
+            raise ValueError(
+                f"Integration {self.id!r} sets cli_config but "
+                f"managed_by={self.managed_by!r}; expected 'cli'."
+            )
+        if self.managed_by == "cli" and self.cli_config is None:
+            raise ValueError(f"Integration {self.id!r} has managed_by='cli' but no cli_config.")
         return self
 
 

--- a/apps/api/app/models/subagent_models.py
+++ b/apps/api/app/models/subagent_models.py
@@ -10,8 +10,8 @@ field lives in a separate key space — that's the name registered with
 """
 
 from dataclasses import dataclass
-from typing import Literal
 
+from app.models.integration_provider import ManagedBy
 from app.models.mcp_config import MCPConfig, SubAgentConfig
 
 
@@ -20,7 +20,7 @@ class Subagent:
     id: str
     name: str
     provider: str
-    managed_by: Literal["self", "composio", "mcp", "internal"]
+    managed_by: ManagedBy
     config: SubAgentConfig
     short_name: str | None = None
     mcp_config: MCPConfig | None = None

--- a/apps/api/app/schemas/integrations/responses.py
+++ b/apps/api/app/schemas/integrations/responses.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, ConfigDict, field_validator
 from pydantic.alias_generators import to_camel
 
+from app.models.cli_config import CliConnectPhase
 from app.models.integration_instructions_models import InstructionsEditor
 from app.models.integration_models import UserIntegrationStatus
 from app.models.integration_provider import ManagedBy
@@ -189,7 +190,7 @@ class CliConnectDetail(CamelModel):
     leaves ``pending``.
     """
 
-    phase: Literal["installing", "needs_token", "awaiting_approval", "connected", "failed"]
+    phase: CliConnectPhase
     # The CLI's own login output, relayed verbatim (the URL and code to
     # approve). Never parsed by GAIA — vendors word and reword this freely.
     instructions: str | None = None

--- a/apps/api/app/schemas/integrations/responses.py
+++ b/apps/api/app/schemas/integrations/responses.py
@@ -173,6 +173,13 @@ class IntegrationToolsResponse(CamelModel):
     count: int = 0
 
 
+# The outcome of a connect attempt, shared by the direct connect endpoint and
+# the marketplace "add" path. One alias because they are the same fact: adding a
+# public integration performs a connect and forwards its result verbatim, so a
+# status the connect can produce is a status the add can return.
+ConnectStatus = Literal["connected", "redirect", "error", "pending"]
+
+
 class CliConnectDetail(CamelModel):
     """Live state of a CLI connect attempt, for the client to render and poll.
 
@@ -194,7 +201,7 @@ class CliConnectDetail(CamelModel):
 class ConnectIntegrationResponse(CamelModel):
     # ``pending`` is the CLI transport's steady state while an install runs or
     # a device login waits on the user; ``cli`` says what to show meanwhile.
-    status: Literal["connected", "redirect", "error", "pending"]
+    status: ConnectStatus
     integration_id: str
     name: str
     message: str | None = None
@@ -289,7 +296,7 @@ class AddIntegrationResponse(CamelModel):
 
     integration_id: str
     name: str
-    status: Literal["connected", "redirect", "error"]
+    status: ConnectStatus
     message: str = "Integration added successfully"
     redirect_url: str | None = None
     tools_count: int | None = None

--- a/apps/api/app/schemas/integrations/responses.py
+++ b/apps/api/app/schemas/integrations/responses.py
@@ -8,6 +8,7 @@ from pydantic.alias_generators import to_camel
 
 from app.models.integration_instructions_models import InstructionsEditor
 from app.models.integration_models import UserIntegrationStatus
+from app.models.integration_provider import ManagedBy
 from app.models.oauth_models import IntegrationContent
 from app.schemas.common import SuccessResponse
 
@@ -41,7 +42,7 @@ class IntegrationConfigItem(CamelModel):
     display_priority: int
     included_integrations: list[str]
     is_featured: bool
-    managed_by: Literal["self", "composio", "mcp", "internal"]
+    managed_by: ManagedBy
     auth_type: Literal["none", "oauth", "bearer"] | None = None
     requires_auth: bool = False
     source: Literal["platform"] = "platform"
@@ -99,7 +100,7 @@ class IntegrationResponse(CamelModel, CloneCountMixin):
     name: str
     description: str
     category: str
-    managed_by: Literal["self", "composio", "mcp", "internal"]
+    managed_by: ManagedBy
     source: Literal["platform", "custom"]
     is_featured: bool
     display_priority: int
@@ -135,7 +136,7 @@ class MyIntegrationItem(CamelModel, CloneCountMixin):
     description: str
     category: str
     source: Literal["platform", "custom"]
-    managed_by: Literal["self", "composio", "mcp", "internal"]
+    managed_by: ManagedBy
     status: Literal["connected", "created", "expired", "not_connected"]
     # When the upstream grant died, so the UI can say how long it has been broken.
     expired_at: datetime | None = None
@@ -172,14 +173,35 @@ class IntegrationToolsResponse(CamelModel):
     count: int = 0
 
 
+class CliConnectDetail(CamelModel):
+    """Live state of a CLI connect attempt, for the client to render and poll.
+
+    A CLI connect is neither instant nor a redirect: it installs a tool and
+    then waits on a human. This block carries what the user has to see and do
+    right now, and the client re-POSTs the connect endpoint until ``status``
+    leaves ``pending``.
+    """
+
+    phase: Literal["installing", "needs_token", "awaiting_approval", "connected", "failed"]
+    # The CLI's own login output, relayed verbatim (the URL and code to
+    # approve). Never parsed by GAIA — vendors word and reword this freely.
+    instructions: str | None = None
+    # Prompt copy for the paste-a-token shape.
+    token_label: str | None = None
+    token_help_url: str | None = None
+
+
 class ConnectIntegrationResponse(CamelModel):
-    status: Literal["connected", "redirect", "error"]
+    # ``pending`` is the CLI transport's steady state while an install runs or
+    # a device login waits on the user; ``cli`` says what to show meanwhile.
+    status: Literal["connected", "redirect", "error", "pending"]
     integration_id: str
     name: str
     message: str | None = None
     tools_count: int | None = None
     redirect_url: str | None = None
     error: str | None = None
+    cli: CliConnectDetail | None = None
 
 
 class PublishIntegrationResponse(SuccessResponse, CamelModel):

--- a/apps/api/app/services/cli/__init__.py
+++ b/apps/api/app/services/cli/__init__.py
@@ -1,0 +1,24 @@
+"""CLI-backed integrations: running real vendor command-line tools for a user.
+
+``runtime`` owns the sandbox mechanics (install, launcher, execution);
+``connect`` owns the idempotent connect state machine built on top of it.
+"""
+
+from app.services.cli.connect import (
+    CliConnectOutcome,
+    CliConnectPhase,
+    advance,
+    disconnect,
+    is_connected,
+)
+from app.services.cli.runtime import CliResult, CliState
+
+__all__ = [
+    "CliConnectOutcome",
+    "CliConnectPhase",
+    "CliResult",
+    "CliState",
+    "advance",
+    "disconnect",
+    "is_connected",
+]

--- a/apps/api/app/services/cli/__init__.py
+++ b/apps/api/app/services/cli/__init__.py
@@ -4,13 +4,8 @@
 ``connect`` owns the idempotent connect state machine built on top of it.
 """
 
-from app.services.cli.connect import (
-    CliConnectOutcome,
-    CliConnectPhase,
-    advance,
-    disconnect,
-    is_connected,
-)
+from app.models.cli_config import CliConnectPhase
+from app.services.cli.connect import CliConnectOutcome, advance, disconnect
 from app.services.cli.runtime import CliResult, CliState
 
 __all__ = [
@@ -20,5 +15,4 @@ __all__ = [
     "CliState",
     "advance",
     "disconnect",
-    "is_connected",
 ]

--- a/apps/api/app/services/cli/connect.py
+++ b/apps/api/app/services/cli/connect.py
@@ -1,0 +1,218 @@
+"""Connecting a CLI integration: one idempotent step at a time.
+
+Connecting a CLI is not a redirect — it is a short-lived process (install the
+tool, log it in, confirm the login took) whose duration is dominated by things
+GAIA does not control: an npm install, and a human walking to their phone to
+approve a device code.
+
+The flow is therefore modelled as a **state machine with no state of its own**.
+:func:`advance` is idempotent: each call reads the truth from the sandbox
+(is the CLI installed? does it consider itself logged in? is a login still
+polling?), takes at most one action, and reports where things stand. The client
+calls it repeatedly until it reports a terminal phase.
+
+Deriving the state instead of storing it is what makes this survive the things
+that actually happen in production: the sandbox is recreated roughly hourly
+(so "installed" must be re-read, never remembered), a replica can be replaced
+mid-flow (so no in-process task may own the progress), and a token can be
+revoked upstream at any time (so "connected" must mean the CLI says so now, not
+that it once did).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from e2b import AsyncSandbox
+
+from app.constants.cli_integrations import LOGIN_TIMEOUT_SECONDS
+from app.constants.log_tags import LogTag
+from app.db.repositories.user_integrations import user_integration_repository
+from app.models.cli_config import CliConfig
+from app.services.cli import runtime
+from app.services.integrations.user_integration_status import update_user_integration_status
+from app.services.integrations.user_integrations import add_user_integration
+from app.services.sandbox import acquire_sandbox
+from shared.py.wide_events import log
+
+# ``installing`` — the CLI is being fetched into the sandbox.
+# ``needs_token`` — waiting for the user to paste a secret.
+# ``awaiting_approval`` — a device login is live; ``instructions`` says what to do.
+# ``connected`` / ``failed`` — terminal.
+CliConnectPhase = Literal["installing", "needs_token", "awaiting_approval", "connected", "failed"]
+
+_TERMINAL: frozenset[CliConnectPhase] = frozenset({"connected", "failed"})
+
+
+@dataclass(frozen=True)
+class CliConnectOutcome:
+    """Where a connect attempt stands after one :func:`advance` call."""
+
+    phase: CliConnectPhase
+    message: str | None = None
+    # The login command's own output, relayed verbatim. For a device login this
+    # is the URL and code the user needs. Never parsed — see runtime.start_login.
+    instructions: str | None = None
+    # Prompt copy for the token shape, so the client need not know the config.
+    token_label: str | None = None
+    token_help_url: str | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.phase in _TERMINAL
+
+
+async def advance(
+    user_id: str,
+    integration_id: str,
+    config: CliConfig,
+    *,
+    token: str | None = None,
+) -> CliConnectOutcome:
+    """Move one step toward a connected CLI, and report where it stands.
+
+    Safe to call repeatedly and concurrently: every branch is either a read or
+    an idempotent write, so a duplicate call costs a round trip and changes
+    nothing.
+    """
+    log.set(
+        integration={"id": integration_id, "managed_by": "cli", "action": "cli_connect"},
+        cli={"command": config.command, "auth_kind": config.auth.kind},
+    )
+    # The record must exist before the first status transition, and a user may
+    # reach a platform CLI integration without ever having "added" it. Guarded
+    # on existence rather than blindly added: this function is the client's poll
+    # loop, and ``add_user_integration`` raises on a duplicate, so an unguarded
+    # add fails every call after the first.
+
+    if not await user_integration_repository.exists(user_id, integration_id):
+        await add_user_integration(user_id, integration_id, initial_status="created")
+
+    async with acquire_sandbox(user_id) as sbx:
+        if token is not None:
+            written = await runtime.write_token(sbx, integration_id, config, token)
+            if not written.ok:
+                return _failed(
+                    integration_id,
+                    "The CLI rejected that token.",
+                    detail=written.stderr or written.stdout,
+                )
+
+        state = await runtime.probe_state(sbx, integration_id, config)
+
+        if state.install_error:
+            return _failed(
+                integration_id,
+                f"Could not install {config.command}.",
+                detail=state.install_error,
+            )
+
+        if state.authenticated:
+            await update_user_integration_status(user_id, integration_id, "connected")
+            log.set(outcome="connected")
+            return CliConnectOutcome(phase="connected")
+
+        if config.auth.kind == "none":
+            # Nothing to log into, yet the CLI does not report itself ready —
+            # a broken install rather than a missing credential.
+            return _failed(
+                integration_id,
+                f"{config.command} is installed but not reporting as ready.",
+            )
+
+        if config.auth.kind == "token":
+            # A token was just written and the CLI still says no: report that
+            # plainly rather than silently asking for the same token again.
+            if token is not None:
+                return _failed(
+                    integration_id,
+                    f"{config.command} did not accept that token.",
+                )
+            return CliConnectOutcome(
+                phase="needs_token",
+                token_label=config.auth.token_label,
+                token_help_url=config.auth.token_help_url,
+            )
+
+        return await _advance_device_login(sbx, integration_id, config, state)
+
+
+async def _advance_device_login(
+    sbx: AsyncSandbox,
+    integration_id: str,
+    config: CliConfig,
+    state: runtime.CliState,
+) -> CliConnectOutcome:
+    """Drive the device-code shape: start a login, or report the live one.
+
+    Two CLI behaviours have to be handled by the same code, because both exist
+    in the wild: one keeps a process alive polling the vendor
+    (``link-cli auth login --interval``), the other prints the code and exits,
+    leaving the exchange to the next status call. Neither is detectable from
+    the output, so liveness alone never decides — an already-printed login
+    stays on screen until it is old enough to have expired.
+    """
+    age = state.login_age_seconds
+    login_is_fresh = age is not None and age < LOGIN_TIMEOUT_SECONDS
+
+    if state.login_running or (login_is_fresh and state.login_output):
+        return CliConnectOutcome(
+            phase="awaiting_approval",
+            instructions=state.login_output or None,
+            message="Waiting for you to approve the login.",
+        )
+
+    if login_is_fresh and not state.login_output:
+        # Started moments ago and has not printed yet (vendor CLIs take a few
+        # seconds to reach their device endpoint). Keep the client polling
+        # rather than starting a second login.
+        return CliConnectOutcome(
+            phase="awaiting_approval", message=f"Starting {config.command} login…"
+        )
+
+    started = await runtime.start_login(sbx, integration_id, config)
+    if not started.ok:
+        return _failed(
+            integration_id,
+            f"Could not start the {config.command} login.",
+            detail=started.stderr or started.stdout,
+        )
+    return CliConnectOutcome(phase="awaiting_approval", message=f"Starting {config.command} login…")
+
+
+async def disconnect(user_id: str, integration_id: str, config: CliConfig) -> None:
+    """Log the CLI out and remove everything it installed for this user."""
+    log.set(integration={"id": integration_id, "action": "cli_disconnect"})
+    async with acquire_sandbox(user_id) as sbx:
+        await runtime.cancel_login(sbx, integration_id)
+        await runtime.clear_credentials(sbx, integration_id, config)
+
+
+async def is_connected(user_id: str, integration_id: str, config: CliConfig) -> bool:
+    """Ask the CLI itself whether it is still logged in."""
+    async with acquire_sandbox(user_id) as sbx:
+        state = await runtime.probe_state(sbx, integration_id, config)
+        return state.authenticated
+
+
+def _failed(integration_id: str, message: str, *, detail: str | None = None) -> CliConnectOutcome:
+    """A terminal failure, logged with the underlying detail.
+
+    The detail is surfaced to the user too: an install or login failure is
+    almost always something they can act on (a bad token, a network block),
+    and hiding the CLI's own error behind "connection failed" makes it
+    unfixable.
+    """
+    log.set(outcome="failed")
+    log.warning(
+        f"{LogTag.INTEGRATION} CLI connect failed",
+        integration_id=integration_id,
+        reason=message,
+        detail=(detail or "")[:500],
+    )
+    return CliConnectOutcome(
+        phase="failed",
+        message=message,
+        instructions=detail.strip() if detail and detail.strip() else None,
+    )

--- a/apps/api/app/services/cli/connect.py
+++ b/apps/api/app/services/cli/connect.py
@@ -23,25 +23,19 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from typing import Literal
 
 from e2b import AsyncSandbox
 
 from app.constants.cli_integrations import LOGIN_TIMEOUT_SECONDS
 from app.constants.log_tags import LogTag
 from app.db.repositories.user_integrations import user_integration_repository
-from app.models.cli_config import CliConfig
+from app.models.cli_config import CliConfig, CliConnectPhase
 from app.services.cli import runtime
 from app.services.integrations.user_integration_status import update_user_integration_status
 from app.services.integrations.user_integrations import add_user_integration
-from app.services.sandbox import acquire_sandbox
+from app.services.sandbox import SandboxAcquisitionError, acquire_sandbox
+from app.services.sandbox.errors import SandboxRateLimitError
 from shared.py.wide_events import log
-
-# ``installing`` — the CLI is being fetched into the sandbox.
-# ``needs_token`` — waiting for the user to paste a secret.
-# ``awaiting_approval`` — a device login is live; ``instructions`` says what to do.
-# ``connected`` / ``failed`` — terminal.
-CliConnectPhase = Literal["installing", "needs_token", "awaiting_approval", "connected", "failed"]
 
 _TERMINAL: frozenset[CliConnectPhase] = frozenset({"connected", "failed"})
 
@@ -89,6 +83,30 @@ async def advance(
 
     await _ensure_attached(user_id, integration_id)
 
+    try:
+        return await _advance_in_sandbox(user_id, integration_id, config, token)
+    except SandboxRateLimitError:
+        # A quota the user owns and can wait out, not a broken integration.
+        return _failed(
+            integration_id,
+            "You have started too many workspaces recently. Wait a few minutes and connect again.",
+        )
+    except SandboxAcquisitionError as e:
+        return _failed(
+            integration_id,
+            f"GAIA could not start the workspace that runs {config.command}. "
+            "This is usually temporary; try again in a minute.",
+            detail=str(e),
+        )
+
+
+async def _advance_in_sandbox(
+    user_id: str,
+    integration_id: str,
+    config: CliConfig,
+    token: str | None,
+) -> CliConnectOutcome:
+    """The part of :func:`advance` that needs a live sandbox."""
     async with acquire_sandbox(user_id) as sbx:
         # Only the token shape has somewhere to put a secret. The connect
         # endpoint is public and takes a bearer_token for the MCP transport, so
@@ -208,13 +226,6 @@ async def disconnect(user_id: str, integration_id: str, config: CliConfig) -> No
     async with acquire_sandbox(user_id) as sbx:
         await runtime.cancel_login(sbx, integration_id)
         await runtime.clear_credentials(sbx, integration_id, config)
-
-
-async def is_connected(user_id: str, integration_id: str, config: CliConfig) -> bool:
-    """Ask the CLI itself whether it is still logged in."""
-    async with acquire_sandbox(user_id) as sbx:
-        state = await runtime.probe_state(sbx, integration_id, config)
-        return state.authenticated
 
 
 def _failed(integration_id: str, message: str, *, detail: str | None = None) -> CliConnectOutcome:

--- a/apps/api/app/services/cli/connect.py
+++ b/apps/api/app/services/cli/connect.py
@@ -21,6 +21,7 @@ that it once did).
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from typing import Literal
 
@@ -86,17 +87,20 @@ async def advance(
     # loop, and ``add_user_integration`` raises on a duplicate, so an unguarded
     # add fails every call after the first.
 
-    if not await user_integration_repository.exists(user_id, integration_id):
-        await add_user_integration(user_id, integration_id, initial_status="created")
+    await _ensure_attached(user_id, integration_id)
 
     async with acquire_sandbox(user_id) as sbx:
-        if token is not None:
+        # Only the token shape has somewhere to put a secret. The connect
+        # endpoint is public and takes a bearer_token for the MCP transport, so
+        # a token can arrive for a device-login CLI; writing it would raise on
+        # the missing token_env and surface as an opaque error.
+        if token is not None and config.auth.kind == "token":
             written = await runtime.write_token(sbx, integration_id, config, token)
             if not written.ok:
                 return _failed(
                     integration_id,
                     "The CLI rejected that token.",
-                    detail=written.stderr or written.stdout,
+                    detail=runtime.user_visible_output(written.stderr or written.stdout),
                 )
 
         state = await runtime.probe_state(sbx, integration_id, config)
@@ -138,6 +142,23 @@ async def advance(
         return await _advance_device_login(sbx, integration_id, config, state)
 
 
+async def _ensure_attached(user_id: str, integration_id: str) -> None:
+    """Attach the integration to the user, tolerating an existing record.
+
+    ``advance`` IS the client's poll loop and two polls can overlap (a retry
+    fired while a request is still in flight, the same page open twice), so the
+    existence check alone is a race: both callers see "absent" and the loser's
+    duplicate insert would surface as a user-visible connect error on a call
+    that should have been a no-op.
+    """
+    if await user_integration_repository.exists(user_id, integration_id):
+        return
+    # Raised only for "already added" here; the integration is resolved by the
+    # caller before this point, so it cannot be the not-found case.
+    with contextlib.suppress(ValueError):
+        await add_user_integration(user_id, integration_id, initial_status="created")
+
+
 async def _advance_device_login(
     sbx: AsyncSandbox,
     integration_id: str,
@@ -176,7 +197,7 @@ async def _advance_device_login(
         return _failed(
             integration_id,
             f"Could not start the {config.command} login.",
-            detail=started.stderr or started.stdout,
+            detail=runtime.user_visible_output(started.stderr or started.stdout),
         )
     return CliConnectOutcome(phase="awaiting_approval", message=f"Starting {config.command} login…")
 

--- a/apps/api/app/services/cli/runtime.py
+++ b/apps/api/app/services/cli/runtime.py
@@ -111,9 +111,11 @@ class CliState:
     installed: bool
     authenticated: bool
     login_running: bool
-    # Seconds since the detached login started, or ``None`` if none has been
-    # started in this sandbox. Read from the login log's mtime so it needs no
-    # external bookkeeping.
+    # Seconds since the detached login STARTED, or ``None`` if none has been
+    # started in this sandbox. Read from the pid file's mtime -- written once
+    # at launch and never touched again. The log's mtime would measure the
+    # last write instead, so a login that prints progress while it polls
+    # would look permanently fresh and never be restarted.
     login_age_seconds: int | None
     # The login command's own output, verbatim — the URL and code a human needs.
     login_output: str
@@ -315,6 +317,44 @@ async def ensure_installed(sbx: AsyncSandbox, integration_id: str, config: CliCo
     return result
 
 
+def _state_script(integration_id: str, config: CliConfig) -> str:
+    """The block that reports install/auth/login state in one round trip.
+
+    Extracted from :func:`probe_state` so its three bounds are readable and
+    testable on their own: each one exists because of a way this hung or lied.
+
+    * ``timeout ... </dev/null`` around the verify command, because it runs on
+      every poll tick while the per-user sandbox lock is held; a verify that
+      waits on a TTY would queue that user's every other tool call behind it.
+    * ``age`` from the PID file, written once at launch, not from the log,
+      whose mtime is its last write -- a login that prints progress while it
+      polls would look permanently fresh and never be restarted.
+    * ``tail -c`` on the log, because truncating in Python still drags an
+      unbounded stream across the wire on each of up to 240 ticks.
+    """
+    pid_path = shlex.quote(_login_pid_path(integration_id))
+    return f"""
+gaia_authed=0
+if timeout {VERIFY_TIMEOUT_SECONDS} sh -c {shlex.quote(config.auth.verify_command)} \
+     >/dev/null 2>&1 </dev/null; then gaia_authed=1; fi
+
+gaia_running=0
+gaia_pid=$(cat {pid_path} 2>/dev/null || true)
+if [ -n "$gaia_pid" ] && kill -0 "$gaia_pid" 2>/dev/null; then gaia_running=1; fi
+
+gaia_age=-1
+if [ -f {pid_path} ]; then
+  gaia_now=$(date +%s)
+  gaia_mtime=$(stat -c %Y {pid_path} 2>/dev/null || echo "$gaia_now")
+  gaia_age=$((gaia_now - gaia_mtime))
+fi
+
+echo "{_STATE_LINE} authenticated=$gaia_authed running=$gaia_running age=$gaia_age"
+echo "{_OUTPUT_BEGIN}"
+tail -c {LOGIN_OUTPUT_MAX_CHARS * 4} {shlex.quote(_login_log_path(integration_id))} 2>/dev/null || true
+"""
+
+
 async def probe_state(sbx: AsyncSandbox, integration_id: str, config: CliConfig) -> CliState:
     """Every fact the connect flow needs, in one sandbox round trip.
 
@@ -323,31 +363,7 @@ async def probe_state(sbx: AsyncSandbox, integration_id: str, config: CliConfig)
     CLI consider itself logged in, is a detached login still polling, and what
     has that login printed for the user.
     """
-    script = _wrap(
-        integration_id,
-        config,
-        f"""
-gaia_authed=0
-if ( {config.auth.verify_command} ) >/dev/null 2>&1; then gaia_authed=1; fi
-
-gaia_running=0
-gaia_pid=$(cat {shlex.quote(_login_pid_path(integration_id))} 2>/dev/null || true)
-if [ -n "$gaia_pid" ] && kill -0 "$gaia_pid" 2>/dev/null; then gaia_running=1; fi
-
-gaia_age=-1
-if [ -f {shlex.quote(_login_log_path(integration_id))} ]; then
-  gaia_now=$(date +%s)
-  gaia_mtime=$(stat -c %Y {shlex.quote(_login_log_path(integration_id))} 2>/dev/null || echo "$gaia_now")
-  gaia_age=$((gaia_now - gaia_mtime))
-fi
-
-echo "{_STATE_LINE} authenticated=$gaia_authed running=$gaia_running age=$gaia_age"
-echo "{_OUTPUT_BEGIN}"
-cat {shlex.quote(_login_log_path(integration_id))} 2>/dev/null || true
-""",
-        # The verify command is the slow part (a network round trip to the
-        # vendor); everything else is local.
-    )
+    script = _wrap(integration_id, config, _state_script(integration_id, config))
     # The install guard rides inside this same shell, and a cold sandbox is
     # exactly the state probe_state is called in (advance calls it first). A
     # verify-sized budget here would kill the install that has to finish before
@@ -405,6 +421,11 @@ async def start_login(sbx: AsyncSandbox, integration_id: str, config: CliConfig)
     log_path = _login_log_path(integration_id)
     pid_path = _login_pid_path(integration_id)
     detached = (
+        # Kill any predecessor FIRST. Deleting its pid file without killing it
+        # orphans the process with its only handle gone, so cancel_login can
+        # never reach it and a restarting login leaks one per attempt.
+        f"gaia_prev=$(cat {shlex.quote(pid_path)} 2>/dev/null || true); "
+        f'if [ -n "$gaia_prev" ]; then kill "$gaia_prev" 2>/dev/null || true; fi; '
         f"rm -f {shlex.quote(log_path)} {shlex.quote(pid_path)}; "
         f"nohup sh -c {shlex.quote(config.auth.login_command)} "
         f"> {shlex.quote(log_path)} 2>&1 & "

--- a/apps/api/app/services/cli/runtime.py
+++ b/apps/api/app/services/cli/runtime.py
@@ -1,0 +1,490 @@
+"""Run a third-party CLI inside the user's sandbox.
+
+This module owns the only place GAIA knows anything mechanical about CLI
+integrations: where a CLI is installed, how it is put on ``PATH``, and how its
+credentials are pointed at durable storage. Everything provider-specific
+arrives as data in :class:`~app.models.cli_config.CliConfig`.
+
+Three invariants shape the code.
+
+**Installs are ephemeral, logins are not.** The sandbox is recreated roughly
+hourly, taking the installed package with it, while the CLI's credentials live
+on JuiceFS and survive. Every entry point therefore re-installs on demand
+rather than assuming a prior call did — the guard is a single ``test -f`` folded
+into the same shell invocation, so a warm sandbox pays nothing (measured 2.2 s
+for a full CLI call) and a cold one self-heals instead of reporting "command
+not found" (27 s for an npm-based CLI, 4.5 s for a release tarball).
+
+**One round trip per operation.** Sandbox commands are serialised per user, so
+each extra round trip is latency every other tool call for that user waits on.
+The install guard, the install itself, the launcher generation and the actual
+work all ride in one script; :func:`probe_state` answers every question the
+connect flow asks in a single call.
+
+**The CLI is the source of truth for its own login.** GAIA never parses login
+output and never stores a vendor credential in its own database. Connection
+state is whatever ``verify_command`` exits with, which is the only signal that
+stays correct when a token is revoked, expires, or is rotated outside GAIA.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shlex
+
+from e2b import AsyncSandbox, CommandExitException
+
+from app.agents.workspace.paths import WORKSPACE_ROOT
+from app.constants.cli_integrations import (
+    APPS_DIR,
+    CLI_HOME_ROOT,
+    GAIA_OPT_ROOT,
+    INSTALL_TIMEOUT_SECONDS,
+    LAUNCHER_DIR,
+    LOGIN_OUTPUT_MAX_CHARS,
+    RUNTIME_BIN_DIR,
+    SANDBOX_USER_ROOT,
+    VERIFY_TIMEOUT_SECONDS,
+    app_dir,
+    home_dir,
+    install_marker_path,
+    launcher_path,
+)
+from app.constants.log_tags import LogTag
+from app.models.cli_config import CliConfig
+from shared.py.wide_events import log
+
+# Exit code the install guard uses to say "install ran and failed". Chosen
+# outside the range a vendor CLI realistically returns so an install failure is
+# never mistaken for the user's command exiting non-zero.
+INSTALL_FAILED_EXIT_CODE = 111
+
+# Where the install script's own output goes, so it never contaminates the
+# output of the command the agent actually asked for. Read back verbatim when
+# an install fails, which is the only time anyone wants it.
+_INSTALL_LOG = "install.log"
+
+# A device login blocks for minutes while the human approves in a browser, and
+# sandbox commands are serialised per user — running it in the foreground would
+# freeze every other tool call for that user for the whole window. It is
+# therefore detached, with its output and pid on local disk beside the install.
+_LOGIN_LOG = "login.log"
+_LOGIN_PID = "login.pid"
+
+# Environment file inside the CLI's durable HOME, sourced by the launcher.
+# Holds token-shaped credentials for CLIs whose authentication *is* an
+# environment variable. Lives with that CLI's own config rather than in a GAIA
+# table, so "log out" and "delete the app" are the same operation.
+_ENV_FILE = ".gaia-env"
+
+# Markers framing the structured block probe_state() parses. Chosen to be
+# inert in shell and absent from any plausible CLI output.
+_STATE_LINE = "__GAIA_CLI_STATE__"
+_OUTPUT_BEGIN = "__GAIA_CLI_OUTPUT_BEGIN__"
+
+
+@dataclass(frozen=True)
+class CliResult:
+    """Outcome of one CLI invocation."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0
+
+    @property
+    def install_failed(self) -> bool:
+        return self.exit_code == INSTALL_FAILED_EXIT_CODE
+
+
+@dataclass(frozen=True)
+class CliState:
+    """Everything the connect flow needs, read from the sandbox in one call.
+
+    Deliberately derived rather than stored: the sandbox filesystem and the
+    CLI's own exit code already hold this state, so there is no second copy to
+    fall out of sync when a sandbox is recreated or a token is revoked
+    upstream.
+    """
+
+    installed: bool
+    authenticated: bool
+    login_running: bool
+    # Seconds since the detached login started, or ``None`` if none has been
+    # started in this sandbox. Read from the login log's mtime so it needs no
+    # external bookkeeping.
+    login_age_seconds: int | None
+    # The login command's own output, verbatim — the URL and code a human needs.
+    login_output: str
+    # Populated only when the install itself failed, so the connect flow can
+    # say why instead of "connection failed".
+    install_error: str = ""
+
+
+# Roots that exist only because GAIA runs the CLI in a sandbox. A vendor CLI
+# routinely echoes where it put its config; that path is meaningful to a
+# developer on a laptop and meaningless (and confusing) to a user who never
+# asked for a sandbox. Lines mentioning one are dropped before the output is
+# shown, which is a presentation rule about OUR paths, not an attempt to parse
+# the vendor's text.
+_INTERNAL_PATH_ROOTS = (WORKSPACE_ROOT, SANDBOX_USER_ROOT, GAIA_OPT_ROOT)
+
+
+def user_visible_output(text: str) -> str:
+    """Strip lines that expose GAIA's own sandbox paths, keeping the rest verbatim."""
+    kept = [
+        line for line in text.splitlines() if not any(root in line for root in _INTERNAL_PATH_ROOTS)
+    ]
+    return "\n".join(kept).strip()
+
+
+def _bin_search_path(integration_id: str) -> str:
+    """PATH fragment covering every layout an install command might produce.
+
+    npm drops binaries in ``node_modules/.bin``; release tarballs use ``bin/``;
+    ``pip install --user`` and friends use ``.local/bin``; a bare ``curl`` of a
+    single binary lands in the app dir itself. Searching all four means the
+    config never has to declare a layout.
+    """
+    app = app_dir(integration_id)
+    return ":".join(
+        [
+            f"{app}/node_modules/.bin",
+            f"{app}/bin",
+            f"{app}/.local/bin",
+            app,
+            RUNTIME_BIN_DIR,
+        ]
+    )
+
+
+def _launcher_body(integration_id: str) -> str:
+    """The generated launcher, minus the shebang and resolved-binary binding.
+
+    Those two lines are prepended by the install script, which is the only
+    place the resolved binary path is known.
+
+    Every CLI invocation goes through this. It is what makes credentials
+    durable (``HOME`` on JuiceFS) and what lets two different CLIs appear in
+    the same pipeline without fighting over ``~/.config`` — each one's launcher
+    pins its own environment only for the duration of that exec.
+    """
+    home = home_dir(integration_id)
+    return f"""# Generated by GAIA for the {integration_id!r} CLI integration. Do not edit:
+# rewritten on every (re)install.
+export HOME={shlex.quote(home)}
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_STATE_HOME="$HOME/.local/state"
+export XDG_CACHE_HOME="$HOME/.cache"
+# Credentials for CLIs whose auth is an environment variable (written by the
+# token connect flow). Absent for device-login CLIs, which keep their own
+# config under $HOME instead.
+if [ -f "$HOME/{_ENV_FILE}" ]; then . "$HOME/{_ENV_FILE}"; fi
+export PATH={shlex.quote(_bin_search_path(integration_id))}:"$PATH"
+exec "$GAIA_CLI_BINARY" "$@"
+"""
+
+
+def _install_script(integration_id: str, config: CliConfig) -> str:
+    """Idempotent install: no-op when warm, full install when cold.
+
+    Written as one script rather than orchestrated from Python so a cold call
+    costs the same single round trip as a warm one.
+    """
+    app = app_dir(integration_id)
+    marker = install_marker_path(integration_id)
+    launcher = launcher_path(config.command)
+    log_path = f"{app}/{_INSTALL_LOG}"
+    # HOME during install points at LOCAL disk, not the durable JuiceFS home:
+    # installers write caches (npm's ~/.npm is hundreds of files) that would be
+    # pathologically slow on JuiceFS and are worthless to persist.
+    install_home = f"{app}/.home"
+
+    return f"""
+gaia_install() {{
+  mkdir -p {shlex.quote(app)} {shlex.quote(install_home)} \\
+           {shlex.quote(home_dir(integration_id))} {shlex.quote(LAUNCHER_DIR)} || return 1
+  (
+    set -e
+    cd {shlex.quote(app)}
+    export HOME={shlex.quote(install_home)}
+    export PATH={shlex.quote(RUNTIME_BIN_DIR)}:"$PATH"
+    {config.install_command}
+  ) >{shlex.quote(log_path)} 2>&1 || return 1
+
+  # Resolve what the install actually produced rather than requiring the config
+  # to declare a path — npm, tarballs and single-binary downloads all differ.
+  gaia_bin=$(PATH={shlex.quote(_bin_search_path(integration_id))} \\
+             command -v {shlex.quote(config.command)} 2>/dev/null) || return 1
+  [ -n "$gaia_bin" ] || return 1
+
+  # Two-part emit: the resolved binary must be expanded by THIS shell, while
+  # the body must not be (it contains $HOME, $PATH and $@ for the launcher's
+  # own runtime). A quoted heredoc for the body keeps those literal.
+  {{
+    printf '#!/bin/sh\\n'
+    printf "GAIA_CLI_BINARY='%s'\\n" "$gaia_bin"
+    cat <<'GAIA_LAUNCHER_EOF'
+{_launcher_body(integration_id)}
+GAIA_LAUNCHER_EOF
+  }} > {shlex.quote(launcher)} || return 1
+  chmod 0755 {shlex.quote(launcher)} || return 1
+  touch {shlex.quote(marker)} || return 1
+}}
+
+if [ ! -f {shlex.quote(marker)} ] || [ ! -x {shlex.quote(launcher)} ]; then
+  if ! gaia_install; then
+    echo "gaia: failed to install {config.command}" >&2
+    tail -40 {shlex.quote(log_path)} >&2 2>/dev/null
+    exit {INSTALL_FAILED_EXIT_CODE}
+  fi
+fi
+"""
+
+
+def _wrap(integration_id: str, config: CliConfig, command: str) -> str:
+    """Install guard + the caller's command, sharing one shell.
+
+    ``PATH`` carries the launcher directory and the Node runtime, so the
+    caller's command names the CLI exactly as a human would (``link-cli auth
+    status``), and shell features — pipes, redirection, ``&&`` — work normally.
+    """
+    return (
+        f"{_install_script(integration_id, config)}\n"
+        f'export PATH={shlex.quote(f"{LAUNCHER_DIR}:{RUNTIME_BIN_DIR}")}:"$PATH"\n'
+        f"{command}\n"
+    )
+
+
+async def _run(
+    sbx: AsyncSandbox, script: str, *, timeout: int, cwd: str | None = None
+) -> CliResult:
+    """Execute a prepared script, normalising e2b's non-zero-exit exception."""
+    try:
+        result = await sbx.commands.run(script, timeout=timeout, cwd=cwd)
+        return CliResult(
+            exit_code=result.exit_code or 0,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+    except CommandExitException as e:
+        # A non-zero exit is a normal outcome for a CLI (not logged in, no such
+        # resource); the SDK raises rather than returning, so translate it back.
+        return CliResult(exit_code=e.exit_code, stdout=e.stdout or "", stderr=e.stderr or "")
+
+
+def _login_log_path(integration_id: str) -> str:
+    return f"{app_dir(integration_id)}/{_LOGIN_LOG}"
+
+
+def _login_pid_path(integration_id: str) -> str:
+    return f"{app_dir(integration_id)}/{_LOGIN_PID}"
+
+
+async def execute(
+    sbx: AsyncSandbox,
+    integration_id: str,
+    config: CliConfig,
+    command: str,
+    *,
+    timeout: int,
+    cwd: str | None = None,
+) -> CliResult:
+    """Run a shell command with this integration's CLI available on PATH."""
+    return await _run(sbx, _wrap(integration_id, config, command), timeout=timeout, cwd=cwd)
+
+
+async def ensure_installed(sbx: AsyncSandbox, integration_id: str, config: CliConfig) -> CliResult:
+    """Install the CLI if this sandbox does not already have it.
+
+    Safe to call on every request: warm sandboxes short-circuit on a marker
+    file. Returns the outcome so a caller can surface *why* an install failed.
+    """
+    result = await _run(
+        sbx, _install_script(integration_id, config), timeout=INSTALL_TIMEOUT_SECONDS
+    )
+    if not result.ok:
+        log.warning(
+            f"{LogTag.INTEGRATION} CLI install failed",
+            integration_id=integration_id,
+            command=config.command,
+            exit_code=result.exit_code,
+        )
+    return result
+
+
+async def probe_state(sbx: AsyncSandbox, integration_id: str, config: CliConfig) -> CliState:
+    """Every fact the connect flow needs, in one sandbox round trip.
+
+    Installs on demand first (so a recreated sandbox reports honestly rather
+    than "not authenticated"), then answers three questions at once: does the
+    CLI consider itself logged in, is a detached login still polling, and what
+    has that login printed for the user.
+    """
+    script = _wrap(
+        integration_id,
+        config,
+        f"""
+gaia_authed=0
+if ( {config.auth.verify_command} ) >/dev/null 2>&1; then gaia_authed=1; fi
+
+gaia_running=0
+gaia_pid=$(cat {shlex.quote(_login_pid_path(integration_id))} 2>/dev/null || true)
+if [ -n "$gaia_pid" ] && kill -0 "$gaia_pid" 2>/dev/null; then gaia_running=1; fi
+
+gaia_age=-1
+if [ -f {shlex.quote(_login_log_path(integration_id))} ]; then
+  gaia_now=$(date +%s)
+  gaia_mtime=$(stat -c %Y {shlex.quote(_login_log_path(integration_id))} 2>/dev/null || echo "$gaia_now")
+  gaia_age=$((gaia_now - gaia_mtime))
+fi
+
+echo "{_STATE_LINE} authenticated=$gaia_authed running=$gaia_running age=$gaia_age"
+echo "{_OUTPUT_BEGIN}"
+cat {shlex.quote(_login_log_path(integration_id))} 2>/dev/null || true
+""",
+        # The verify command is the slow part (a network round trip to the
+        # vendor); everything else is local.
+    )
+    result = await _run(sbx, script, timeout=VERIFY_TIMEOUT_SECONDS + 30)
+
+    if result.install_failed:
+        return CliState(
+            installed=False,
+            authenticated=False,
+            login_running=False,
+            login_age_seconds=None,
+            login_output="",
+            install_error=user_visible_output(result.stderr)[:LOGIN_OUTPUT_MAX_CHARS],
+        )
+    return _parse_state(result.stdout)
+
+
+def _parse_state(stdout: str) -> CliState:
+    """Read the structured block emitted by :func:`probe_state`'s script."""
+    flags: dict[str, str] = {}
+    output_lines: list[str] = []
+    in_output = False
+    for line in stdout.splitlines():
+        if in_output:
+            output_lines.append(line)
+        elif line.startswith(_STATE_LINE):
+            flags = dict(part.split("=", 1) for part in line.split()[1:] if "=" in part)
+        elif line.startswith(_OUTPUT_BEGIN):
+            in_output = True
+
+    age = int(flags.get("age", "-1"))
+    return CliState(
+        # Reaching the state line at all means the install guard passed.
+        installed=bool(flags),
+        authenticated=flags.get("authenticated") == "1",
+        login_running=flags.get("running") == "1",
+        login_age_seconds=None if age < 0 else age,
+        login_output=user_visible_output("\n".join(output_lines))[:LOGIN_OUTPUT_MAX_CHARS],
+    )
+
+
+async def start_login(sbx: AsyncSandbox, integration_id: str, config: CliConfig) -> CliResult:
+    """Launch a device login detached, and return as soon as it is running.
+
+    The CLI's own instructions ("open <url> and enter <code>") land in a log
+    that :func:`probe_state` reads back verbatim. GAIA deliberately does not
+    parse them: every vendor words this differently and rewords it between
+    releases, so relaying the tool's own text is both more robust and more
+    honest to the user than a guessed-at URL.
+    """
+    if not config.auth.login_command:  # pragma: no cover - forbidden by validator
+        raise ValueError(f"{integration_id}: device login without login_command")
+
+    log_path = _login_log_path(integration_id)
+    pid_path = _login_pid_path(integration_id)
+    detached = (
+        f"rm -f {shlex.quote(log_path)} {shlex.quote(pid_path)}; "
+        f"nohup sh -c {shlex.quote(config.auth.login_command)} "
+        f"> {shlex.quote(log_path)} 2>&1 & "
+        f"echo $! > {shlex.quote(pid_path)}"
+    )
+    return await _run(sbx, _wrap(integration_id, config, detached), timeout=INSTALL_TIMEOUT_SECONDS)
+
+
+async def cancel_login(sbx: AsyncSandbox, integration_id: str) -> None:
+    """Stop an in-flight device login and forget its output."""
+    pid_path = _login_pid_path(integration_id)
+    await _run(
+        sbx,
+        f"gaia_pid=$(cat {shlex.quote(pid_path)} 2>/dev/null || true); "
+        f'if [ -n "$gaia_pid" ]; then kill "$gaia_pid" 2>/dev/null || true; fi; '
+        f"rm -f {shlex.quote(pid_path)} {shlex.quote(_login_log_path(integration_id))}; true",
+        timeout=30,
+    )
+
+
+async def write_token(
+    sbx: AsyncSandbox, integration_id: str, config: CliConfig, token: str
+) -> CliResult:
+    """Persist a pasted secret into the CLI's own durable HOME.
+
+    Written as a shell env file the launcher sources, so the credential sits
+    with that CLI's other config and is removed by the same "delete the app
+    directory" that logs it out. Written with ``sbx.files.write`` rather than a
+    shell command so the secret never appears in argv or shell history.
+    """
+    env_var = config.auth.token_env
+    if not env_var:  # pragma: no cover - forbidden by CliAuthSpec's validator
+        raise ValueError(f"{integration_id}: token auth without token_env")
+
+    # The install both creates the durable HOME and generates the launcher that
+    # will source this file, so it must land first.
+    installed = await ensure_installed(sbx, integration_id, config)
+    if not installed.ok:
+        return installed
+
+    path = f"{home_dir(integration_id)}/{_ENV_FILE}"
+    await sbx.files.write(path, f"export {env_var}={shlex.quote(token)}\n")
+    # 0600: the sandbox is single-tenant, but a credential file should still not
+    # be readable by anything the agent later runs under another identity.
+    await _run(sbx, f"chmod 0600 {shlex.quote(path)}", timeout=30)
+
+    if not config.auth.login_command:
+        # Exporting the variable *is* the authentication; nothing further to run.
+        return CliResult(exit_code=0, stdout="", stderr="")
+    return await execute(
+        sbx, integration_id, config, config.auth.login_command, timeout=INSTALL_TIMEOUT_SECONDS
+    )
+
+
+async def clear_credentials(sbx: AsyncSandbox, integration_id: str, config: CliConfig) -> None:
+    """Log the CLI out and remove its durable state.
+
+    Runs the declared ``logout_command`` when there is one — some vendors
+    revoke the token server-side, which deleting a local file does not — and
+    then removes the durable HOME regardless, so disconnect is complete even
+    for a CLI that offers no logout at all.
+    """
+    if config.auth.logout_command:
+        await execute(
+            sbx,
+            integration_id,
+            config,
+            # A CLI that is already logged out exits non-zero here; that is not
+            # a failure of the disconnect, so it never blocks the wipe below.
+            f"{config.auth.logout_command} || true",
+            timeout=INSTALL_TIMEOUT_SECONDS,
+        )
+    await _run(
+        sbx,
+        "rm -rf "
+        f"{shlex.quote(home_dir(integration_id))} "
+        f"{shlex.quote(app_dir(integration_id))} "
+        f"{shlex.quote(launcher_path(config.command))}",
+        timeout=120,
+    )
+
+
+def workspace_roots() -> tuple[str, str, str]:
+    """The three directories this subsystem owns, for diagnostics and tests."""
+    return APPS_DIR, LAUNCHER_DIR, CLI_HOME_ROOT

--- a/apps/api/app/services/cli/runtime.py
+++ b/apps/api/app/services/cli/runtime.py
@@ -36,8 +36,6 @@ from e2b import AsyncSandbox, CommandExitException
 
 from app.agents.workspace.paths import WORKSPACE_ROOT
 from app.constants.cli_integrations import (
-    APPS_DIR,
-    CLI_HOME_ROOT,
     GAIA_OPT_ROOT,
     INSTALL_TIMEOUT_SECONDS,
     LAUNCHER_DIR,
@@ -487,8 +485,3 @@ async def clear_credentials(sbx: AsyncSandbox, integration_id: str, config: CliC
         f"{shlex.quote(launcher_path(config.command))}",
         timeout=120,
     )
-
-
-def workspace_roots() -> tuple[str, str, str]:
-    """The three directories this subsystem owns, for diagnostics and tests."""
-    return APPS_DIR, LAUNCHER_DIR, CLI_HOME_ROOT

--- a/apps/api/app/services/cli/runtime.py
+++ b/apps/api/app/services/cli/runtime.py
@@ -350,7 +350,11 @@ cat {shlex.quote(_login_log_path(integration_id))} 2>/dev/null || true
         # The verify command is the slow part (a network round trip to the
         # vendor); everything else is local.
     )
-    result = await _run(sbx, script, timeout=VERIFY_TIMEOUT_SECONDS + 30)
+    # The install guard rides inside this same shell, and a cold sandbox is
+    # exactly the state probe_state is called in (advance calls it first). A
+    # verify-sized budget here would kill the install that has to finish before
+    # the verify can mean anything.
+    result = await _run(sbx, script, timeout=INSTALL_TIMEOUT_SECONDS + VERIFY_TIMEOUT_SECONDS)
 
     if result.install_failed:
         return CliState(

--- a/apps/api/app/services/cli/tools.py
+++ b/apps/api/app/services/cli/tools.py
@@ -18,6 +18,7 @@ connect flow records.
 
 from dataclasses import dataclass
 
+from app.constants.cli_integrations import cli_tool_name
 from app.models.cli_config import CliConfig
 from app.services.integrations.integration_resolver import IntegrationResolver
 
@@ -29,6 +30,15 @@ class CliIntegration:
     id: str
     name: str
     config: CliConfig
+    # Platform integrations are curated and their ids are unique, so their tool
+    # keeps the clean name; custom ones are per-user documents sharing one
+    # process-global registry and need disambiguating.
+    is_platform: bool
+
+    @property
+    def tool_name(self) -> str:
+        """The registry name of this integration's tool."""
+        return cli_tool_name(self.config.command, self.id, is_platform=self.is_platform)
 
 
 async def resolve_cli_integration(integration_id: str) -> CliIntegration | None:
@@ -45,4 +55,5 @@ async def resolve_cli_integration(integration_id: str) -> CliIntegration | None:
         id=resolved.integration_id,
         name=resolved.name,
         config=resolved.cli_config,
+        is_platform=resolved.source == "platform",
     )

--- a/apps/api/app/services/cli/tools.py
+++ b/apps/api/app/services/cli/tools.py
@@ -1,0 +1,48 @@
+"""Which integrations are CLI-backed, wherever they were defined.
+
+An integration is CLI-backed when it carries a :class:`CliConfig`: platform
+ones declare it in ``oauth_config``, user-created ones carry it on their Mongo
+document. Both answer the same two questions the tool builder needs — which
+executable is this, and what is the product called — so callers resolve through
+here instead of reading two catalogs and branching on where the integration was
+defined. ``cli_config`` (not ``managed_by``) is the discriminator, matching the
+rest of this subsystem: the connect provider and the resolver both key off the
+spec being present, so a document that has one always behaves as a CLI.
+
+Whether a *user* may reach the tool is a separate question and deliberately not
+answered here. The tool is user-agnostic by construction — it resolves the
+sandbox and the credentials from the run's user at call time — so one tool
+serves everyone, and the only per-user fact left is the connection status the
+connect flow records.
+"""
+
+from dataclasses import dataclass
+
+from app.models.cli_config import CliConfig
+from app.services.integrations.integration_resolver import IntegrationResolver
+
+
+@dataclass(frozen=True, slots=True)
+class CliIntegration:
+    """A CLI-backed integration: everything needed to build and name its tool."""
+
+    id: str
+    name: str
+    config: CliConfig
+
+
+async def resolve_cli_integration(integration_id: str) -> CliIntegration | None:
+    """The CLI integration behind ``integration_id``, platform or custom.
+
+    ``None`` means "not CLI-backed" — an MCP server, a Composio toolkit, or no
+    such integration — which is what lets a caller dispatch on transport
+    without knowing which catalog the integration came from.
+    """
+    resolved = await IntegrationResolver.resolve(integration_id)
+    if resolved is None or resolved.cli_config is None:
+        return None
+    return CliIntegration(
+        id=resolved.integration_id,
+        name=resolved.name,
+        config=resolved.cli_config,
+    )

--- a/apps/api/app/services/hil/classification.py
+++ b/apps/api/app/services/hil/classification.py
@@ -12,6 +12,12 @@ Resolution order (first match wins):
 4. A cached Mongo classification for a previously-seen custom tool.
 5. A one-shot LLM classification, persisted to Mongo + the live registry.
 
+A CLI-backed call is the one exception, and it takes a ``command_shape`` (see
+:mod:`app.services.hil.command_shape`). One CLI integration is one tool, so its name
+covers every command that CLI can run and step 3 has nothing to say about any of them:
+the verdict resolves on steps 4-5 alone, keyed by ``(tool name, command shape)``, and is
+never written back to the registry's name-keyed flag.
+
 Any failure — registry unavailable, LLM error, or a tool absent from every
 source — resolves to destructive (fail closed).
 """
@@ -27,7 +33,7 @@ from app.constants.hil import HIL_EXEMPT_TOOLS, HIL_LLM_TIMEOUT_SECONDS
 from app.constants.log_tags import LogTag
 from app.db.repositories.hil import hil_tool_risk_repository
 from app.models.hil_models import HILToolRiskRecord
-from app.services.hil.prompts import TOOL_CLASSIFY_PROMPT
+from app.services.hil.prompts import CLI_COMMAND_CLASSIFY_PROMPT, TOOL_CLASSIFY_PROMPT
 from app.services.mcp.langchain_adapter import MCP_ANNOTATIONS_METADATA_KEY
 from shared.py.wide_events import log
 
@@ -42,12 +48,18 @@ async def is_tool_destructive(
     description: str = "",
     *,
     destructive_hint: bool | None = None,
+    command_shape: str | None = None,
 ) -> bool:
-    """Return whether ``tool_name`` must be gated by HIL. Fails closed.
+    """Return whether this call must be gated by HIL. Fails closed.
 
     ``destructive_hint`` is the caller-read MCP ``destructiveHint`` (see
     :func:`mcp_destructive_hint`); it escalates an otherwise-unclassified tool
     to destructive without an LLM call.
+
+    ``command_shape`` is set only for a CLI-backed call (see
+    :func:`app.services.hil.command_shape.cli_command_shape`). It moves the verdict from
+    the tool to the command the call would run — including ``""``, which means the
+    command could not be shaped at all and therefore gates.
     """
     if tool_name in HIL_EXEMPT_TOOLS:
         return False
@@ -56,6 +68,8 @@ async def is_tool_destructive(
     if destructive_hint is True:
         return True
     try:
+        if command_shape is not None:
+            return await _classify_command(tool_name, description, command_shape)
         registry = await get_tool_registry()
         flag = registry.is_tool_destructive(tool_name)
         if flag is not None:
@@ -91,34 +105,68 @@ def mcp_destructive_hint(tool: BaseTool | None) -> bool | None:
 
 async def _classify_unknown_tool(registry: ToolRegistry, tool_name: str, description: str) -> bool:
     """Resolve an unclassified custom tool from the Mongo cache, else the LLM."""
-    description_hash = _description_hash(description)
-    cached = await _cached_classification(tool_name, description_hash)
+    subject_hash = _subject_hash(description)
+    cached = await _cached_classification(tool_name, subject_hash)
     if cached is not None:
         registry.mark_tool_destructive(tool_name, cached)
         return cached
 
     result = await _classify_with_llm(tool_name, description)
-    await _persist_classification(tool_name, description_hash, result)
+    await _persist_classification(tool_name, subject_hash, result)
     registry.mark_tool_destructive(tool_name, result.is_destructive)
     return result.is_destructive
 
 
-async def _cached_classification(tool_name: str, description_hash: str) -> bool | None:
-    """A prior classification for this exact tool+description, or ``None``."""
-    record = await hil_tool_risk_repository.find_classification(tool_name, description_hash)
+async def _classify_command(tool_name: str, description: str, command_shape: str) -> bool:
+    """Resolve ONE CLI command's risk from the Mongo cache, else the LLM.
+
+    The registry's ``destructive`` flag is deliberately neither read nor written here.
+    It is keyed by tool name, and one CLI tool name covers every command that CLI can
+    run: a verdict earned by ``gh repo delete`` must never become the verdict for
+    ``gh pr list``, in either direction.
+    """
+    if not command_shape:
+        # The command could not be reduced to anything stable enough to classify or
+        # cache (see command_shape). An unreadable command is not a safe one.
+        log.warning(f"{LogTag.HIL} Unshapeable CLI command, failing closed", tool_name=tool_name)
+        return True
+
+    subject_hash = _subject_hash(description, command_shape)
+    cached = await _cached_classification(tool_name, subject_hash)
+    if cached is not None:
+        return cached
+
+    result = await _classify_with_llm(tool_name, description, command_shape)
+    await _persist_classification(tool_name, subject_hash, result, command_shape)
+    return result.is_destructive
+
+
+async def _cached_classification(tool_name: str, subject_hash: str) -> bool | None:
+    """A prior classification of this exact subject for this tool, or ``None``."""
+    record = await hil_tool_risk_repository.find_classification(tool_name, subject_hash)
     return record.is_destructive if record else None
 
 
-async def _classify_with_llm(tool_name: str, description: str) -> _ClassifyResult:
-    """Classify a TOOL, not a request — so this call deliberately carries no
-    user attribution. The verdict is cached per tool+description (DB + registry)
-    and shared by every user, so billing its COGS to whichever user happened to
-    trigger the first classification would be arbitrary. The unattributed-spend
-    warning from ``ainvoke_structured`` is expected here, and rare: this runs
-    once per tool, not per call."""
+async def _classify_with_llm(
+    tool_name: str, description: str, command_shape: str = ""
+) -> _ClassifyResult:
+    """Classify a TOOL — or, for a CLI-backed call, the COMMAND it would run — and never
+    a request, so this call deliberately carries no user attribution. The verdict is
+    cached per subject (DB + registry) and shared by every user, so billing its COGS to
+    whichever user happened to trigger the first classification would be arbitrary. The
+    unattributed-spend warning from ``ainvoke_structured`` is expected here, and rare:
+    this runs once per subject, not per call."""
+    described = description or "(none provided)"
+    prompt = (
+        CLI_COMMAND_CLASSIFY_PROMPT.format(
+            name=tool_name, description=described, command=command_shape
+        )
+        if command_shape
+        else TOOL_CLASSIFY_PROMPT.format(name=tool_name, description=described)
+    )
     return await ainvoke_structured(
         _ClassifyResult,
-        TOOL_CLASSIFY_PROMPT.format(name=tool_name, description=description or "(none provided)"),
+        prompt,
         label="hil_tool_classification",
         config=SILENT_LLM_CONFIG,
         options=StructuredCallOptions(timeout=HIL_LLM_TIMEOUT_SECONDS),
@@ -126,18 +174,27 @@ async def _classify_with_llm(tool_name: str, description: str) -> _ClassifyResul
 
 
 async def _persist_classification(
-    tool_name: str, description_hash: str, result: _ClassifyResult
+    tool_name: str, subject_hash: str, result: _ClassifyResult, command_shape: str = ""
 ) -> None:
     """Cache the classification in Mongo so restarts/refreshes don't re-run the
-    LLM (the description_hash key means only a changed description re-classifies)."""
+    LLM (the hashed subject means only a changed description — or a different CLI
+    command shape — re-classifies)."""
     record = HILToolRiskRecord(
         tool_name=tool_name,
-        description_hash=description_hash,
+        description_hash=subject_hash,
         is_destructive=result.is_destructive,
+        command_shape=command_shape,
         rationale=result.rationale,
     )
     await hil_tool_risk_repository.upsert_classification(record)
 
 
-def _description_hash(description: str) -> str:
-    return hashlib.md5(description.encode(), usedforsecurity=False).hexdigest()  # nosec B324
+def _subject_hash(description: str, command_shape: str = "") -> str:
+    """The cache key's body: what was classified, not merely which tool asked.
+
+    A CLI command's shape is folded in, so one tool name holds one verdict per command
+    it can run. Everything else hashes the description alone, byte for byte as before,
+    so verdicts cached before CLI tools existed still hit.
+    """
+    subject = f"{description}\n{command_shape}" if command_shape else description
+    return hashlib.md5(subject.encode(), usedforsecurity=False).hexdigest()  # nosec B324

--- a/apps/api/app/services/hil/command_shape.py
+++ b/apps/api/app/services/hil/command_shape.py
@@ -77,6 +77,32 @@ def cli_command_shape(tool: BaseTool | None, args: Mapping[str, Any] | None) -> 
     return derive_command_shape(command) if isinstance(command, str) else ""
 
 
+# Commands that take another command as an argument. The shape of the wrapper
+# says nothing about the shape of what it runs, so these fail closed rather than
+# resolve to a reassuring head word.
+_SHELL_EXEC_WRAPPERS = frozenset(
+    {
+        "sh",
+        "bash",
+        "zsh",
+        "dash",
+        "ksh",
+        "eval",
+        "exec",
+        "env",
+        "xargs",
+        "nohup",
+        "timeout",
+        "sudo",
+        "doas",
+        "nice",
+        "setsid",
+        "watch",
+        "command",
+    }
+)
+
+
 def derive_command_shape(command: str) -> str:
     """The classification key for one shell string, or ``""`` when it has none."""
     try:
@@ -102,6 +128,13 @@ def _tokenize(command: str) -> list[str]:
     lexer = shlex.shlex(command, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
     lexer.whitespace = _WHITESPACE
     lexer.whitespace_split = True
+    # shlex honours `#` as a comment even in the MIDDLE of a word and discards
+    # the rest of the line; a POSIX shell only starts a comment at the start of
+    # a word. Left on, `gh api /user#x && gh repo delete acme/api` tokenizes to
+    # `gh api` and the delete disappears from the shape entirely, so the gate
+    # judges a prefix and runs the whole string. Nothing here needs comment
+    # handling: only the shape words matter.
+    lexer.commenters = ""
     return list(lexer)
 
 
@@ -125,7 +158,15 @@ def _leading_words(segment: list[str]) -> str:
 
     A segment with no words is not "harmless": ``--force`` alone, a bare redirection,
     a path-qualified executable — none of them shape, so all of them gate.
+
+    Neither does a segment whose head hands the real command to another shell.
+    ``sh -c 'gh repo delete acme/api'`` would otherwise shape as a bare ``sh``:
+    the payload is a quoted argument, not a separator, so it never becomes its
+    own segment, and the classifier would judge a command name that says nothing
+    about what runs.
     """
+    if segment and segment[0] in _SHELL_EXEC_WRAPPERS:
+        return ""
     words: list[str] = []
     for token in segment:
         if not words and _ENV_ASSIGNMENT.match(token):

--- a/apps/api/app/services/hil/command_shape.py
+++ b/apps/api/app/services/hil/command_shape.py
@@ -1,0 +1,138 @@
+"""Reduce a CLI tool call's shell string to the key its risk is classified under.
+
+A CLI integration exposes exactly ONE tool (``run_gh``), so the tool name carries no
+risk information: ``gh pr list`` and ``gh repo delete acme/api`` arrive under it alike.
+What carries the risk is the command, and what makes a command cacheable is its
+*shape* — the leading command words of every program the string would run, with flags,
+arguments and redirection targets dropped::
+
+    gh pr list --json number | jq .          ->  gh pr list ; jq
+    LOG=1 link-cli spend-request create -x   ->  link-cli spend-request create
+
+Derived structurally, never from a per-vendor table of dangerous verbs: a table only
+knows the CLIs somebody thought to enumerate, and the long tail nobody enumerated is
+precisely why running a real CLI is worth doing (see ``agents/tools/cli/cli_tool``).
+
+Two rules carry the safety weight:
+
+* **Every chained command is in the shape.** Keeping only the first would let
+  ``gh pr list && gh repo delete acme/api`` cache under a verdict earned by
+  ``gh pr list`` — one harmless prefix and the gate is off for everything behind it.
+  Command substitution counts as chaining for the same reason.
+* **Unshapeable is empty.** ``""`` comes back for anything this cannot reduce (an
+  unbalanced quote, a segment that is only flags, an empty string), and the caller
+  gates on it rather than guessing what an unparseable command does.
+"""
+
+from collections.abc import Mapping
+import re
+import shlex
+from typing import Any, Final
+
+from langchain_core.tools import BaseTool
+
+from app.agents.tools.cli.cli_tool import CLI_INTEGRATION_METADATA_KEY
+from app.constants.hil import HIL_CLI_SHAPE_MAX_WORDS
+
+# The argument the shell string arrives in — ``CliToolInput.command``.
+CLI_COMMAND_ARG: Final = "command"
+
+# Metacharacters that end one command and begin another. ``(``, ``)`` and the backtick
+# are in here because command substitution RUNS what it wraps: without them
+# ``echo $(gh repo delete acme/api)`` would shape as a harmless bare ``echo``.
+_SEPARATOR_CHARS: Final = frozenset(";&|()`\n")
+
+# Everything the lexer must hand back as its own token instead of gluing onto a word.
+# The redirection operators are not separators (they take a target, not a command) but
+# must still break the run of command words.
+_PUNCTUATION_CHARS: Final = "".join(sorted(_SEPARATOR_CHARS | {"<", ">"}))
+
+# Newline separates commands here, so it must not be eaten as whitespace first.
+_WHITESPACE: Final = " \t\r"
+
+# A shape word: a plain command or subcommand name. Anything carrying an argument's
+# shape — a flag, a path, a URL, a number, a quoted phrase — fails this and ends the
+# run, which is what keeps one shape stable across calls that differ only in target.
+_SHAPE_WORD: Final = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]*$")
+
+# ``FOO=bar cmd ...`` — an environment prefix, not the command being run.
+_ENV_ASSIGNMENT: Final = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# How the shapes of chained commands are joined. One joiner for every separator kind:
+# what the classifier needs to know is that all of them run, not how they are wired.
+_JOINER: Final = " ; "
+
+
+def cli_command_shape(tool: BaseTool | None, args: Mapping[str, Any] | None) -> str | None:
+    """The shape of the command a CLI-backed call would run.
+
+    ``None`` — and only ``None`` — means "not a CLI tool", which leaves the caller
+    classifying by tool name exactly as before. A CLI tool whose ``command`` argument
+    is missing or not a string yields ``""``, which gates.
+    """
+    metadata = getattr(tool, "metadata", None)
+    if not isinstance(metadata, dict) or CLI_INTEGRATION_METADATA_KEY not in metadata:
+        return None
+    command = args.get(CLI_COMMAND_ARG) if args else None
+    return derive_command_shape(command) if isinstance(command, str) else ""
+
+
+def derive_command_shape(command: str) -> str:
+    """The classification key for one shell string, or ``""`` when it has none."""
+    try:
+        tokens = _tokenize(command)
+    except ValueError:
+        # An unterminated quote: where it was meant to close decides what runs, and
+        # guessing is exactly the wrong call for a gate.
+        return ""
+    shapes: list[str] = []
+    for segment in _segments(tokens):
+        head = _leading_words(segment)
+        if not head:
+            return ""
+        shapes.append(head)
+    return _JOINER.join(shapes)
+
+
+def _tokenize(command: str) -> list[str]:
+    """Split like a shell would: quotes honoured, metacharacters as their own tokens.
+
+    Raises ``ValueError`` on an unterminated quote.
+    """
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
+    lexer.whitespace = _WHITESPACE
+    lexer.whitespace_split = True
+    return list(lexer)
+
+
+def _segments(tokens: list[str]) -> list[list[str]]:
+    """The token runs between separators — one per command the string would run."""
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if _is_separator(token):
+            segments.append([])
+        else:
+            segments[-1].append(token)
+    return [segment for segment in segments if segment]
+
+
+def _is_separator(token: str) -> bool:
+    return bool(token) and all(char in _SEPARATOR_CHARS for char in token)
+
+
+def _leading_words(segment: list[str]) -> str:
+    """One command's leading words, or ``""`` when it has none to take.
+
+    A segment with no words is not "harmless": ``--force`` alone, a bare redirection,
+    a path-qualified executable — none of them shape, so all of them gate.
+    """
+    words: list[str] = []
+    for token in segment:
+        if not words and _ENV_ASSIGNMENT.match(token):
+            continue
+        if not _SHAPE_WORD.match(token):
+            break
+        words.append(token)
+        if len(words) == HIL_CLI_SHAPE_MAX_WORDS:
+            break
+    return " ".join(words)

--- a/apps/api/app/services/hil/command_shape.py
+++ b/apps/api/app/services/hil/command_shape.py
@@ -31,7 +31,7 @@ from typing import Any, Final
 
 from langchain_core.tools import BaseTool
 
-from app.agents.tools.cli.cli_tool import CLI_INTEGRATION_METADATA_KEY
+from app.constants.cli_integrations import CLI_INTEGRATION_METADATA_KEY
 from app.constants.hil import HIL_CLI_SHAPE_MAX_WORDS
 
 # The argument the shell string arrives in — ``CliToolInput.command``.
@@ -82,6 +82,7 @@ def cli_command_shape(tool: BaseTool | None, args: Mapping[str, Any] | None) -> 
 # resolve to a reassuring head word.
 _SHELL_EXEC_WRAPPERS = frozenset(
     {
+        # Shells and direct exec.
         "sh",
         "bash",
         "zsh",
@@ -89,6 +90,9 @@ _SHELL_EXEC_WRAPPERS = frozenset(
         "ksh",
         "eval",
         "exec",
+        "source",
+        ".",
+        # Run-something-else wrappers.
         "env",
         "xargs",
         "nohup",
@@ -96,9 +100,34 @@ _SHELL_EXEC_WRAPPERS = frozenset(
         "sudo",
         "doas",
         "nice",
+        "ionice",
         "setsid",
         "watch",
         "command",
+        "stdbuf",
+        "flock",
+        "script",
+        "busybox",
+        "chroot",
+        "unshare",
+        # Interpreters: `python3 -c '<payload>'` hides its payload in an
+        # argument exactly the way `sh -c` does.
+        "python",
+        "python3",
+        "node",
+        "deno",
+        "bun",
+        "perl",
+        "ruby",
+        "php",
+        "awk",
+        "sed",
+        # Tools whose flags run arbitrary commands (`find -exec`, `git -c
+        # alias`, `make` recipes, `ssh host cmd`).
+        "find",
+        "git",
+        "make",
+        "ssh",
     }
 )
 
@@ -159,20 +188,28 @@ def _leading_words(segment: list[str]) -> str:
     A segment with no words is not "harmless": ``--force`` alone, a bare redirection,
     a path-qualified executable — none of them shape, so all of them gate.
 
-    Neither does a segment whose head hands the real command to another shell.
+    Neither does a segment that hands the real command to something else.
     ``sh -c 'gh repo delete acme/api'`` would otherwise shape as a bare ``sh``:
     the payload is a quoted argument, not a separator, so it never becomes its
     own segment, and the classifier would judge a command name that says nothing
     about what runs.
+
+    The env-assignment strip happens BEFORE that check and the check applies to
+    every shape word, not just the first. Doing it the other way round left
+    ``FOO=1 sh -c '<payload>'`` shaping as ``sh`` and ``LC_ALL=C env gh repo
+    delete`` shaping as ``env gh repo delete`` — one assignment in front was
+    enough to walk a payload past the gate, and the verdict is cached per shape
+    for every user.
     """
-    if segment and segment[0] in _SHELL_EXEC_WRAPPERS:
-        return ""
     words: list[str] = []
     for token in segment:
         if not words and _ENV_ASSIGNMENT.match(token):
             continue
         if not _SHAPE_WORD.match(token):
             break
+        if token in _SHELL_EXEC_WRAPPERS:
+            # Whatever this would have run is in an argument we cannot see.
+            return ""
         words.append(token)
         if len(words) == HIL_CLI_SHAPE_MAX_WORDS:
             break

--- a/apps/api/app/services/hil/policy.py
+++ b/apps/api/app/services/hil/policy.py
@@ -122,14 +122,22 @@ async def is_gated(
         return True
     if _argument_gate_hit(tool_name, args):
         return True
-    override = prefs.tool_overrides.get(tool_name)
-    if override is not None:
-        return override
+    command_shape = cli_command_shape(tool, args)
+    # Overrides are keyed by tool NAME, and a CLI-backed tool has exactly one
+    # name for every command it can run. Honouring "don't ask again for
+    # run_gh", earned by approving `gh pr list`, would also pre-approve
+    # `gh repo delete` — the very collapse _classify_command exists to prevent.
+    # Until overrides can be keyed per command, a CLI call always falls through
+    # to per-command classification.
+    if command_shape is None:
+        override = prefs.tool_overrides.get(tool_name)
+        if override is not None:
+            return override
     return await is_tool_destructive(
         tool_name,
         getattr(tool, "description", "") or "",
         destructive_hint=mcp_destructive_hint(tool),
-        command_shape=cli_command_shape(tool, args),
+        command_shape=command_shape,
     )
 
 

--- a/apps/api/app/services/hil/policy.py
+++ b/apps/api/app/services/hil/policy.py
@@ -22,6 +22,7 @@ from app.constants.hil import HIL_EXEMPT_TOOLS, HIL_PAUSING_TOOLS
 from app.constants.log_tags import LogTag
 from app.models.hil_models import HIL_DEFAULT_MODE, HILPreferences
 from app.services.hil.classification import is_tool_destructive, mcp_destructive_hint
+from app.services.hil.command_shape import cli_command_shape
 from app.services.hil.preferences import get_hil_preferences
 from app.services.hil.utils import current_tool_calls, tool_of, unpack_tool_call
 from shared.py.wide_events import log
@@ -94,7 +95,7 @@ async def resolve_policy(request: ToolCallRequest, user_id: str, tool_name: str)
     prefs = await _preferences(user_id)
     if prefs.mode == "always_allow":
         return "allow"
-    if not await is_gated(prefs, tool_name, tool_of(request)):  # args resolved above
+    if not await is_gated(prefs, tool_name, tool_of(request), call.args):
         return "allow"
     return "auto" if prefs.mode == "auto" else "ask"
 
@@ -112,6 +113,10 @@ async def is_gated(
     to the user's own account confirm first"), not classifier opinions.
     Otherwise a user's per-tool choice wins in both directions — even over an
     MCP destructiveHint — since it is a deliberate setting on their own account.
+
+    ``args`` is what makes a CLI-backed call classifiable at all: its tool name is one
+    per integration, so the risk lives in the ``command`` argument (see
+    ``cli_command_shape``). Every caller passes the call's own args.
     """
     if await _is_always_gated(tool_name):
         return True
@@ -124,6 +129,7 @@ async def is_gated(
         tool_name,
         getattr(tool, "description", "") or "",
         destructive_hint=mcp_destructive_hint(tool),
+        command_shape=cli_command_shape(tool, args),
     )
 
 

--- a/apps/api/app/services/hil/prompts.py
+++ b/apps/api/app/services/hil/prompts.py
@@ -101,6 +101,29 @@ TOOL_CLASSIFY_PROMPT = (
 )
 
 
+# One CLI integration is one tool, so the tool name says nothing about risk — the command
+# does. This judges a command SHAPE (``app/services/hil/command_shape.py``): the leading
+# words of every program the call would run, with flags and arguments stripped. Two things
+# follow, and both are stated to the model, because neither is obvious from the shape
+# alone: a stripped command that only SOME arguments make dangerous must be treated as
+# dangerous, and a chain is as destructive as its worst link.
+CLI_COMMAND_CLASSIFY_PROMPT = (
+    "An AI assistant may run the command-line invocation below autonomously on the "
+    "user's behalf, through its `{name}` tool.\n"
+    "Mark it destructive if running it is irreversible or produces an effect visible to "
+    "other people — sending, posting, publishing, merging, deploying, deleting, or "
+    "paying. Reading, listing, searching, and fetching data are NOT destructive.\n"
+    "You are shown the command's leading words only; flags and arguments have been "
+    "removed. Judge what this command does in general: if some arguments would make it "
+    "destructive, it is destructive.\n"
+    "Several commands separated by ` ; ` all run — that is destructive if ANY one of "
+    "them is.\n\n"
+    "Tool name: {name}\n"
+    "What the tool does: {description}\n"
+    "Command: {command}"
+)
+
+
 # --- what a blocked call tells the agent -----------------------------------------------
 
 # A decline ENDS the run, and the executor's final text is delivered to the user as a

--- a/apps/api/app/services/integrations/authoring/__init__.py
+++ b/apps/api/app/services/integrations/authoring/__init__.py
@@ -1,0 +1,43 @@
+"""Creating an integration from a description of what should back it.
+
+Importing this package registers every author; ``create_integration`` is the
+only entry point callers need.
+"""
+
+from app.services.integrations.authoring.base import (
+    AuthoredIntegration,
+    CliBlueprint,
+    IntegrationAuthor,
+    IntegrationBlueprint,
+    McpBlueprint,
+    get_author,
+    register_author,
+)
+from app.services.integrations.authoring.cli_author import CliIntegrationAuthor
+from app.services.integrations.authoring.mcp_author import McpIntegrationAuthor
+
+
+async def create_integration(user_id: str, blueprint: IntegrationBlueprint) -> AuthoredIntegration:
+    """Create the integration described by ``blueprint``.
+
+    Raises ``ValueError`` for a blueprint kind nothing can author, so a caller
+    that grows a new kind fails loudly rather than silently creating nothing.
+    """
+    author = get_author(blueprint.kind)
+    if author is None:
+        raise ValueError(f"No author registered for integration kind {blueprint.kind!r}")
+    return await author.create(user_id, blueprint)
+
+
+__all__ = [
+    "AuthoredIntegration",
+    "CliBlueprint",
+    "CliIntegrationAuthor",
+    "IntegrationAuthor",
+    "IntegrationBlueprint",
+    "McpBlueprint",
+    "McpIntegrationAuthor",
+    "create_integration",
+    "get_author",
+    "register_author",
+]

--- a/apps/api/app/services/integrations/authoring/base.py
+++ b/apps/api/app/services/integrations/authoring/base.py
@@ -49,6 +49,8 @@ class CliBlueprint(BlueprintBase):
     command: str
     install_command: str
     capabilities: list[str] = Field(default_factory=list)
+    # The vendor's site, used to fetch the integration's icon.
+    homepage: str | None = None
     auth_kind: Literal["none", "device", "token"] = "none"
     login_command: str | None = None
     verify_command: str

--- a/apps/api/app/services/integrations/authoring/base.py
+++ b/apps/api/app/services/integrations/authoring/base.py
@@ -1,0 +1,98 @@
+"""Describing an integration to be created, independently of how it is backed.
+
+Creating an integration used to mean exactly one thing — point GAIA at an MCP
+server URL — so the request shape, the validation and the creation path were all
+MCP-shaped and fused together. A second transport (a CLI) needs the same
+lifecycle (validate, create the catalog document, attach it to the user, verify
+it actually works) with entirely different specifics.
+
+A blueprint is the caller's intent; an author turns one kind of blueprint into a
+real integration. The caller — today a chat tool, tomorrow an endpoint — states
+what it wants and never branches on transport.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Annotated, ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from app.models.integration_models import Integration
+from app.models.integration_provider import ManagedBy
+
+
+class BlueprintBase(BaseModel):
+    """Fields every integration needs regardless of what backs it."""
+
+    name: str = Field(min_length=1, max_length=100)
+    description: str = Field(default="", max_length=500)
+    category: str = Field(default="custom", max_length=50)
+
+
+class McpBlueprint(BlueprintBase):
+    """An integration backed by an MCP server."""
+
+    kind: Literal["mcp"] = "mcp"
+    server_url: str
+    requires_auth: bool = False
+    auth_type: Literal["none", "oauth", "bearer"] | None = None
+    # A bearer token the user supplied up front, when they already have one.
+    bearer_token: str | None = None
+
+
+class CliBlueprint(BlueprintBase):
+    """An integration backed by a real command-line tool."""
+
+    kind: Literal["cli"] = "cli"
+    command: str
+    install_command: str
+    capabilities: list[str] = Field(default_factory=list)
+    auth_kind: Literal["none", "device", "token"] = "none"
+    login_command: str | None = None
+    verify_command: str
+    logout_command: str | None = None
+    token_env: str | None = None
+    token_label: str | None = None
+    token_help_url: str | None = None
+
+
+IntegrationBlueprint = Annotated[McpBlueprint | CliBlueprint, Field(discriminator="kind")]
+
+
+@dataclass(frozen=True)
+class AuthoredIntegration:
+    """The created integration, plus whether it is usable yet.
+
+    ``needs_connection`` is what the caller tells the user next: an MCP server
+    with no auth is ready immediately, while a CLI with a device login still
+    needs them to approve something.
+    """
+
+    integration: Integration
+    needs_connection: bool
+    # Free-text, user-facing: what to do next, or what could not be verified.
+    note: str | None = None
+
+
+class IntegrationAuthor(ABC):
+    """Turns one kind of blueprint into a stored, attached integration."""
+
+    kind: ClassVar[str]
+    managed_by: ClassVar[ManagedBy]
+
+    @abstractmethod
+    async def create(self, user_id: str, blueprint: IntegrationBlueprint) -> AuthoredIntegration:
+        """Validate, persist, and attach the integration to the user."""
+
+
+_AUTHORS: dict[str, IntegrationAuthor] = {}
+
+
+def register_author(author: IntegrationAuthor) -> None:
+    _AUTHORS[author.kind] = author
+
+
+def get_author(kind: str) -> IntegrationAuthor | None:
+    return _AUTHORS.get(kind)

--- a/apps/api/app/services/integrations/authoring/cli_author.py
+++ b/apps/api/app/services/integrations/authoring/cli_author.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import ClassVar
 import uuid
 
@@ -66,17 +65,19 @@ class CliIntegrationAuthor(IntegrationAuthor):
 
         icon_url = await fetch_favicon_safely(cli_config.homepage)
         integration_id = str(uuid.uuid4())
+        # Only the fields whose value is NOT the model's own default are passed:
+        # an authored integration is private, unpublished, unfeatured, and
+        # stamped with the current time because that is what Integration already
+        # says. Restating them adds nothing a reader can rely on and nothing a
+        # test can catch -- the invariants are pinned in test_authoring.py
+        # instead, where they fail if a default ever moves.
         integration = Integration(
             integration_id=integration_id,
             name=blueprint.name,
             description=blueprint.description,
             category=blueprint.category,
             managed_by=self.managed_by,
-            source="custom",
-            is_public=False,
             created_by=user_id,
-            display_priority=0,
-            is_featured=False,
             icon_url=icon_url,
             cli_config=cli_config,
             # The capabilities double as the integration's displayed tool list:
@@ -84,9 +85,6 @@ class CliIntegrationAuthor(IntegrationAuthor):
             # tool list means to a user, and it is what publishing validates.
             tools=[IntegrationTool(name=capability) for capability in cli_config.capabilities],
             requires_auth=cli_config.requires_auth,
-            created_at=datetime.now(UTC),
-            published_at=None,
-            clone_count=0,
         )
 
         await integration_repository.create(integration)

--- a/apps/api/app/services/integrations/authoring/cli_author.py
+++ b/apps/api/app/services/integrations/authoring/cli_author.py
@@ -1,0 +1,115 @@
+"""Creating a CLI-backed integration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import ClassVar
+import uuid
+
+from pydantic import ValidationError
+
+from app.constants.log_tags import LogTag
+from app.db.repositories.integrations import integration_repository
+from app.models.cli_config import CliAuthSpec, CliConfig
+from app.models.integration_models import Integration, IntegrationTool
+from app.models.integration_provider import ManagedBy
+from app.services.integrations.authoring.base import (
+    AuthoredIntegration,
+    CliBlueprint,
+    IntegrationAuthor,
+    IntegrationBlueprint,
+    register_author,
+)
+from app.services.integrations.user_integrations import add_user_integration
+from shared.py.wide_events import log
+
+
+class CliIntegrationAuthor(IntegrationAuthor):
+    """Stores a CLI integration so the connect flow can take it from there.
+
+    Deliberately does NOT install or run the CLI here. Creation is a catalog
+    write and must stay fast and side-effect-free in the user's sandbox; the
+    first real install happens on connect, where there is a UI showing progress
+    and somewhere sensible to report a failure.
+    """
+
+    kind: ClassVar[str] = "cli"
+    managed_by: ClassVar[ManagedBy] = "cli"
+
+    async def create(self, user_id: str, blueprint: IntegrationBlueprint) -> AuthoredIntegration:
+        if not isinstance(blueprint, CliBlueprint):  # pragma: no cover - dispatch guarantees this
+            raise TypeError(f"{type(self).__name__} cannot author a {blueprint.kind!r} blueprint")
+
+        try:
+            cli_config = CliConfig(
+                command=blueprint.command,
+                install_command=blueprint.install_command,
+                capabilities=blueprint.capabilities,
+                auth=CliAuthSpec(
+                    kind=blueprint.auth_kind,
+                    login_command=blueprint.login_command,
+                    verify_command=blueprint.verify_command,
+                    logout_command=blueprint.logout_command,
+                    token_env=blueprint.token_env,
+                    token_label=blueprint.token_label,
+                    token_help_url=blueprint.token_help_url,
+                ),
+            )
+        except ValidationError as e:
+            # The blueprint came from an LLM that read a CLI's help text, so an
+            # incoherent auth spec (device without a login command, token
+            # without a variable name) is the expected failure. Surface exactly
+            # what is wrong so it can fix it and retry.
+            raise ValueError(f"Invalid CLI configuration: {e}") from e
+
+        integration_id = str(uuid.uuid4())
+        integration = Integration(
+            integration_id=integration_id,
+            name=blueprint.name,
+            description=blueprint.description,
+            category=blueprint.category,
+            managed_by=self.managed_by,
+            source="custom",
+            is_public=False,
+            created_by=user_id,
+            display_priority=0,
+            is_featured=False,
+            cli_config=cli_config,
+            # The capabilities double as the integration's displayed tool list:
+            # they are what this integration can do, which is exactly what the
+            # tool list means to a user, and it is what publishing validates.
+            tools=[IntegrationTool(name=capability) for capability in cli_config.capabilities],
+            requires_auth=cli_config.auth.kind != "none",
+            created_at=datetime.now(UTC),
+            icon_url=None,
+            published_at=None,
+            clone_count=0,
+        )
+
+        await integration_repository.create(integration)
+        try:
+            await add_user_integration(user_id, integration_id, initial_status="created")
+        except Exception:
+            # Leaving a catalog row nobody owns would surface as a ghost
+            # integration in the marketplace, so undo it.
+            log.error(
+                f"{LogTag.INTEGRATION} Failed to attach authored CLI integration, rolling back",
+                integration_id=integration_id,
+                user_id=user_id,
+            )
+            await integration_repository.delete(integration_id)
+            raise
+
+        needs_connection = cli_config.auth.kind != "none"
+        return AuthoredIntegration(
+            integration=integration,
+            needs_connection=True,
+            note=(
+                f"Connect it to install {cli_config.command} and sign in."
+                if needs_connection
+                else f"Connect it once to install {cli_config.command}."
+            ),
+        )
+
+
+register_author(CliIntegrationAuthor())

--- a/apps/api/app/services/integrations/authoring/cli_author.py
+++ b/apps/api/app/services/integrations/authoring/cli_author.py
@@ -21,6 +21,7 @@ from app.services.integrations.authoring.base import (
     register_author,
 )
 from app.services.integrations.user_integrations import add_user_integration
+from app.utils.favicon_utils import fetch_favicon_safely
 from shared.py.wide_events import log
 
 
@@ -45,6 +46,7 @@ class CliIntegrationAuthor(IntegrationAuthor):
                 command=blueprint.command,
                 install_command=blueprint.install_command,
                 capabilities=blueprint.capabilities,
+                homepage=blueprint.homepage,
                 auth=CliAuthSpec(
                     kind=blueprint.auth_kind,
                     login_command=blueprint.login_command,
@@ -62,6 +64,7 @@ class CliIntegrationAuthor(IntegrationAuthor):
             # what is wrong so it can fix it and retry.
             raise ValueError(f"Invalid CLI configuration: {e}") from e
 
+        icon_url = await fetch_favicon_safely(cli_config.homepage)
         integration_id = str(uuid.uuid4())
         integration = Integration(
             integration_id=integration_id,
@@ -74,14 +77,14 @@ class CliIntegrationAuthor(IntegrationAuthor):
             created_by=user_id,
             display_priority=0,
             is_featured=False,
+            icon_url=icon_url,
             cli_config=cli_config,
             # The capabilities double as the integration's displayed tool list:
             # they are what this integration can do, which is exactly what the
             # tool list means to a user, and it is what publishing validates.
             tools=[IntegrationTool(name=capability) for capability in cli_config.capabilities],
-            requires_auth=cli_config.auth.kind != "none",
+            requires_auth=cli_config.requires_auth,
             created_at=datetime.now(UTC),
-            icon_url=None,
             published_at=None,
             clone_count=0,
         )
@@ -100,7 +103,7 @@ class CliIntegrationAuthor(IntegrationAuthor):
             await integration_repository.delete(integration_id)
             raise
 
-        needs_connection = cli_config.auth.kind != "none"
+        needs_connection = cli_config.requires_auth
         return AuthoredIntegration(
             integration=integration,
             needs_connection=True,

--- a/apps/api/app/services/integrations/authoring/mcp_author.py
+++ b/apps/api/app/services/integrations/authoring/mcp_author.py
@@ -1,0 +1,70 @@
+"""Creating an MCP-backed integration."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from app.models.integration_models import CreateCustomIntegrationRequest
+from app.models.integration_provider import ManagedBy
+from app.services.integrations.authoring.base import (
+    AuthoredIntegration,
+    IntegrationAuthor,
+    IntegrationBlueprint,
+    McpBlueprint,
+    register_author,
+)
+from app.services.integrations.custom_crud import create_and_connect_custom_integration
+from app.services.mcp.mcp_client import get_mcp_client
+from app.utils.url_safety import assert_safe_url_shape
+
+
+class McpIntegrationAuthor(IntegrationAuthor):
+    """Wraps the existing custom-MCP creation path.
+
+    Adds no logic of its own: MCP creation already probes the server, discovers
+    its auth requirements and pulls the live tool list, and that behaviour is
+    what the UI flow relies on. This exists so a caller can create an MCP
+    integration and a CLI integration through the same call.
+    """
+
+    kind: ClassVar[str] = "mcp"
+    managed_by: ClassVar[ManagedBy] = "mcp"
+
+    async def create(self, user_id: str, blueprint: IntegrationBlueprint) -> AuthoredIntegration:
+        if not isinstance(blueprint, McpBlueprint):  # pragma: no cover - dispatch guarantees this
+            raise TypeError(f"{type(self).__name__} cannot author a {blueprint.kind!r} blueprint")
+
+        # Same SSRF shape check the HTTP request model applies. Re-asserted here
+        # because this path is reachable from a chat tool, which never went
+        # through that model.
+        assert_safe_url_shape(blueprint.server_url)
+
+        request = CreateCustomIntegrationRequest(
+            name=blueprint.name,
+            description=blueprint.description or None,
+            category=blueprint.category,
+            server_url=blueprint.server_url,
+            requires_auth=blueprint.requires_auth,
+            auth_type=blueprint.auth_type,
+            is_public=False,
+            bearer_token=blueprint.bearer_token,
+        )
+        mcp_client = await get_mcp_client(user_id=user_id)
+        integration, result = await create_and_connect_custom_integration(
+            user_id, request, mcp_client
+        )
+
+        status = str(result.get("status", ""))
+        connected = status == "connected"
+        return AuthoredIntegration(
+            integration=integration,
+            needs_connection=not connected,
+            note=(
+                f"Connected. {result.get('tools_count', 0)} tools available."
+                if connected
+                else str(result.get("error") or "Connect it to finish authenticating.")
+            ),
+        )
+
+
+register_author(McpIntegrationAuthor())

--- a/apps/api/app/services/integrations/authoring/mcp_author.py
+++ b/apps/api/app/services/integrations/authoring/mcp_author.py
@@ -39,6 +39,10 @@ class McpIntegrationAuthor(IntegrationAuthor):
         # through that model.
         assert_safe_url_shape(blueprint.server_url)
 
+        # An authored integration starts private; publishing is a separate,
+        # deliberate step. That is the request model's own default, so it is
+        # not restated here -- it is pinned by a test instead, which can fail
+        # if the default ever moves.
         request = CreateCustomIntegrationRequest(
             name=blueprint.name,
             description=blueprint.description or None,
@@ -46,7 +50,6 @@ class McpIntegrationAuthor(IntegrationAuthor):
             server_url=blueprint.server_url,
             requires_auth=blueprint.requires_auth,
             auth_type=blueprint.auth_type,
-            is_public=False,
             bearer_token=blueprint.bearer_token,
         )
         mcp_client = await get_mcp_client(user_id=user_id)
@@ -54,8 +57,7 @@ class McpIntegrationAuthor(IntegrationAuthor):
             user_id, request, mcp_client
         )
 
-        status = str(result.get("status", ""))
-        connected = status == "connected"
+        connected = result.get("status") == "connected"
         return AuthoredIntegration(
             integration=integration,
             needs_connection=not connected,

--- a/apps/api/app/services/integrations/connect_dispatch.py
+++ b/apps/api/app/services/integrations/connect_dispatch.py
@@ -1,0 +1,98 @@
+"""The one place an integration connection is started, for every entry point.
+
+Both the authenticated ``POST /connect/{id}`` endpoint and the login-free
+``GET /connect-link`` redemption land here, so a transport is wired into all of
+them at once. The dispatch itself is transport-agnostic: it resolves the
+integration, checks the shared preconditions, and hands off to the registered
+provider.
+"""
+
+from __future__ import annotations
+
+from app.constants.log_tags import LogTag
+from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.services.analytics_service import AnalyticsEvents, capture_context_event
+from app.services.integrations.integration_resolver import IntegrationResolver
+from app.services.integrations.providers import ConnectContext, get_provider
+from shared.py.wide_events import log
+
+
+async def initiate_integration_connection(
+    user_id: str,
+    integration_id: str,
+    *,
+    user_email: str = "",
+    redirect_path: str = "/integrations",
+    bearer_token: str | None = None,
+) -> ConnectIntegrationResponse | None:
+    """Start or advance a connection. ``None`` when the integration is unknown.
+
+    Callers map ``None`` to a 404 (or a friendly bounce). Everything else —
+    including a failure — comes back as a response the client can render.
+    """
+    resolved = await IntegrationResolver.resolve(integration_id)
+    if not resolved:
+        return None
+
+    log.set(
+        user={"id": user_id},
+        integration={
+            "id": integration_id,
+            "managed_by": resolved.managed_by,
+            "source": resolved.source,
+        },
+    )
+
+    def _error(message: str) -> ConnectIntegrationResponse:
+        log.set(outcome="error")
+        return ConnectIntegrationResponse(
+            status="error",
+            integration_id=integration_id,
+            name=resolved.name,
+            error=message,
+        )
+
+    if (
+        resolved.source == "platform"
+        and resolved.platform_integration
+        and not resolved.platform_integration.available
+    ):
+        return _error(f"Integration {integration_id} is not available yet")
+
+    provider = get_provider(resolved.managed_by)
+    if provider is None:
+        # ``internal`` integrations reach this legitimately: they are always on
+        # and have nothing to connect.
+        return _error(f"Unsupported integration type: {resolved.managed_by}")
+
+    ctx = ConnectContext(
+        user_id=user_id,
+        integration_id=integration_id,
+        resolved=resolved,
+        redirect_path=redirect_path,
+        user_email=user_email,
+        secret=bearer_token,
+    )
+
+    try:
+        result = await provider.connect(ctx)
+    except Exception as e:
+        log.error(
+            f"{LogTag.INTEGRATION} Failed to initiate connection",
+            integration_id=integration_id,
+            user_id=user_id,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        return _error(str(e))
+
+    log.set(outcome=result.status)
+    if result.status == "connected":
+        # Fired here rather than per transport so every way of completing a
+        # connection is counted the same. The OAuth transports normally
+        # complete at their callback instead, which reports separately.
+        capture_context_event(
+            AnalyticsEvents.INTEGRATION_CONNECTED,
+            {"integration_id": integration_id, "managed_by": resolved.managed_by},
+        )
+    return result

--- a/apps/api/app/services/integrations/connect_dispatch.py
+++ b/apps/api/app/services/integrations/connect_dispatch.py
@@ -84,7 +84,15 @@ async def initiate_integration_connection(
             error=str(e),
             error_type=type(e).__name__,
         )
-        return _error(str(e))
+        # The raw text here is an upstream failure ("500: Failed to create
+        # sandbox: failed to run reserve script: redis: connection pool
+        # timeout") that names GAIA's internals and tells the user nothing they
+        # can act on. The detail stays on the wide event above, where it is
+        # actually useful; the user gets the one thing they can do.
+        return _error(
+            f"Something went wrong connecting {resolved.name}. "
+            "This is usually temporary; try again in a moment."
+        )
 
     log.set(outcome=result.status)
     if result.status == "connected":

--- a/apps/api/app/services/integrations/connect_dispatch.py
+++ b/apps/api/app/services/integrations/connect_dispatch.py
@@ -1,4 +1,4 @@
-"""The one place an integration connection is started, for every entry point.
+"""The one place an integration connection is started or torn down.
 
 Both the authenticated ``POST /connect/{id}`` endpoint and the login-free
 ``GET /connect-link`` redemption land here, so a transport is wired into all of
@@ -10,10 +10,15 @@ provider.
 from __future__ import annotations
 
 from app.constants.log_tags import LogTag
-from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.schemas.integrations.responses import (
+    ConnectIntegrationResponse,
+    IntegrationSuccessResponse,
+)
 from app.services.analytics_service import AnalyticsEvents, capture_context_event
+from app.services.integrations.integration_connection_service import _invalidate_caches
 from app.services.integrations.integration_resolver import IntegrationResolver
 from app.services.integrations.providers import ConnectContext, get_provider
+from app.services.integrations_fs import schedule_user_integrations_sync
 from shared.py.wide_events import log
 
 
@@ -104,3 +109,37 @@ async def initiate_integration_connection(
             {"integration_id": integration_id, "managed_by": resolved.managed_by},
         )
     return result
+
+
+async def disconnect_integration(user_id: str, integration_id: str) -> IntegrationSuccessResponse:
+    """Disconnect an integration for the user."""
+    log.set(integration={"provider": integration_id, "action": "disconnect"})
+    resolved = await IntegrationResolver.resolve(integration_id)
+    if not resolved:
+        raise ValueError(f"Integration {integration_id} not found")
+
+    # Same registry the connect path uses. Two hand-written dispatches is how a
+    # transport ends up wired into one and not the other -- which is what this
+    # function used to be.
+    provider = get_provider(resolved.managed_by)
+    if provider is None:
+        raise ValueError(f"Integration {integration_id} disconnect not supported")
+    await provider.disconnect(user_id, resolved)
+
+    await _invalidate_caches(user_id, integration_id, resolved.managed_by)
+
+    # Reflect the reduced connected set in the user's workspace VFS.
+    schedule_user_integrations_sync(user_id)
+
+    log.set(
+        integration={
+            "provider": integration_id,
+            "action": "disconnect",
+            "managed_by": resolved.managed_by,
+            "status": "disconnected",
+        }
+    )
+    return IntegrationSuccessResponse(
+        message=f"Successfully disconnected {resolved.name}",
+        integration_id=integration_id,
+    )

--- a/apps/api/app/services/integrations/custom_crud.py
+++ b/apps/api/app/services/integrations/custom_crud.py
@@ -86,6 +86,45 @@ async def create_custom_integration(
     return integration
 
 
+async def _updated_mcp_config(
+    user_id: str,
+    integration_id: str,
+    request: UpdateCustomIntegrationRequest,
+    doc: Integration,
+) -> MCPConfig:
+    """The integration's MCP config with this request's changes applied.
+
+    Pointing an integration at a different server orphans the vector data
+    indexed under the old one, so that is cleaned up here rather than left to
+    accumulate. Best effort: a stale namespace is not worth failing the edit.
+    """
+    config_changes: dict[str, object] = {}
+
+    if request.server_url is not None:
+        old_server_url = doc.mcp_config.server_url if doc.mcp_config else ""
+        config_changes["server_url"] = request.server_url
+        if old_server_url and old_server_url != request.server_url:
+            try:
+                await cleanup_integration_chroma_data(integration_id, old_server_url)
+            except Exception as e:
+                log.warning(
+                    f"{LogTag.INTEGRATION} Failed to clean old namespace for",
+                    integration_id=integration_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    user_id=user_id,
+                )
+
+    if request.requires_auth is not None:
+        config_changes["requires_auth"] = request.requires_auth
+    if request.auth_type is not None:
+        config_changes["auth_type"] = request.auth_type
+
+    if doc.mcp_config:
+        return doc.mcp_config.model_copy(update=config_changes)
+    return MCPConfig.model_validate(config_changes)
+
+
 async def update_custom_integration(
     user_id: str,
     integration_id: str,
@@ -99,41 +138,13 @@ async def update_custom_integration(
         return None
 
     changes: dict[str, object] = {"updated_at": datetime.now(UTC)}
-    if request.name is not None:
-        changes["name"] = request.name
-    if request.description is not None:
-        changes["description"] = request.description
-    if request.is_public is not None:
-        changes["is_public"] = request.is_public
+    for field in ("name", "description", "is_public"):
+        value = getattr(request, field)
+        if value is not None:
+            changes[field] = value
 
     if any([request.server_url, request.requires_auth, request.auth_type]):
-        config_changes: dict[str, object] = {}
-        if request.server_url is not None:
-            old_server_url = doc.mcp_config.server_url if doc.mcp_config else ""
-            config_changes["server_url"] = request.server_url
-
-            # Clean up old ChromaDB namespace when server_url changes
-            if old_server_url and old_server_url != request.server_url:
-                try:
-                    await cleanup_integration_chroma_data(integration_id, old_server_url)
-                except Exception as e:
-                    log.warning(
-                        f"{LogTag.INTEGRATION} Failed to clean old namespace for",
-                        integration_id=integration_id,
-                        error=str(e),
-                        error_type=type(e).__name__,
-                        user_id=user_id,
-                    )
-
-        if request.requires_auth is not None:
-            config_changes["requires_auth"] = request.requires_auth
-        if request.auth_type is not None:
-            config_changes["auth_type"] = request.auth_type
-        changes["mcp_config"] = (
-            doc.mcp_config.model_copy(update=config_changes)
-            if doc.mcp_config
-            else MCPConfig.model_validate(config_changes)
-        )
+        changes["mcp_config"] = await _updated_mcp_config(user_id, integration_id, request, doc)
 
     update = IntegrationUpdate.model_validate(changes)
     updated = await integration_repository.update(integration_id, update)
@@ -151,8 +162,106 @@ async def update_custom_integration(
     return updated
 
 
+async def _unpublish(integration_id: str) -> None:
+    """Drop a published integration from the public store and the cached list.
+
+    Best effort: a failure here leaves a stale marketplace entry, which is worth
+    a warning but not worth failing the delete the user asked for.
+    """
+    try:
+        await remove_public_integration(integration_id)
+    except Exception as e:
+        log.warning(
+            f"{LogTag.INTEGRATION} Failed to remove from public integrations",
+            error=str(e),
+            error_type=type(e).__name__,
+            integration_id=integration_id,
+        )
+    await delete_cache_by_pattern("marketplace:community:*")
+
+
+async def _unlink_every_user(integration_id: str) -> None:
+    """Remove every user's link to an integration whose catalog row is gone.
+
+    Goes through the canonical mutator per user so each row delete and its cache
+    invalidation stay coupled.
+    """
+    for affected_user_id in await user_integration_repository.user_ids_with_integration(
+        integration_id
+    ):
+        try:
+            await remove_user_integration(affected_user_id, integration_id)
+        except Exception as e:
+            log.debug(
+                f"{LogTag.INTEGRATION} Failed to remove integration for user",
+                affected_user_id=affected_user_id,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+
+
+async def _delete_credentials(integration_id: str, user_id: str | None = None) -> None:
+    """Delete stored MCP credentials for an integration, or for one user of it."""
+    conditions = [MCPCredential.integration_id == integration_id]
+    if user_id is not None:
+        conditions.append(MCPCredential.user_id == user_id)
+    try:
+        async with get_db_session() as session:
+            await session.execute(delete(MCPCredential).where(*conditions))
+            await session.commit()
+    except Exception as e:
+        log.warning(
+            f"{LogTag.INTEGRATION} Failed to delete MCP credentials",
+            error=str(e),
+            error_type=type(e).__name__,
+            integration_id=integration_id,
+            user_id=user_id,
+        )
+
+
+async def _clear_derived_state(integration_id: str, doc: Integration) -> None:
+    """Drop the caches and vector data derived from an integration."""
+    try:
+        await delete_cache("mcp:tools:all")
+    except Exception as e:
+        log.debug(
+            f"{LogTag.INTEGRATION} Cache deletion for mcp:tools:all failed",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+    try:
+        server_url = doc.mcp_config.server_url if doc.mcp_config else ""
+        await cleanup_integration_chroma_data(integration_id, server_url)
+    except Exception as e:
+        log.debug(
+            f"{LogTag.INTEGRATION} Chroma store deletion failed for",
+            integration_id=integration_id,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+
+
+async def _delete_as_creator(user_id: str, integration_id: str, doc: Integration) -> bool:
+    """Remove the integration itself, and everything derived from it."""
+    if doc.is_public:
+        await _unpublish(integration_id)
+
+    if not await integration_repository.delete_custom(integration_id, user_id):
+        return False
+
+    await _unlink_every_user(integration_id)
+    await _delete_credentials(integration_id)
+    await _clear_derived_state(integration_id, doc)
+    return True
+
+
 async def delete_custom_integration(user_id: str, integration_id: str) -> bool:
-    """Delete or remove a custom integration based on ownership."""
+    """Delete or remove a custom integration based on ownership.
+
+    Three cases, and the ownership check is what separates them: no catalog row
+    at all, the creator (who removes the integration for everyone), and everyone
+    else (who only drops their own link and credential).
+    """
     log.set(integration={"provider": integration_id, "action": "delete_custom_integration"})
     doc = await integration_repository.get_custom(integration_id)
 
@@ -163,100 +272,13 @@ async def delete_custom_integration(user_id: str, integration_id: str) -> bool:
         # (see app/decorators/caching.py); cast back to the real contract.
         return cast(bool, await remove_user_integration(user_id, integration_id))
 
-    is_creator = doc.created_by == user_id
+    if doc.created_by == user_id:
+        return await _delete_as_creator(user_id, integration_id, doc)
 
-    if is_creator:
-        if doc.is_public:
-            try:
-                await remove_public_integration(integration_id)
-            except Exception as e:
-                log.warning(
-                    f"{LogTag.INTEGRATION} Failed to remove from public integrations",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                    user_id=user_id,
-                    integration_id=integration_id,
-                )
-            # Drop the deleted integration from the cached community marketplace list.
-            await delete_cache_by_pattern("marketplace:community:*")
-
-        deleted = await integration_repository.delete_custom(integration_id, user_id)
-
-        if deleted:
-            affected_user_ids = await user_integration_repository.user_ids_with_integration(
-                integration_id
-            )
-
-            # Remove each user's link through the canonical mutator so the row
-            # delete and its cache invalidation stay coupled per user.
-            for affected_user_id in affected_user_ids:
-                try:
-                    await remove_user_integration(affected_user_id, integration_id)
-                except Exception as e:
-                    log.debug(
-                        f"{LogTag.INTEGRATION} Failed to remove integration for user",
-                        affected_user_id=affected_user_id,
-                        error=str(e),
-                        error_type=type(e).__name__,
-                    )
-
-            try:
-                async with get_db_session() as session:
-                    await session.execute(
-                        delete(MCPCredential).where(MCPCredential.integration_id == integration_id)
-                    )
-                    await session.commit()
-            except Exception as e:
-                log.warning(
-                    f"{LogTag.INTEGRATION} Failed to delete MCP credentials",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                    user_id=user_id,
-                    integration_id=integration_id,
-                )
-
-            try:
-                await delete_cache("mcp:tools:all")
-            except Exception as e:
-                log.debug(
-                    f"{LogTag.INTEGRATION} Cache deletion for mcp:tools:all failed",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-
-            try:
-                server_url = doc.mcp_config.server_url if doc.mcp_config else ""
-                await cleanup_integration_chroma_data(integration_id, server_url)
-            except Exception as e:
-                log.debug(
-                    f"{LogTag.INTEGRATION} Chroma store deletion failed for",
-                    integration_id=integration_id,
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-
-            return True
+    if not await remove_user_integration(user_id, integration_id):
         return False
-    if await remove_user_integration(user_id, integration_id):
-        try:
-            async with get_db_session() as session:
-                await session.execute(
-                    delete(MCPCredential).where(
-                        MCPCredential.integration_id == integration_id,
-                        MCPCredential.user_id == user_id,
-                    )
-                )
-                await session.commit()
-        except Exception as e:
-            log.debug(
-                f"{LogTag.INTEGRATION} MCP credential deletion failed for",
-                integration_id=integration_id,
-                error=str(e),
-                error_type=type(e).__name__,
-            )
-
-        return True
-    return False
+    await _delete_credentials(integration_id, user_id)
+    return True
 
 
 async def create_and_connect_custom_integration(

--- a/apps/api/app/services/integrations/custom_crud.py
+++ b/apps/api/app/services/integrations/custom_crud.py
@@ -33,7 +33,7 @@ from app.services.integrations.user_integrations import (
 )
 from app.services.mcp.mcp_client import MCPClient
 from app.services.mcp.mcp_token_store import MCPTokenStore
-from app.utils.favicon_utils import fetch_favicon_from_url
+from app.utils.favicon_utils import fetch_favicon_safely
 from shared.py.wide_events import log
 
 
@@ -271,7 +271,7 @@ async def create_and_connect_custom_integration(
             "action": "create_and_connect_custom_integration",
         }
     )
-    icon_url = await _fetch_icon_safely(request.server_url)
+    icon_url = await fetch_favicon_safely(request.server_url)
     integration = await create_custom_integration(user_id, request, icon_url)
     integration_id = integration.integration_id
 
@@ -296,14 +296,6 @@ async def create_and_connect_custom_integration(
 
     # No auth required - try direct connection
     return await _connect_without_auth(integration, mcp_client)
-
-
-async def _fetch_icon_safely(server_url: str) -> str | None:
-    """Fetch favicon with error handling."""
-    try:
-        return await fetch_favicon_from_url(server_url)
-    except Exception:
-        return None
 
 
 async def _probe_connection_safely(mcp_client: MCPClient, server_url: str) -> dict[str, Any]:

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -75,6 +75,14 @@ def build_integrations_config() -> IntegrationsConfigResponse:
                 # A CLI declares its auth shape in cli_config, not mcp_config;
                 # without this every CLI integration renders as "no sign-in
                 # needed" and the connect dialog looks like a no-op.
+                #
+                # KNOWN INCONSISTENCY, pre-dating the CLI transport: a Composio
+                # integration has neither config, so it falls to `False` here
+                # while IntegrationResolver reports `True` for the same row.
+                # Every Composio card therefore claims no sign-in is needed for
+                # what is pure OAuth. Left as-is deliberately: this field is
+                # read by the marketplace UI, so changing it moves behaviour for
+                # 23 shipped integrations and is a product call, not a cleanup.
                 requires_auth=(
                     integration.mcp_config.requires_auth
                     if integration.mcp_config

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -14,6 +14,7 @@ from app.config.oauth_config import (
     get_integration_scopes,
 )
 from app.config.token_repository import token_repository
+from app.constants.integrations import MANAGED_BY_CLI, MANAGED_BY_MCP
 from app.constants.log_tags import LogTag
 from app.db.redis import delete_cache
 from app.helpers.mcp_helpers import get_api_base_url
@@ -82,11 +83,7 @@ def build_integrations_config() -> IntegrationsConfigResponse:
                 requires_auth=(
                     integration.mcp_config.requires_auth
                     if integration.mcp_config
-                    else (
-                        integration.cli_config.auth.kind != "none"
-                        if integration.cli_config
-                        else False
-                    )
+                    else (integration.cli_config.requires_auth if integration.cli_config else False)
                 ),
                 slug=integration.id,  # Platform integrations use ID as slug
             )
@@ -501,7 +498,7 @@ async def disconnect_integration(user_id: str, integration_id: str) -> Integrati
     if not resolved:
         raise ValueError(f"Integration {integration_id} not found")
 
-    if resolved.managed_by == "cli":
+    if resolved.managed_by == MANAGED_BY_CLI:
         # Checked before the custom-source branch: a user-authored CLI
         # integration is `source == "custom"` too, and the MCP teardown would be
         # both wrong and a no-op for it.
@@ -561,10 +558,18 @@ async def _invalidate_caches(user_id: str, integration_id: str, managed_by: str)
             )
 
     # Determine whether to delete record or set status to "created"
-    if managed_by == "mcp":
-        # MCP integrations: record already deleted in main disconnect logic
+    if managed_by in (MANAGED_BY_MCP, MANAGED_BY_CLI):
+        # Both transports already removed the record in the disconnect helper
+        # above. Falling through would call update_user_integration_status,
+        # which is an UPSERT: for a user-authored integration whose catalog
+        # document was just deleted, it recreates the user_integrations row with
+        # status "created". The row is then invisible (get_user_integrations
+        # drops rows whose document is missing) but permanent -- exists() stays
+        # true forever and a second disconnect raises "not found".
         log.info(
-            f"{LogTag.INTEGRATION} MCP integration record removed", integration_id=integration_id
+            f"{LogTag.INTEGRATION} Integration record already removed",
+            integration_id=integration_id,
+            managed_by=managed_by,
         )
     else:
         # Check if it's a platform integration (defined in oauth_config.py)

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -435,7 +435,20 @@ async def disconnect_integration(user_id: str, integration_id: str) -> Integrati
         # would be both wrong and a no-op for it. `cli_config` is pinned by the
         # catalog validator for this transport.
         if resolved.cli_config:
-            await cli_disconnect(user_id, integration_id, resolved.cli_config)
+            try:
+                await cli_disconnect(user_id, integration_id, resolved.cli_config)
+            except Exception as e:
+                # Best-effort cleanup: the durable HOME is per-integration and is
+                # recreated on the next connect anyway. Letting an unreachable
+                # sandbox abort the disconnect would leave the user owning an
+                # integration they cannot remove until it comes back.
+                log.warning(
+                    f"{LogTag.INTEGRATION} CLI teardown failed; removing the record anyway",
+                    integration_id=integration_id,
+                    user_id=user_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
         await remove_user_integration(user_id, integration_id)
         if (
             resolved.source == "custom"

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -23,6 +23,7 @@ from app.schemas.integrations.responses import (
     IntegrationsConfigResponse,
     IntegrationSuccessResponse,
 )
+from app.services.cli import disconnect as cli_disconnect
 from app.services.composio.composio_service import get_composio_service
 from app.services.integrations.custom_crud import delete_custom_integration
 from app.services.integrations.integration_resolver import IntegrationResolver
@@ -71,8 +72,17 @@ def build_integrations_config() -> IntegrationsConfigResponse:
                 is_featured=integration.is_featured,
                 managed_by=integration.managed_by,
                 auth_type=auth_type_literal,
+                # A CLI declares its auth shape in cli_config, not mcp_config;
+                # without this every CLI integration renders as "no sign-in
+                # needed" and the connect dialog looks like a no-op.
                 requires_auth=(
-                    integration.mcp_config.requires_auth if integration.mcp_config else False
+                    integration.mcp_config.requires_auth
+                    if integration.mcp_config
+                    else (
+                        integration.cli_config.auth.kind != "none"
+                        if integration.cli_config
+                        else False
+                    )
                 ),
                 slug=integration.id,  # Platform integrations use ID as slug
             )
@@ -412,87 +422,6 @@ async def connect_self_integration(
     )
 
 
-async def initiate_integration_connection(
-    user_id: str,
-    integration_id: str,
-    *,
-    user_email: str = "",
-    redirect_path: str = "/integrations",
-    bearer_token: str | None = None,
-) -> ConnectIntegrationResponse | None:
-    """Resolve an integration and start its connect flow.
-
-    Single source of truth for the connect dispatch, shared by the
-    ``POST /connect/{id}`` endpoint and the login-free ``GET /connect-link``
-    entry point. Returns ``None`` when the integration does not exist (callers
-    map that to 404 / a friendly error); otherwise a ``ConnectIntegrationResponse``
-    whose ``redirect_url`` is the provider OAuth URL.
-    """
-    resolved = await IntegrationResolver.resolve(integration_id)
-    if not resolved:
-        return None
-
-    def _error(message: str) -> ConnectIntegrationResponse:
-        return ConnectIntegrationResponse(
-            status="error",
-            integration_id=integration_id,
-            name=resolved.name,
-            error=message,
-        )
-
-    if (
-        resolved.source == "platform"
-        and resolved.platform_integration
-        and not resolved.platform_integration.available
-    ):
-        return _error(f"Integration {integration_id} is not available yet")
-
-    provider = resolved.platform_integration.provider if resolved.platform_integration else None
-    try:
-        if resolved.managed_by == "mcp":
-            return await connect_mcp_integration(
-                user_id=user_id,
-                integration_id=integration_id,
-                integration_name=resolved.name,
-                requires_auth=resolved.requires_auth,
-                redirect_path=redirect_path,
-                server_url=resolved.mcp_config.server_url if resolved.mcp_config else None,
-                is_platform=resolved.source == "platform",
-                bearer_token=bearer_token,
-            )
-        if resolved.managed_by == "composio":
-            if not provider:
-                return _error("Provider not configured")
-            return await connect_composio_integration(
-                user_id=user_id,
-                integration_id=integration_id,
-                integration_name=resolved.name,
-                provider=provider,
-                redirect_path=redirect_path,
-            )
-        if resolved.managed_by == "self":
-            if not provider:
-                return _error("Provider not configured")
-            return await connect_self_integration(
-                user_id=user_id,
-                user_email=user_email,
-                integration_id=integration_id,
-                integration_name=resolved.name,
-                provider=provider,
-                redirect_path=redirect_path,
-            )
-        return _error(f"Unsupported integration type: {resolved.managed_by}")
-    except Exception as e:
-        log.error(
-            f"{LogTag.INTEGRATION} Failed to initiate connection for",
-            integration_id=integration_id,
-            error=str(e),
-            error_type=type(e).__name__,
-            user_id=user_id,
-        )
-        return _error(str(e))
-
-
 async def disconnect_integration(user_id: str, integration_id: str) -> IntegrationSuccessResponse:
     """Disconnect an integration for the user."""
     log.set(integration={"provider": integration_id, "action": "disconnect"})
@@ -500,7 +429,22 @@ async def disconnect_integration(user_id: str, integration_id: str) -> Integrati
     if not resolved:
         raise ValueError(f"Integration {integration_id} not found")
 
-    if resolved.source == "custom":
+    if resolved.managed_by == "cli":
+        # Checked before the custom-source branch: a user-authored CLI
+        # integration is `source == "custom"` too, and the MCP teardown below
+        # would be both wrong and a no-op for it. `cli_config` is pinned by the
+        # catalog validator for this transport.
+        if resolved.cli_config:
+            await cli_disconnect(user_id, integration_id, resolved.cli_config)
+        await remove_user_integration(user_id, integration_id)
+        if (
+            resolved.source == "custom"
+            and resolved.custom_doc
+            and resolved.custom_doc.get("created_by") == user_id
+        ):
+            await delete_custom_integration(user_id, integration_id)
+
+    elif resolved.source == "custom":
         mcp_client = await get_mcp_client(user_id=user_id)
         await mcp_client.disconnect(integration_id)
         await remove_user_integration(user_id, integration_id)

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -1,5 +1,6 @@
 """Integration connection service - handles connect/disconnect logic."""
 
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Literal
 
@@ -26,7 +27,10 @@ from app.schemas.integrations.responses import (
 from app.services.cli import disconnect as cli_disconnect
 from app.services.composio.composio_service import get_composio_service
 from app.services.integrations.custom_crud import delete_custom_integration
-from app.services.integrations.integration_resolver import IntegrationResolver
+from app.services.integrations.integration_resolver import (
+    IntegrationResolver,
+    ResolvedIntegration,
+)
 from app.services.integrations.user_integration_status import (
     update_user_integration_status,
 )
@@ -121,27 +125,44 @@ async def _redirect_to_oauth(
     )
 
 
+@dataclass(frozen=True)
+class McpConnectRequest:
+    """One attempt to connect an MCP-backed integration.
+
+    A single request rather than nine parameters threaded through four helpers:
+    every step of the flow needs the same identity (user, integration, display
+    name) plus the same handful of knobs, and re-listing them at each hop is how
+    a helper ends up reading `is_platform` from one call site and not the other.
+    """
+
+    user_id: str
+    integration_id: str
+    integration_name: str
+    requires_auth: bool
+    redirect_path: str
+    server_url: str | None = None
+    is_platform: bool = False
+    probe_result: McpProbeResult | None = None
+    bearer_token: str | None = None
+
+
 async def _handle_auth_required(
-    user_id: str,
-    integration_id: str,
-    integration_name: str,
-    redirect_path: str,
+    request: McpConnectRequest,
+    mcp_client: MCPClient,
     *,
-    is_platform: bool,
     detected_auth_type: str | None,
     probe_result: McpProbeResult | None,
-    mcp_client: MCPClient,
 ) -> ConnectIntegrationResponse:
     """Bearer servers return bearer_required (frontend collects a key); everything
     else gets the OAuth redirect."""
-    if not is_platform:
-        await update_user_integration_status(user_id, integration_id, "created")
+    if not request.is_platform:
+        await update_user_integration_status(request.user_id, request.integration_id, "created")
 
     if detected_auth_type == "bearer":
         return ConnectIntegrationResponse(
             status="error",
-            integration_id=integration_id,
-            name=integration_name,
+            integration_id=request.integration_id,
+            name=request.integration_name,
             error="bearer_required",
             message="This integration requires an API key.",
         )
@@ -152,144 +173,120 @@ async def _handle_auth_required(
     # given. Typing both ends surfaced it.
     return await _redirect_to_oauth(
         mcp_client,
-        integration_id,
-        integration_name,
-        redirect_path,
+        request.integration_id,
+        request.integration_name,
+        request.redirect_path,
         challenge_data=probe_result.get("oauth_challenge") if probe_result else None,
     )
 
 
 async def _handle_connect_failure(
-    user_id: str,
-    integration_id: str,
-    integration_name: str,
-    is_platform: bool,
-    error: Exception,
+    request: McpConnectRequest, error: Exception
 ) -> ConnectIntegrationResponse:
     """Surface a connection failure as a structured error, never a 500."""
-    if not is_platform:
-        await update_user_integration_status(user_id, integration_id, "created")
+    if not request.is_platform:
+        await update_user_integration_status(request.user_id, request.integration_id, "created")
     log.warning(
         f"{LogTag.INTEGRATION} MCP connection failed for",
-        integration_id=integration_id,
+        integration_id=request.integration_id,
         error=error,
-        user_id=user_id,
+        user_id=request.user_id,
     )
-    log.set(integration={"provider": integration_name, "action": "connect_mcp", "status": "error"})
+    log.set(
+        integration={
+            "provider": request.integration_name,
+            "action": "connect_mcp",
+            "status": "error",
+        }
+    )
     return ConnectIntegrationResponse(
         status="error",
-        integration_id=integration_id,
-        name=integration_name,
+        integration_id=request.integration_id,
+        name=request.integration_name,
         error=str(error),
         message="Connection failed",
     )
 
 
-async def connect_mcp_integration(
-    user_id: str,
-    integration_id: str,
-    integration_name: str,
-    requires_auth: bool,
-    redirect_path: str,
-    server_url: str | None = None,
-    is_platform: bool = False,
-    probe_result: McpProbeResult | None = None,
-    bearer_token: str | None = None,
-) -> ConnectIntegrationResponse:
+async def connect_mcp_integration(request: McpConnectRequest) -> ConnectIntegrationResponse:
     """Handle MCP integration connection."""
-    log.set(integration={"provider": integration_name, "action": "connect_mcp"})
-    mcp_client = await get_mcp_client(user_id=user_id)
+    log.set(integration={"provider": request.integration_name, "action": "connect_mcp"})
+    mcp_client = await get_mcp_client(user_id=request.user_id)
 
     # Bearer token flow - store and connect directly
-    if bearer_token:
-        return await _connect_with_bearer_token(
-            user_id, integration_id, integration_name, bearer_token, mcp_client
-        )
+    if request.bearer_token:
+        return await _connect_with_bearer_token(request, request.bearer_token, mcp_client)
 
     # Use provided probe_result or perform probe if needed
-    if server_url and not requires_auth and probe_result is None:
-        probe_result = await mcp_client.probe_connection(server_url)
+    probe_result = request.probe_result
+    requires_auth = request.requires_auth
+    if request.server_url and not requires_auth and probe_result is None:
+        probe_result = await mcp_client.probe_connection(request.server_url)
 
     # Check if probe detected auth requirement
     detected_auth_type: str | None = None
     if probe_result and not requires_auth and probe_result.get("requires_auth"):
         detected_auth_type = probe_result.get("auth_type", "oauth")
         await mcp_client.update_integration_auth_status(
-            integration_id, requires_auth=True, auth_type=detected_auth_type
+            request.integration_id, requires_auth=True, auth_type=detected_auth_type
         )
         requires_auth = True
 
     if requires_auth:
         return await _handle_auth_required(
-            user_id,
-            integration_id,
-            integration_name,
-            redirect_path,
-            is_platform=is_platform,
+            request,
+            mcp_client,
             detected_auth_type=detected_auth_type,
             probe_result=probe_result,
-            mcp_client=mcp_client,
         )
 
     try:
-        tools = await mcp_client.connect(integration_id)
+        tools = await mcp_client.connect(request.integration_id)
     except OAuthAuthenticationError:
         # mcp-use only learned auth was needed at connect time — route to OAuth.
         return await _handle_auth_required(
-            user_id,
-            integration_id,
-            integration_name,
-            redirect_path,
-            is_platform=is_platform,
-            detected_auth_type=None,
-            probe_result=None,
-            mcp_client=mcp_client,
+            request, mcp_client, detected_auth_type=None, probe_result=None
         )
     except Exception as e:
-        return await _handle_connect_failure(
-            user_id, integration_id, integration_name, is_platform, e
-        )
+        return await _handle_connect_failure(request, e)
 
     tools_count = len(tools) if tools else 0
-    await invalidate_user_integration_caches(user_id)
+    await invalidate_user_integration_caches(request.user_id)
 
     log.set(
         integration={
-            "provider": integration_name,
+            "provider": request.integration_name,
             "action": "connect_mcp",
             "status": "connected",
-            "auth_type": "bearer" if bearer_token else "none",
+            # Reached only on the no-token path; the bearer flow returns above.
+            "auth_type": "none",
             "tools_count": tools_count,
         }
     )
     return ConnectIntegrationResponse(
         status="connected",
-        integration_id=integration_id,
-        name=integration_name,
+        integration_id=request.integration_id,
+        name=request.integration_name,
         tools_count=tools_count,
         message="Integration connected successfully",
     )
 
 
 async def _connect_with_bearer_token(
-    user_id: str,
-    integration_id: str,
-    integration_name: str,
-    bearer_token: str,
-    mcp_client: MCPClient,
+    request: McpConnectRequest, bearer_token: str, mcp_client: MCPClient
 ) -> ConnectIntegrationResponse:
     """Store bearer token and attempt connection."""
-    token_store = MCPTokenStore(user_id)
-    await token_store.store_bearer_token(integration_id, bearer_token)
+    token_store = MCPTokenStore(request.user_id)
+    await token_store.store_bearer_token(request.integration_id, bearer_token)
 
     try:
-        tools = await mcp_client.connect(integration_id)
+        tools = await mcp_client.connect(request.integration_id)
         # Busts the full per-user integration cache set (status + tools:user:*).
-        await update_user_integration_status(user_id, integration_id, "connected")
+        await update_user_integration_status(request.user_id, request.integration_id, "connected")
         tools_count = len(tools) if tools else 0
         log.set(
             integration={
-                "provider": integration_name,
+                "provider": request.integration_name,
                 "action": "connect_mcp",
                 "auth_type": "bearer",
                 "status": "connected",
@@ -298,18 +295,18 @@ async def _connect_with_bearer_token(
         )
         return ConnectIntegrationResponse(
             status="connected",
-            integration_id=integration_id,
-            name=integration_name,
+            integration_id=request.integration_id,
+            name=request.integration_name,
             tools_count=tools_count,
             message="Integration connected successfully",
         )
     except Exception as e:
         # Rollback: clean up stored credentials on connection failure
-        await token_store.delete_credentials(integration_id)
-        await invalidate_user_integration_caches(user_id)
+        await token_store.delete_credentials(request.integration_id)
+        await invalidate_user_integration_caches(request.user_id)
         log.set(
             integration={
-                "provider": integration_name,
+                "provider": request.integration_name,
                 "action": "connect_mcp",
                 "auth_type": "bearer",
                 "status": "error",
@@ -317,8 +314,8 @@ async def _connect_with_bearer_token(
         )
         return ConnectIntegrationResponse(
             status="error",
-            integration_id=integration_id,
-            name=integration_name,
+            integration_id=request.integration_id,
+            name=request.integration_name,
             error=str(e),
             message="Connection failed",
         )
@@ -422,6 +419,81 @@ async def connect_self_integration(
     )
 
 
+def _require_provider(resolved: ResolvedIntegration) -> str:
+    """The upstream provider slug, or a loud failure.
+
+    Composio and the self-managed OAuth flow both revoke by provider, and a
+    catalog entry missing one cannot be torn down at all — better a raised
+    ValueError than a silent no-op that leaves the grant live upstream.
+    """
+    provider = resolved.platform_integration.provider if resolved.platform_integration else None
+    if not provider:
+        raise ValueError(f"Provider not configured for {resolved.integration_id}")
+    return provider
+
+
+async def _delete_if_user_authored(user_id: str, resolved: ResolvedIntegration) -> None:
+    """Drop the catalog document too, but only for the user who authored it.
+
+    A custom integration cloned from someone else's is removed from this user
+    without deleting the original.
+    """
+    if (
+        resolved.source == "custom"
+        and resolved.custom_doc
+        and resolved.custom_doc.get("created_by") == user_id
+    ):
+        await delete_custom_integration(user_id, resolved.integration_id)
+
+
+async def _disconnect_cli(user_id: str, resolved: ResolvedIntegration) -> None:
+    """Tear down the CLI's sandbox state, then detach it from the user."""
+    # `cli_config` is pinned by the catalog validator for this transport.
+    if resolved.cli_config:
+        try:
+            await cli_disconnect(user_id, resolved.integration_id, resolved.cli_config)
+        except Exception as e:
+            # Best-effort cleanup: the durable HOME is per-integration and is
+            # recreated on the next connect anyway. Letting an unreachable
+            # sandbox abort the disconnect would leave the user owning an
+            # integration they cannot remove until it comes back.
+            log.warning(
+                f"{LogTag.INTEGRATION} CLI teardown failed; removing the record anyway",
+                integration_id=resolved.integration_id,
+                user_id=user_id,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
+    await remove_user_integration(user_id, resolved.integration_id)
+    await _delete_if_user_authored(user_id, resolved)
+
+
+async def _disconnect_mcp(user_id: str, resolved: ResolvedIntegration) -> None:
+    """Drop the MCP session and the user's record of the server."""
+    mcp_client = await get_mcp_client(user_id=user_id)
+    await mcp_client.disconnect(resolved.integration_id)
+    await remove_user_integration(user_id, resolved.integration_id)
+
+
+async def _disconnect_custom_mcp(user_id: str, resolved: ResolvedIntegration) -> None:
+    """An MCP server the user added themselves: also drop the catalog document."""
+    await _disconnect_mcp(user_id, resolved)
+    await _delete_if_user_authored(user_id, resolved)
+
+
+async def _disconnect_composio(user_id: str, resolved: ResolvedIntegration) -> None:
+    """Delete the connected account Composio holds for this provider."""
+    composio_service = get_composio_service()
+    await composio_service.delete_connected_account(
+        user_id=user_id, provider=_require_provider(resolved)
+    )
+
+
+async def _disconnect_self(user_id: str, resolved: ResolvedIntegration) -> None:
+    """Revoke the OAuth token GAIA obtained itself."""
+    await token_repository.revoke_token(user_id=user_id, provider=_require_provider(resolved))
+
+
 async def disconnect_integration(user_id: str, integration_id: str) -> IntegrationSuccessResponse:
     """Disconnect an integration for the user."""
     log.set(integration={"provider": integration_id, "action": "disconnect"})
@@ -431,57 +503,17 @@ async def disconnect_integration(user_id: str, integration_id: str) -> Integrati
 
     if resolved.managed_by == "cli":
         # Checked before the custom-source branch: a user-authored CLI
-        # integration is `source == "custom"` too, and the MCP teardown below
-        # would be both wrong and a no-op for it. `cli_config` is pinned by the
-        # catalog validator for this transport.
-        if resolved.cli_config:
-            try:
-                await cli_disconnect(user_id, integration_id, resolved.cli_config)
-            except Exception as e:
-                # Best-effort cleanup: the durable HOME is per-integration and is
-                # recreated on the next connect anyway. Letting an unreachable
-                # sandbox abort the disconnect would leave the user owning an
-                # integration they cannot remove until it comes back.
-                log.warning(
-                    f"{LogTag.INTEGRATION} CLI teardown failed; removing the record anyway",
-                    integration_id=integration_id,
-                    user_id=user_id,
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-        await remove_user_integration(user_id, integration_id)
-        if (
-            resolved.source == "custom"
-            and resolved.custom_doc
-            and resolved.custom_doc.get("created_by") == user_id
-        ):
-            await delete_custom_integration(user_id, integration_id)
-
+        # integration is `source == "custom"` too, and the MCP teardown would be
+        # both wrong and a no-op for it.
+        await _disconnect_cli(user_id, resolved)
     elif resolved.source == "custom":
-        mcp_client = await get_mcp_client(user_id=user_id)
-        await mcp_client.disconnect(integration_id)
-        await remove_user_integration(user_id, integration_id)
-        if resolved.custom_doc and resolved.custom_doc.get("created_by") == user_id:
-            await delete_custom_integration(user_id, integration_id)
-
+        await _disconnect_custom_mcp(user_id, resolved)
     elif resolved.managed_by == "composio":
-        composio_service = get_composio_service()
-        provider = resolved.platform_integration.provider if resolved.platform_integration else None
-        if not provider:
-            raise ValueError(f"Provider not configured for {integration_id}")
-        await composio_service.delete_connected_account(user_id=user_id, provider=provider)
-
+        await _disconnect_composio(user_id, resolved)
     elif resolved.managed_by == "self":
-        provider = resolved.platform_integration.provider if resolved.platform_integration else None
-        if not provider:
-            raise ValueError(f"Provider not configured for {integration_id}")
-        await token_repository.revoke_token(user_id=user_id, provider=provider)
-
+        await _disconnect_self(user_id, resolved)
     elif resolved.managed_by == "mcp":
-        mcp_client = await get_mcp_client(user_id=user_id)
-        await mcp_client.disconnect(integration_id)
-        await remove_user_integration(user_id, integration_id)
-
+        await _disconnect_mcp(user_id, resolved)
     else:
         raise ValueError(f"Integration {integration_id} disconnect not supported")
 

--- a/apps/api/app/services/integrations/integration_connection_service.py
+++ b/apps/api/app/services/integrations/integration_connection_service.py
@@ -13,7 +13,6 @@ from app.config.oauth_config import (
     get_integration_by_id,
     get_integration_scopes,
 )
-from app.config.token_repository import token_repository
 from app.constants.integrations import MANAGED_BY_CLI, MANAGED_BY_MCP
 from app.constants.log_tags import LogTag
 from app.db.redis import delete_cache
@@ -23,13 +22,10 @@ from app.schemas.integrations.responses import (
     ConnectIntegrationResponse,
     IntegrationConfigItem,
     IntegrationsConfigResponse,
-    IntegrationSuccessResponse,
 )
-from app.services.cli import disconnect as cli_disconnect
 from app.services.composio.composio_service import get_composio_service
 from app.services.integrations.custom_crud import delete_custom_integration
 from app.services.integrations.integration_resolver import (
-    IntegrationResolver,
     ResolvedIntegration,
 )
 from app.services.integrations.user_integration_status import (
@@ -39,7 +35,6 @@ from app.services.integrations.user_integrations import (
     invalidate_user_integration_caches,
     remove_user_integration,
 )
-from app.services.integrations_fs import schedule_user_integrations_sync
 from app.services.mcp.mcp_client import MCPClient, get_mcp_client
 from app.services.mcp.mcp_token_store import MCPTokenStore
 from app.services.oauth.oauth_state_service import create_oauth_state
@@ -416,7 +411,7 @@ async def connect_self_integration(
     )
 
 
-def _require_provider(resolved: ResolvedIntegration) -> str:
+def require_provider(resolved: ResolvedIntegration) -> str:
     """The upstream provider slug, or a loud failure.
 
     Composio and the self-managed OAuth flow both revoke by provider, and a
@@ -429,7 +424,7 @@ def _require_provider(resolved: ResolvedIntegration) -> str:
     return provider
 
 
-async def _delete_if_user_authored(user_id: str, resolved: ResolvedIntegration) -> None:
+async def delete_if_user_authored(user_id: str, resolved: ResolvedIntegration) -> None:
     """Drop the catalog document too, but only for the user who authored it.
 
     A custom integration cloned from someone else's is removed from this user
@@ -441,96 +436,6 @@ async def _delete_if_user_authored(user_id: str, resolved: ResolvedIntegration) 
         and resolved.custom_doc.get("created_by") == user_id
     ):
         await delete_custom_integration(user_id, resolved.integration_id)
-
-
-async def _disconnect_cli(user_id: str, resolved: ResolvedIntegration) -> None:
-    """Tear down the CLI's sandbox state, then detach it from the user."""
-    # `cli_config` is pinned by the catalog validator for this transport.
-    if resolved.cli_config:
-        try:
-            await cli_disconnect(user_id, resolved.integration_id, resolved.cli_config)
-        except Exception as e:
-            # Best-effort cleanup: the durable HOME is per-integration and is
-            # recreated on the next connect anyway. Letting an unreachable
-            # sandbox abort the disconnect would leave the user owning an
-            # integration they cannot remove until it comes back.
-            log.warning(
-                f"{LogTag.INTEGRATION} CLI teardown failed; removing the record anyway",
-                integration_id=resolved.integration_id,
-                user_id=user_id,
-                error=str(e),
-                error_type=type(e).__name__,
-            )
-    await remove_user_integration(user_id, resolved.integration_id)
-    await _delete_if_user_authored(user_id, resolved)
-
-
-async def _disconnect_mcp(user_id: str, resolved: ResolvedIntegration) -> None:
-    """Drop the MCP session and the user's record of the server."""
-    mcp_client = await get_mcp_client(user_id=user_id)
-    await mcp_client.disconnect(resolved.integration_id)
-    await remove_user_integration(user_id, resolved.integration_id)
-
-
-async def _disconnect_custom_mcp(user_id: str, resolved: ResolvedIntegration) -> None:
-    """An MCP server the user added themselves: also drop the catalog document."""
-    await _disconnect_mcp(user_id, resolved)
-    await _delete_if_user_authored(user_id, resolved)
-
-
-async def _disconnect_composio(user_id: str, resolved: ResolvedIntegration) -> None:
-    """Delete the connected account Composio holds for this provider."""
-    composio_service = get_composio_service()
-    await composio_service.delete_connected_account(
-        user_id=user_id, provider=_require_provider(resolved)
-    )
-
-
-async def _disconnect_self(user_id: str, resolved: ResolvedIntegration) -> None:
-    """Revoke the OAuth token GAIA obtained itself."""
-    await token_repository.revoke_token(user_id=user_id, provider=_require_provider(resolved))
-
-
-async def disconnect_integration(user_id: str, integration_id: str) -> IntegrationSuccessResponse:
-    """Disconnect an integration for the user."""
-    log.set(integration={"provider": integration_id, "action": "disconnect"})
-    resolved = await IntegrationResolver.resolve(integration_id)
-    if not resolved:
-        raise ValueError(f"Integration {integration_id} not found")
-
-    if resolved.managed_by == MANAGED_BY_CLI:
-        # Checked before the custom-source branch: a user-authored CLI
-        # integration is `source == "custom"` too, and the MCP teardown would be
-        # both wrong and a no-op for it.
-        await _disconnect_cli(user_id, resolved)
-    elif resolved.source == "custom":
-        await _disconnect_custom_mcp(user_id, resolved)
-    elif resolved.managed_by == "composio":
-        await _disconnect_composio(user_id, resolved)
-    elif resolved.managed_by == "self":
-        await _disconnect_self(user_id, resolved)
-    elif resolved.managed_by == "mcp":
-        await _disconnect_mcp(user_id, resolved)
-    else:
-        raise ValueError(f"Integration {integration_id} disconnect not supported")
-
-    await _invalidate_caches(user_id, integration_id, resolved.managed_by)
-
-    # Reflect the reduced connected set in the user's workspace VFS.
-    schedule_user_integrations_sync(user_id)
-
-    log.set(
-        integration={
-            "provider": integration_id,
-            "action": "disconnect",
-            "managed_by": resolved.managed_by,
-            "status": "disconnected",
-        }
-    )
-    return IntegrationSuccessResponse(
-        message=f"Successfully disconnected {resolved.name}",
-        integration_id=integration_id,
-    )
 
 
 async def _invalidate_caches(user_id: str, integration_id: str, managed_by: str) -> None:

--- a/apps/api/app/services/integrations/integration_resolver.py
+++ b/apps/api/app/services/integrations/integration_resolver.py
@@ -92,7 +92,7 @@ class IntegrationResolver:
             if integration.cli_config:
                 # A CLI's auth shape is declared by its own spec, not by the
                 # MCP-flavoured document fields.
-                requires_auth = integration.cli_config.auth.kind != "none"
+                requires_auth = integration.cli_config.requires_auth
 
             if mcp_config:
                 # mcp_config is authoritative, but log if document-level values conflict

--- a/apps/api/app/services/integrations/integration_resolver.py
+++ b/apps/api/app/services/integrations/integration_resolver.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from app.config.oauth_config import get_integration_by_id
 from app.constants.log_tags import LogTag
 from app.db.repositories.integrations import integration_repository
+from app.models.cli_config import CliConfig
+from app.models.integration_provider import ManagedBy
 from app.models.mcp_config import MCPConfig
 from app.models.oauth_models import OAuthIntegration
 from shared.py.wide_events import log
@@ -24,11 +26,12 @@ class ResolvedIntegration:
     name: str
     description: str
     category: str
-    managed_by: str
+    managed_by: ManagedBy
     source: str  # "platform" or "custom"
     requires_auth: bool
     auth_type: str | None  # "none", "oauth", "bearer"
     mcp_config: MCPConfig | None
+    cli_config: CliConfig | None
     # Original sources for backward compatibility
     platform_integration: OAuthIntegration | None
     custom_doc: dict | None
@@ -73,6 +76,7 @@ class IntegrationResolver:
                 requires_auth=requires_auth,
                 auth_type=auth_type,
                 mcp_config=platform_integration.mcp_config,
+                cli_config=platform_integration.cli_config,
                 platform_integration=platform_integration,
                 custom_doc=None,
             )
@@ -84,6 +88,11 @@ class IntegrationResolver:
             mcp_config = integration.mcp_config
             requires_auth = integration.requires_auth
             auth_type = integration.auth_type or "none"
+
+            if integration.cli_config:
+                # A CLI's auth shape is declared by its own spec, not by the
+                # MCP-flavoured document fields.
+                requires_auth = integration.cli_config.auth.kind != "none"
 
             if mcp_config:
                 # mcp_config is authoritative, but log if document-level values conflict
@@ -125,6 +134,7 @@ class IntegrationResolver:
                 requires_auth=requires_auth,
                 auth_type=auth_type,
                 mcp_config=mcp_config,
+                cli_config=integration.cli_config,
                 platform_integration=None,
                 custom_doc=integration.model_dump(),
             )

--- a/apps/api/app/services/integrations/my_integrations.py
+++ b/apps/api/app/services/integrations/my_integrations.py
@@ -59,17 +59,17 @@ async def get_my_integrations(user_id: str) -> MyIntegrationsResponse:
             if ui is not None
             else ("connected" if status_map.get(cfg.id) else "not_connected")
         )
-        tool_count = (
+        # A CLI integration exposes ONE tool wrapping the whole command, so the
+        # registry counts it as 1 (0 until the category is lazily registered).
+        # Neither number is what a user means by "what can this do" — the
+        # declared capabilities are, so they win outright rather than acting as
+        # a fallback for a missing count.
+        capability_count = _cli_capability_count(cfg.id)
+        tool_count = capability_count or (
             (len(ui.integration.tools) or counts.get(cfg.id.lower(), 0))
             if ui is not None
             else counts.get(cfg.id.lower(), 0)
         )
-        if not tool_count:
-            # A CLI integration exposes one tool wrapping the whole command, so
-            # the registry count is 1 (and 0 until the category is lazily
-            # registered) — neither is what a user means by "what can this do".
-            # Its declared capabilities are.
-            tool_count = _cli_capability_count(cfg.id)
         items.append(
             MyIntegrationItem(
                 id=cfg.id,

--- a/apps/api/app/services/integrations/my_integrations.py
+++ b/apps/api/app/services/integrations/my_integrations.py
@@ -9,6 +9,7 @@ tools are fetched on demand via `get_integration_tools`.
 
 import asyncio
 
+from app.config.oauth_config import get_integration_by_id
 from app.constants.cache import ONE_DAY_TTL
 from app.decorators.caching import Cacheable
 from app.schemas.integrations.responses import (
@@ -63,6 +64,12 @@ async def get_my_integrations(user_id: str) -> MyIntegrationsResponse:
             if ui is not None
             else counts.get(cfg.id.lower(), 0)
         )
+        if not tool_count:
+            # A CLI integration exposes one tool wrapping the whole command, so
+            # the registry count is 1 (and 0 until the category is lazily
+            # registered) — neither is what a user means by "what can this do".
+            # Its declared capabilities are.
+            tool_count = _cli_capability_count(cfg.id)
         items.append(
             MyIntegrationItem(
                 id=cfg.id,
@@ -146,3 +153,11 @@ async def get_integration_tools(integration_id: str, user_id: str) -> Integratio
 
     tools = await get_integration_tool_list(integration_id)
     return IntegrationToolsResponse(integration_id=integration_id, tools=tools, count=len(tools))
+
+
+def _cli_capability_count(integration_id: str) -> int:
+    """How many capabilities a CLI-backed platform integration declares, else 0."""
+    integration = get_integration_by_id(integration_id)
+    if integration is None or integration.cli_config is None:
+        return 0
+    return len(integration.cli_config.capabilities)

--- a/apps/api/app/services/integrations/providers/__init__.py
+++ b/apps/api/app/services/integrations/providers/__init__.py
@@ -1,0 +1,37 @@
+"""Integration transports, registered once at import.
+
+Importing this package is what makes a transport reachable; the dispatch looks
+providers up by ``managed_by`` and never names them individually.
+"""
+
+from app.services.integrations.providers.base import (
+    ConnectContext,
+    IntegrationProvider,
+    get_provider,
+    register_provider,
+)
+from app.services.integrations.providers.cli_provider import CliIntegrationProvider
+from app.services.integrations.providers.oauth_providers import (
+    ComposioIntegrationProvider,
+    McpIntegrationProvider,
+    SelfIntegrationProvider,
+)
+
+for _provider in (
+    McpIntegrationProvider(),
+    ComposioIntegrationProvider(),
+    SelfIntegrationProvider(),
+    CliIntegrationProvider(),
+):
+    register_provider(_provider)
+
+__all__ = [
+    "CliIntegrationProvider",
+    "ComposioIntegrationProvider",
+    "ConnectContext",
+    "IntegrationProvider",
+    "McpIntegrationProvider",
+    "SelfIntegrationProvider",
+    "get_provider",
+    "register_provider",
+]

--- a/apps/api/app/services/integrations/providers/base.py
+++ b/apps/api/app/services/integrations/providers/base.py
@@ -64,6 +64,15 @@ class IntegrationProvider(ABC):
         a user can double-click Connect on any of them.
         """
 
+    @abstractmethod
+    async def disconnect(self, user_id: str, resolved: ResolvedIntegration) -> None:
+        """Undo a connection: revoke upstream, and drop what GAIA stored.
+
+        The mirror of :meth:`connect`, and on the same interface for the same
+        reason: a transport that is reachable from one and not the other is
+        exactly the drift the registry exists to prevent.
+        """
+
     def error(self, ctx: ConnectContext, message: str) -> ConnectIntegrationResponse:
         """A terminal failure in this transport's connect flow."""
         return ConnectIntegrationResponse(

--- a/apps/api/app/services/integrations/providers/base.py
+++ b/apps/api/app/services/integrations/providers/base.py
@@ -1,0 +1,91 @@
+"""One uniform way to connect an integration, whatever backs it.
+
+Connecting used to be an ``if managed_by == ...`` chain, written out twice —
+once in the ``POST /connect/{id}`` endpoint and once in
+``initiate_integration_connection`` — with a different call signature per
+branch. Two copies of a five-way dispatch is how a transport ends up wired into
+one entry point and not the other (the login-free connect-link path already
+supported fewer transports than the endpoint did).
+
+A provider normalises the differences behind one call. Adding a transport is a
+new module plus a registry entry, and it is reachable from every entry point at
+once by construction.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar
+
+from app.models.integration_provider import ManagedBy
+from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.services.integrations.integration_resolver import ResolvedIntegration
+
+
+@dataclass(frozen=True)
+class ConnectContext:
+    """Everything any transport needs to start or advance a connection.
+
+    A single context rather than per-transport signatures: the endpoint should
+    not have to know that Composio wants a provider slug while a CLI wants a
+    pasted secret.
+    """
+
+    user_id: str
+    integration_id: str
+    resolved: ResolvedIntegration
+    redirect_path: str
+    # Only the self-managed (Google) flow uses this, as an OAuth login hint.
+    user_email: str = ""
+    # A secret the user pasted: an MCP bearer token, or a CLI's access token.
+    # One field because it is one product concept — "the thing you pasted into
+    # the connect dialog" — and the transport decides what to do with it.
+    secret: str | None = None
+
+    @property
+    def provider_slug(self) -> str | None:
+        """The upstream provider name, for transports keyed on it."""
+        platform = self.resolved.platform_integration
+        return platform.provider if platform else None
+
+
+class IntegrationProvider(ABC):
+    """Adapter for one integration transport."""
+
+    managed_by: ClassVar[ManagedBy]
+
+    @abstractmethod
+    async def connect(self, ctx: ConnectContext) -> ConnectIntegrationResponse:
+        """Start or advance a connection, and report where it stands.
+
+        Implementations must be safe to call more than once for the same
+        ``(user, integration)``: the CLI transport is polled by the client, and
+        a user can double-click Connect on any of them.
+        """
+
+    def error(self, ctx: ConnectContext, message: str) -> ConnectIntegrationResponse:
+        """A terminal failure in this transport's connect flow."""
+        return ConnectIntegrationResponse(
+            status="error",
+            integration_id=ctx.integration_id,
+            name=ctx.resolved.name,
+            error=message,
+        )
+
+
+_PROVIDERS: dict[ManagedBy, IntegrationProvider] = {}
+
+
+def register_provider(provider: IntegrationProvider) -> None:
+    """Register a transport. Called once per module at import time."""
+    _PROVIDERS[provider.managed_by] = provider
+
+
+def get_provider(managed_by: ManagedBy) -> IntegrationProvider | None:
+    """The transport for ``managed_by``, or ``None`` if it cannot be connected.
+
+    ``internal`` integrations legitimately land here as ``None``: they are
+    always available and have nothing to connect.
+    """
+    return _PROVIDERS.get(managed_by)

--- a/apps/api/app/services/integrations/providers/cli_provider.py
+++ b/apps/api/app/services/integrations/providers/cli_provider.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal
 
+from app.constants.log_tags import LogTag
 from app.models.integration_provider import ManagedBy
 from app.schemas.integrations.responses import CliConnectDetail, ConnectIntegrationResponse
-from app.services.cli import advance
+from app.services.cli import advance, disconnect as cli_disconnect
 from app.services.cli.connect import CliConnectOutcome
+from app.services.integrations.integration_connection_service import delete_if_user_authored
+from app.services.integrations.integration_resolver import ResolvedIntegration
 from app.services.integrations.providers.base import ConnectContext, IntegrationProvider
+from app.services.integrations.user_integrations import remove_user_integration
+from shared.py.wide_events import log
 
 
 class CliIntegrationProvider(IntegrationProvider):
@@ -32,6 +37,27 @@ class CliIntegrationProvider(IntegrationProvider):
 
         outcome = await advance(ctx.user_id, ctx.integration_id, config, token=ctx.secret or None)
         return _to_response(ctx, outcome)
+
+    async def disconnect(self, user_id: str, resolved: ResolvedIntegration) -> None:
+        """Tear down the CLI's sandbox state, then detach it from the user."""
+        # `cli_config` is pinned by the catalog validator for this transport.
+        if resolved.cli_config:
+            try:
+                await cli_disconnect(user_id, resolved.integration_id, resolved.cli_config)
+            except Exception as e:
+                # Best-effort cleanup: the durable HOME is per-integration and is
+                # recreated on the next connect anyway. Letting an unreachable
+                # sandbox abort the disconnect would leave the user owning an
+                # integration they cannot remove until it comes back.
+                log.warning(
+                    f"{LogTag.INTEGRATION} CLI teardown failed; removing the record anyway",
+                    integration_id=resolved.integration_id,
+                    user_id=user_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+        await remove_user_integration(user_id, resolved.integration_id)
+        await delete_if_user_authored(user_id, resolved)
 
 
 def _to_response(ctx: ConnectContext, outcome: CliConnectOutcome) -> ConnectIntegrationResponse:

--- a/apps/api/app/services/integrations/providers/cli_provider.py
+++ b/apps/api/app/services/integrations/providers/cli_provider.py
@@ -1,0 +1,60 @@
+"""Connecting an integration backed by a real command-line tool."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from app.models.integration_provider import ManagedBy
+from app.schemas.integrations.responses import CliConnectDetail, ConnectIntegrationResponse
+from app.services.cli import advance
+from app.services.cli.connect import CliConnectOutcome
+from app.services.integrations.providers.base import ConnectContext, IntegrationProvider
+
+
+class CliIntegrationProvider(IntegrationProvider):
+    """Drives the CLI connect state machine one step per call.
+
+    Unlike the OAuth transports, this returns ``pending`` for as long as the
+    work takes — an install, then a human approving a device code — and the
+    client re-POSTs until it does not. There is no redirect to hand off to and
+    no callback to wait on: the CLI is being driven inside the user's own
+    sandbox, so GAIA is the one holding the progress.
+    """
+
+    managed_by: ClassVar[ManagedBy] = "cli"
+
+    async def connect(self, ctx: ConnectContext) -> ConnectIntegrationResponse:
+        config = ctx.resolved.cli_config
+        if config is None:
+            # The catalog validator pins cli_config for managed_by="cli", so
+            # this means a hand-written Mongo document rather than a code path.
+            return self.error(ctx, f"{ctx.integration_id} has no CLI configuration")
+
+        outcome = await advance(ctx.user_id, ctx.integration_id, config, token=ctx.secret or None)
+        return _to_response(ctx, outcome)
+
+
+def _to_response(ctx: ConnectContext, outcome: CliConnectOutcome) -> ConnectIntegrationResponse:
+    """Map the connect state machine's outcome onto the shared response shape."""
+    detail = CliConnectDetail(
+        phase=outcome.phase,
+        instructions=outcome.instructions,
+        token_label=outcome.token_label,
+        token_help_url=outcome.token_help_url,
+    )
+    status: Literal["connected", "error", "pending"]
+    if outcome.phase == "connected":
+        status = "connected"
+    elif outcome.phase == "failed":
+        status = "error"
+    else:
+        status = "pending"
+
+    return ConnectIntegrationResponse(
+        status=status,
+        integration_id=ctx.integration_id,
+        name=ctx.resolved.name,
+        message=outcome.message,
+        error=outcome.message if outcome.phase == "failed" else None,
+        cli=detail,
+    )

--- a/apps/api/app/services/integrations/providers/oauth_providers.py
+++ b/apps/api/app/services/integrations/providers/oauth_providers.py
@@ -10,15 +10,22 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from app.config.token_repository import token_repository
 from app.models.integration_provider import ManagedBy
 from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.services.composio.composio_service import get_composio_service
 from app.services.integrations.integration_connection_service import (
     McpConnectRequest,
     connect_composio_integration,
     connect_mcp_integration,
     connect_self_integration,
+    delete_if_user_authored,
+    require_provider,
 )
+from app.services.integrations.integration_resolver import ResolvedIntegration
 from app.services.integrations.providers.base import ConnectContext, IntegrationProvider
+from app.services.integrations.user_integrations import remove_user_integration
+from app.services.mcp.mcp_client import get_mcp_client
 
 
 class McpIntegrationProvider(IntegrationProvider):
@@ -41,6 +48,18 @@ class McpIntegrationProvider(IntegrationProvider):
             )
         )
 
+    async def disconnect(self, user_id: str, resolved: ResolvedIntegration) -> None:
+        """Drop the MCP session and the user's record of the server.
+
+        A server the user added themselves also loses its catalog document; a
+        platform one is shared, so only the link goes.
+        """
+        mcp_client = await get_mcp_client(user_id=user_id)
+        await mcp_client.disconnect(resolved.integration_id)
+        await remove_user_integration(user_id, resolved.integration_id)
+        if resolved.source == "custom":
+            await delete_if_user_authored(user_id, resolved)
+
 
 class ComposioIntegrationProvider(IntegrationProvider):
     """A connection brokered and hosted by Composio."""
@@ -57,6 +76,13 @@ class ComposioIntegrationProvider(IntegrationProvider):
             integration_name=ctx.resolved.name,
             provider=provider,
             redirect_path=ctx.redirect_path,
+        )
+
+    async def disconnect(self, user_id: str, resolved: ResolvedIntegration) -> None:
+        """Delete the connected account Composio holds for this provider."""
+        composio_service = get_composio_service()
+        await composio_service.delete_connected_account(
+            user_id=user_id, provider=require_provider(resolved)
         )
 
 
@@ -77,3 +103,7 @@ class SelfIntegrationProvider(IntegrationProvider):
             provider=provider,
             redirect_path=ctx.redirect_path,
         )
+
+    async def disconnect(self, user_id: str, resolved: ResolvedIntegration) -> None:
+        """Revoke the OAuth token GAIA obtained itself."""
+        await token_repository.revoke_token(user_id=user_id, provider=require_provider(resolved))

--- a/apps/api/app/services/integrations/providers/oauth_providers.py
+++ b/apps/api/app/services/integrations/providers/oauth_providers.py
@@ -13,6 +13,7 @@ from typing import ClassVar
 from app.models.integration_provider import ManagedBy
 from app.schemas.integrations.responses import ConnectIntegrationResponse
 from app.services.integrations.integration_connection_service import (
+    McpConnectRequest,
     connect_composio_integration,
     connect_mcp_integration,
     connect_self_integration,
@@ -28,14 +29,16 @@ class McpIntegrationProvider(IntegrationProvider):
     async def connect(self, ctx: ConnectContext) -> ConnectIntegrationResponse:
         mcp_config = ctx.resolved.mcp_config
         return await connect_mcp_integration(
-            user_id=ctx.user_id,
-            integration_id=ctx.integration_id,
-            integration_name=ctx.resolved.name,
-            requires_auth=ctx.resolved.requires_auth,
-            redirect_path=ctx.redirect_path,
-            server_url=mcp_config.server_url if mcp_config else None,
-            is_platform=ctx.resolved.source == "platform",
-            bearer_token=ctx.secret,
+            McpConnectRequest(
+                user_id=ctx.user_id,
+                integration_id=ctx.integration_id,
+                integration_name=ctx.resolved.name,
+                requires_auth=ctx.resolved.requires_auth,
+                redirect_path=ctx.redirect_path,
+                server_url=mcp_config.server_url if mcp_config else None,
+                is_platform=ctx.resolved.source == "platform",
+                bearer_token=ctx.secret,
+            )
         )
 
 

--- a/apps/api/app/services/integrations/providers/oauth_providers.py
+++ b/apps/api/app/services/integrations/providers/oauth_providers.py
@@ -1,0 +1,76 @@
+"""The three OAuth-shaped transports, adapted to the provider interface.
+
+These are thin on purpose: the connection logic already lives in
+``integration_connection_service`` and is unchanged. All that happens here is
+normalising three different call signatures into one, so the dispatch does not
+have to know which arguments each transport wants.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from app.models.integration_provider import ManagedBy
+from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.services.integrations.integration_connection_service import (
+    connect_composio_integration,
+    connect_mcp_integration,
+    connect_self_integration,
+)
+from app.services.integrations.providers.base import ConnectContext, IntegrationProvider
+
+
+class McpIntegrationProvider(IntegrationProvider):
+    """An MCP server — platform-configured or user-supplied."""
+
+    managed_by: ClassVar[ManagedBy] = "mcp"
+
+    async def connect(self, ctx: ConnectContext) -> ConnectIntegrationResponse:
+        mcp_config = ctx.resolved.mcp_config
+        return await connect_mcp_integration(
+            user_id=ctx.user_id,
+            integration_id=ctx.integration_id,
+            integration_name=ctx.resolved.name,
+            requires_auth=ctx.resolved.requires_auth,
+            redirect_path=ctx.redirect_path,
+            server_url=mcp_config.server_url if mcp_config else None,
+            is_platform=ctx.resolved.source == "platform",
+            bearer_token=ctx.secret,
+        )
+
+
+class ComposioIntegrationProvider(IntegrationProvider):
+    """A connection brokered and hosted by Composio."""
+
+    managed_by: ClassVar[ManagedBy] = "composio"
+
+    async def connect(self, ctx: ConnectContext) -> ConnectIntegrationResponse:
+        provider = ctx.provider_slug
+        if not provider:
+            return self.error(ctx, "Provider not configured")
+        return await connect_composio_integration(
+            user_id=ctx.user_id,
+            integration_id=ctx.integration_id,
+            integration_name=ctx.resolved.name,
+            provider=provider,
+            redirect_path=ctx.redirect_path,
+        )
+
+
+class SelfIntegrationProvider(IntegrationProvider):
+    """An OAuth flow GAIA runs itself."""
+
+    managed_by: ClassVar[ManagedBy] = "self"
+
+    async def connect(self, ctx: ConnectContext) -> ConnectIntegrationResponse:
+        provider = ctx.provider_slug
+        if not provider:
+            return self.error(ctx, "Provider not configured")
+        return await connect_self_integration(
+            user_id=ctx.user_id,
+            user_email=ctx.user_email,
+            integration_id=ctx.integration_id,
+            integration_name=ctx.resolved.name,
+            provider=provider,
+            redirect_path=ctx.redirect_path,
+        )

--- a/apps/api/app/services/onboarding/onboarding_service.py
+++ b/apps/api/app/services/onboarding/onboarding_service.py
@@ -23,9 +23,7 @@ from app.models.user_models import (
     OnboardingStatusResponse,
     UserDocument,
 )
-from app.services.integrations.integration_connection_service import (
-    disconnect_integration,
-)
+from app.services.integrations.connect_dispatch import disconnect_integration
 from app.services.onboarding.intelligence_job import (
     abort_active_intelligence_job,
     abort_active_workflows_job,

--- a/apps/api/app/utils/favicon_utils.py
+++ b/apps/api/app/utils/favicon_utils.py
@@ -21,6 +21,7 @@ import tldextract
 from app.constants.cache import FAVICON_CACHE_TTL
 from app.constants.log_tags import LogTag
 from app.db.redis import get_cache, set_cache
+from app.utils.url_safety import assert_public_http_url
 from shared.py.wide_events import log
 
 IconFormat = Literal["png", "svg", "ico", "other"]
@@ -294,3 +295,34 @@ async def fetch_favicon_from_url(server_url: str) -> str | None:
 async def fetch_favicon_uncached(server_url: str) -> str | None:
     """Resolve a favicon bypassing the cache (for diagnostics / dev tooling)."""
     return await _fetch_favicon_impl(server_url)
+
+
+async def fetch_favicon_safely(url: str | None) -> str | None:
+    """The favicon for ``url``, or ``None`` — never raising, never fetching a
+    private address.
+
+    The single entry point for every caller that turns a URL into an
+    integration's icon (an MCP server, a CLI vendor's homepage). Two things it
+    adds over ``fetch_favicon_from_url``:
+
+    * ``None``/blank in, ``None`` out, so callers need no guard of their own.
+    * The RESOLVING SSRF check. Callers shape-check their URL when it is
+      accepted, but that check deliberately does not resolve DNS, so a hostname
+      pointing at a private address still reaches here. An icon is never worth
+      an outbound request to somebody's internal network.
+
+    An icon is cosmetic; a failure to get one must never fail the operation that
+    wanted it, so everything is swallowed.
+    """
+    if not url or not url.strip():
+        return None
+    try:
+        await assert_public_http_url(url)
+    except ValueError as e:
+        log.warning(
+            f"{LogTag.TOOL} Refusing to fetch a favicon from a non-public URL",
+            server_url=url,
+            error=str(e),
+        )
+        return None
+    return await fetch_favicon_from_url(url)

--- a/apps/api/scripts/build_e2b_template.py
+++ b/apps/api/scripts/build_e2b_template.py
@@ -173,6 +173,10 @@ def build(name: str) -> str:
         # left `node` with a 12s startup; from the image it is 0.3s).
         # Symlinked into /usr/local/bin because e2b runs commands via a
         # non-login `bash -c`, which never sources /etc/profile.d.
+        #
+        # Installed BEFORE the sudo strip below purges apt, and it needs no
+        # writable app directories of its own: per-integration installs and
+        # launchers live under the sandbox user's own home at runtime.
         .run_cmd(
             f"mkdir -p {RUNTIME_DIR} && "
             f"curl -fsSL {NODE_TARBALL_URL} -o /tmp/node.tar.xz && "
@@ -181,6 +185,42 @@ def build(name: str) -> str:
             f"ln -sf {RUNTIME_BIN_DIR}/node /usr/local/bin/node && "
             f"ln -sf {RUNTIME_BIN_DIR}/npm /usr/local/bin/npm && "
             f"ln -sf {RUNTIME_BIN_DIR}/npx /usr/local/bin/npx",
+            user="root",
+        )
+        # Strip the sandbox user from every privilege group, then purge the
+        # `sudo` package itself. Removing the setuid binary closes the last
+        # theoretical escalation surface — even if a future regression added
+        # a password or a NOPASSWD rule back, there's no `sudo` for it to
+        # apply to. The API uses commands.run(user="root") for the handful
+        # of operations that genuinely need root; nothing in our sandbox
+        # codepath ever shells out to `sudo`.
+        .run_cmd(
+            "set -e; "
+            "if id -u user >/dev/null 2>&1; then "
+            "  gpasswd -d user sudo 2>/dev/null || true; "
+            "  gpasswd -d user wheel 2>/dev/null || true; "
+            "fi; "
+            "rm -f /etc/sudoers.d/*-user /etc/sudoers.d/90-cloud-init-users "
+            "       /etc/sudoers.d/nopasswd-user /etc/sudoers.d/user; "
+            "if [ -f /etc/sudoers ]; then "
+            "  sed -i '/^%sudo[[:space:]].*NOPASSWD/d' /etc/sudoers; "
+            "  sed -i '/^user[[:space:]].*NOPASSWD/d' /etc/sudoers; "
+            "fi; "
+            # Purge sudo entirely. `--allow-remove-essential` is not needed
+            # — sudo is not Essential. Run after the group-strip so we don't
+            # leave a sudoers.d entry pointing at a now-removed binary.
+            "DEBIAN_FRONTEND=noninteractive apt-get purge -y sudo 2>&1 | tail -3; "
+            "apt-get autoremove -y --purge 2>&1 | tail -3; "
+            "rm -rf /var/lib/apt/lists/*",
+            user="root",
+        )
+        # Cache + workspace dirs. /workspace and /mnt/jfs are mode 0750 owned
+        # by `user` so unprivileged ops work but no cross-uid leak is possible.
+        .run_cmd(
+            "mkdir -p /var/cache/juicefs /workspace /mnt/jfs && "
+            "chown -R user:user /workspace /mnt/jfs && "
+            "chmod 0750 /workspace /mnt/jfs && "
+            "chmod 0755 /var/cache/juicefs",
             user="root",
         )
         # Stage the mount script in /tmp (E2B's copy step has issues writing

--- a/apps/api/scripts/build_e2b_template.py
+++ b/apps/api/scripts/build_e2b_template.py
@@ -53,6 +53,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.agents.workspace.system_files import system_files
 from app.config.secrets import inject_infisical_secrets
+from app.constants.cli_integrations import (
+    NODE_TARBALL_URL,
+    RUNTIME_BIN_DIR,
+    RUNTIME_DIR,
+)
 
 JUICEFS_VERSION = "1.3.0"
 JUICEFS_TARBALL = (
@@ -162,40 +167,20 @@ def build(name: str) -> str:
             "rm -rf /tmp/juicefs.tar.gz /tmp/juicefs /tmp/LICENSE /tmp/README.md",
             user="root",
         )
-        # Strip the sandbox user from every privilege group, then purge the
-        # `sudo` package itself. Removing the setuid binary closes the last
-        # theoretical escalation surface — even if a future regression added
-        # a password or a NOPASSWD rule back, there's no `sudo` for it to
-        # apply to. The API uses commands.run(user="root") for the handful
-        # of operations that genuinely need root; nothing in our sandbox
-        # codepath ever shells out to `sudo`.
+        # Node runtime for CLI-backed integrations (see
+        # app/constants/cli_integrations.py for why it is baked rather than
+        # installed per sandbox: on JuiceFS the same extract took >600s and
+        # left `node` with a 12s startup; from the image it is 0.3s).
+        # Symlinked into /usr/local/bin because e2b runs commands via a
+        # non-login `bash -c`, which never sources /etc/profile.d.
         .run_cmd(
-            "set -e; "
-            "if id -u user >/dev/null 2>&1; then "
-            "  gpasswd -d user sudo 2>/dev/null || true; "
-            "  gpasswd -d user wheel 2>/dev/null || true; "
-            "fi; "
-            "rm -f /etc/sudoers.d/*-user /etc/sudoers.d/90-cloud-init-users "
-            "       /etc/sudoers.d/nopasswd-user /etc/sudoers.d/user; "
-            "if [ -f /etc/sudoers ]; then "
-            "  sed -i '/^%sudo[[:space:]].*NOPASSWD/d' /etc/sudoers; "
-            "  sed -i '/^user[[:space:]].*NOPASSWD/d' /etc/sudoers; "
-            "fi; "
-            # Purge sudo entirely. `--allow-remove-essential` is not needed
-            # — sudo is not Essential. Run after the group-strip so we don't
-            # leave a sudoers.d entry pointing at a now-removed binary.
-            "DEBIAN_FRONTEND=noninteractive apt-get purge -y sudo 2>&1 | tail -3; "
-            "apt-get autoremove -y --purge 2>&1 | tail -3; "
-            "rm -rf /var/lib/apt/lists/*",
-            user="root",
-        )
-        # Cache + workspace dirs. /workspace and /mnt/jfs are mode 0750 owned
-        # by `user` so unprivileged ops work but no cross-uid leak is possible.
-        .run_cmd(
-            "mkdir -p /var/cache/juicefs /workspace /mnt/jfs && "
-            "chown -R user:user /workspace /mnt/jfs && "
-            "chmod 0750 /workspace /mnt/jfs && "
-            "chmod 0755 /var/cache/juicefs",
+            f"mkdir -p {RUNTIME_DIR} && "
+            f"curl -fsSL {NODE_TARBALL_URL} -o /tmp/node.tar.xz && "
+            f"tar -xJf /tmp/node.tar.xz -C {RUNTIME_DIR} --strip-components=1 && "
+            "rm -f /tmp/node.tar.xz && "
+            f"ln -sf {RUNTIME_BIN_DIR}/node /usr/local/bin/node && "
+            f"ln -sf {RUNTIME_BIN_DIR}/npm /usr/local/bin/npm && "
+            f"ln -sf {RUNTIME_BIN_DIR}/npx /usr/local/bin/npx",
             user="root",
         )
         # Stage the mount script in /tmp (E2B's copy step has issues writing

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -694,3 +694,29 @@ def _reset_limit_origin() -> Iterator[None]:
     from app.services.limit_upsell import LimitHitOrigin, mark_run_origin
 
     mark_run_origin(LimitHitOrigin.INTERACTIVE)
+
+
+@pytest.fixture(autouse=True)
+def _reset_integrations_catalog_cache() -> Iterator[None]:
+    """Keep a patched integrations catalog from leaking between tests.
+
+    ``build_integrations_config`` is ``lru_cache``d and the cache is
+    process-wide, so a test that patches ``OAUTH_INTEGRATIONS`` leaves a stale
+    catalog behind for every test that runs after it. That produced failures
+    that only appeared under certain orderings — the victim being whichever
+    later test read the catalog, never the one that poisoned it — and it showed
+    up under mutmut as an unexplained "no result" rather than a failure,
+    because per-mutant test selection changes the order.
+
+    Clearing before each test costs ~0.04ms (about 0.7s across the whole
+    suite), which is a fair price for removing an entire class of
+    order-dependence instead of asking each caller to remember.
+    """
+    # Imported here, not at module level: the integrations service pulls in the
+    # MCP client and Composio, which collection should not pay for.
+    from app.services.integrations.integration_connection_service import (
+        build_integrations_config,
+    )
+
+    build_integrations_config.cache_clear()
+    return

--- a/apps/api/tests/integration/test_oauth_integration_lifecycle.py
+++ b/apps/api/tests/integration/test_oauth_integration_lifecycle.py
@@ -669,6 +669,7 @@ class TestDisconnectIntegration:
             requires_auth=True,
             auth_type="oauth",
             mcp_config=None,
+            cli_config=None,
             platform_integration=gmail_config,
             custom_doc=None,
         )
@@ -713,6 +714,7 @@ class TestDisconnectIntegration:
             requires_auth=False,
             auth_type="none",
             mcp_config=MCPConfig(server_url="https://mcp.deepwiki.com/mcp"),
+            cli_config=None,
             platform_integration=get_integration_by_id("deepwiki"),
             custom_doc=None,
         )
@@ -760,6 +762,7 @@ class TestDisconnectIntegration:
             requires_auth=False,
             auth_type="none",
             mcp_config=MCPConfig(server_url="https://custom.example.com/mcp"),
+            cli_config=None,
             platform_integration=None,
             custom_doc={"integration_id": "my-custom-mcp", "created_by": USER_ID},
         )

--- a/apps/api/tests/integration/test_oauth_integration_lifecycle.py
+++ b/apps/api/tests/integration/test_oauth_integration_lifecycle.py
@@ -43,13 +43,13 @@ from app.models.integration_models import (
 from app.models.integration_provider import ManagedBy
 from app.models.mcp_config import MCPConfig
 from app.models.oauth_models import OAuthIntegration
+from app.services.integrations.connect_dispatch import disconnect_integration
 from app.services.integrations.integration_connection_service import (
     McpConnectRequest,
     build_integrations_config,
     connect_composio_integration,
     connect_mcp_integration,
     connect_self_integration,
-    disconnect_integration,
 )
 from app.services.integrations.integration_resolver import (
     IntegrationResolver,
@@ -679,13 +679,20 @@ class TestDisconnectIntegration:
         with (
             patch.object(IntegrationResolver, "resolve", AsyncMock(return_value=resolved)),
             patch(
-                "app.services.integrations.integration_connection_service.get_composio_service",
+                "app.services.integrations.providers.oauth_providers.get_composio_service",
                 return_value=mock_composio,
             ),
             patch(
                 "app.services.integrations.integration_connection_service.delete_cache",
                 AsyncMock(),
             ),
+            patch(
+                "app.services.integrations.providers.oauth_providers.remove_user_integration",
+                AsyncMock(return_value=True),
+            ),
+            # A platform Composio integration's record is removed by
+            # _invalidate_caches, which still lives in the connection service --
+            # the provider only revokes upstream.
             patch(
                 "app.services.integrations.integration_connection_service.remove_user_integration",
                 AsyncMock(return_value=True),
@@ -727,11 +734,11 @@ class TestDisconnectIntegration:
         with (
             patch.object(IntegrationResolver, "resolve", AsyncMock(return_value=resolved)),
             patch(
-                "app.services.integrations.integration_connection_service.get_mcp_client",
+                "app.services.integrations.providers.oauth_providers.get_mcp_client",
                 AsyncMock(return_value=mock_mcp_client),
             ),
             patch(
-                "app.services.integrations.integration_connection_service.remove_user_integration",
+                "app.services.integrations.providers.oauth_providers.remove_user_integration",
                 AsyncMock(return_value=True),
             ),
             patch(
@@ -776,11 +783,11 @@ class TestDisconnectIntegration:
         with (
             patch.object(IntegrationResolver, "resolve", AsyncMock(return_value=resolved)),
             patch(
-                "app.services.integrations.integration_connection_service.get_mcp_client",
+                "app.services.integrations.providers.oauth_providers.get_mcp_client",
                 AsyncMock(return_value=mock_mcp_client),
             ),
             patch(
-                "app.services.integrations.integration_connection_service.remove_user_integration",
+                "app.services.integrations.providers.oauth_providers.remove_user_integration",
                 mock_remove,
             ),
             patch(

--- a/apps/api/tests/integration/test_oauth_integration_lifecycle.py
+++ b/apps/api/tests/integration/test_oauth_integration_lifecycle.py
@@ -25,7 +25,7 @@ Mocking boundaries:
 
 from contextlib import contextmanager
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, get_args
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -40,9 +40,11 @@ from app.models.integration_models import (
     UserIntegrationDocument,
     UserIntegrationStatus,
 )
+from app.models.integration_provider import ManagedBy
 from app.models.mcp_config import MCPConfig
 from app.models.oauth_models import OAuthIntegration
 from app.services.integrations.integration_connection_service import (
+    McpConnectRequest,
     build_integrations_config,
     connect_composio_integration,
     connect_mcp_integration,
@@ -1147,7 +1149,7 @@ class TestOAuthConfigHelpers:
             assert integration.id, f"Integration missing id: {integration}"
             assert integration.name, f"Integration {integration.id} missing name"
             assert integration.provider, f"Integration {integration.id} missing provider"
-            assert integration.managed_by in ("self", "composio", "mcp", "internal"), (
+            assert integration.managed_by in get_args(ManagedBy), (
                 f"Integration {integration.id} has invalid managed_by: {integration.managed_by}"
             )
 
@@ -1223,11 +1225,13 @@ class TestMCPIntegrationConnection:
             ),
         ):
             response = await connect_mcp_integration(
-                user_id=USER_ID,
-                integration_id="deepwiki",
-                integration_name="DeepWiki",
-                requires_auth=False,
-                redirect_path="/integrations",
+                McpConnectRequest(
+                    user_id=USER_ID,
+                    integration_id="deepwiki",
+                    integration_name="DeepWiki",
+                    requires_auth=False,
+                    redirect_path="/integrations",
+                )
             )
 
             assert response.status == "connected"
@@ -1260,12 +1264,14 @@ class TestMCPIntegrationConnection:
             # only update_user_integration_status is (no patch needed for caches here)
         ):
             response = await connect_mcp_integration(
-                user_id=USER_ID,
-                integration_id="custom-api",
-                integration_name="Custom API",
-                requires_auth=False,
-                redirect_path="/integrations",
-                bearer_token="sk-test-bearer-token",
+                McpConnectRequest(
+                    user_id=USER_ID,
+                    integration_id="custom-api",
+                    integration_name="Custom API",
+                    requires_auth=False,
+                    redirect_path="/integrations",
+                    bearer_token="sk-test-bearer-token",
+                )
             )
 
             assert response.status == "connected"
@@ -1299,12 +1305,14 @@ class TestMCPIntegrationConnection:
             ),
         ):
             response = await connect_mcp_integration(
-                user_id=USER_ID,
-                integration_id="broken-api",
-                integration_name="Broken API",
-                requires_auth=False,
-                redirect_path="/integrations",
-                bearer_token="sk-bad-token",
+                McpConnectRequest(
+                    user_id=USER_ID,
+                    integration_id="broken-api",
+                    integration_name="Broken API",
+                    requires_auth=False,
+                    redirect_path="/integrations",
+                    bearer_token="sk-bad-token",
+                )
             )
 
             assert response.status == "error"
@@ -1334,12 +1342,14 @@ class TestMCPIntegrationConnection:
             ),
         ):
             response = await connect_mcp_integration(
-                user_id=USER_ID,
-                integration_id="linear",
-                integration_name="Linear",
-                requires_auth=True,
-                redirect_path="/integrations",
-                is_platform=True,
+                McpConnectRequest(
+                    user_id=USER_ID,
+                    integration_id="linear",
+                    integration_name="Linear",
+                    requires_auth=True,
+                    redirect_path="/integrations",
+                    is_platform=True,
+                )
             )
 
             assert response.status == "redirect"

--- a/apps/api/tests/unit/agents/test_handoff_tools.py
+++ b/apps/api/tests/unit/agents/test_handoff_tools.py
@@ -321,7 +321,9 @@ class TestGetSubagentById:
             "mcp_config": {},
             "icon_url": None,
         }
-        resolved = SimpleNamespace(custom_doc=resolved_doc, source="user_integrations")
+        resolved = SimpleNamespace(
+            custom_doc=resolved_doc, source="user_integrations", managed_by="cli"
+        )
         with (
             patch(
                 "app.agents.core.subagents.handoff_tools.get_subagent_by_id",
@@ -345,6 +347,9 @@ class TestGetSubagentById:
 
         assert result["id"] == "res_id"
         assert result["source"] == "user_integrations"
+        # The transport comes from the resolved integration, not an assumed
+        # "mcp": handoff names and labels the subagent from it.
+        assert result["managed_by"] == "cli"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/agents/test_handoff_tools.py
+++ b/apps/api/tests/unit/agents/test_handoff_tools.py
@@ -19,7 +19,10 @@ from app.agents.core.subagents.handoff_tools import (
     handoff,
     index_custom_mcp_as_subagent,
 )
-from app.agents.core.subagents.provider_subagents import SubagentUnavailableError
+from app.agents.core.subagents.provider_subagents import (
+    SubagentUnavailableError,
+    custom_subagent_name,
+)
 from app.agents.core.subagents.subagent_runner import SubagentOutcome, subagent_row_id
 from app.constants.hil import HIL_RESUME_CONFIG_KEY
 from app.db.repositories.user_integrations import user_integration_repository
@@ -426,6 +429,50 @@ class TestResolveSubagent:
         assert graph is mock_graph
         assert is_custom is True
         assert int_id == "abc"
+
+    async def test_a_custom_cli_integration_gets_the_cli_graph_name(self):
+        """The graph name is the handoff layer's only handle on the subagent,
+        and provider_subagents registers a CLI-backed one under a different
+        name from an MCP one. Derive the wrong flavour here and the handoff
+        records a call against a graph that was never registered."""
+        custom_dict = {"id": "abc", "name": "Some CLI", "managed_by": "cli"}
+        with (
+            patch(
+                "app.agents.core.subagents.handoff_tools._get_subagent_by_id",
+                new_callable=AsyncMock,
+                return_value=custom_dict,
+            ),
+            patch(
+                "app.agents.core.subagents.handoff_tools.create_subagent_for_user",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            _, name, _, _ = await _resolve_subagent("abc", "user1")
+
+        assert name == custom_subagent_name("abc", is_cli=True)
+
+    async def test_a_custom_mcp_integration_gets_the_mcp_graph_name(self):
+        # The same derivation the other way: only managed_by == "cli" exactly
+        # selects the CLI flavour, so every other custom integration keeps the
+        # MCP name it is registered under.
+        custom_dict = {"id": "abc", "name": "Custom", "managed_by": "mcp"}
+        with (
+            patch(
+                "app.agents.core.subagents.handoff_tools._get_subagent_by_id",
+                new_callable=AsyncMock,
+                return_value=custom_dict,
+            ),
+            patch(
+                "app.agents.core.subagents.handoff_tools.create_subagent_for_user",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            _, name, _, _ = await _resolve_subagent("abc", "user1")
+
+        assert name == custom_subagent_name("abc", is_cli=False)
+        assert name != custom_subagent_name("abc", is_cli=True)
 
     async def test_custom_mcp_no_user_id(self):
         custom_dict = {"id": "abc", "name": "Custom"}

--- a/apps/api/tests/unit/agents/test_provider_subagents.py
+++ b/apps/api/tests/unit/agents/test_provider_subagents.py
@@ -6,12 +6,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.agents.tools.core.registry import integration_destructive_tools
+from app.constants.cli_integrations import cli_tool_name
+from app.constants.log_tags import LogTag
 from app.models.cli_config import CliAuthSpec, CliConfig
 from app.models.integration_models import Integration
 from app.models.mcp_config import ComposioConfig, MCPConfig, SubAgentConfig
 from app.models.oauth_models import OAuthIntegration
 from app.models.subagent_models import Subagent
 from app.services.cli.tools import CliIntegration
+from tests.helpers import captured_wide_event
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1028,7 +1031,10 @@ class TestCliSubagentTools:
             ),
             patch(
                 "app.agents.core.subagents.provider_subagents.get_integration_by_id",
-                return_value=integration,
+                # Keyed, not constant: the catalog entry carrying the CLI spec
+                # must be the one this subagent names, or the wrong CLI is
+                # registered under the right subagent.
+                side_effect=lambda iid: integration if iid == "stripe_link" else None,
             ),
             patch(
                 "app.agents.core.subagents.provider_subagents.get_mcp_client",
@@ -1058,6 +1064,9 @@ class TestCliSubagentTools:
         assert options.is_delegated is True
         assert options.require_integration is True
         registry._index_category_tools.assert_awaited_once_with("stripe_link")
+        # The catalog entry's display name is what the tool description tells
+        # the model this CLI is for; without it the model gets a bare command.
+        assert "Test Integration" in category["tools"][0].description
 
         assert mock_factory.call_args.kwargs["config"].tool_space == "stripe_link"
 
@@ -1103,8 +1112,9 @@ class TestCliSubagentTools:
             ),
             patch(
                 "app.agents.core.subagents.provider_subagents.resolve_cli_integration",
-                new_callable=AsyncMock,
-                return_value=integration,
+                # Keyed on the id: resolving anything else would build a
+                # subagent for an integration the caller never asked for.
+                side_effect=lambda iid: integration if iid == "custom_abc" else None,
             ),
             patch(
                 "app.agents.core.subagents.provider_subagents._create_custom_mcp_subagent",
@@ -1144,11 +1154,26 @@ class TestCliSubagentTools:
             ) as mock_factory,
         ):
             mock_repo.is_connected = AsyncMock(return_value=False)
-            with pytest.raises(SubagentUnavailableError, match="not connected"):
-                await _create_custom_cli_subagent(_cli_integration("custom_abc"), "user_123")
+            async with captured_wide_event() as event:
+                with pytest.raises(SubagentUnavailableError) as exc_info:
+                    await _create_custom_cli_subagent(_cli_integration("custom_abc"), "user_123")
 
         mock_get_registry.assert_not_called()
         mock_factory.assert_not_called()
+        # Scoped to this user AND this integration: a check against either one
+        # alone would let one user's connection unlock another's CLI.
+        mock_repo.is_connected.assert_awaited_once_with("user_123", "custom_abc")
+        # handoff relays this reason to the model verbatim, so it has to name
+        # the integration and say what the user must do.
+        assert str(exc_info.value) == (
+            "Stripe Link is not connected. Ask the user to connect it first."
+        )
+        (refusal,) = event["warnings"]
+        assert refusal == {
+            "msg": f"{LogTag.AGENT} Custom CLI subagent refused: integration not connected",
+            "integration_id": "custom_abc",
+            "user_id": "user_123",
+        }
 
     async def test_custom_cli_binds_its_single_tool_directly(self):
         from app.agents.core.subagents.provider_subagents import _create_custom_cli_subagent
@@ -1176,9 +1201,17 @@ class TestCliSubagentTools:
             ) as mock_factory,
         ):
             mock_repo.is_connected = AsyncMock(return_value=True)
-            result = await _create_custom_cli_subagent(_cli_integration("custom_abc"), "user_123")
+            async with captured_wide_event() as event:
+                result = await _create_custom_cli_subagent(
+                    _cli_integration("custom_abc"), "user_123"
+                )
 
         assert result is mock_graph
+        # The provider keys the subagent's tool lookups and its call records;
+        # the event is how a failed handoff is traced back to this graph.
+        assert mock_factory.call_args.kwargs["provider"] == "custom_abc"
+        assert mock_factory.call_args.kwargs["llm"] is not None
+        assert event["subagent"] == {"name": "custom_cli_custom_abc", "provider": "custom_abc"}
         # The id is the namespace: a CLI has no server URL to derive one from.
         assert registry._add_category.call_args.kwargs["options"].space == "custom_abc"
 
@@ -1189,3 +1222,84 @@ class TestCliSubagentTools:
         assert cfg.use_direct_tools is True
         assert cfg.disable_retrieve_tools is True
         assert cfg.source_label == "Stripe Link"
+
+
+class TestCliCategoryWiring:
+    """What ``register_cli_tools`` writes into the process-global registry.
+
+    One tool covers everything the CLI can do, so the category around it is the
+    only place the gating, the namespacing and the risk verdict are expressed.
+    Each field below is read by a different consumer, and a wrong value fails
+    somewhere far from here.
+    """
+
+    async def test_the_tool_is_built_from_this_integrations_own_spec(self):
+        # A custom integration's tool name carries a digest of its id so two
+        # users authoring `gh` do not collide in the process-global registry.
+        # Building it from the wrong id, or forgetting it is not a platform
+        # entry, hands one user's tool to the other.
+        from app.agents.core.subagents.provider_subagents import register_cli_tools
+
+        registry = _cli_tool_registry()
+        integration = _cli_integration("custom_abc", is_platform=False)
+
+        await register_cli_tools(registry, integration, tool_space="custom_abc")
+
+        (tool,) = registry._add_category.call_args.kwargs["tools"]
+        assert tool.name == cli_tool_name("link-cli", "custom_abc", is_platform=False)
+        assert tool.name != cli_tool_name("link-cli", "custom_abc", is_platform=True)
+        # The display name is what tells the model what this CLI is for.
+        assert "Stripe Link" in tool.description
+
+    async def test_the_category_is_gated_on_this_integration(self):
+        # `require_integration` only locks the tool if the catalog knows WHICH
+        # integration to check; a wrong name reports it locked forever or
+        # unlocked always.
+        from app.agents.core.subagents.provider_subagents import register_cli_tools
+
+        registry = _cli_tool_registry()
+
+        await register_cli_tools(registry, _cli_integration("custom_abc"), tool_space="space_x")
+
+        options = registry._add_category.call_args.kwargs["options"]
+        assert options.integration_name == "custom_abc"
+        assert options.require_integration is True
+        assert options.space == "space_x"
+
+    async def test_the_risk_set_is_looked_up_by_the_integrations_own_id(self):
+        # A curated id is used deliberately: it is the only way to observe that
+        # the lookup happened at all, since an unknown id and a dropped lookup
+        # both produce None (uncurated, which fails closed at gate time).
+        from app.agents.core.subagents.provider_subagents import register_cli_tools
+
+        curated = integration_destructive_tools("linear")
+        assert curated, "fixture needs a catalog entry with a curated destructive set"
+        registry = _cli_tool_registry()
+
+        await register_cli_tools(registry, _cli_integration("linear"), tool_space="linear")
+
+        assert registry._add_category.call_args.kwargs["risk"].destructive_tools == curated
+
+    async def test_an_uncurated_integration_stays_uncurated(self):
+        # None is not "no destructive commands" — it is "nobody classified
+        # these", which sends every command to the HIL classifier. Turning it
+        # into an empty set would silently mark them all safe.
+        from app.agents.core.subagents.provider_subagents import register_cli_tools
+
+        registry = _cli_tool_registry()
+
+        await register_cli_tools(registry, _cli_integration("custom_abc"), tool_space="custom_abc")
+
+        assert registry._add_category.call_args.kwargs["risk"].destructive_tools is None
+
+    async def test_the_wide_event_says_which_cli_was_registered(self):
+        # Registration is process-global and happens once; when the wrong tool
+        # is bound, this event is the only record of what was registered.
+        from app.agents.core.subagents.provider_subagents import register_cli_tools
+
+        async with captured_wide_event() as event:
+            await register_cli_tools(
+                _cli_tool_registry(), _cli_integration("custom_abc"), tool_space="custom_abc"
+            )
+
+        assert event["cli"] == {"integration_id": "custom_abc", "command": "link-cli"}

--- a/apps/api/tests/unit/agents/test_provider_subagents.py
+++ b/apps/api/tests/unit/agents/test_provider_subagents.py
@@ -8,7 +8,7 @@ import pytest
 from app.agents.tools.core.registry import integration_destructive_tools
 from app.models.cli_config import CliAuthSpec, CliConfig
 from app.models.integration_models import Integration
-from app.models.mcp_config import MCPConfig, SubAgentConfig
+from app.models.mcp_config import ComposioConfig, MCPConfig, SubAgentConfig
 from app.models.oauth_models import OAuthIntegration
 from app.models.subagent_models import Subagent
 from app.services.cli.tools import CliIntegration
@@ -81,21 +81,18 @@ def _cli_tool_registry() -> AsyncMock:
 def _make_integration(
     integration_id: str = "test_int",
     managed_by: str = "composio",
-    mcp_config: MCPConfig | None = None,
     subagent_config: SubAgentConfig | None = None,
-    composio_config: MagicMock | None = None,
     provider: str = "test_provider",
     cli_config: CliConfig | None = None,
 ) -> OAuthIntegration:
+    """Build the catalog entry for an integration under test.
+
+    ``composio_config`` is derived rather than passed: ``OAuthIntegration``
+    pins the invariant that a Composio-managed entry must carry one, so a
+    caller could never usefully leave it out or supply a different one.
+    """
     if subagent_config is None:
         subagent_config = _make_subagent_config()
-    if composio_config is None and managed_by == "composio":
-        from app.models.mcp_config import ComposioConfig
-
-        composio_config = ComposioConfig(  # type: ignore[assignment]  # real ComposioConfig replaces the mock in this test
-            auth_config_id="test_auth",
-            toolkit="test_toolkit",
-        )
 
     return OAuthIntegration(
         id=integration_id,
@@ -105,9 +102,12 @@ def _make_integration(
         provider=provider,
         scopes=[],
         managed_by=managed_by,  # type: ignore[arg-type]  # fixture uses a plain string for the managed_by Literal
-        mcp_config=mcp_config,
         subagent_config=subagent_config,
-        composio_config=composio_config,
+        composio_config=(
+            ComposioConfig(auth_config_id="test_auth", toolkit="test_toolkit")
+            if managed_by == "composio"
+            else None
+        ),
         cli_config=cli_config,
     )
 

--- a/apps/api/tests/unit/agents/test_provider_subagents.py
+++ b/apps/api/tests/unit/agents/test_provider_subagents.py
@@ -66,8 +66,15 @@ def _cli_config(command: str = "link-cli") -> CliConfig:
     )
 
 
-def _cli_integration(integration_id: str = "stripe_link") -> CliIntegration:
-    return CliIntegration(id=integration_id, name="Stripe Link", config=_cli_config())
+def _cli_integration(
+    integration_id: str = "stripe_link", *, is_platform: bool = True
+) -> CliIntegration:
+    return CliIntegration(
+        id=integration_id,
+        name="Stripe Link",
+        config=_cli_config(),
+        is_platform=is_platform,
+    )
 
 
 def _cli_tool_registry() -> AsyncMock:

--- a/apps/api/tests/unit/agents/test_provider_subagents.py
+++ b/apps/api/tests/unit/agents/test_provider_subagents.py
@@ -6,10 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.agents.tools.core.registry import integration_destructive_tools
+from app.models.cli_config import CliAuthSpec, CliConfig
 from app.models.integration_models import Integration
 from app.models.mcp_config import MCPConfig, SubAgentConfig
 from app.models.oauth_models import OAuthIntegration
 from app.models.subagent_models import Subagent
+from app.services.cli.tools import CliIntegration
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -51,6 +53,31 @@ def _make_subagent_config(**overrides) -> SubAgentConfig:
     return SubAgentConfig(**defaults)  # type: ignore[arg-type]  # fixture spreads an untyped defaults dict into the model
 
 
+def _cli_config(command: str = "link-cli") -> CliConfig:
+    return CliConfig(
+        command=command,
+        install_command=f"npm install {command}",
+        capabilities=["payment links"],
+        auth=CliAuthSpec(
+            kind="device",
+            login_command=f"{command} auth login",
+            verify_command=f"{command} auth status",
+        ),
+    )
+
+
+def _cli_integration(integration_id: str = "stripe_link") -> CliIntegration:
+    return CliIntegration(id=integration_id, name="Stripe Link", config=_cli_config())
+
+
+def _cli_tool_registry() -> AsyncMock:
+    registry = AsyncMock()
+    registry._categories = {}
+    registry._add_category = MagicMock()
+    registry._index_category_tools = AsyncMock()
+    return registry
+
+
 def _make_integration(
     integration_id: str = "test_int",
     managed_by: str = "composio",
@@ -58,6 +85,7 @@ def _make_integration(
     subagent_config: SubAgentConfig | None = None,
     composio_config: MagicMock | None = None,
     provider: str = "test_provider",
+    cli_config: CliConfig | None = None,
 ) -> OAuthIntegration:
     if subagent_config is None:
         subagent_config = _make_subagent_config()
@@ -80,6 +108,7 @@ def _make_integration(
         mcp_config=mcp_config,
         subagent_config=subagent_config,
         composio_config=composio_config,
+        cli_config=cli_config,
     )
 
 
@@ -421,6 +450,11 @@ class TestCreateSubagentForUser:
         with (
             patch(
                 "app.agents.core.subagents.provider_subagents.get_subagent_by_id",
+                return_value=None,
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.resolve_cli_integration",
+                new_callable=AsyncMock,
                 return_value=None,
             ),
             patch(
@@ -943,3 +977,208 @@ class TestRegisterSubagentProviders:
         assert count == 1
         registered_names = [c.kwargs["name"] for c in mock_providers.register.call_args_list]
         assert registered_names == ["agent_1"]
+
+
+# ---------------------------------------------------------------------------
+# CLI integrations
+# ---------------------------------------------------------------------------
+
+
+class TestCliSubagentTools:
+    async def test_platform_cli_registers_delegated_gated_category(self):
+        # The category shape IS the gating: `space` is how the subagent finds
+        # the tool, `is_delegated` keeps the raw shell out of executor
+        # discovery, and `require_integration` is what marks it locked until
+        # the user connects.
+        from app.agents.core.subagents.provider_subagents import create_subagent
+
+        subagent = _make_subagent(
+            integration_id="stripe_link",
+            managed_by="cli",
+            provider="stripe_link",
+            subagent_config=_make_subagent_config(
+                agent_name="stripe_link_agent",
+                tool_space="stripe_link",
+                use_direct_tools=True,
+                disable_retrieve_tools=True,
+                auto_bind_tools=["run_link_cli"],
+            ),
+        )
+        integration = _make_integration(
+            integration_id="stripe_link",
+            managed_by="cli",
+            cli_config=_cli_config(),
+            subagent_config=subagent.config,
+        )
+        registry = _cli_tool_registry()
+        mock_graph = MagicMock()
+
+        with (
+            patch(
+                "app.agents.core.subagents.provider_subagents.get_tool_registry",
+                new_callable=AsyncMock,
+                return_value=registry,
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.get_integration_by_id",
+                return_value=integration,
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.get_mcp_client",
+                new_callable=AsyncMock,
+            ) as mock_get_mcp_client,
+            patch(
+                "app.agents.core.subagents.provider_subagents.init_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.SubAgentFactory.create_provider_subagent",
+                new_callable=AsyncMock,
+                return_value=mock_graph,
+            ) as mock_factory,
+        ):
+            result = await create_subagent(subagent)
+
+        assert result is mock_graph
+        mock_get_mcp_client.assert_not_called()
+        registry.register_provider_tools.assert_not_called()
+
+        category = registry._add_category.call_args.kwargs
+        assert category["name"] == "stripe_link"
+        assert [t.name for t in category["tools"]] == ["run_link_cli"]
+        options = category["options"]
+        assert options.space == "stripe_link"
+        assert options.is_delegated is True
+        assert options.require_integration is True
+        registry._index_category_tools.assert_awaited_once_with("stripe_link")
+
+        assert mock_factory.call_args.kwargs["config"].tool_space == "stripe_link"
+
+    async def test_platform_cli_without_cli_config_fails_loudly(self):
+        # A managed_by="cli" entry with no spec would otherwise build a
+        # tool-less agent that reports healthy.
+        from app.agents.core.subagents.provider_subagents import (
+            register_cli_subagent_tools,
+        )
+
+        subagent = _make_subagent(integration_id="stripe_link", managed_by="cli")
+
+        with patch(
+            "app.agents.core.subagents.provider_subagents.get_integration_by_id",
+            return_value=None,
+        ):
+            with pytest.raises(ValueError, match="no matching OAuth integration"):
+                await register_cli_subagent_tools(subagent, _cli_tool_registry())
+
+    async def test_registration_is_idempotent(self):
+        from app.agents.core.subagents.provider_subagents import register_cli_tools
+
+        registry = _cli_tool_registry()
+        registry._categories = {"stripe_link": MagicMock()}
+
+        await register_cli_tools(registry, _cli_integration(), tool_space="stripe_link")
+
+        registry._add_category.assert_not_called()
+        registry._index_category_tools.assert_not_awaited()
+
+    async def test_custom_cli_integration_is_dispatched_to_the_cli_builder(self):
+        # A user-created CLI integration is not in the static registry, so the
+        # custom branch must route on its spec instead of assuming MCP.
+        from app.agents.core.subagents.provider_subagents import create_subagent_for_user
+
+        mock_graph = MagicMock()
+        integration = _cli_integration("custom_abc")
+
+        with (
+            patch(
+                "app.agents.core.subagents.provider_subagents.get_subagent_by_id",
+                return_value=None,
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.resolve_cli_integration",
+                new_callable=AsyncMock,
+                return_value=integration,
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents._create_custom_mcp_subagent",
+                new_callable=AsyncMock,
+            ) as mock_mcp,
+            patch(
+                "app.agents.core.subagents.provider_subagents._create_custom_cli_subagent",
+                new_callable=AsyncMock,
+                return_value=mock_graph,
+            ) as mock_cli,
+        ):
+            result = await create_subagent_for_user("custom_abc", "user_123")
+
+        assert result is mock_graph
+        mock_mcp.assert_not_called()
+        mock_cli.assert_awaited_once_with(integration, "user_123")
+
+    async def test_custom_cli_refuses_when_not_connected(self):
+        # Nothing upstream gates a custom integration, so an unconnected CLI
+        # must be refused here rather than handed over unauthenticated.
+        from app.agents.core.subagents.provider_subagents import (
+            SubagentUnavailableError,
+            _create_custom_cli_subagent,
+        )
+
+        with (
+            patch(
+                "app.agents.core.subagents.provider_subagents.user_integration_repository"
+            ) as mock_repo,
+            patch(
+                "app.agents.core.subagents.provider_subagents.get_tool_registry",
+                new_callable=AsyncMock,
+            ) as mock_get_registry,
+            patch(
+                "app.agents.core.subagents.provider_subagents.SubAgentFactory.create_provider_subagent",
+                new_callable=AsyncMock,
+            ) as mock_factory,
+        ):
+            mock_repo.is_connected = AsyncMock(return_value=False)
+            with pytest.raises(SubagentUnavailableError, match="not connected"):
+                await _create_custom_cli_subagent(_cli_integration("custom_abc"), "user_123")
+
+        mock_get_registry.assert_not_called()
+        mock_factory.assert_not_called()
+
+    async def test_custom_cli_binds_its_single_tool_directly(self):
+        from app.agents.core.subagents.provider_subagents import _create_custom_cli_subagent
+
+        registry = _cli_tool_registry()
+        mock_graph = MagicMock()
+
+        with (
+            patch(
+                "app.agents.core.subagents.provider_subagents.user_integration_repository"
+            ) as mock_repo,
+            patch(
+                "app.agents.core.subagents.provider_subagents.get_tool_registry",
+                new_callable=AsyncMock,
+                return_value=registry,
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.init_llm",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.agents.core.subagents.provider_subagents.SubAgentFactory.create_provider_subagent",
+                new_callable=AsyncMock,
+                return_value=mock_graph,
+            ) as mock_factory,
+        ):
+            mock_repo.is_connected = AsyncMock(return_value=True)
+            result = await _create_custom_cli_subagent(_cli_integration("custom_abc"), "user_123")
+
+        assert result is mock_graph
+        # The id is the namespace: a CLI has no server URL to derive one from.
+        assert registry._add_category.call_args.kwargs["options"].space == "custom_abc"
+
+        call_kwargs = mock_factory.call_args.kwargs
+        assert call_kwargs["name"] == "custom_cli_custom_abc"
+        cfg = call_kwargs["config"]
+        assert cfg.tool_space == "custom_abc"
+        assert cfg.use_direct_tools is True
+        assert cfg.disable_retrieve_tools is True
+        assert cfg.source_label == "Stripe Link"

--- a/apps/api/tests/unit/api/test_integrations_config_endpoint.py
+++ b/apps/api/tests/unit/api/test_integrations_config_endpoint.py
@@ -5,11 +5,18 @@ and POST /connect/{integration_id}.  Service layer is mocked;
 only HTTP status codes, response shapes, and error handling are verified.
 """
 
+from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
+from fastapi import HTTPException
 from httpx import AsyncClient
+import pytest
 
+from app.api.v1.endpoints.integrations import config as config_endpoint
+from app.schemas.integrations.requests import ConnectIntegrationRequest
+from app.schemas.integrations.responses import ConnectIntegrationResponse
 from app.services.analytics_service import AnalyticsEvents
+from tests.helpers import captured_wide_event
 
 API = "/api/v1/integrations"
 _MODULE = "app.api.v1.endpoints.integrations.config"
@@ -229,3 +236,110 @@ class TestConnectIntegration:
     async def test_requires_auth(self, unauthed_client: AsyncClient) -> None:
         resp = await unauthed_client.post(f"{API}/connect/github", json={})
         assert resp.status_code == 401
+
+
+class TestConnectIntegrationHandler:
+    """The connect handler called directly, without the router in the way.
+
+    The HTTP tests above prove the wire contract. These prove the two things
+    the handler itself decides — which identity it acts for, and what it puts
+    on the wide event — which the router's own error handling would otherwise
+    flatten into an anonymous 400.
+    """
+
+    USER: ClassVar[dict[str, str]] = {
+        "user_id": "507f1f77bcf86cd799439011",
+        "email": "test@example.com",
+    }
+
+    async def _call(self, user: dict, **overrides: object) -> ConnectIntegrationResponse:
+        request = ConnectIntegrationRequest(**overrides)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
+        return await config_endpoint.connect_integration_endpoint(
+            integration_id="stripe_link", request=request, user=user
+        )
+
+    async def test_acts_for_the_authenticated_user_and_their_email(self):
+        # The dispatch keys the connection on this user id, and forwards the
+        # email as the OAuth login hint. Reading either from the wrong claim
+        # would connect an integration to the wrong account.
+        with patch(
+            f"{_MODULE}.initiate_integration_connection",
+            new_callable=AsyncMock,
+            return_value=ConnectIntegrationResponse(
+                status="connected", integration_id="stripe_link", name="Stripe Link"
+            ),
+        ) as dispatch:
+            await self._call(self.USER, redirect_path="/chat/7", bearer_token="paste-me")
+
+        assert dispatch.await_args.kwargs == {
+            "user_id": "507f1f77bcf86cd799439011",
+            "integration_id": "stripe_link",
+            "user_email": "test@example.com",
+            "redirect_path": "/chat/7",
+            "bearer_token": "paste-me",
+        }
+
+    async def test_a_token_carrying_no_user_id_is_refused_by_name(self):
+        # A validated token with no subject claim is a broken session, not an
+        # anonymous one; the message has to say so rather than fail as a
+        # generic 400 the caller cannot diagnose.
+        with pytest.raises(HTTPException) as exc_info:
+            await self._call({"email": "test@example.com"})
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "User ID not found"
+
+    async def test_an_unknown_user_id_claim_is_not_silently_accepted(self):
+        # Reading the wrong claim name must fail closed. If it ever resolved to
+        # something truthy, every connect would run as whatever that value is.
+        with pytest.raises(HTTPException) as exc_info:
+            await self._call({"userId": "507f1f77bcf86cd799439011"})
+
+        assert exc_info.value.status_code == 400
+
+    async def test_a_caller_with_no_email_still_connects(self):
+        # Bot and connect-link users have no email claim. The login hint is
+        # optional; requiring it would lock them out of every connect.
+        with patch(
+            f"{_MODULE}.initiate_integration_connection",
+            new_callable=AsyncMock,
+            return_value=ConnectIntegrationResponse(
+                status="pending", integration_id="stripe_link", name="Stripe Link"
+            ),
+        ) as dispatch:
+            await self._call({"user_id": "507f1f77bcf86cd799439011"})
+
+        assert dispatch.await_args.kwargs["user_email"] == ""
+
+    async def test_the_wide_event_names_the_operation_the_user_and_the_integration(self):
+        # This is the only record tying a failed connect to who asked for it and
+        # for what; the key names are the schema the log queries join on.
+        with patch(
+            f"{_MODULE}.initiate_integration_connection",
+            new_callable=AsyncMock,
+            return_value=ConnectIntegrationResponse(
+                status="pending", integration_id="stripe_link", name="Stripe Link"
+            ),
+        ):
+            async with captured_wide_event() as event:
+                await self._call(self.USER)
+                operation = event["operation"]
+
+        assert operation == "connect_integration"
+        assert event["integration_id"] == "stripe_link"
+        assert event["user"] == {"id": "507f1f77bcf86cd799439011"}
+        assert event["integration"] == {"id": "stripe_link"}
+
+    async def test_an_unresolvable_integration_is_a_404_naming_it(self):
+        with (
+            patch(
+                f"{_MODULE}.initiate_integration_connection",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await self._call(self.USER)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Integration stripe_link not found"

--- a/apps/api/tests/unit/api/test_integrations_config_endpoint.py
+++ b/apps/api/tests/unit/api/test_integrations_config_endpoint.py
@@ -5,7 +5,7 @@ and POST /connect/{integration_id}.  Service layer is mocked;
 only HTTP status codes, response shapes, and error handling are verified.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from httpx import AsyncClient
 
@@ -41,36 +41,6 @@ def _config_item(
         "source": "platform",
         "slug": iid,
     }
-
-
-def _resolved(
-    managed_by: str = "mcp",
-    name: str = "TestInt",
-    source: str = "platform",
-    requires_auth: bool = False,
-    provider: str | None = None,
-    available: bool = True,
-    server_url: str | None = "https://mcp.example.com",
-) -> MagicMock:
-    mock = MagicMock()
-    mock.managed_by = managed_by
-    mock.name = name
-    mock.source = source
-    mock.requires_auth = requires_auth
-    if source == "platform":
-        pi = MagicMock()
-        pi.available = available
-        pi.provider = provider
-        mock.platform_integration = pi
-    else:
-        mock.platform_integration = None
-    if managed_by == "mcp":
-        mock.mcp_config = MagicMock()
-        mock.mcp_config.requires_auth = requires_auth
-        mock.mcp_config.server_url = server_url
-    else:
-        mock.mcp_config = None
-    return mock
 
 
 # ===========================================================================

--- a/apps/api/tests/unit/api/test_integrations_config_endpoint.py
+++ b/apps/api/tests/unit/api/test_integrations_config_endpoint.py
@@ -9,10 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import AsyncClient
 
-from app.models.user_models import UserDocument
 from app.services.analytics_service import AnalyticsEvents
 
 API = "/api/v1/integrations"
+_MODULE = "app.api.v1.endpoints.integrations.config"
 
 
 # ---------------------------------------------------------------------------
@@ -173,268 +173,89 @@ class TestDisconnectIntegration:
 
 
 class TestConnectIntegration:
-    async def test_connect_mcp_success(self, client: AsyncClient) -> None:
+    """The endpoint is a thin pass-through now.
+
+    Choosing a transport moved to ``connect_dispatch`` so the authenticated
+    endpoint and the login-free connect-link path cannot drift apart; the
+    per-transport behaviour is covered in
+    ``tests/unit/services/integrations/test_connect_dispatch.py``. What is left
+    to verify here is the HTTP contract.
+    """
+
+    async def test_passes_the_request_through_and_returns_the_result(
+        self, client: AsyncClient
+    ) -> None:
         from app.schemas.integrations.responses import ConnectIntegrationResponse
 
-        resolved = _resolved(managed_by="mcp")
-        mock_result = ConnectIntegrationResponse(
-            status="connected",
-            integration_id="test-mcp",
-            name="TestInt",
-            tools_count=3,
+        result = ConnectIntegrationResponse(
+            status="connected", integration_id="test-mcp", name="TestInt", tools_count=3
         )
-        with (
-            patch(
-                "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-                new_callable=AsyncMock,
-                return_value=resolved,
-            ),
-            patch(
-                "app.api.v1.endpoints.integrations.config.connect_mcp_integration",
-                new_callable=AsyncMock,
-                return_value=mock_result,
-            ),
-            patch("app.api.v1.endpoints.integrations.config.capture_context_event") as mock_capture,
-        ):
-            resp = await client.post(
-                f"{API}/connect/test-mcp",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "connected"
-        mock_capture.assert_called_once_with(
-            AnalyticsEvents.INTEGRATION_CONNECTED,
-            {"integration_id": "test-mcp", "managed_by": "mcp"},
-        )
-
-    async def test_connect_composio_success(self, client: AsyncClient) -> None:
-        from app.schemas.integrations.responses import ConnectIntegrationResponse
-
-        resolved = _resolved(managed_by="composio", provider="GITHUB")
-        mock_result = ConnectIntegrationResponse(
-            status="redirect",
-            integration_id="github",
-            name="GitHub",
-            redirect_url="https://oauth.example.com",
-        )
-        with (
-            patch(
-                "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-                new_callable=AsyncMock,
-                return_value=resolved,
-            ),
-            patch(
-                "app.api.v1.endpoints.integrations.config.connect_composio_integration",
-                new_callable=AsyncMock,
-                return_value=mock_result,
-            ),
-            patch("app.api.v1.endpoints.integrations.config.capture_context_event") as mock_capture,
-        ):
-            resp = await client.post(
-                f"{API}/connect/github",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "redirect"
-        # OAuth-managed connects complete at their callback, not here.
-        mock_capture.assert_not_called()
-
-    async def test_connect_self_success(self, client: AsyncClient) -> None:
-        from app.schemas.integrations.responses import ConnectIntegrationResponse
-
-        resolved = _resolved(managed_by="self", provider="GCAL")
-        mock_result = ConnectIntegrationResponse(
-            status="redirect",
-            integration_id="gcal",
-            name="Google Calendar",
-            redirect_url="https://oauth.google.com",
-        )
-        with (
-            patch(
-                "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-                new_callable=AsyncMock,
-                return_value=resolved,
-            ),
-            patch(
-                "app.api.v1.endpoints.integrations.config.connect_self_integration",
-                new_callable=AsyncMock,
-                return_value=mock_result,
-            ),
-        ):
-            resp = await client.post(
-                f"{API}/connect/gcal",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-
-    async def test_connect_not_found(self, client: AsyncClient) -> None:
         with patch(
-            "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
+            f"{_MODULE}.initiate_integration_connection",
+            new_callable=AsyncMock,
+            return_value=result,
+        ) as dispatch:
+            resp = await client.post(
+                f"{API}/connect/test-mcp", json={"redirect_path": "/integrations"}
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "connected"
+        assert body["toolsCount"] == 3
+        kwargs = dispatch.await_args.kwargs
+        assert kwargs["integration_id"] == "test-mcp"
+        assert kwargs["redirect_path"] == "/integrations"
+
+    async def test_forwards_a_pasted_secret(self, client: AsyncClient) -> None:
+        from app.schemas.integrations.responses import ConnectIntegrationResponse
+
+        with patch(
+            f"{_MODULE}.initiate_integration_connection",
+            new_callable=AsyncMock,
+            return_value=ConnectIntegrationResponse(
+                status="connected", integration_id="gh", name="GitHub"
+            ),
+        ) as dispatch:
+            await client.post(f"{API}/connect/gh", json={"bearer_token": "secret-value"})
+
+        assert dispatch.await_args.kwargs["bearer_token"] == "secret-value"
+
+    async def test_surfaces_a_pending_cli_connect(self, client: AsyncClient) -> None:
+        from app.schemas.integrations.responses import (
+            CliConnectDetail,
+            ConnectIntegrationResponse,
+        )
+
+        with patch(
+            f"{_MODULE}.initiate_integration_connection",
+            new_callable=AsyncMock,
+            return_value=ConnectIntegrationResponse(
+                status="pending",
+                integration_id="stripe_link",
+                name="Stripe Link",
+                cli=CliConnectDetail(
+                    phase="awaiting_approval", instructions="open https://link.test/d"
+                ),
+            ),
+        ):
+            resp = await client.post(f"{API}/connect/stripe_link", json={})
+
+        body = resp.json()
+        assert resp.status_code == 200
+        assert body["status"] == "pending"
+        assert body["cli"]["phase"] == "awaiting_approval"
+        assert body["cli"]["instructions"] == "open https://link.test/d"
+
+    async def test_unknown_integration_is_a_404(self, client: AsyncClient) -> None:
+        with patch(
+            f"{_MODULE}.initiate_integration_connection",
             new_callable=AsyncMock,
             return_value=None,
         ):
-            resp = await client.post(
-                f"{API}/connect/nonexistent",
-                json={"redirect_path": "/integrations"},
-            )
+            resp = await client.post(f"{API}/connect/nope", json={})
         assert resp.status_code == 404
 
-    async def test_connect_unavailable_platform(self, client: AsyncClient) -> None:
-        resolved = _resolved(managed_by="mcp", available=False)
-        with patch(
-            "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-            new_callable=AsyncMock,
-            return_value=resolved,
-        ):
-            resp = await client.post(
-                f"{API}/connect/unavailable",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "error"
-        assert "not available" in resp.json()["error"]
-
-    async def test_connect_composio_no_provider(self, client: AsyncClient) -> None:
-        """HTTPException(400) raised inside try is caught by outer except
-        Exception handler, so response is 200 with status='error'."""
-        resolved = _resolved(managed_by="composio", provider=None)
-        with patch(
-            "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-            new_callable=AsyncMock,
-            return_value=resolved,
-        ):
-            resp = await client.post(
-                f"{API}/connect/noprov",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "error"
-
-    async def test_connect_self_no_provider(self, client: AsyncClient) -> None:
-        resolved = _resolved(managed_by="self", provider=None)
-        with patch(
-            "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-            new_callable=AsyncMock,
-            return_value=resolved,
-        ):
-            resp = await client.post(
-                f"{API}/connect/noprov",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "error"
-
-    async def test_connect_unsupported_type(self, client: AsyncClient) -> None:
-        resolved = _resolved(managed_by="unknown")
-        with patch(
-            "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-            new_callable=AsyncMock,
-            return_value=resolved,
-        ):
-            resp = await client.post(
-                f"{API}/connect/weird",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "error"
-        assert "Unsupported" in resp.json()["error"]
-
-    async def test_connect_service_exception(self, client: AsyncClient) -> None:
-        """When the connect function itself raises, endpoint returns error
-        status (not 500)."""
-        resolved = _resolved(managed_by="mcp")
-        with (
-            patch(
-                "app.api.v1.endpoints.integrations.config.IntegrationResolver.resolve",
-                new_callable=AsyncMock,
-                return_value=resolved,
-            ),
-            patch(
-                "app.api.v1.endpoints.integrations.config.connect_mcp_integration",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("conn failed"),
-            ),
-        ):
-            resp = await client.post(
-                f"{API}/connect/test-mcp",
-                json={"redirect_path": "/integrations"},
-            )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "error"
-        assert "conn failed" in data["error"]
-
-    async def test_connect_requires_auth(self, unauthed_client: AsyncClient) -> None:
-        resp = await unauthed_client.post(
-            f"{API}/connect/github",
-            json={"redirect_path": "/integrations"},
-        )
+    async def test_requires_auth(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.post(f"{API}/connect/github", json={})
         assert resp.status_code == 401
-
-
-_MODULE = "app.api.v1.endpoints.integrations.config"
-_VALID_UID = "507f1f77bcf86cd799439011"
-
-
-class TestConnectLinkEndpoint:
-    """The login-free connect link: self-authenticating, redirects into OAuth."""
-
-    async def test_valid_token_redirects_to_oauth(self, client: AsyncClient) -> None:
-        result = MagicMock(status="redirect", redirect_url="https://oauth.example/go", error=None)
-        with (
-            patch(
-                f"{_MODULE}.resolve_and_consume_connect_code",
-                new_callable=AsyncMock,
-                return_value=(_VALID_UID, "notion"),
-            ),
-            patch(
-                f"{_MODULE}.user_repository.get",
-                new_callable=AsyncMock,
-                return_value=UserDocument(email="a@b.com"),
-            ),
-            patch(
-                f"{_MODULE}.initiate_integration_connection",
-                new_callable=AsyncMock,
-                return_value=result,
-            ),
-        ):
-            resp = await client.get(f"{API}/connect-link?code=somecode", follow_redirects=False)
-        assert resp.status_code in (302, 307)
-        assert resp.headers["location"] == "https://oauth.example/go"
-
-    async def test_invalid_token_redirects_to_error(self, client: AsyncClient) -> None:
-        with patch(
-            f"{_MODULE}.resolve_and_consume_connect_code",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
-            resp = await client.get(f"{API}/connect-link?code=bad", follow_redirects=False)
-        assert resp.status_code in (302, 307)
-        assert "connect_error=invalid_or_expired_link" in resp.headers["location"]
-
-    async def test_works_without_login(self, unauthed_client: AsyncClient) -> None:
-        """The whole point: a logged-out user reaches it (not 401) and is sent
-        into OAuth — identity comes from the single-use code, not a session."""
-        result = MagicMock(status="redirect", redirect_url="https://oauth.example/go", error=None)
-        with (
-            patch(
-                f"{_MODULE}.resolve_and_consume_connect_code",
-                new_callable=AsyncMock,
-                return_value=(_VALID_UID, "notion"),
-            ),
-            patch(
-                f"{_MODULE}.user_repository.get",
-                new_callable=AsyncMock,
-                return_value=UserDocument(email="a@b.com"),
-            ),
-            patch(
-                f"{_MODULE}.initiate_integration_connection",
-                new_callable=AsyncMock,
-                return_value=result,
-            ),
-        ):
-            resp = await unauthed_client.get(
-                f"{API}/connect-link?code=somecode", follow_redirects=False
-            )
-        assert resp.status_code != 401
-        assert resp.headers["location"] == "https://oauth.example/go"

--- a/apps/api/tests/unit/api/test_integrations_public_endpoint.py
+++ b/apps/api/tests/unit/api/test_integrations_public_endpoint.py
@@ -2,15 +2,21 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from fastapi import HTTPException
 from httpx import AsyncClient
 import pytest
 
+from app.api.v1.endpoints.integrations import public as public_endpoint
 from app.models.integration_models import (
     Integration,
     IntegrationWithCreator,
     UserIntegrationDocument,
 )
+from app.schemas.integrations.requests import ConnectIntegrationRequest
+from app.schemas.integrations.responses import ConnectIntegrationResponse
 from app.services.analytics_service import AnalyticsEvents
+from app.services.integrations.integration_connection_service import McpConnectRequest
+from tests.helpers import captured_wide_event
 
 # Base URL for integration public endpoints
 # routes.py: prefix="/integrations", public.py router has no extra prefix
@@ -584,3 +590,126 @@ class TestSearchIntegrations:
 
         assert resp.status_code == 500
         assert "Failed to search" in resp.json()["detail"]
+
+
+class TestAddPublicIntegrationHandler:
+    """The add handler called directly, without the router in the way.
+
+    The HTTP tests above cover the wire contract. These cover what the handler
+    itself decides before any of that is visible: which catalog row it reads,
+    and what it writes to the wide event — the only record of who added what
+    when a marketplace add goes wrong.
+    """
+
+    USER = "507f1f77bcf86cd799439011"
+
+    async def _call(self, integration_id: str = "integ1") -> object:
+        return await public_endpoint.add_public_integration(
+            integration_id=integration_id,
+            request=ConnectIntegrationRequest(redirect_path="/integrations"),
+            user_id=self.USER,
+        )
+
+    async def test_the_requested_integration_is_the_one_looked_up(self):
+        # The id in the path is the row that gets cloned into the user's
+        # workspace; looking up anything else would add the wrong integration
+        # under the right name.
+        existing = UserIntegrationDocument(
+            user_id="u1", integration_id="integ1", status="connected"
+        )
+        with (
+            patch(f"{_PUBLIC}.integration_repository") as repo,
+            patch(f"{_PUBLIC}.user_integration_repository") as user_repo,
+        ):
+            repo.get_public = AsyncMock(
+                side_effect=lambda iid: _integration("integ1", "Integ") if iid == "integ1" else None
+            )
+            user_repo.get_for_user = AsyncMock(return_value=existing)
+
+            result = await self._call("integ1")
+
+        repo.get_public.assert_awaited_once_with("integ1")
+        assert result.status == "connected"
+
+    async def test_an_integration_that_is_not_public_is_a_404(self):
+        # get_public returns None for a private or missing row. Adding it
+        # anyway would publish someone else's private integration by id.
+        with patch(f"{_PUBLIC}.integration_repository") as repo:
+            repo.get_public = AsyncMock(return_value=None)
+            with pytest.raises(HTTPException) as exc_info:
+                await self._call("not-public")
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Integration not found"
+
+    async def test_the_wide_event_names_the_operation_the_user_and_the_integration(self):
+        existing = UserIntegrationDocument(
+            user_id="u1", integration_id="integ1", status="connected"
+        )
+        with (
+            patch(f"{_PUBLIC}.integration_repository") as repo,
+            patch(f"{_PUBLIC}.user_integration_repository") as user_repo,
+        ):
+            repo.get_public = AsyncMock(return_value=_integration("integ1", "Integ"))
+            user_repo.get_for_user = AsyncMock(return_value=existing)
+
+            async with captured_wide_event() as event:
+                await self._call("integ1")
+                operation = event["operation"]
+
+        assert operation == "add_public_integration"
+        assert event["integration_id"] == "integ1"
+        assert event["user"] == {"id": self.USER}
+        assert event["integration"] == {"id": "integ1"}
+
+    async def test_the_marketplace_add_connects_the_community_server_as_non_platform(self):
+        """Everything the MCP connect branches on comes from the catalog row.
+
+        ``is_platform`` is the one that matters most: a platform integration may
+        use GAIA's own credentials, and a community integration anyone can
+        publish must never be treated as one. The rest are asserted with it
+        because a dropped field is as wrong as a flipped one — the request is
+        built once and nothing downstream can recover a missing server URL or
+        the token the user pasted.
+        """
+        original = _integration(
+            "integ1",
+            "Community MCP",
+            mcp_config={
+                "server_url": "https://mcp.community.test",
+                "requires_auth": True,
+                "auth_type": "bearer",
+            },
+        )
+        with (
+            patch(f"{_PUBLIC}.integration_repository") as repo,
+            patch(f"{_PUBLIC}.user_integration_repository") as user_repo,
+            patch(f"{_PUBLIC}.add_user_integration", new_callable=AsyncMock),
+            patch(
+                f"{_PUBLIC}.connect_mcp_integration",
+                new_callable=AsyncMock,
+                return_value=ConnectIntegrationResponse(
+                    status="connected", integration_id="integ1", name="Community MCP"
+                ),
+            ) as connect,
+        ):
+            repo.get_public = AsyncMock(return_value=original)
+            repo.increment_clone_count = AsyncMock()
+            user_repo.get_for_user = AsyncMock(return_value=None)
+
+            await public_endpoint.add_public_integration(
+                integration_id="integ1",
+                request=ConnectIntegrationRequest(redirect_path="/chat/7", bearer_token="paste-me"),
+                user_id=self.USER,
+            )
+
+        assert connect.await_args.args[0] == McpConnectRequest(
+            user_id=self.USER,
+            integration_id="integ1",
+            integration_name="Community MCP",
+            requires_auth=True,
+            redirect_path="/chat/7",
+            server_url="https://mcp.community.test",
+            is_platform=False,
+            bearer_token="paste-me",
+        )

--- a/apps/api/tests/unit/constants/test_cli_tool_name.py
+++ b/apps/api/tests/unit/constants/test_cli_tool_name.py
@@ -1,0 +1,73 @@
+"""The registry name for a CLI integration's tool.
+
+The tool registry is process-global and keyed by name alone, while custom CLI
+integrations are per-user Mongo documents. Two users each authoring a CLI called
+``gh`` therefore share one registry slot unless the name disambiguates them.
+"""
+
+import pytest
+
+from app.constants.cli_integrations import app_dir, cli_tool_name, install_marker_path
+
+
+class TestPlatformNames:
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ("link-cli", "run_link_cli"),
+            ("gh", "run_gh"),
+            ("wrangler", "run_wrangler"),
+            ("tool.js", "run_tool_js"),
+        ],
+    )
+    def test_curated_integrations_keep_the_clean_name(self, command, expected):
+        # The model both selects this name and types the command inside it, so
+        # keeping them the same word measurably reduces it inventing another.
+        assert cli_tool_name(command, "stripe_link", is_platform=True) == expected
+
+    def test_the_name_does_not_depend_on_the_integration_id(self):
+        a = cli_tool_name("gh", "one", is_platform=True)
+        b = cli_tool_name("gh", "two", is_platform=True)
+        assert a == b == "run_gh"
+
+
+class TestCustomNames:
+    def test_two_users_authoring_the_same_cli_do_not_collide(self):
+        # Last-writer-wins in the registry would give one user's approval cards,
+        # Chroma namespace and cached HIL verdict to the other user's tool.
+        a = cli_tool_name("gh", "11111111-1111-1111-1111-111111111111", is_platform=False)
+        b = cli_tool_name("gh", "22222222-2222-2222-2222-222222222222", is_platform=False)
+        assert a != b
+
+    def test_the_command_is_still_readable_in_the_name(self):
+        name = cli_tool_name("gh", "some-uuid", is_platform=False)
+        assert name.startswith("run_gh_")
+
+    def test_the_same_integration_always_gets_the_same_name(self):
+        # Registration is idempotent and re-runs on every subagent build; a
+        # non-deterministic name would register a new tool each time.
+        first = cli_tool_name("gh", "stable-id", is_platform=False)
+        second = cli_tool_name("gh", "stable-id", is_platform=False)
+        assert first == second
+
+    def test_a_custom_name_never_shadows_the_platform_form(self):
+        assert cli_tool_name("gh", "any-id", is_platform=False) != cli_tool_name(
+            "gh", "any-id", is_platform=True
+        )
+
+
+class TestInstallMarkerPath:
+    """Where the "this CLI is already installed" marker lives.
+
+    ``probe_state`` skips the ~20 s install when this file exists, so the path
+    is the whole of that decision. It has to sit inside the integration's own
+    app directory: a shared location would let installing one CLI convince the
+    sandbox that every other CLI was installed too, and the agent would then
+    invoke a command that is not there.
+    """
+
+    def test_the_marker_lives_inside_that_integrations_app_directory(self):
+        assert install_marker_path("stripe_link").startswith(f"{app_dir('stripe_link')}/")
+
+    def test_two_integrations_do_not_share_a_marker(self):
+        assert install_marker_path("stripe_link") != install_marker_path("github_cli")

--- a/apps/api/tests/unit/models/test_cli_config.py
+++ b/apps/api/tests/unit/models/test_cli_config.py
@@ -97,8 +97,15 @@ class TestCliConfigCommandValidation:
         ],
     )
     def test_rejects_unsafe_command_names(self, bad: str):
-        with pytest.raises(ValidationError):
+        # The message has to say both which value was rejected and what a
+        # legal one looks like: the caller is often a model that read a
+        # vendor's docs, and "invalid command" alone gives it nothing to fix.
+        with pytest.raises(ValidationError) as exc_info:
             CliConfig(command=bad, install_command="true", auth=_auth())
+        assert _message(exc_info) == (
+            f"command {bad!r} must be a bare executable name "
+            "(letters, digits, dot, dash, underscore)"
+        )
 
     @pytest.mark.parametrize("good", ["gh", "link-cli", "wrangler", "tool.js", "a_b", "x1"])
     def test_accepts_plain_executable_names(self, good: str):
@@ -110,8 +117,9 @@ class TestCliConfigCommandValidation:
 
     @pytest.mark.parametrize("blank", ["", "   ", "\n\t "])
     def test_rejects_blank_install_command(self, blank: str):
-        with pytest.raises(ValidationError, match="install_command cannot be empty"):
+        with pytest.raises(ValidationError) as exc_info:
             CliConfig(command="gh", install_command=blank, auth=_auth())
+        assert _message(exc_info) == "install_command cannot be empty"
 
     def test_capabilities_default_to_empty_not_shared(self):
         first = CliConfig(command="gh", install_command="true", auth=_auth())

--- a/apps/api/tests/unit/models/test_cli_config.py
+++ b/apps/api/tests/unit/models/test_cli_config.py
@@ -1,0 +1,99 @@
+"""Unit tests for CLI integration configuration models."""
+
+from pydantic import ValidationError
+import pytest
+
+from app.models.cli_config import CliAuthSpec, CliConfig
+
+
+def _auth(**overrides: object) -> CliAuthSpec:
+    base: dict[str, object] = {"kind": "none", "verify_command": "tool --version"}
+    base.update(overrides)
+    return CliAuthSpec(**base)  # type: ignore[arg-type]
+
+
+class TestCliAuthSpecShapeInvariants:
+    """Each auth shape must carry the fields its connect flow reads.
+
+    These are the failures that would otherwise surface as a connect dialog
+    that collects a secret and drops it, or a device login with nothing to run.
+    """
+
+    def test_device_requires_login_command(self):
+        with pytest.raises(ValidationError, match="requires login_command"):
+            _auth(kind="device")
+
+    def test_device_accepts_login_command(self):
+        spec = _auth(kind="device", login_command="tool auth login")
+        assert spec.login_command == "tool auth login"
+
+    def test_token_requires_token_env(self):
+        with pytest.raises(ValidationError, match="requires token_env"):
+            _auth(kind="token", token_label="API token")
+
+    def test_token_requires_token_label(self):
+        with pytest.raises(ValidationError, match="requires token_label"):
+            _auth(kind="token", token_env="TOOL_TOKEN")
+
+    def test_token_shape_is_complete(self):
+        spec = _auth(kind="token", token_env="TOOL_TOKEN", token_label="API token")
+        assert spec.token_env == "TOOL_TOKEN"
+
+    def test_none_must_not_declare_a_login(self):
+        with pytest.raises(ValidationError, match="must not set login_command"):
+            _auth(kind="none", login_command="tool auth login")
+
+    @pytest.mark.parametrize(
+        "bad", ["lower_case", "1STARTS_WITH_DIGIT", "HAS-DASH", "HAS SPACE", ""]
+    )
+    def test_token_env_rejects_non_environment_names(self, bad: str):
+        # token_env is interpolated into `export <name>=...`; anything that is
+        # not a shell-legal variable name would produce a broken env file.
+        with pytest.raises(ValidationError):
+            _auth(kind="token", token_env=bad, token_label="x")
+
+    @pytest.mark.parametrize("good", ["GH_TOKEN", "T", "_LEADING", "A1_B2"])
+    def test_token_env_accepts_environment_names(self, good: str):
+        assert _auth(kind="token", token_env=good, token_label="x").token_env == good
+
+
+class TestCliConfigCommandValidation:
+    """``command`` becomes a filename on PATH and is interpolated into shell."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../escape",
+            "/usr/bin/absolute",
+            "with space",
+            "semi;colon",
+            "pipe|char",
+            "dollar$sign",
+            "back`tick`",
+            "amp&",
+            "",
+            "-leading-dash",
+        ],
+    )
+    def test_rejects_unsafe_command_names(self, bad: str):
+        with pytest.raises(ValidationError):
+            CliConfig(command=bad, install_command="true", auth=_auth())
+
+    @pytest.mark.parametrize("good", ["gh", "link-cli", "wrangler", "tool.js", "a_b", "x1"])
+    def test_accepts_plain_executable_names(self, good: str):
+        assert CliConfig(command=good, install_command="true", auth=_auth()).command == good
+
+    def test_rejects_command_longer_than_the_bound(self):
+        with pytest.raises(ValidationError):
+            CliConfig(command="a" * 65, install_command="true", auth=_auth())
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\n\t "])
+    def test_rejects_blank_install_command(self, blank: str):
+        with pytest.raises(ValidationError, match="install_command cannot be empty"):
+            CliConfig(command="gh", install_command=blank, auth=_auth())
+
+    def test_capabilities_default_to_empty_not_shared(self):
+        first = CliConfig(command="gh", install_command="true", auth=_auth())
+        second = CliConfig(command="gh", install_command="true", auth=_auth())
+        first.capabilities.append("mutated")
+        assert second.capabilities == []

--- a/apps/api/tests/unit/models/test_cli_config.py
+++ b/apps/api/tests/unit/models/test_cli_config.py
@@ -9,7 +9,7 @@ from app.models.cli_config import CliAuthSpec, CliConfig
 def _auth(**overrides: object) -> CliAuthSpec:
     base: dict[str, object] = {"kind": "none", "verify_command": "tool --version"}
     base.update(overrides)
-    return CliAuthSpec(**base)  # type: ignore[arg-type]
+    return CliAuthSpec(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
 
 
 class TestCliAuthSpecShapeInvariants:

--- a/apps/api/tests/unit/models/test_cli_config.py
+++ b/apps/api/tests/unit/models/test_cli_config.py
@@ -12,6 +12,20 @@ def _auth(**overrides: object) -> CliAuthSpec:
     return CliAuthSpec(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
 
 
+def _message(exc_info: pytest.ExceptionInfo[ValidationError]) -> str:
+    """The single validation error's own message, without pydantic's wrapper.
+
+    Asserted verbatim throughout this file because these strings are not just
+    developer diagnostics: an authored CLI integration comes from a model that
+    read a vendor's help text, ``cli_author`` re-raises them as "Invalid CLI
+    configuration: <msg>", and that sentence is the entire instruction the
+    model gets for its retry. Reworded to something vaguer and the retry
+    guesses.
+    """
+    (error,) = exc_info.value.errors()
+    return str(error["msg"]).removeprefix("Value error, ")
+
+
 class TestCliAuthSpecShapeInvariants:
     """Each auth shape must carry the fields its connect flow reads.
 
@@ -20,37 +34,44 @@ class TestCliAuthSpecShapeInvariants:
     """
 
     def test_device_requires_login_command(self):
-        with pytest.raises(ValidationError, match="requires login_command"):
+        with pytest.raises(ValidationError) as exc_info:
             _auth(kind="device")
+        assert _message(exc_info) == "auth.kind='device' requires login_command"
 
     def test_device_accepts_login_command(self):
         spec = _auth(kind="device", login_command="tool auth login")
         assert spec.login_command == "tool auth login"
 
     def test_token_requires_token_env(self):
-        with pytest.raises(ValidationError, match="requires token_env"):
+        with pytest.raises(ValidationError) as exc_info:
             _auth(kind="token", token_label="API token")
+        assert _message(exc_info) == "auth.kind='token' requires token_env"
 
     def test_token_requires_token_label(self):
-        with pytest.raises(ValidationError, match="requires token_label"):
+        with pytest.raises(ValidationError) as exc_info:
             _auth(kind="token", token_env="TOOL_TOKEN")
+        assert _message(exc_info) == "auth.kind='token' requires token_label for the UI prompt"
 
     def test_token_shape_is_complete(self):
         spec = _auth(kind="token", token_env="TOOL_TOKEN", token_label="API token")
         assert spec.token_env == "TOOL_TOKEN"
 
     def test_none_must_not_declare_a_login(self):
-        with pytest.raises(ValidationError, match="must not set login_command"):
+        with pytest.raises(ValidationError) as exc_info:
             _auth(kind="none", login_command="tool auth login")
+        assert _message(exc_info) == "auth.kind='none' must not set login_command"
 
     @pytest.mark.parametrize(
         "bad", ["lower_case", "1STARTS_WITH_DIGIT", "HAS-DASH", "HAS SPACE", ""]
     )
     def test_token_env_rejects_non_environment_names(self, bad: str):
         # token_env is interpolated into `export <name>=...`; anything that is
-        # not a shell-legal variable name would produce a broken env file.
-        with pytest.raises(ValidationError):
+        # not a shell-legal variable name would produce a broken env file. The
+        # message quotes the offending value so the author can see which of
+        # their fields is wrong.
+        with pytest.raises(ValidationError) as exc_info:
             _auth(kind="token", token_env=bad, token_label="x")
+        assert _message(exc_info) == (f"token_env {bad!r} is not a valid environment variable name")
 
     @pytest.mark.parametrize("good", ["GH_TOKEN", "T", "_LEADING", "A1_B2"])
     def test_token_env_accepts_environment_names(self, good: str):

--- a/apps/api/tests/unit/models/test_oauth_models.py
+++ b/apps/api/tests/unit/models/test_oauth_models.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 import pytest
 
 from app.models.cli_config import CliAuthSpec, CliConfig
+from app.models.integration_models import IntegrationResponse
 from app.models.mcp_config import ComposioConfig
 from app.models.oauth_models import OAuthIntegration
 
@@ -93,3 +94,63 @@ class TestComposioTransportInvariant:
                 managed_by="mcp",
                 composio_config=ComposioConfig(auth_config_id="ac_1", toolkit="stripe"),
             )
+
+
+class TestPlatformCliRowRenderedForTheApi:
+    """``IntegrationResponse.from_oauth_integration`` is what the catalog
+    endpoint returns, so these two fields are what the marketplace card shows
+    for a CLI-backed platform integration."""
+
+    TOKEN_CLI = CliConfig(
+        command="gh",
+        install_command="npm install -g gh",
+        capabilities=["list pull requests", "create issues"],
+        auth=CliAuthSpec(
+            kind="token",
+            verify_command="gh auth status",
+            token_env="GH_TOKEN",
+            token_label="GitHub token",
+        ),
+    )
+
+    def test_a_cli_needing_a_token_is_reported_as_requiring_auth(self):
+        # The card renders a Connect button off this flag. Reported as False,
+        # a CLI the user must paste a token into looks ready to use.
+        response = IntegrationResponse.from_oauth_integration(
+            _integration(managed_by="cli", cli_config=self.TOKEN_CLI)
+        )
+
+        assert response.requires_auth is True
+
+    def test_a_cli_needing_no_credentials_is_not_reported_as_requiring_auth(self):
+        no_auth = CLI_CONFIG  # kind="none"
+        response = IntegrationResponse.from_oauth_integration(
+            _integration(managed_by="cli", cli_config=no_auth)
+        )
+
+        assert response.requires_auth is False
+
+    def test_the_declared_capabilities_are_the_displayed_tool_list(self):
+        # One tool wraps the whole CLI, so listing that tool tells the user
+        # nothing. The capabilities are the answer to "what can this do".
+        response = IntegrationResponse.from_oauth_integration(
+            _integration(managed_by="cli", cli_config=self.TOKEN_CLI)
+        )
+
+        assert [tool.name for tool in response.tools] == [
+            "list pull requests",
+            "create issues",
+        ]
+
+    def test_a_non_cli_row_lists_no_tools_here(self):
+        # Composio and MCP tool lists load live; baking an empty list in is
+        # deliberate, not an oversight.
+        response = IntegrationResponse.from_oauth_integration(
+            _integration(
+                managed_by="composio",
+                composio_config=ComposioConfig(auth_config_id="ac_1", toolkit="stripe"),
+            )
+        )
+
+        assert response.tools == []
+        assert response.requires_auth is True

--- a/apps/api/tests/unit/models/test_oauth_models.py
+++ b/apps/api/tests/unit/models/test_oauth_models.py
@@ -1,0 +1,95 @@
+"""Unit tests for the platform catalog entry's transport invariants.
+
+``OAuthIntegration`` is the shape of every row in ``oauth_config``. The connect
+dispatch and the subagent tool factory both branch on ``managed_by`` and then
+reach straight for the matching config block, so a row where the two disagree
+does not fail at import — it fails much later as an integration that resolves
+to nothing. The validator exists to turn that into a config error the moment
+the catalog is loaded, and these tests pin both directions of it.
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+import pytest
+
+from app.models.cli_config import CliAuthSpec, CliConfig
+from app.models.mcp_config import ComposioConfig
+from app.models.oauth_models import OAuthIntegration
+
+CLI_CONFIG = CliConfig(
+    command="link-cli",
+    install_command="npm install @stripe/link-cli",
+    auth=CliAuthSpec(kind="none", verify_command="link-cli auth status"),
+)
+
+
+def _integration(**overrides: object) -> OAuthIntegration:
+    base: dict[str, object] = {
+        "id": "stripe_link",
+        "name": "Stripe Link",
+        "description": "Pay for things",
+        "category": "business",
+        "provider": "stripe_link",
+        "scopes": [],
+    }
+    base.update(overrides)
+    return OAuthIntegration(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
+
+
+class TestCliTransportInvariant:
+    def test_a_cli_row_without_a_cli_config_is_rejected_by_name(self):
+        # The tool factory reads cli_config immediately after selecting on
+        # managed_by; without one the integration would offer a Connect button
+        # that resolves to nothing. The message names the row so the catalog
+        # entry can be found.
+        with pytest.raises(ValidationError) as exc_info:
+            _integration(managed_by="cli")
+
+        assert "Integration 'stripe_link' has managed_by='cli' but no cli_config." in str(
+            exc_info.value
+        )
+
+    def test_a_cli_config_on_a_non_cli_row_is_rejected_and_names_the_transport(self):
+        # The other direction: a config block nothing will ever read. The
+        # message has to say which transport the row actually claims, because
+        # that is the half that is wrong.
+        with pytest.raises(ValidationError) as exc_info:
+            _integration(
+                managed_by="composio",
+                composio_config=ComposioConfig(auth_config_id="ac_1", toolkit="stripe"),
+                cli_config=CLI_CONFIG,
+            )
+
+        assert (
+            "Integration 'stripe_link' sets cli_config but managed_by='composio'; expected 'cli'."
+            in str(exc_info.value)
+        )
+
+    def test_a_coherent_cli_row_is_accepted(self):
+        integration = _integration(managed_by="cli", cli_config=CLI_CONFIG)
+
+        assert integration.managed_by == "cli"
+        assert integration.cli_config is CLI_CONFIG
+
+    @pytest.mark.parametrize("managed_by", ["self", "mcp", "internal"])
+    def test_the_other_transports_need_no_cli_config(self, managed_by: str):
+        # Only the exact string "cli" selects the CLI branch; a validator that
+        # matched more loosely would demand a cli_config from every OAuth row
+        # in the catalog and break startup.
+        integration = _integration(managed_by=managed_by)
+
+        assert integration.cli_config is None
+
+
+class TestComposioTransportInvariant:
+    def test_a_composio_row_without_a_composio_config_is_rejected(self):
+        with pytest.raises(ValidationError, match="no composio_config"):
+            _integration(managed_by="composio")
+
+    def test_a_composio_config_on_a_non_composio_row_is_rejected(self):
+        with pytest.raises(ValidationError, match="expected 'composio'"):
+            _integration(
+                managed_by="mcp",
+                composio_config=ComposioConfig(auth_config_id="ac_1", toolkit="stripe"),
+            )

--- a/apps/api/tests/unit/services/cli/test_connect.py
+++ b/apps/api/tests/unit/services/cli/test_connect.py
@@ -1,0 +1,264 @@
+"""Unit tests for the CLI connect state machine.
+
+The machine keeps no state of its own — every call re-reads the sandbox — so the
+tests drive it by varying only the observed :class:`CliState` and asserting the
+phase and the single action taken. That is exactly the contract the client polls
+against.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.constants.cli_integrations import LOGIN_TIMEOUT_SECONDS
+from app.models.cli_config import CliAuthSpec, CliConfig
+from app.services.cli import connect
+from app.services.cli.runtime import CliResult, CliState
+
+USER = "user-1"
+INTEGRATION = "stripe_link"
+
+DEVICE = CliConfig(
+    command="link-cli",
+    install_command="npm install x",
+    auth=CliAuthSpec(
+        kind="device",
+        login_command="link-cli auth login",
+        verify_command="link-cli auth status",
+    ),
+)
+TOKEN = CliConfig(
+    command="gh",
+    install_command="curl x",
+    auth=CliAuthSpec(
+        kind="token",
+        verify_command="gh auth status",
+        token_env="GH_TOKEN",
+        token_label="GitHub token",
+        token_help_url="https://github.test/tokens",
+    ),
+)
+NO_AUTH = CliConfig(
+    command="fmt",
+    install_command="npm i fmt",
+    auth=CliAuthSpec(kind="none", verify_command="fmt -v"),
+)
+
+
+def state(**overrides: object) -> CliState:
+    base: dict[str, object] = {
+        "installed": True,
+        "authenticated": False,
+        "login_running": False,
+        "login_age_seconds": None,
+        "login_output": "",
+        "install_error": "",
+    }
+    base.update(overrides)
+    return CliState(**base)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def env():
+    """Patch everything outside this module; expose the doubles for assertions."""
+    sandbox = MagicMock()
+
+    @contextlib.asynccontextmanager
+    async def _acquire(_user_id: str):
+        yield sandbox
+
+    with (
+        patch.object(connect, "acquire_sandbox", _acquire),
+        patch.object(connect, "add_user_integration", AsyncMock()) as add_user,
+        patch.object(
+            connect.user_integration_repository, "exists", AsyncMock(return_value=False)
+        ) as exists,
+        patch.object(connect, "update_user_integration_status", AsyncMock()) as set_status,
+        patch.object(connect.runtime, "probe_state", AsyncMock()) as probe,
+        patch.object(connect.runtime, "start_login", AsyncMock()) as start_login,
+        patch.object(connect.runtime, "write_token", AsyncMock()) as write_token,
+    ):
+        start_login.return_value = CliResult(exit_code=0, stdout="", stderr="")
+        write_token.return_value = CliResult(exit_code=0, stdout="", stderr="")
+        yield MagicMock(
+            sandbox=sandbox,
+            add_user=add_user,
+            exists=exists,
+            set_status=set_status,
+            probe=probe,
+            start_login=start_login,
+            write_token=write_token,
+        )
+
+
+class TestAlreadyAuthenticated:
+    async def test_reports_connected_and_records_it(self, env):
+        env.probe.return_value = state(authenticated=True)
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "connected"
+        assert outcome.is_terminal
+        env.set_status.assert_awaited_once_with(USER, INTEGRATION, "connected")
+
+    async def test_does_not_start_another_login(self, env):
+        env.probe.return_value = state(authenticated=True)
+        await connect.advance(USER, INTEGRATION, DEVICE)
+        env.start_login.assert_not_awaited()
+
+    async def test_attaches_the_integration_before_transitioning(self, env):
+        env.probe.return_value = state(authenticated=True)
+        await connect.advance(USER, INTEGRATION, DEVICE)
+        env.add_user.assert_awaited_once()
+
+
+class TestIdempotency:
+    """advance() IS the client's poll loop, so every call must be safe."""
+
+    async def test_does_not_re_add_an_integration_the_user_already_has(self, env):
+        # add_user_integration raises on a duplicate, so an unguarded add turns
+        # the second poll into "already added to workspace" and the connect
+        # dialog dies one tick after it opens.
+        env.exists.return_value = True
+        env.probe.return_value = state(login_running=True, login_age_seconds=3, login_output="go")
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        env.add_user.assert_not_awaited()
+        assert outcome.phase == "awaiting_approval"
+
+    async def test_repeated_polls_stay_on_the_same_phase(self, env):
+        env.exists.return_value = True
+        env.probe.return_value = state(login_running=True, login_age_seconds=3, login_output="go")
+        phases = [(await connect.advance(USER, INTEGRATION, DEVICE)).phase for _ in range(3)]
+        assert phases == ["awaiting_approval"] * 3
+        env.start_login.assert_not_awaited()
+
+
+class TestInstallFailure:
+    async def test_surfaces_the_install_error_to_the_user(self, env):
+        env.probe.return_value = state(installed=False, install_error="npm ERR! 404")
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "failed"
+        assert "link-cli" in (outcome.message or "")
+        assert "404" in (outcome.instructions or "")
+
+    async def test_never_marks_the_integration_connected(self, env):
+        env.probe.return_value = state(installed=False, install_error="boom")
+        await connect.advance(USER, INTEGRATION, DEVICE)
+        env.set_status.assert_not_awaited()
+
+
+class TestDeviceLogin:
+    async def test_starts_a_login_when_none_has_run(self, env):
+        env.probe.return_value = state()
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "awaiting_approval"
+        env.start_login.assert_awaited_once()
+
+    async def test_relays_the_cli_output_verbatim_while_polling(self, env):
+        instructions = 'verification_url: "https://link.test/d?code=abc"\nphrase: abc'
+        env.probe.return_value = state(
+            login_running=True, login_age_seconds=5, login_output=instructions
+        )
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "awaiting_approval"
+        assert outcome.instructions == instructions
+
+    async def test_does_not_restart_a_running_login(self, env):
+        env.probe.return_value = state(
+            login_running=True, login_age_seconds=5, login_output="go here"
+        )
+        await connect.advance(USER, INTEGRATION, DEVICE)
+        env.start_login.assert_not_awaited()
+
+    async def test_keeps_showing_a_finished_login_that_already_printed_its_code(self, env):
+        # Some CLIs print the code and exit, leaving the exchange to the next
+        # status call. Restarting there would invalidate the code the user is
+        # currently typing.
+        env.probe.return_value = state(
+            login_running=False, login_age_seconds=30, login_output="enter code ABC"
+        )
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "awaiting_approval"
+        assert outcome.instructions == "enter code ABC"
+        env.start_login.assert_not_awaited()
+
+    async def test_waits_rather_than_restarting_when_a_fresh_login_has_not_printed_yet(self, env):
+        env.probe.return_value = state(login_running=False, login_age_seconds=2, login_output="")
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "awaiting_approval"
+        env.start_login.assert_not_awaited()
+
+    async def test_restarts_once_the_previous_attempt_is_stale(self, env):
+        env.probe.return_value = state(
+            login_running=False,
+            login_age_seconds=LOGIN_TIMEOUT_SECONDS + 1,
+            login_output="expired code",
+        )
+        await connect.advance(USER, INTEGRATION, DEVICE)
+        env.start_login.assert_awaited_once()
+
+    async def test_reports_failure_when_the_login_cannot_be_started(self, env):
+        env.probe.return_value = state()
+        env.start_login.return_value = CliResult(exit_code=1, stdout="", stderr="no such command")
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "failed"
+        assert "no such command" in (outcome.instructions or "")
+
+
+class TestTokenAuth:
+    async def test_asks_for_the_token_with_the_configured_prompt(self, env):
+        env.probe.return_value = state()
+        outcome = await connect.advance(USER, "gh", TOKEN)
+        assert outcome.phase == "needs_token"
+        assert outcome.token_label == "GitHub token"
+        assert outcome.token_help_url == "https://github.test/tokens"
+
+    async def test_writes_a_supplied_token_before_re_probing(self, env):
+        env.probe.return_value = state(authenticated=True)
+        outcome = await connect.advance(USER, "gh", TOKEN, token="ghp_x")
+        env.write_token.assert_awaited_once()
+        assert env.write_token.await_args.args[3] == "ghp_x"
+        assert outcome.phase == "connected"
+
+    async def test_reports_a_rejected_token_instead_of_asking_again(self, env):
+        # Re-prompting on a bad token is an infinite loop from the user's side:
+        # they paste the same value and see the same dialog with no explanation.
+        env.probe.return_value = state(authenticated=False)
+        outcome = await connect.advance(USER, "gh", TOKEN, token="bad")
+        assert outcome.phase == "failed"
+        assert "did not accept" in (outcome.message or "")
+
+    async def test_surfaces_a_write_failure(self, env):
+        env.write_token.return_value = CliResult(exit_code=1, stdout="", stderr="invalid token")
+        outcome = await connect.advance(USER, "gh", TOKEN, token="bad")
+        assert outcome.phase == "failed"
+        assert "invalid token" in (outcome.instructions or "")
+        env.probe.assert_not_awaited()
+
+    async def test_never_starts_a_device_login(self, env):
+        env.probe.return_value = state()
+        await connect.advance(USER, "gh", TOKEN)
+        env.start_login.assert_not_awaited()
+
+
+class TestNoAuth:
+    async def test_connects_when_the_cli_reports_ready(self, env):
+        env.probe.return_value = state(authenticated=True)
+        assert (await connect.advance(USER, "fmt", NO_AUTH)).phase == "connected"
+
+    async def test_fails_when_the_cli_does_not_report_ready(self, env):
+        # Nothing to log into, so a failing verify means a broken install, not a
+        # missing credential — asking the user for one would be misleading.
+        env.probe.return_value = state(authenticated=False)
+        outcome = await connect.advance(USER, "fmt", NO_AUTH)
+        assert outcome.phase == "failed"
+        assert "not reporting as ready" in (outcome.message or "")
+
+
+class TestIsConnected:
+    async def test_defers_entirely_to_the_cli(self, env):
+        env.probe.return_value = state(authenticated=True)
+        assert await connect.is_connected(USER, INTEGRATION, DEVICE) is True
+        env.probe.return_value = state(authenticated=False)
+        assert await connect.is_connected(USER, INTEGRATION, DEVICE) is False

--- a/apps/api/tests/unit/services/cli/test_connect.py
+++ b/apps/api/tests/unit/services/cli/test_connect.py
@@ -58,7 +58,7 @@ def state(**overrides: object) -> CliState:
         "install_error": "",
     }
     base.update(overrides)
-    return CliState(**base)  # type: ignore[arg-type]
+    return CliState(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
 
 
 @pytest.fixture

--- a/apps/api/tests/unit/services/cli/test_connect.py
+++ b/apps/api/tests/unit/services/cli/test_connect.py
@@ -256,14 +256,6 @@ class TestNoAuth:
         assert "not reporting as ready" in (outcome.message or "")
 
 
-class TestIsConnected:
-    async def test_defers_entirely_to_the_cli(self, env):
-        env.probe.return_value = state(authenticated=True)
-        assert await connect.is_connected(USER, INTEGRATION, DEVICE) is True
-        env.probe.return_value = state(authenticated=False)
-        assert await connect.is_connected(USER, INTEGRATION, DEVICE) is False
-
-
 class TestReviewFixes:
     """Behaviours added after review; each one had a concrete failure."""
 
@@ -308,3 +300,48 @@ class TestReviewFixes:
         env.add_user.side_effect = RuntimeError("mongo down")
         with pytest.raises(RuntimeError):
             await connect.advance(USER, INTEGRATION, DEVICE)
+
+
+class TestInfrastructureFailuresAreExplained:
+    """A user cannot act on "500: failed to run reserve script"."""
+
+    async def test_an_unavailable_sandbox_says_what_to_do(self, env):
+        from app.services.sandbox import SandboxAcquisitionError
+
+        with patch.object(
+            connect,
+            "acquire_sandbox",
+            MagicMock(side_effect=SandboxAcquisitionError("e2b 500: reserve script failed")),
+        ):
+            outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+
+        assert outcome.phase == "failed"
+        assert "link-cli" in (outcome.message or "")
+        assert "try again" in (outcome.message or "").lower()
+
+    async def test_a_sandbox_rate_limit_is_named_as_the_users_own_quota(self, env):
+        from app.services.sandbox.errors import SandboxRateLimitError
+
+        with patch.object(
+            connect,
+            "acquire_sandbox",
+            MagicMock(side_effect=SandboxRateLimitError("too many")),
+        ):
+            outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+
+        assert outcome.phase == "failed"
+        assert "too many workspaces" in (outcome.message or "")
+        # A quota is not a broken integration, so no upstream noise is shown.
+        assert outcome.instructions is None
+
+    async def test_the_integration_is_still_attached_before_the_failure(self, env):
+        from app.services.sandbox import SandboxAcquisitionError
+
+        with patch.object(
+            connect,
+            "acquire_sandbox",
+            MagicMock(side_effect=SandboxAcquisitionError("down")),
+        ):
+            await connect.advance(USER, INTEGRATION, DEVICE)
+        # Otherwise a user who hits a blip has no record to retry against.
+        env.add_user.assert_awaited_once()

--- a/apps/api/tests/unit/services/cli/test_connect.py
+++ b/apps/api/tests/unit/services/cli/test_connect.py
@@ -262,3 +262,49 @@ class TestIsConnected:
         assert await connect.is_connected(USER, INTEGRATION, DEVICE) is True
         env.probe.return_value = state(authenticated=False)
         assert await connect.is_connected(USER, INTEGRATION, DEVICE) is False
+
+
+class TestReviewFixes:
+    """Behaviours added after review; each one had a concrete failure."""
+
+    async def test_a_token_sent_to_a_device_login_is_ignored_not_fatal(self, env):
+        # The connect endpoint is public and carries bearer_token for the MCP
+        # transport, so a token can arrive for a device CLI. Writing it would
+        # raise on the missing token_env and surface as an opaque error.
+        env.probe.return_value = state(login_running=True, login_age_seconds=2, login_output="go")
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE, token="stray")
+        env.write_token.assert_not_awaited()
+        assert outcome.phase == "awaiting_approval"
+
+    async def test_a_failed_login_start_does_not_leak_sandbox_paths(self, env):
+        env.probe.return_value = state()
+        env.start_login.return_value = CliResult(
+            exit_code=1, stdout="", stderr="cannot write /workspace/.gaia/apps/x/login.log"
+        )
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "failed"
+        assert "/workspace" not in (outcome.instructions or "")
+
+    async def test_a_rejected_token_does_not_leak_sandbox_paths(self, env):
+        env.exists.return_value = False
+        env.write_token.return_value = CliResult(
+            exit_code=1, stdout="", stderr="bad token; see /home/user/.gaia/apps/gh/install.log"
+        )
+        outcome = await connect.advance(USER, "gh", TOKEN, token="bad")
+        assert outcome.phase == "failed"
+        assert "/home/user" not in (outcome.instructions or "")
+
+    async def test_a_duplicate_attach_losing_a_race_is_not_an_error(self, env):
+        # Two overlapping polls both see "absent"; the loser's insert raises.
+        # That must stay a no-op, not a user-visible connect failure.
+        env.exists.return_value = False
+        env.add_user.side_effect = ValueError("Integration 'x' already added to workspace")
+        env.probe.return_value = state(authenticated=True)
+        outcome = await connect.advance(USER, INTEGRATION, DEVICE)
+        assert outcome.phase == "connected"
+
+    async def test_an_unrelated_attach_failure_still_propagates(self, env):
+        env.exists.return_value = False
+        env.add_user.side_effect = RuntimeError("mongo down")
+        with pytest.raises(RuntimeError):
+            await connect.advance(USER, INTEGRATION, DEVICE)

--- a/apps/api/tests/unit/services/cli/test_runtime.py
+++ b/apps/api/tests/unit/services/cli/test_runtime.py
@@ -1,0 +1,290 @@
+"""Unit tests for the CLI sandbox runtime.
+
+The scripts this module generates are executed by a real shell inside the
+sandbox, so the tests that matter most check them AS SHELL: every script is
+parsed with ``sh -n``, including with adversarial install commands and
+integration ids. A quoting bug here is not a cosmetic defect — it is arbitrary
+shell in the user's sandbox, or an install that silently never happens.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.constants.cli_integrations import app_dir, home_dir, launcher_path
+from app.models.cli_config import CliAuthSpec, CliConfig
+from app.services.cli import runtime
+
+pytestmark = pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX sh required")
+
+
+def make_config(**overrides: object) -> CliConfig:
+    base: dict[str, object] = {
+        "command": "link-cli",
+        "install_command": "npm install @stripe/link-cli",
+        "auth": CliAuthSpec(
+            kind="device",
+            login_command="link-cli auth login",
+            verify_command="link-cli auth status",
+        ),
+    }
+    base.update(overrides)
+    return CliConfig(**base)  # type: ignore[arg-type]
+
+
+def assert_valid_shell(script: str) -> None:
+    """Parse the script with a real shell; fail with its complaint if invalid."""
+    result = subprocess.run(["sh", "-n"], input=script, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, f"generated script is not valid shell:\n{result.stderr}"
+
+
+class TestGeneratedScriptsAreValidShell:
+    def test_install_script_parses(self):
+        assert_valid_shell(runtime._install_script("stripe_link", make_config()))
+
+    def test_wrapped_command_parses(self):
+        assert_valid_shell(runtime._wrap("stripe_link", make_config(), "link-cli --version"))
+
+    @pytest.mark.parametrize(
+        "install_command",
+        [
+            "npm install pkg && echo done",
+            "curl -fsSL 'https://example.test/a b.tgz' -o x.tgz && tar -xzf x.tgz",
+            'printf "#!/bin/sh\\necho hi\\n" > bin/tool && chmod +x bin/tool',
+            "sh -c 'echo nested single quotes'",
+            'echo "double \\"escaped\\" quotes"',
+            "echo $HOME && echo ${PATH} && echo `date`",
+            "echo 'unbalanced-looking; but fine'",
+            "for i in 1 2 3; do echo $i; done",
+        ],
+    )
+    def test_install_command_is_embedded_verbatim_and_stays_parseable(self, install_command: str):
+        # install_command is intentionally free-form shell (that is what makes an
+        # arbitrary vendor CLI installable), so it is embedded rather than quoted
+        # — but embedding it must not break the surrounding script.
+        script = runtime._install_script("app_id", make_config(install_command=install_command))
+        assert install_command in script
+        assert_valid_shell(script)
+
+    @pytest.mark.parametrize(
+        "user_command",
+        [
+            "link-cli --version",
+            "link-cli auth status --format json | grep -q true",
+            "link-cli list && echo ok || echo failed",
+            "link-cli x > out.json 2>&1",
+            "echo 'single' && echo \"double\"",
+        ],
+    )
+    def test_user_commands_keep_shell_features(self, user_command: str):
+        script = runtime._wrap("app_id", make_config(), user_command)
+        assert user_command in script
+        assert_valid_shell(script)
+
+    def test_probe_state_script_parses_with_a_piped_verify_command(self):
+        config = make_config(
+            auth=CliAuthSpec(
+                kind="device",
+                login_command="link-cli auth login",
+                verify_command=(
+                    "link-cli auth status --format json "
+                    "| grep -qi '\"authenticated\"[[:space:]]*:[[:space:]]*true'"
+                ),
+            )
+        )
+        # probe_state builds its script through _wrap; rebuild the same shape.
+        script = runtime._wrap(
+            "stripe_link", config, f"if ( {config.auth.verify_command} ); then :; fi"
+        )
+        assert_valid_shell(script)
+
+
+class TestLauncher:
+    def test_points_home_at_durable_storage(self):
+        body = runtime._launcher_body("stripe_link")
+        assert f"export HOME={home_dir('stripe_link')}" in body
+        # The durable home must be the JuiceFS workspace, never local disk:
+        # local disk is lost when the sandbox is recreated, which would log the
+        # user out of every CLI roughly hourly.
+        assert home_dir("stripe_link").startswith("/workspace/")
+
+    def test_sets_xdg_variables_for_tools_that_honour_them(self):
+        body = runtime._launcher_body("x")
+        for var in ("XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME"):
+            assert f"export {var}=" in body
+
+    def test_sources_the_credential_env_file_when_present(self):
+        body = runtime._launcher_body("x")
+        assert 'if [ -f "$HOME/.gaia-env" ]' in body
+        assert '. "$HOME/.gaia-env"' in body
+
+    def test_execs_the_resolved_binary_with_all_arguments(self):
+        assert 'exec "$GAIA_CLI_BINARY" "$@"' in runtime._launcher_body("x")
+
+    def test_search_path_covers_every_install_layout(self):
+        path = runtime._bin_search_path("app_id")
+        app = app_dir("app_id")
+        # npm, release tarball, pip --user, and a bare downloaded binary.
+        for expected in (f"{app}/node_modules/.bin", f"{app}/bin", f"{app}/.local/bin", app):
+            assert expected in path
+
+
+class TestInstallGuard:
+    def test_skips_install_when_the_marker_and_launcher_both_exist(self):
+        script = runtime._install_script("app_id", make_config())
+        # The guard reinstalls when EITHER is missing: the marker alone is not
+        # enough, because the launcher lives on local disk and a sandbox can be
+        # recreated with a stale marker from a previous layout.
+        assert "if [ ! -f " in script
+        assert "|| [ ! -x " in script
+
+    def test_reports_a_distinct_exit_code_for_install_failure(self):
+        script = runtime._install_script("app_id", make_config())
+        assert f"exit {runtime.INSTALL_FAILED_EXIT_CODE}" in script
+
+    def test_install_runs_with_home_on_local_disk(self):
+        # npm's cache is hundreds of small files; on JuiceFS the same install
+        # was measured at >600s versus ~20s locally.
+        script = runtime._install_script("app_id", make_config())
+        assert f"export HOME={app_dir('app_id')}/.home" in script
+
+    def test_writes_the_launcher_for_the_configured_command(self):
+        script = runtime._install_script("app_id", make_config(command="gh"))
+        assert launcher_path("gh") in script
+
+
+class TestParseState:
+    def test_reads_every_flag(self):
+        stdout = (
+            f"{runtime._STATE_LINE} authenticated=1 running=0 age=42\n"
+            f"{runtime._OUTPUT_BEGIN}\n"
+            "go to https://example.test\ncode ABCD\n"
+        )
+        state = runtime._parse_state(stdout)
+        assert state.installed is True
+        assert state.authenticated is True
+        assert state.login_running is False
+        assert state.login_age_seconds == 42
+        assert state.login_output == "go to https://example.test\ncode ABCD"
+
+    def test_negative_age_means_no_login_has_been_started(self):
+        stdout = (
+            f"{runtime._STATE_LINE} authenticated=0 running=0 age=-1\n{runtime._OUTPUT_BEGIN}\n"
+        )
+        assert runtime._parse_state(stdout).login_age_seconds is None
+
+    def test_output_after_the_marker_is_captured_verbatim_including_markers(self):
+        # A CLI could legitimately print something resembling our own marker;
+        # everything after the first output marker is payload, not protocol.
+        stdout = (
+            f"{runtime._STATE_LINE} authenticated=0 running=1 age=3\n"
+            f"{runtime._OUTPUT_BEGIN}\n"
+            f"{runtime._STATE_LINE} authenticated=1 running=0 age=0\n"
+        )
+        state = runtime._parse_state(stdout)
+        assert state.authenticated is False, "a marker inside CLI output must not be re-read"
+        assert runtime._STATE_LINE in state.login_output
+
+    def test_missing_state_line_reports_not_installed(self):
+        assert runtime._parse_state("total garbage").installed is False
+
+    def test_empty_stdout_reports_not_installed(self):
+        state = runtime._parse_state("")
+        assert state.installed is False
+        assert state.authenticated is False
+
+    def test_output_is_truncated_to_the_documented_bound(self):
+        from app.constants.cli_integrations import LOGIN_OUTPUT_MAX_CHARS
+
+        stdout = (
+            f"{runtime._STATE_LINE} authenticated=0 running=1 age=1\n"
+            f"{runtime._OUTPUT_BEGIN}\n" + ("x" * (LOGIN_OUTPUT_MAX_CHARS * 2))
+        )
+        assert len(runtime._parse_state(stdout).login_output) <= LOGIN_OUTPUT_MAX_CHARS
+
+
+class TestProbeStateInstallFailure:
+    async def test_reports_the_install_error_rather_than_not_authenticated(self):
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(
+            return_value=MagicMock(
+                exit_code=runtime.INSTALL_FAILED_EXIT_CODE,
+                stdout="",
+                stderr="npm ERR! 404 no such package",
+            )
+        )
+        state = await runtime.probe_state(sandbox, "app_id", make_config())
+        assert state.installed is False
+        assert state.authenticated is False
+        assert "404" in state.install_error
+
+
+class TestWriteToken:
+    async def test_never_puts_the_secret_in_a_shell_command(self):
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(return_value=MagicMock(exit_code=0, stdout="", stderr=""))
+        sandbox.files.write = AsyncMock()
+        config = make_config(
+            auth=CliAuthSpec(
+                kind="token",
+                verify_command="gh auth status",
+                token_env="GH_TOKEN",
+                token_label="GitHub token",
+            )
+        )
+        secret = "ghp_supersecretvalue"
+
+        await runtime.write_token(sandbox, "gh", config, secret)
+
+        sandbox.files.write.assert_awaited_once()
+        path, body = sandbox.files.write.await_args.args
+        assert path == f"{home_dir('gh')}/.gaia-env"
+        assert secret in body
+        # argv and shell history are readable inside the sandbox and are
+        # persisted by the bash tool's run logs; the secret must not reach them.
+        for call in sandbox.commands.run.await_args_list:
+            assert secret not in call.args[0]
+
+
+class TestUserVisibleOutput:
+    """CLI output is relayed to the user verbatim, minus GAIA's own plumbing."""
+
+    def test_drops_lines_naming_the_durable_home(self):
+        text = (
+            'verification_url: "https://app.link.com/device/setup?code=abc"\n'
+            "credentials_path: /workspace/.gaia/apps/stripe_link/.config/x.json\n"
+            "phrase: abc"
+        )
+        out = runtime.user_visible_output(text)
+        assert "/workspace" not in out
+        assert "https://app.link.com/device/setup?code=abc" in out
+        assert "phrase: abc" in out
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "config written to /home/user/.gaia/apps/gh/x",
+            "installed into /opt/gaia/runtime/bin",
+            "see /workspace/.gaia/apps/gh/install.log",
+        ],
+    )
+    def test_drops_every_internal_root(self, line: str):
+        assert runtime.user_visible_output(f"keep me\n{line}\nkeep me too") == (
+            "keep me\nkeep me too"
+        )
+
+    def test_keeps_vendor_paths_that_are_not_ours(self):
+        # A vendor's own URL or a path on the user's real machine is theirs to
+        # show; only GAIA's sandbox roots are noise.
+        text = "open https://dashboard.example.test/tokens\nrun: gh auth login"
+        assert runtime.user_visible_output(text) == text
+
+    def test_empty_input_stays_empty(self):
+        assert runtime.user_visible_output("") == ""
+
+    def test_output_that_is_entirely_internal_collapses_to_nothing(self):
+        assert runtime.user_visible_output("/workspace/a\n/opt/gaia/b") == ""

--- a/apps/api/tests/unit/services/cli/test_runtime.py
+++ b/apps/api/tests/unit/services/cli/test_runtime.py
@@ -9,10 +9,12 @@ shell in the user's sandbox, or an install that silently never happens.
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 from unittest.mock import AsyncMock, MagicMock
 
+from e2b import CommandExitException
 import pytest
 
 from app.constants.cli_integrations import app_dir, home_dir, launcher_path
@@ -34,6 +36,26 @@ def make_config(**overrides: object) -> CliConfig:
     }
     base.update(overrides)
     return CliConfig(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
+
+
+def _token_config(**overrides: object) -> CliConfig:
+    """A token-shape CLI: the only shape that has a secret to write."""
+    spec: dict[str, object] = {
+        "kind": "token",
+        "verify_command": "gh auth status",
+        "token_env": "GH_TOKEN",
+        "token_label": "GitHub token",
+    }
+    spec.update(overrides)
+    return make_config(command="gh", auth=CliAuthSpec(**spec))  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
+
+
+def _token_sandbox() -> MagicMock:
+    """A sandbox where every command succeeds, so only the writes vary."""
+    sandbox = MagicMock()
+    sandbox.commands.run = AsyncMock(return_value=MagicMock(exit_code=0, stdout="", stderr=""))
+    sandbox.files.write = AsyncMock()
+    return sandbox
 
 
 def assert_valid_shell(script: str) -> None:
@@ -249,6 +271,95 @@ class TestWriteToken:
         for call in sandbox.commands.run.await_args_list:
             assert secret not in call.args[0]
 
+    async def test_the_env_file_exports_the_configured_variable(self):
+        # The launcher sources this file and the CLI reads its own vendor-native
+        # variable name; export the wrong one and the CLI is simply never
+        # authenticated, with no error anywhere to say why.
+        sandbox = _token_sandbox()
+        config = _token_config(token_env="CLOUDFLARE_API_TOKEN")
+
+        await runtime.write_token(sandbox, "wrangler", config, "cf-secret")
+
+        path, body = sandbox.files.write.await_args.args
+        assert path == f"{home_dir('wrangler')}/.gaia-env"
+        assert body == "export CLOUDFLARE_API_TOKEN=cf-secret\n"
+
+    async def test_a_token_containing_shell_metacharacters_cannot_break_out(self):
+        # The file is sourced by the launcher on every invocation, so an
+        # unquoted value is arbitrary shell running before every CLI call.
+        sandbox = _token_sandbox()
+        nasty = "abc'; rm -rf / #"
+
+        await runtime.write_token(sandbox, "gh", _token_config(), nasty)
+
+        _path, body = sandbox.files.write.await_args.args
+        assert_valid_shell(body)
+        # The payload survives as data, not as a second command.
+        assert body == f"export GH_TOKEN={shlex.quote(nasty)}\n"
+
+    async def test_the_credential_file_is_locked_down(self):
+        sandbox = _token_sandbox()
+
+        await runtime.write_token(sandbox, "gh", _token_config(), "secret")
+
+        path = f"{home_dir('gh')}/.gaia-env"
+        chmods = [
+            call.args[0]
+            for call in sandbox.commands.run.await_args_list
+            if call.args[0].startswith("chmod")
+        ]
+        assert chmods == [f"chmod 0600 {shlex.quote(path)}"]
+
+    async def test_a_failed_install_never_writes_the_token(self):
+        # The install is what creates the durable HOME and the launcher that
+        # sources this file. Writing first would drop a credential into a
+        # directory nothing reads, and report success.
+        sandbox = MagicMock()
+        sandbox.files.write = AsyncMock()
+        sandbox.commands.run = AsyncMock(
+            return_value=MagicMock(
+                exit_code=runtime.INSTALL_FAILED_EXIT_CODE, stdout="", stderr="npm ERR! 404"
+            )
+        )
+
+        result = await runtime.write_token(sandbox, "gh", _token_config(), "secret")
+
+        assert result.ok is False
+        assert "404" in result.stderr
+        sandbox.files.write.assert_not_awaited()
+
+    async def test_exporting_the_variable_is_the_whole_login_when_no_login_command(self):
+        # Most token CLIs need nothing else. Running a login command that was
+        # never configured would fail the connect for a CLI that is in fact
+        # authenticated.
+        sandbox = _token_sandbox()
+        config = _token_config()
+        assert config.auth.login_command is None
+
+        result = await runtime.write_token(sandbox, "gh", config, "secret")
+
+        assert result.ok is True
+        assert not [
+            call.args[0]
+            for call in sandbox.commands.run.await_args_list
+            if "auth login" in call.args[0]
+        ]
+
+    async def test_a_configured_login_command_is_run_with_the_token_in_place(self):
+        # `gh auth login --with-token` materialises the CLI's own config from
+        # the exported variable, so it has to run AFTER the env file exists.
+        sandbox = _token_sandbox()
+        config = _token_config(login_command="gh auth login --with-token")
+
+        await runtime.write_token(sandbox, "gh", config, "secret")
+
+        scripts = [call.args[0] for call in sandbox.commands.run.await_args_list]
+        login = [s for s in scripts if "gh auth login --with-token" in s]
+        assert len(login) == 1
+        assert scripts.index(login[0]) > scripts.index(
+            next(s for s in scripts if s.startswith("chmod"))
+        )
+
 
 class TestUserVisibleOutput:
     """CLI output is relayed to the user verbatim, minus GAIA's own plumbing."""
@@ -349,3 +460,98 @@ class TestLoginLifecycleHardening:
         kill_index = script.index("kill ")
         remove_index = script.index("rm -f")
         assert kill_index < remove_index, "the predecessor must die before its pid file is removed"
+
+
+class TestRunningAScriptInTheSandbox:
+    """``_run`` is the single door to the sandbox, and the only place e2b's
+    exception-on-nonzero is turned back into a result.
+
+    A CLI exiting non-zero is ordinary — not signed in, no such repo — and the
+    connect state machine reads the exit code to decide what to do next. An
+    escaped exception would surface as "failed to connect" for a CLI that
+    merely answered "no".
+    """
+
+    async def test_the_callers_timeout_and_directory_reach_the_sandbox(self):
+        # The timeout is the only bound on a hung vendor CLI, and the cwd is
+        # what puts anything the CLI writes into the turn's session directory.
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(return_value=MagicMock(exit_code=0, stdout="", stderr=""))
+
+        await runtime._run(sandbox, "echo hi", timeout=45, cwd="/workspace/session-7")
+
+        sandbox.commands.run.assert_awaited_once_with(
+            "echo hi", timeout=45, cwd="/workspace/session-7"
+        )
+
+    async def test_absent_output_is_reported_as_empty_not_as_missing(self):
+        # e2b returns None for a stream that produced nothing. Callers slice and
+        # search these, and `user_visible_output` splits them.
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(
+            return_value=MagicMock(exit_code=0, stdout=None, stderr=None)
+        )
+
+        result = await runtime._run(sandbox, "true", timeout=5)
+
+        assert result.stdout == ""
+        assert result.stderr == ""
+        assert result.exit_code == 0
+
+    async def test_output_that_exists_is_passed_through_untouched(self):
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(
+            return_value=MagicMock(exit_code=0, stdout="hello", stderr="warn")
+        )
+
+        result = await runtime._run(sandbox, "true", timeout=5)
+
+        assert result.stdout == "hello"
+        assert result.stderr == "warn"
+
+    async def test_a_non_zero_exit_becomes_a_result_carrying_the_reason(self):
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(
+            side_effect=CommandExitException(
+                stderr="gh: not logged in", stdout="partial", exit_code=4, error=None
+            )
+        )
+
+        result = await runtime._run(sandbox, "gh auth status", timeout=5)
+
+        assert result.ok is False
+        assert result.exit_code == 4
+        assert result.stdout == "partial"
+        assert result.stderr == "gh: not logged in"
+
+    async def test_a_non_zero_exit_with_no_output_still_reports_empty_strings(self):
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(
+            side_effect=CommandExitException(stderr="", stdout="", exit_code=1, error=None)
+        )
+
+        result = await runtime._run(sandbox, "false", timeout=5)
+
+        assert result.exit_code == 1
+        assert result.stdout == ""
+        assert result.stderr == ""
+
+
+class TestExecuteForwardsTheCallersIntent:
+    async def test_the_command_runs_for_this_integration_with_its_bounds(self):
+        # `execute` is what the agent's CLI tool calls: the integration decides
+        # which launcher is on PATH, and the timeout/cwd come from the call.
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(return_value=MagicMock(exit_code=0, stdout="", stderr=""))
+        config = make_config()
+
+        await runtime.execute(
+            sandbox, "stripe_link", config, "link-cli --version", timeout=30, cwd="/workspace/s1"
+        )
+
+        script, kwargs = (
+            sandbox.commands.run.await_args.args[0],
+            sandbox.commands.run.await_args.kwargs,
+        )
+        assert kwargs == {"timeout": 30, "cwd": "/workspace/s1"}
+        assert script == runtime._wrap("stripe_link", config, "link-cli --version")

--- a/apps/api/tests/unit/services/cli/test_runtime.py
+++ b/apps/api/tests/unit/services/cli/test_runtime.py
@@ -288,3 +288,64 @@ class TestUserVisibleOutput:
 
     def test_output_that_is_entirely_internal_collapses_to_nothing(self):
         assert runtime.user_visible_output("/workspace/a\n/opt/gaia/b") == ""
+
+
+class TestLoginLifecycleHardening:
+    """Defects found reviewing this branch, each with a concrete failure."""
+
+    def test_age_is_measured_from_the_pid_file_not_the_log(self):
+        # The log's mtime is its LAST WRITE. A login that prints progress while
+        # it polls (link-cli auth login --interval does exactly this) would look
+        # permanently fresh, so the connect flow would never restart an expired
+        # device code and the user would stare at a dead one until the client
+        # cap fired.
+        script = runtime._state_script("app_id", make_config())
+        assert runtime._login_pid_path("app_id") in script
+        stat_lines = [line for line in script.splitlines() if "stat -c %Y" in line]
+        assert stat_lines, "expected an mtime read"
+        for line in stat_lines:
+            assert runtime._login_pid_path("app_id") in line
+            assert runtime._login_log_path("app_id") not in line
+
+    def test_the_verify_command_carries_its_own_deadline_and_no_stdin(self):
+        # Without these, an authored verify_command that waits on a TTY blocks
+        # for the whole probe budget while holding the per-user sandbox lock,
+        # queueing every other tool call that user makes behind it.
+        from app.constants.cli_integrations import VERIFY_TIMEOUT_SECONDS
+
+        script = runtime._state_script("app_id", make_config())
+        assert f"timeout {VERIFY_TIMEOUT_SECONDS}" in script
+        assert "</dev/null" in script
+
+    def test_a_verify_command_with_a_pipe_survives_being_bounded(self):
+        # The bound wraps the command in `sh -c`, so it has to be quoted as one
+        # argument or a piped verify would be split.
+        config = make_config(
+            auth=CliAuthSpec(
+                kind="device",
+                login_command="tool auth login",
+                verify_command="tool auth status --json | grep -q true",
+            )
+        )
+        script = runtime._wrap("app_id", config, runtime._state_script("app_id", config))
+        assert_valid_shell(script)
+        assert "grep -q true" in script
+
+    def test_the_login_log_read_is_bounded_in_the_sandbox(self):
+        # Truncating in Python still pulls an unbounded log across the wire on
+        # every one of up to 240 poll ticks.
+        script = runtime._state_script("app_id", make_config())
+        assert "tail -c" in script
+        assert f"cat {runtime._login_log_path('app_id')}" not in script
+
+    async def test_starting_a_login_kills_the_one_it_replaces(self):
+        # Deleting the pid file without killing the process orphans it: its only
+        # handle is gone, so cancel_login can never reach it.
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(return_value=MagicMock(exit_code=0, stdout="", stderr=""))
+        await runtime.start_login(sandbox, "app_id", make_config())
+
+        script = sandbox.commands.run.await_args.args[0]
+        kill_index = script.index("kill ")
+        remove_index = script.index("rm -f")
+        assert kill_index < remove_index, "the predecessor must die before its pid file is removed"

--- a/apps/api/tests/unit/services/cli/test_runtime.py
+++ b/apps/api/tests/unit/services/cli/test_runtime.py
@@ -33,7 +33,7 @@ def make_config(**overrides: object) -> CliConfig:
         ),
     }
     base.update(overrides)
-    return CliConfig(**base)  # type: ignore[arg-type]
+    return CliConfig(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
 
 
 def assert_valid_shell(script: str) -> None:

--- a/apps/api/tests/unit/services/hil/test_hil_classification.py
+++ b/apps/api/tests/unit/services/hil/test_hil_classification.py
@@ -22,7 +22,7 @@ from app.services.hil.classification import (
     is_tool_destructive,
     mcp_destructive_hint,
 )
-from app.services.hil.prompts import TOOL_CLASSIFY_PROMPT
+from app.services.hil.prompts import CLI_COMMAND_CLASSIFY_PROMPT, TOOL_CLASSIFY_PROMPT
 from app.services.mcp.langchain_adapter import MCP_ANNOTATIONS_METADATA_KEY
 
 from .conftest import make_tool
@@ -263,3 +263,103 @@ class TestTheClassifierCallItself:
         assert prompt == TOOL_CLASSIFY_PROMPT.format(
             name="mystery_tool", description="(none provided)"
         )
+
+
+class TestCliCommandClassification:
+    """A CLI integration is ONE tool, so a name-keyed verdict would gate `gh pr list`
+    exactly as hard as `gh repo delete` — or, far worse, gate neither. These pin the
+    verdict to the command, and pin the registry's name-keyed flag out of the way."""
+
+    async def test_two_commands_of_one_tool_get_two_independent_verdicts(self) -> None:
+        # The bug this whole path exists for: one tool name, two risks. A verdict cached
+        # for a listing must never answer for a deletion.
+        verdicts = {
+            "gh pr list": _ClassifyResult(is_destructive=False, rationale="reads"),
+            "gh repo delete": _ClassifyResult(is_destructive=True, rationale="irreversible"),
+        }
+        cache: dict[tuple[str, str], HILToolRiskRecord] = {}
+
+        async def find(tool_name: str, subject_hash: str) -> HILToolRiskRecord | None:
+            return cache.get((tool_name, subject_hash))
+
+        async def upsert(record: HILToolRiskRecord) -> None:
+            cache[(record.tool_name, record.description_hash)] = record
+
+        async def classify(_schema: object, prompt: str, **_kwargs: object) -> _ClassifyResult:
+            return next(v for shape, v in verdicts.items() if prompt.endswith(shape))
+
+        with (
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(f"{MODULE}.ainvoke_structured", side_effect=classify) as llm,
+        ):
+            repo.find_classification = AsyncMock(side_effect=find)
+            repo.upsert_classification = AsyncMock(side_effect=upsert)
+
+            listing = await is_tool_destructive("run_gh", "Run gh.", command_shape="gh pr list")
+            deleting = await is_tool_destructive(
+                "run_gh", "Run gh.", command_shape="gh repo delete"
+            )
+            # The same command again is served from the cache, not re-judged.
+            again = await is_tool_destructive("run_gh", "Run gh.", command_shape="gh repo delete")
+
+        assert (listing, deleting, again) == (False, True, True)
+        assert llm.await_count == 2
+        assert {record.command_shape for record in cache.values()} == {
+            "gh pr list",
+            "gh repo delete",
+        }
+
+    async def test_the_registry_flag_is_neither_read_nor_written_for_a_command(self) -> None:
+        # Writing back would poison every other command of the same CLI through the
+        # name-keyed flag; reading it would let one poisoned entry answer for all of them.
+        registry = registry_with(False)
+        with (
+            patch(f"{MODULE}.get_tool_registry", new=AsyncMock(return_value=registry)) as get_reg,
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(
+                f"{MODULE}.ainvoke_structured",
+                new=AsyncMock(return_value=_ClassifyResult(is_destructive=True, rationale="del")),
+            ),
+        ):
+            repo.find_classification = AsyncMock(return_value=None)
+            repo.upsert_classification = AsyncMock()
+            result = await is_tool_destructive("run_gh", "Run gh.", command_shape="gh repo delete")
+
+        assert result is True
+        assert get_reg.await_count == 0
+        registry.mark_tool_destructive.assert_not_called()
+
+    async def test_an_unshapeable_command_gates_without_asking_anyone(self) -> None:
+        with (
+            patch(f"{MODULE}.get_tool_registry", new=AsyncMock()) as get_reg,
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(f"{MODULE}.ainvoke_structured", new=AsyncMock()) as llm,
+        ):
+            repo.find_classification = AsyncMock(return_value=None)
+            assert await is_tool_destructive("run_gh", "Run gh.", command_shape="") is True
+
+        assert llm.await_count == 0
+        assert get_reg.await_count == 0
+        repo.find_classification.assert_not_awaited()
+
+    async def test_a_broken_cache_still_gates_the_command(self, mongo: MagicMock) -> None:
+        mongo.find_classification = AsyncMock(side_effect=ConnectionError("mongo down"))
+        with patch(f"{MODULE}.ainvoke_structured", new=AsyncMock()):
+            assert (
+                await is_tool_destructive("run_gh", "Run gh.", command_shape="gh pr list") is True
+            )
+
+    async def test_the_classifier_is_shown_the_command_it_is_judging(self) -> None:
+        # Without the command in the prompt the verdict is about `run_gh` in the
+        # abstract, which is exactly the useless answer this replaces.
+        with patch(
+            f"{MODULE}.ainvoke_structured",
+            new=AsyncMock(return_value=_ClassifyResult(is_destructive=True)),
+        ) as llm:
+            await _classify_with_llm("run_gh", "Run the gh CLI.", "gh repo delete")
+
+        _schema, prompt = llm.await_args.args
+        assert prompt == CLI_COMMAND_CLASSIFY_PROMPT.format(
+            name="run_gh", description="Run the gh CLI.", command="gh repo delete"
+        )
+        assert llm.await_args.kwargs["label"] == "hil_tool_classification"

--- a/apps/api/tests/unit/services/hil/test_hil_classification.py
+++ b/apps/api/tests/unit/services/hil/test_hil_classification.py
@@ -15,6 +15,7 @@ import pytest
 
 from app.agents.llm.client import SILENT_LLM_CONFIG, StructuredCallOptions
 from app.constants.hil import HIL_LLM_TIMEOUT_SECONDS
+from app.constants.log_tags import LogTag
 from app.models.hil_models import HILToolRiskRecord
 from app.services.hil.classification import (
     _classify_with_llm,
@@ -24,6 +25,8 @@ from app.services.hil.classification import (
 )
 from app.services.hil.prompts import CLI_COMMAND_CLASSIFY_PROMPT, TOOL_CLASSIFY_PROMPT
 from app.services.mcp.langchain_adapter import MCP_ANNOTATIONS_METADATA_KEY
+from shared.py.wide_events import log as wide_log
+from tests.helpers import captured_wide_event
 
 from .conftest import make_tool
 
@@ -218,6 +221,10 @@ class TestRegistryAndCache:
         assert result is True
         assert persisted.is_destructive is True
         assert persisted.tool_name == "wipe_db"
+        # Not a CLI call, so there is no command to record. The stored shape is
+        # part of what a later lookup matches on, and a placeholder here would
+        # be a cache entry nothing ever hits again.
+        assert persisted.command_shape == ""
         registry.mark_tool_destructive.assert_called_once_with("wipe_db", True)
 
 
@@ -363,3 +370,123 @@ class TestCliCommandClassification:
             name="run_gh", description="Run the gh CLI.", command="gh repo delete"
         )
         assert llm.await_args.kwargs["label"] == "hil_tool_classification"
+
+
+class TestTheCacheKeyIdentifiesWhatWasJudged:
+    """A verdict is stored per (tool, subject) and reused forever, so both halves
+    of that key have to be the real ones. A key that ignores half its input hands
+    one tool's answer to another question."""
+
+    async def test_the_lookup_is_scoped_to_the_tool_that_asked(self) -> None:
+        # Verdicts are shared across every user, so a lookup that ignored the
+        # tool name would hand `wipe_db`'s "destructive" answer to every other
+        # unclassified tool with the same description.
+        with (
+            patch(f"{MODULE}.get_tool_registry", new=AsyncMock(return_value=registry_with(None))),
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(
+                f"{MODULE}.ainvoke_structured",
+                new=AsyncMock(return_value=_ClassifyResult(is_destructive=False)),
+            ),
+        ):
+            repo.find_classification = AsyncMock(
+                side_effect=lambda tool_name, subject_hash: (
+                    HILToolRiskRecord(
+                        tool_name=tool_name, description_hash=subject_hash, is_destructive=True
+                    )
+                    if tool_name == "wipe_db"
+                    else None
+                )
+            )
+            repo.upsert_classification = AsyncMock()
+
+            hit = await is_tool_destructive("wipe_db", "Wipes the database.")
+            miss = await is_tool_destructive("list_files", "Wipes the database.")
+
+        assert hit is True
+        assert miss is False
+
+    async def test_a_reworded_description_reclassifies_the_same_command(self) -> None:
+        # The description is what the classifier is actually shown alongside the
+        # command, so a changed description is a changed question. Keying on the
+        # command alone would serve a verdict earned under the old wording.
+        seen: list[str] = []
+        with (
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(
+                f"{MODULE}.ainvoke_structured",
+                new=AsyncMock(return_value=_ClassifyResult(is_destructive=False)),
+            ),
+        ):
+            repo.find_classification = AsyncMock(
+                side_effect=lambda _tool, subject_hash: seen.append(subject_hash)
+            )
+            repo.upsert_classification = AsyncMock()
+
+            await is_tool_destructive("run_gh", "Run the gh CLI.", command_shape="gh pr list")
+            await is_tool_destructive("run_gh", "Run GitHub's CLI.", command_shape="gh pr list")
+
+        first, second = seen
+        assert first != second
+
+    async def test_two_commands_of_one_tool_do_not_share_a_key(self) -> None:
+        seen: list[str] = []
+        with (
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(
+                f"{MODULE}.ainvoke_structured",
+                new=AsyncMock(return_value=_ClassifyResult(is_destructive=False)),
+            ),
+        ):
+            repo.find_classification = AsyncMock(
+                side_effect=lambda _tool, subject_hash: seen.append(subject_hash)
+            )
+            repo.upsert_classification = AsyncMock()
+
+            await is_tool_destructive("run_gh", "Run the gh CLI.", command_shape="gh pr list")
+            await is_tool_destructive("run_gh", "Run the gh CLI.", command_shape="gh repo delete")
+
+        first, second = seen
+        assert first != second
+
+
+class TestWhatTheCommandClassifierIsAsked:
+    async def test_the_prompt_carries_the_tool_the_description_and_the_command(self) -> None:
+        # Reached through `is_tool_destructive`, not `_classify_with_llm`, so
+        # this also pins what the CLI branch forwards: get any of the three
+        # wrong and the LLM judges a question nobody asked.
+        with (
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(
+                f"{MODULE}.ainvoke_structured",
+                new=AsyncMock(return_value=_ClassifyResult(is_destructive=True)),
+            ) as llm,
+        ):
+            repo.find_classification = AsyncMock(return_value=None)
+            repo.upsert_classification = AsyncMock()
+
+            await is_tool_destructive("run_gh", "Run the gh CLI.", command_shape="gh repo delete")
+
+        _schema, prompt = llm.await_args.args
+        assert prompt == CLI_COMMAND_CLASSIFY_PROMPT.format(
+            name="run_gh", description="Run the gh CLI.", command="gh repo delete"
+        )
+
+    async def test_an_unshapeable_command_records_why_it_gated(self) -> None:
+        # Gating with no explanation is indistinguishable from the classifier
+        # deciding the command is dangerous; this warning is the only signal
+        # that the shaper, not the model, made the call.
+        with (
+            patch(f"{MODULE}.log", wide_log),
+            patch(f"{MODULE}.hil_tool_risk_repository") as repo,
+            patch(f"{MODULE}.ainvoke_structured", new=AsyncMock()),
+        ):
+            repo.find_classification = AsyncMock(return_value=None)
+            async with captured_wide_event() as event:
+                assert await is_tool_destructive("run_gh", "Run gh.", command_shape="") is True
+
+        (warning,) = event["warnings"]
+        assert warning == {
+            "msg": f"{LogTag.HIL} Unshapeable CLI command, failing closed",
+            "tool_name": "run_gh",
+        }

--- a/apps/api/tests/unit/services/hil/test_hil_command_shape.py
+++ b/apps/api/tests/unit/services/hil/test_hil_command_shape.py
@@ -1,0 +1,170 @@
+"""Attacks on the CLI command shape (app/services/hil/command_shape.py).
+
+The shape is the ONLY thing standing between "one CLI is one tool" and "one verdict
+covers every command that CLI can run". So two properties are attacked here:
+
+* **Nothing that runs is left out of the shape.** A second command hidden behind a
+  harmless first — after ``&&``, a ``;``, a pipe, a newline, or inside ``$( )`` — would
+  otherwise ride a verdict earned by the first, forever, from the cache.
+* **Unshapeable means empty, never a guess.** Every string this cannot reduce comes back
+  ``""``, which the classifier turns into "destructive". A shape that quietly degraded to
+  the executable alone would be a gate that reads what it wants to read.
+
+The counterweight to both: a shape must stay STABLE across calls that differ only in
+their arguments, or every call mints a new cache key and pays for a new LLM verdict.
+"""
+
+import pytest
+
+from app.agents.tools.cli.cli_tool import (
+    CLI_COMMAND_METADATA_KEY,
+    CLI_INTEGRATION_METADATA_KEY,
+)
+from app.constants.hil import HIL_CLI_SHAPE_MAX_WORDS
+from app.services.hil.command_shape import cli_command_shape, derive_command_shape
+
+from .conftest import make_tool
+
+# Exactly what ``build_cli_tool`` stamps on the tool it builds.
+CLI_METADATA = {CLI_INTEGRATION_METADATA_KEY: "github", CLI_COMMAND_METADATA_KEY: "gh"}
+
+
+class TestTheLeadingCommandWords:
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ("gh pr list", "gh pr list"),
+            ("gh pr list --json number", "gh pr list"),
+            ("link-cli spend-request create --amount 5", "link-cli spend-request create"),
+            ("gh  pr   list  ", "gh pr list"),  # whitespace is not information
+            ("gh pr list > out.json", "gh pr list"),  # a redirect target is not a command
+            ("wrangler d1 execute db --command 'DROP TABLE t'", "wrangler d1 execute db"),
+        ],
+    )
+    def test_flags_and_arguments_are_dropped(self, command: str, expected: str) -> None:
+        assert derive_command_shape(command) == expected
+
+    def test_calls_differing_only_in_arguments_share_one_shape(self) -> None:
+        # The whole point of a shape: one classification, then cache hits forever. If
+        # these diverge, every call pays for its own LLM verdict.
+        assert derive_command_shape("gh pr list --json number --limit 5") == "gh pr list"
+        assert derive_command_shape("gh pr list --state closed") == "gh pr list"
+
+    def test_the_shape_is_bounded_so_one_cli_cannot_mint_unlimited_keys(self) -> None:
+        shape = derive_command_shape("kubectl delete pod alpha beta gamma delta")
+        assert len(shape.split(" ")) == HIL_CLI_SHAPE_MAX_WORDS
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            ("FOO=bar gh pr list", "gh pr list"),
+            ("GH_TOKEN=x LOG_LEVEL=debug gh auth status", "gh auth status"),
+        ],
+    )
+    def test_an_environment_prefix_is_not_the_command(self, command: str, expected: str) -> None:
+        assert derive_command_shape(command) == expected
+
+    def test_a_quoted_argument_is_one_token_however_it_is_punctuated(self) -> None:
+        # A `;` inside quotes runs nothing. Splitting on it would invent a second
+        # command out of an issue title and gate a harmless call forever after.
+        assert (
+            derive_command_shape('gh issue create --title "ship it; then deploy"')
+            == "gh issue create"
+        )
+        assert derive_command_shape('link-cli note add "a; b"') == "link-cli note add"
+
+    def test_a_flag_before_the_subcommand_ends_the_shape_there(self) -> None:
+        # Deliberately coarse: `--repo` and its value are indistinguishable from
+        # subcommands, so the shape stops rather than guessing. A bare `gh` is a shape
+        # the classifier can only read as "could be anything", which gates.
+        assert derive_command_shape("gh --repo acme/api pr list") == "gh"
+
+
+class TestChainedCommandsAreAllInTheShape:
+    """Each of these hides a repo deletion behind a harmless read. If any one of them
+    reduces to the harmless prefix, that prefix's cached "safe" verdict lets every
+    future chain built the same way run unattended."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr list && gh repo delete acme/api",
+            "gh pr list; gh repo delete acme/api",
+            "gh pr list || gh repo delete acme/api",
+            "gh pr list & gh repo delete acme/api",
+            "gh pr list\ngh repo delete acme/api",
+            "gh pr list | gh repo delete acme/api",
+            "echo $(gh repo delete acme/api)",
+            "echo `gh repo delete acme/api`",
+        ],
+    )
+    def test_a_command_hidden_behind_a_harmless_one_is_still_shaped(self, command: str) -> None:
+        shape = derive_command_shape(command)
+        assert "gh repo delete" in shape
+        assert shape != "gh pr list"
+        assert shape != "echo"
+
+    def test_a_chain_shapes_every_link_in_order(self) -> None:
+        assert (
+            derive_command_shape("gh pr list --json url | jq -r .url && gh pr merge 4")
+            == "gh pr list ; jq ; gh pr merge"
+        )
+
+    def test_a_subshell_does_not_hide_what_it_wraps(self) -> None:
+        assert derive_command_shape("(cd repo && rm -rf .git)") == "cd repo ; rm"
+
+
+class TestUnshapeableFailsClosed:
+    """``""`` is the contract with the classifier: it means "gate this", so anything
+    unreadable must produce it rather than a partial shape."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "",
+            "   ",
+            "\n\t ",
+            "--help",  # flags only: nothing names a command
+            "-rf /",
+            '"just a quoted string"',
+            'gh pr list "unterminated',  # where the quote closes decides what runs
+            "&&",
+            "/usr/local/bin/gh pr list",  # a path-qualified executable is not a plain word
+            "./deploy.sh",
+            "2>&1",
+        ],
+    )
+    def test_it_yields_no_shape_at_all(self, command: str) -> None:
+        assert derive_command_shape(command) == ""
+
+    def test_one_unshapeable_link_discards_the_whole_chain(self) -> None:
+        # The safe direction: a chain is only as classifiable as its least readable
+        # link, so a readable prefix must not be handed over as if it were the command.
+        assert derive_command_shape("gh pr list && ./wipe.sh") == ""
+
+
+class TestReadingTheCallItself:
+    def test_a_cli_tool_call_is_shaped_from_its_command_argument(self) -> None:
+        tool = make_tool(name="run_gh", metadata=CLI_METADATA)
+        assert cli_command_shape(tool, {"command": "gh repo delete acme/api", "timeout": 60}) == (
+            "gh repo delete"
+        )
+
+    @pytest.mark.parametrize("metadata", [None, {}, {"unrelated": "x"}])
+    def test_a_non_cli_tool_has_no_shape_and_is_classified_by_name(
+        self, metadata: dict[str, str] | None
+    ) -> None:
+        # ``None`` is load-bearing: it is what tells the classifier to keep using the
+        # registry's name-keyed flag for every tool that is not CLI-backed.
+        tool = make_tool(name="send_email", metadata=metadata)
+        assert cli_command_shape(tool, {"to": "bob@example.com"}) is None
+
+    def test_a_call_with_no_tool_object_is_classified_by_name(self) -> None:
+        assert cli_command_shape(None, {"command": "gh repo delete acme/api"}) is None
+
+    @pytest.mark.parametrize("args", [None, {}, {"timeout": 60}, {"command": None}, {"command": 7}])
+    def test_a_cli_call_with_no_usable_command_gates(self, args: dict[str, object] | None) -> None:
+        # A CLI tool whose command argument is missing or malformed must fail closed —
+        # ``""`` gates — never fall back to the name-keyed verdict a ``None`` would ask for.
+        tool = make_tool(name="run_gh", metadata=CLI_METADATA)
+        assert cli_command_shape(tool, args) == ""

--- a/apps/api/tests/unit/services/hil/test_hil_command_shape.py
+++ b/apps/api/tests/unit/services/hil/test_hil_command_shape.py
@@ -168,3 +168,37 @@ class TestReadingTheCallItself:
         # ``""`` gates — never fall back to the name-keyed verdict a ``None`` would ask for.
         tool = make_tool(name="run_gh", metadata=CLI_METADATA)
         assert cli_command_shape(tool, args) == ""
+
+
+class TestGateBypassesFoundInReview:
+    """Two ways a chained command could hide from the shape, and did."""
+
+    def test_a_mid_word_hash_does_not_swallow_the_rest_of_the_line(self):
+        # shlex honours `#` as a comment mid-word; a POSIX shell does not, so
+        # the second command really runs. Shaping only the prefix would let
+        # `gh api` (read-only) carry a repo delete past the gate.
+        shape = derive_command_shape("gh api /user#x && gh repo delete acme/api")
+        assert "gh repo delete" in shape
+
+    def test_a_literal_hash_argument_survives(self):
+        assert derive_command_shape("gh issue view '#42'").startswith("gh issue view")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sh -c 'gh repo delete acme/api'",
+            'bash -c "rm -rf /"',
+            'eval "$CMD"',
+            "xargs gh repo delete",
+            "env FOO=1 sh -c 'gh repo delete x'",
+            "timeout 5 sh -c 'gh repo delete x'",
+        ],
+    )
+    def test_shell_exec_wrappers_fail_closed(self, command: str):
+        # The payload is a quoted argument, not a separator, so it never becomes
+        # its own segment. Shaping the wrapper would classify a name that says
+        # nothing about what runs.
+        assert derive_command_shape(command) == ""
+
+    def test_an_ordinary_command_named_like_a_wrapper_argument_still_shapes(self):
+        assert derive_command_shape("gh repo list") == "gh repo list"

--- a/apps/api/tests/unit/services/hil/test_hil_command_shape.py
+++ b/apps/api/tests/unit/services/hil/test_hil_command_shape.py
@@ -202,3 +202,50 @@ class TestGateBypassesFoundInReview:
 
     def test_an_ordinary_command_named_like_a_wrapper_argument_still_shapes(self):
         assert derive_command_shape("gh repo list") == "gh repo list"
+
+
+class TestTheLexerHasNoOpinionsOfItsOwn:
+    """The shape is only as honest as the tokenizer under it.
+
+    Every one of these is a way a shell-like lexer can quietly drop or truncate
+    part of the command. Each one that got through would hand the classifier a
+    shorter, more innocent string than what actually runs — and the verdict for
+    that shorter string is then cached against the real one.
+    """
+
+    def test_quoting_a_subcommand_does_not_hide_it(self) -> None:
+        # Quotes are shell syntax, not part of the word. A lexer that kept them
+        # would fail the shape-word test on `"repo"` and stop at a bare `gh`,
+        # so quoting the dangerous half of the command would be enough to have
+        # it classified as whatever plain `gh` was classified as.
+        assert derive_command_shape('gh "repo" "delete" acme/api') == "gh repo delete"
+        assert derive_command_shape("gh 'repo' delete acme/api") == "gh repo delete"
+
+    @pytest.mark.parametrize(
+        ("command", "expected"),
+        [
+            # `build:prod` is an argument, not a subcommand — the run ends there.
+            ("npm run build:prod", "npm run"),
+            # Nothing shapeable at the head at all: fail closed, do not offer `aws`.
+            ("aws:cli s3 ls", ""),
+            ("g++ --version", ""),
+        ],
+    )
+    def test_a_word_the_shape_cannot_represent_ends_the_run_whole(
+        self, command: str, expected: str
+    ) -> None:
+        # It must not be chopped at the first character the lexer does not
+        # recognise: `aws:cli` truncated to `aws` is a command that was never
+        # typed, and `g++` truncated to `g` shapes an unshapeable string.
+        assert derive_command_shape(command) == expected
+
+    def test_no_character_in_the_command_starts_a_comment(self) -> None:
+        # A commenter character discards the rest of the line, taking every
+        # chained command after it out of the shape. `#` was the one found in
+        # review; the guarantee has to be that there is no such character at
+        # all, so an ordinary env prefix is shaped in full too.
+        assert derive_command_shape("MAX_RETRIES=3 gh pr list") == "gh pr list"
+        assert (
+            derive_command_shape("MAX_RETRIES=3 gh api /user && gh repo delete acme/api")
+            == "gh api ; gh repo delete"
+        )

--- a/apps/api/tests/unit/services/hil/test_hil_policy.py
+++ b/apps/api/tests/unit/services/hil/test_hil_policy.py
@@ -13,8 +13,13 @@ Three things decide whether a destructive call runs unattended, and each is atta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from langchain_core.tools import BaseTool
 import pytest
 
+from app.agents.tools.cli.cli_tool import (
+    CLI_COMMAND_METADATA_KEY,
+    CLI_INTEGRATION_METADATA_KEY,
+)
 from app.models.hil_models import HILPreferences
 from app.services.hil.policy import has_pausing_sibling, is_gated, resolve_policy
 from app.services.mcp.langchain_adapter import MCP_ANNOTATIONS_METADATA_KEY
@@ -671,3 +676,89 @@ class TestArgumentGate:
             patch(f"{MODULE}.is_tool_destructive", new=AsyncMock(return_value=False)),
         ):
             assert await has_pausing_sibling(request, USER_ID, "call-1") is True
+
+
+class TestCliBackedCallsAreClassifiedByCommand:
+    """One CLI integration is one tool name, so the policy has to reach the classifier
+    with the COMMAND. These pin the two halves of that: the shape is derived from the
+    call's own args, and nothing about a non-CLI tool changes."""
+
+    def cli_tool(self) -> BaseTool:
+        return make_tool(
+            name="run_gh",
+            description="Run the gh CLI.",
+            metadata={CLI_INTEGRATION_METADATA_KEY: "github", CLI_COMMAND_METADATA_KEY: "gh"},
+        )
+
+    async def test_the_command_shape_reaches_the_classifier(self) -> None:
+        with patch(f"{MODULE}.is_tool_destructive", new=AsyncMock(return_value=True)) as classify:
+            await is_gated(
+                prefs(),
+                "run_gh",
+                self.cli_tool(),
+                args={"command": "gh repo delete acme/api --yes", "timeout": 60},
+            )
+
+        assert classify.await_args.kwargs["command_shape"] == "gh repo delete"
+
+    async def test_the_shape_travels_through_resolve_policy_not_just_is_gated(self) -> None:
+        # resolve_policy used to classify without the call's args at all — the whole
+        # gate would have gone back to name-only for every CLI call.
+        request = make_request(
+            name="run_gh",
+            args={"command": "gh pr list --json number"},
+            tool=self.cli_tool(),
+        )
+        with (
+            patch(f"{MODULE}.get_hil_preferences", new=AsyncMock(return_value=prefs())),
+            patch(f"{MODULE}.is_tool_destructive", new=AsyncMock(return_value=False)) as classify,
+        ):
+            assert await resolve_policy(request, USER_ID, "run_gh") == "allow"
+
+        assert classify.await_args.kwargs["command_shape"] == "gh pr list"
+
+    async def test_a_cli_sibling_is_classified_by_its_own_command_too(self) -> None:
+        # The double-run guard resolves siblings from the registry; a CLI sibling has to
+        # arrive at the classifier with its command, or a `gh repo delete` sibling reads
+        # as whatever `run_gh` in the abstract reads as.
+        state_messages = [
+            ai_message_with_calls(
+                {"id": "call-1", "name": "web_search", "args": {}},
+                {"id": "call-2", "name": "run_gh", "args": {"command": "gh repo delete acme/api"}},
+            )
+        ]
+        request = make_request(call_id="call-1", messages=state_messages)
+        shapes: list[str | None] = []
+
+        async def classify(_name: str, _description: str, **kwargs: object) -> bool:
+            shape = kwargs["command_shape"]
+            shapes.append(shape if shape is None else str(shape))
+            return shape == "gh repo delete"
+
+        with (
+            patch(f"{MODULE}.get_hil_preferences", new=AsyncMock(return_value=prefs())),
+            patch(
+                f"{MODULE}.get_tool_registry",
+                new=AsyncMock(
+                    return_value=SimpleNamespace(
+                        get_tool_meta=lambda name: SimpleNamespace(
+                            always_gate=False, tool=self.cli_tool()
+                        )
+                        if name == "run_gh"
+                        else None
+                    )
+                ),
+            ),
+            patch(f"{MODULE}.is_tool_destructive", side_effect=classify),
+        ):
+            assert await has_pausing_sibling(request, USER_ID, "call-1") is True
+
+        assert "gh repo delete" in shapes
+
+    async def test_a_non_cli_tool_is_still_classified_by_name_alone(self) -> None:
+        # The regression fence for every existing tool: no shape, so the registry's
+        # name-keyed verdict keeps deciding exactly as it did before.
+        with patch(f"{MODULE}.is_tool_destructive", new=AsyncMock(return_value=True)) as classify:
+            await is_gated(prefs(), "send_email", make_tool(), args={"command": "rm -rf /"})
+
+        assert classify.await_args.kwargs["command_shape"] is None

--- a/apps/api/tests/unit/services/integrations/providers/test_oauth_providers.py
+++ b/apps/api/tests/unit/services/integrations/providers/test_oauth_providers.py
@@ -1,0 +1,138 @@
+"""Unit tests for the OAuth-shaped provider adapters.
+
+These adapters exist to turn three different call signatures into one, so what
+matters is that each forwards the context to its underlying service correctly.
+A silently wrong forward (the bearer token dropped, the wrong id passed as the
+provider slug) would surface as a connect that fails for reasons the user
+cannot act on.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.services.integrations.integration_connection_service import McpConnectRequest
+from app.services.integrations.providers import (
+    ComposioIntegrationProvider,
+    ConnectContext,
+    McpIntegrationProvider,
+    SelfIntegrationProvider,
+)
+
+MODULE = "app.services.integrations.providers.oauth_providers"
+USER = "user-1"
+
+
+def _ctx(
+    *,
+    managed_by: str = "mcp",
+    source: str = "platform",
+    provider: str | None = "acme",
+    secret: str | None = None,
+    requires_auth: bool = True,
+) -> ConnectContext:
+    resolved = MagicMock()
+    resolved.managed_by = managed_by
+    resolved.source = source
+    resolved.name = "Acme"
+    resolved.requires_auth = requires_auth
+    resolved.mcp_config = MagicMock(server_url="https://mcp.example.test")
+    resolved.platform_integration = MagicMock(provider=provider) if source == "platform" else None
+    return ConnectContext(
+        user_id=USER,
+        integration_id="acme",
+        resolved=resolved,
+        redirect_path="/integrations",
+        user_email="user@example.test",
+        secret=secret,
+    )
+
+
+def _ok() -> ConnectIntegrationResponse:
+    return ConnectIntegrationResponse(status="connected", integration_id="acme", name="Acme")
+
+
+def _forwarded_request(connect: AsyncMock) -> McpConnectRequest:
+    """The single request object the MCP transport was called with."""
+    return connect.await_args.args[0]
+
+
+class TestMcpProvider:
+    async def test_forwards_the_server_url_and_platform_flag(self):
+        with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=_ok())) as connect:
+            await McpIntegrationProvider().connect(_ctx())
+        request = _forwarded_request(connect)
+        assert request.server_url == "https://mcp.example.test"
+        assert request.is_platform is True
+        assert request.requires_auth is True
+
+    async def test_a_custom_integration_is_not_marked_platform(self):
+        with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=_ok())) as connect:
+            await McpIntegrationProvider().connect(_ctx(source="custom"))
+        assert _forwarded_request(connect).is_platform is False
+
+    async def test_the_pasted_secret_is_forwarded_as_the_bearer_token(self):
+        # Dropping it here would send the user back to a token dialog that
+        # already has their token.
+        with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=_ok())) as connect:
+            await McpIntegrationProvider().connect(_ctx(secret="paste-me"))
+        assert _forwarded_request(connect).bearer_token == "paste-me"
+
+    async def test_a_missing_mcp_config_forwards_no_url_rather_than_raising(self):
+        ctx = _ctx()
+        ctx.resolved.mcp_config = None
+        with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=_ok())) as connect:
+            await McpIntegrationProvider().connect(ctx)
+        assert _forwarded_request(connect).server_url is None
+
+
+class TestComposioProvider:
+    async def test_forwards_the_provider_slug(self):
+        with patch(
+            f"{MODULE}.connect_composio_integration", AsyncMock(return_value=_ok())
+        ) as connect:
+            await ComposioIntegrationProvider().connect(_ctx(managed_by="composio"))
+        assert connect.await_args.kwargs["provider"] == "acme"
+
+    @pytest.mark.parametrize("provider", [None, ""])
+    async def test_a_missing_provider_is_an_error_not_a_call(self, provider):
+        with patch(
+            f"{MODULE}.connect_composio_integration", AsyncMock(return_value=_ok())
+        ) as connect:
+            result = await ComposioIntegrationProvider().connect(
+                _ctx(managed_by="composio", provider=provider)
+            )
+        connect.assert_not_awaited()
+        assert result.status == "error"
+        assert "Provider not configured" in (result.error or "")
+
+
+class TestSelfProvider:
+    async def test_forwards_the_email_as_the_oauth_login_hint(self):
+        with patch(f"{MODULE}.connect_self_integration", AsyncMock(return_value=_ok())) as connect:
+            await SelfIntegrationProvider().connect(_ctx(managed_by="self"))
+        assert connect.await_args.kwargs["user_email"] == "user@example.test"
+
+    async def test_a_missing_provider_is_an_error_not_a_call(self):
+        with patch(f"{MODULE}.connect_self_integration", AsyncMock(return_value=_ok())) as connect:
+            result = await SelfIntegrationProvider().connect(_ctx(managed_by="self", provider=None))
+        connect.assert_not_awaited()
+        assert result.status == "error"
+
+
+class TestProviderIdentity:
+    @pytest.mark.parametrize(
+        ("provider", "expected"),
+        [
+            (McpIntegrationProvider, "mcp"),
+            (ComposioIntegrationProvider, "composio"),
+            (SelfIntegrationProvider, "self"),
+        ],
+    )
+    def test_each_adapter_declares_the_transport_it_serves(self, provider, expected):
+        # The registry is keyed on this; a wrong value silently shadows another
+        # transport or leaves one unreachable.
+        assert provider.managed_by == expected

--- a/apps/api/tests/unit/services/integrations/providers/test_oauth_providers.py
+++ b/apps/api/tests/unit/services/integrations/providers/test_oauth_providers.py
@@ -4,7 +4,8 @@ These adapters exist to turn three different call signatures into one, so what
 matters is that each forwards the context to its underlying service correctly.
 A silently wrong forward (the bearer token dropped, the wrong id passed as the
 provider slug) would surface as a connect that fails for reasons the user
-cannot act on.
+cannot act on — which is why the forwarded call is asserted whole rather than
+field by field: a dropped argument is exactly as broken as a wrong one.
 """
 
 from __future__ import annotations
@@ -24,26 +25,31 @@ from app.services.integrations.providers import (
 
 MODULE = "app.services.integrations.providers.oauth_providers"
 USER = "user-1"
+# Deliberately different from the provider slug below: an integration id and
+# the upstream provider it is brokered through are separate values, and a
+# transport that confused them would still look right if they matched.
+INTEGRATION = "acme-crm"
+PROVIDER = "acme"
 
 
 def _ctx(
     *,
     managed_by: str = "mcp",
     source: str = "platform",
-    provider: str | None = "acme",
+    provider: str | None = PROVIDER,
     secret: str | None = None,
     requires_auth: bool = True,
 ) -> ConnectContext:
     resolved = MagicMock()
     resolved.managed_by = managed_by
     resolved.source = source
-    resolved.name = "Acme"
+    resolved.name = "Acme CRM"
     resolved.requires_auth = requires_auth
     resolved.mcp_config = MagicMock(server_url="https://mcp.example.test")
     resolved.platform_integration = MagicMock(provider=provider) if source == "platform" else None
     return ConnectContext(
         user_id=USER,
-        integration_id="acme",
+        integration_id=INTEGRATION,
         resolved=resolved,
         redirect_path="/integrations",
         user_email="user@example.test",
@@ -52,7 +58,7 @@ def _ctx(
 
 
 def _ok() -> ConnectIntegrationResponse:
-    return ConnectIntegrationResponse(status="connected", integration_id="acme", name="Acme")
+    return ConnectIntegrationResponse(status="connected", integration_id=INTEGRATION, name="Acme")
 
 
 def _forwarded_request(connect: AsyncMock) -> McpConnectRequest:
@@ -61,15 +67,26 @@ def _forwarded_request(connect: AsyncMock) -> McpConnectRequest:
 
 
 class TestMcpProvider:
-    async def test_forwards_the_server_url_and_platform_flag(self):
+    async def test_the_whole_context_reaches_the_mcp_connect_request(self):
+        # Everything the MCP flow branches on lives in this one object: the URL
+        # it probes, whether it may fall back to platform credentials, and
+        # whether it has to ask for auth at all.
         with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=_ok())) as connect:
-            await McpIntegrationProvider().connect(_ctx())
-        request = _forwarded_request(connect)
-        assert request.server_url == "https://mcp.example.test"
-        assert request.is_platform is True
-        assert request.requires_auth is True
+            await McpIntegrationProvider().connect(_ctx(secret="paste-me"))
+        assert _forwarded_request(connect) == McpConnectRequest(
+            user_id=USER,
+            integration_id=INTEGRATION,
+            integration_name="Acme CRM",
+            requires_auth=True,
+            redirect_path="/integrations",
+            server_url="https://mcp.example.test",
+            is_platform=True,
+            bearer_token="paste-me",
+        )
 
     async def test_a_custom_integration_is_not_marked_platform(self):
+        # Platform MCP servers may use GAIA's own credentials; a user's own
+        # server must never be handed them.
         with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=_ok())) as connect:
             await McpIntegrationProvider().connect(_ctx(source="custom"))
         assert _forwarded_request(connect).is_platform is False
@@ -88,17 +105,31 @@ class TestMcpProvider:
             await McpIntegrationProvider().connect(ctx)
         assert _forwarded_request(connect).server_url is None
 
+    async def test_the_transports_answer_is_returned_unchanged(self):
+        response = _ok()
+        with patch(f"{MODULE}.connect_mcp_integration", AsyncMock(return_value=response)):
+            result = await McpIntegrationProvider().connect(_ctx())
+        assert result is response
+
 
 class TestComposioProvider:
-    async def test_forwards_the_provider_slug(self):
+    async def test_the_whole_context_reaches_composio(self):
         with patch(
             f"{MODULE}.connect_composio_integration", AsyncMock(return_value=_ok())
         ) as connect:
             await ComposioIntegrationProvider().connect(_ctx(managed_by="composio"))
-        assert connect.await_args.kwargs["provider"] == "acme"
+        assert connect.await_args.kwargs == {
+            "user_id": USER,
+            "integration_id": INTEGRATION,
+            "integration_name": "Acme CRM",
+            "provider": PROVIDER,
+            "redirect_path": "/integrations",
+        }
 
     @pytest.mark.parametrize("provider", [None, ""])
     async def test_a_missing_provider_is_an_error_not_a_call(self, provider):
+        # Composio is keyed entirely on the slug; calling it without one would
+        # start a connection against whatever Composio defaults to.
         with patch(
             f"{MODULE}.connect_composio_integration", AsyncMock(return_value=_ok())
         ) as connect:
@@ -107,20 +138,30 @@ class TestComposioProvider:
             )
         connect.assert_not_awaited()
         assert result.status == "error"
-        assert "Provider not configured" in (result.error or "")
+        assert result.error == "Provider not configured"
 
 
 class TestSelfProvider:
-    async def test_forwards_the_email_as_the_oauth_login_hint(self):
+    async def test_the_whole_context_reaches_the_self_hosted_oauth_flow(self):
+        # ``user_email`` is the OAuth login hint: without it Google shows an
+        # account chooser instead of the account the user is signed in as.
         with patch(f"{MODULE}.connect_self_integration", AsyncMock(return_value=_ok())) as connect:
             await SelfIntegrationProvider().connect(_ctx(managed_by="self"))
-        assert connect.await_args.kwargs["user_email"] == "user@example.test"
+        assert connect.await_args.kwargs == {
+            "user_id": USER,
+            "user_email": "user@example.test",
+            "integration_id": INTEGRATION,
+            "integration_name": "Acme CRM",
+            "provider": PROVIDER,
+            "redirect_path": "/integrations",
+        }
 
     async def test_a_missing_provider_is_an_error_not_a_call(self):
         with patch(f"{MODULE}.connect_self_integration", AsyncMock(return_value=_ok())) as connect:
             result = await SelfIntegrationProvider().connect(_ctx(managed_by="self", provider=None))
         connect.assert_not_awaited()
         assert result.status == "error"
+        assert result.error == "Provider not configured"
 
 
 class TestProviderIdentity:

--- a/apps/api/tests/unit/services/integrations/providers/test_oauth_providers.py
+++ b/apps/api/tests/unit/services/integrations/providers/test_oauth_providers.py
@@ -57,6 +57,15 @@ def _ctx(
     )
 
 
+def _resolved(*, source: str = "platform") -> MagicMock:
+    """The catalog resolution a disconnect is handed."""
+    resolved = MagicMock()
+    resolved.integration_id = INTEGRATION
+    resolved.source = source
+    resolved.name = "Acme CRM"
+    return resolved
+
+
 def _ok() -> ConnectIntegrationResponse:
     return ConnectIntegrationResponse(status="connected", integration_id=INTEGRATION, name="Acme")
 
@@ -162,6 +171,50 @@ class TestSelfProvider:
         connect.assert_not_awaited()
         assert result.status == "error"
         assert result.error == "Provider not configured"
+
+
+class TestMcpDisconnect:
+    """Disconnecting an MCP server is three writes, and which of them run
+    depends on who owns the server.
+
+    A platform server is shared by every user, so only the caller's link may go.
+    A server the caller added themselves is theirs alone, so its catalog
+    document goes with it — otherwise the marketplace keeps an entry nobody
+    owns and nobody can remove.
+    """
+
+    async def test_a_custom_server_loses_its_session_link_and_catalog_row(self):
+        resolved = _resolved(source="custom")
+        mcp_client = MagicMock()
+        mcp_client.disconnect = AsyncMock()
+        with (
+            patch(f"{MODULE}.get_mcp_client", AsyncMock(return_value=mcp_client)) as get_client,
+            patch(f"{MODULE}.remove_user_integration", AsyncMock()) as remove,
+            patch(f"{MODULE}.delete_if_user_authored", AsyncMock()) as delete,
+        ):
+            await McpIntegrationProvider().disconnect(USER, resolved)
+
+        # The session is per user, so it is that user's client that must drop it.
+        get_client.assert_awaited_once_with(user_id=USER)
+        mcp_client.disconnect.assert_awaited_once_with(INTEGRATION)
+        remove.assert_awaited_once_with(USER, INTEGRATION)
+        delete.assert_awaited_once_with(USER, resolved)
+
+    async def test_a_platform_server_keeps_its_catalog_row(self):
+        # Deleting it would remove a shared integration from every other user's
+        # marketplace because one person disconnected.
+        resolved = _resolved(source="platform")
+        mcp_client = MagicMock()
+        mcp_client.disconnect = AsyncMock()
+        with (
+            patch(f"{MODULE}.get_mcp_client", AsyncMock(return_value=mcp_client)),
+            patch(f"{MODULE}.remove_user_integration", AsyncMock()) as remove,
+            patch(f"{MODULE}.delete_if_user_authored", AsyncMock()) as delete,
+        ):
+            await McpIntegrationProvider().disconnect(USER, resolved)
+
+        remove.assert_awaited_once_with(USER, INTEGRATION)
+        delete.assert_not_awaited()
 
 
 class TestProviderIdentity:

--- a/apps/api/tests/unit/services/integrations/test_authoring.py
+++ b/apps/api/tests/unit/services/integrations/test_authoring.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 import contextlib
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
 
 import pytest
 
+from app.constants.log_tags import LogTag
+from app.models.cli_config import CliAuthSpec
 from app.models.integration_models import CreateCustomIntegrationRequest
 from app.services.integrations.authoring import (
     CliBlueprint,
@@ -24,6 +28,7 @@ from app.services.integrations.authoring import (
 )
 from app.services.integrations.authoring.cli_author import CliIntegrationAuthor
 from app.services.integrations.authoring.mcp_author import McpIntegrationAuthor
+from tests.helpers import captured_wide_event
 
 USER = "user-1"
 MCP_MODULE = "app.services.integrations.authoring.mcp_author"
@@ -397,3 +402,174 @@ class TestIconFromHomepage:
 
         fetch.assert_awaited_once_with("http://localhost:8080/")
         assert authored.integration.icon_url is None
+
+
+CLI_MODULE = "app.services.integrations.authoring.cli_author"
+
+
+@contextlib.contextmanager
+def cli_creation(attach_error: Exception | None = None) -> Iterator[SimpleNamespace]:
+    """Patch the CLI author's two write boundaries: the catalog and the attach."""
+    with (
+        patch(f"{CLI_MODULE}.integration_repository") as repo,
+        patch(f"{CLI_MODULE}.add_user_integration", AsyncMock(side_effect=attach_error)) as attach,
+        patch(f"{CLI_MODULE}.fetch_favicon_safely", AsyncMock(return_value=None)),
+    ):
+        repo.create = AsyncMock()
+        repo.delete = AsyncMock()
+        yield SimpleNamespace(repo=repo, attach=attach)
+
+
+def _stored(created: SimpleNamespace):
+    """The catalog document the author wrote."""
+    return created.repo.create.await_args.args[0]
+
+
+class TestTheStoredCliDocument:
+    """What the author actually writes to the catalog.
+
+    The blueprint comes from a model reading a vendor's help text, and this
+    document is what every later step reads: the connect flow reads the auth
+    spec, the marketplace reads the visibility flags, and the tool factory
+    reads the command. Nothing downstream can recover a field dropped here.
+    """
+
+    async def test_the_auth_spec_is_stored_whole(self):
+        # The connect state machine branches on every one of these: the login
+        # command it runs detached, the verify command that decides "connected",
+        # the variable it exports the pasted token as, and the copy the dialog
+        # shows. A dropped field surfaces as a connect that hangs or a token
+        # dialog with no label.
+        with cli_creation() as created:
+            await create_integration(
+                USER,
+                cli_blueprint(
+                    auth_kind="token",
+                    login_command="gh auth login --with-token",
+                    logout_command="gh auth logout",
+                    verify_command="gh auth status",
+                    token_env="GH_TOKEN",
+                    token_label="GitHub token",
+                    token_help_url="https://github.test/tokens",
+                ),
+            )
+
+        assert _stored(created).cli_config.auth == CliAuthSpec(
+            kind="token",
+            login_command="gh auth login --with-token",
+            verify_command="gh auth status",
+            logout_command="gh auth logout",
+            token_env="GH_TOKEN",
+            token_label="GitHub token",
+            token_help_url="https://github.test/tokens",
+        )
+
+    async def test_each_authored_integration_gets_its_own_id(self):
+        # The id is the document's identity, the CLI's sandbox directory and
+        # its tool-name digest. Two integrations sharing one would share an
+        # install and a login.
+        with cli_creation() as first:
+            await create_integration(USER, cli_blueprint())
+        with cli_creation() as second:
+            await create_integration(USER, cli_blueprint())
+
+        first_id = _stored(first).integration_id
+        assert uuid.UUID(first_id)
+        assert first_id != _stored(second).integration_id
+
+    async def test_the_row_and_the_attachment_name_the_same_integration(self):
+        # Two writes, one id. Attaching a different id would leave a catalog
+        # row nobody owns and a workspace entry pointing at nothing.
+        with cli_creation() as created:
+            await create_integration(USER, cli_blueprint())
+
+        created.attach.assert_awaited_once_with(
+            USER, _stored(created).integration_id, initial_status="created"
+        )
+
+    async def test_an_authored_integration_starts_private_and_unpublished(self):
+        # Authoring is not publishing. A row that arrived in the marketplace
+        # featured, cloned and public would expose a user's own tool to
+        # everyone without them ever choosing to share it.
+        with cli_creation() as created:
+            await create_integration(USER, cli_blueprint())
+
+        stored = _stored(created)
+        assert stored.is_public is False
+        assert stored.is_featured is False
+        assert stored.display_priority == 0
+        assert stored.clone_count == 0
+        assert stored.published_at is None
+
+    async def test_the_creation_time_is_recorded_in_utc(self):
+        # Read back as an aware timestamp everywhere; a naive local time here
+        # is silently off by the server's offset for every downstream sort.
+        with cli_creation() as created:
+            await create_integration(USER, cli_blueprint())
+
+        created_at = _stored(created).created_at
+        assert created_at.tzinfo is not None
+        assert created_at.utcoffset() == timedelta(0)
+
+    async def test_a_cli_that_needs_a_credential_is_stored_as_requiring_auth(self):
+        # The card renders a Connect button off this, and the resolver reads it
+        # back. Stored False, a CLI needing a token looks ready to use.
+        with cli_creation() as created:
+            await create_integration(USER, cli_blueprint())
+
+        assert _stored(created).requires_auth is True
+
+
+class TestTheAuthorsAnswerToTheCaller:
+    """The caller is a chat tool, so the note is what the model tells the user."""
+
+    async def test_a_cli_with_a_login_says_the_connect_installs_and_signs_in(self):
+        with cli_creation():
+            authored = await create_integration(USER, cli_blueprint())
+
+        assert authored.needs_connection is True
+        assert authored.note == "Connect it to install gh and sign in."
+
+    async def test_a_cli_with_no_login_says_the_connect_only_installs(self):
+        # Still needs a connect — the CLI has to be installed — but promising a
+        # sign-in step that does not exist sends the user looking for a dialog.
+        with cli_creation():
+            authored = await create_integration(
+                USER, cli_blueprint(auth_kind="none", token_env=None, token_label=None)
+            )
+
+        assert authored.needs_connection is True
+        assert authored.note == "Connect it once to install gh."
+
+
+class TestRollbackWhenAttachingFails:
+    async def test_the_orphaned_row_is_deleted_and_the_failure_recorded(self):
+        # A catalog row nobody owns is a marketplace entry that cannot be
+        # connected or deleted; the wide event is the only record of which one
+        # was rolled back and for whom.
+        with cli_creation(attach_error=RuntimeError("mongo down")) as created:
+            async with captured_wide_event() as event:
+                with pytest.raises(RuntimeError):
+                    await create_integration(USER, cli_blueprint())
+
+        integration_id = _stored(created).integration_id
+        created.repo.delete.assert_awaited_once_with(integration_id)
+        (failure,) = event["errors"]
+        assert failure == {
+            "msg": f"{LogTag.INTEGRATION} Failed to attach authored CLI integration, rolling back",
+            "integration_id": integration_id,
+            "user_id": USER,
+        }
+
+
+class TestTheWrongBlueprintKind:
+    async def test_it_names_the_author_and_the_kind(self):
+        # Unreachable through the registry, which dispatches on kind. It is the
+        # guard that makes a future author wired to the wrong kind fail loudly
+        # instead of quietly creating the wrong sort of integration.
+        with pytest.raises(TypeError) as exc_info:
+            await CliIntegrationAuthor().create(
+                USER, McpBlueprint(name="Acme", server_url="https://mcp.example.test")
+            )
+
+        assert str(exc_info.value) == "CliIntegrationAuthor cannot author a 'mcp' blueprint"

--- a/apps/api/tests/unit/services/integrations/test_authoring.py
+++ b/apps/api/tests/unit/services/integrations/test_authoring.py
@@ -36,7 +36,7 @@ def cli_blueprint(**overrides: object) -> CliBlueprint:
         "token_label": "GitHub token",
     }
     base.update(overrides)
-    return CliBlueprint(**base)  # type: ignore[arg-type]
+    return CliBlueprint(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
 
 
 class TestAuthorRegistry:

--- a/apps/api/tests/unit/services/integrations/test_authoring.py
+++ b/apps/api/tests/unit/services/integrations/test_authoring.py
@@ -8,10 +8,14 @@ half-created integration must never be left behind.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+import contextlib
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.integration_models import CreateCustomIntegrationRequest
 from app.services.integrations.authoring import (
     CliBlueprint,
     McpBlueprint,
@@ -19,8 +23,10 @@ from app.services.integrations.authoring import (
     get_author,
 )
 from app.services.integrations.authoring.cli_author import CliIntegrationAuthor
+from app.services.integrations.authoring.mcp_author import McpIntegrationAuthor
 
 USER = "user-1"
+MCP_MODULE = "app.services.integrations.authoring.mcp_author"
 
 
 def cli_blueprint(**overrides: object) -> CliBlueprint:
@@ -37,6 +43,44 @@ def cli_blueprint(**overrides: object) -> CliBlueprint:
     }
     base.update(overrides)
     return CliBlueprint(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
+
+
+def mcp_blueprint(**overrides: object) -> McpBlueprint:
+    # Every field deliberately differs from the model's default, so a field the
+    # author forgets to forward shows up as the default rather than passing.
+    base: dict[str, object] = {
+        "name": "Acme",
+        "description": "Acme's own MCP server",
+        "category": "business",
+        "server_url": "https://mcp.example.test",
+        "requires_auth": True,
+        "auth_type": "bearer",
+        "bearer_token": "tok-123",
+    }
+    base.update(overrides)
+    return McpBlueprint(**base)  # type: ignore[arg-type]  # kwargs dict widens to object; the model validates the real types
+
+
+@contextlib.contextmanager
+def mcp_creation(result: dict[str, object]) -> Iterator[SimpleNamespace]:
+    """Patch the two boundaries the MCP author delegates to.
+
+    The author adds no logic of its own — it builds a request, gets a client,
+    and hands both to the existing custom-MCP creation path — so those two
+    calls are the observable behaviour.
+    """
+    client = MagicMock(name="mcp_client")
+    integration = MagicMock(name="integration")
+    with (
+        patch(f"{MCP_MODULE}.get_mcp_client", AsyncMock(return_value=client)) as get_client,
+        patch(
+            f"{MCP_MODULE}.create_and_connect_custom_integration",
+            AsyncMock(return_value=(integration, result)),
+        ) as create,
+    ):
+        yield SimpleNamespace(
+            client=client, integration=integration, get_client=get_client, create=create
+        )
 
 
 class TestAuthorRegistry:
@@ -142,8 +186,12 @@ class TestCliAuthor:
 
 
 class TestMcpAuthor:
-    async def test_delegates_to_the_existing_custom_mcp_path(self):
-        integration = MagicMock(name="integration")
+    async def test_an_authored_integration_starts_private(self):
+        """Publishing is a separate, deliberate step.
+
+        The request model defaults ``is_public`` to False, so the author does
+        not restate it; this is what stops that default silently moving.
+        """
         with (
             patch(
                 "app.services.integrations.authoring.mcp_author.get_mcp_client",
@@ -151,33 +199,93 @@ class TestMcpAuthor:
             ),
             patch(
                 "app.services.integrations.authoring.mcp_author.create_and_connect_custom_integration",
-                AsyncMock(return_value=(integration, {"status": "connected", "tools_count": 7})),
+                AsyncMock(return_value=(MagicMock(), {"status": "connected"})),
             ) as create,
         ):
-            authored = await create_integration(
+            await create_integration(
                 USER, McpBlueprint(name="Acme", server_url="https://mcp.example.test")
             )
 
-        create.assert_awaited_once()
-        assert authored.integration is integration
+        assert create.await_args.args[1].is_public is False
+
+    async def test_the_blueprint_reaches_the_custom_mcp_path_intact(self):
+        # The whole request is asserted, not a field or two: the MCP creation
+        # path branches on requires_auth and auth_type to decide whether to
+        # probe for OAuth, and on bearer_token to decide whether it can skip
+        # asking the user for one. A field dropped here becomes a connect
+        # dialog that asks for a token the user already gave.
+        with mcp_creation({"status": "connected", "tools_count": 7}) as mcp:
+            authored = await create_integration(USER, mcp_blueprint())
+
+        mcp.get_client.assert_awaited_once_with(user_id=USER)
+        mcp.create.assert_awaited_once_with(
+            USER,
+            CreateCustomIntegrationRequest(
+                name="Acme",
+                description="Acme's own MCP server",
+                category="business",
+                server_url="https://mcp.example.test",
+                requires_auth=True,
+                auth_type="bearer",
+                # An integration a chat turn created belongs to that user and
+                # is not published to the marketplace behind their back.
+                is_public=False,
+                bearer_token="tok-123",
+            ),
+            mcp.client,
+        )
+        assert authored.integration is mcp.integration
+
+    async def test_a_blank_description_is_stored_as_absent_not_as_an_empty_string(self):
+        # The blueprint defaults description to "", and the catalog renders a
+        # missing description differently from a present-but-empty one.
+        with mcp_creation({"status": "connected"}) as mcp:
+            await create_integration(USER, mcp_blueprint(description=""))
+
+        assert mcp.create.await_args.args[1].description is None
+
+    async def test_a_connected_server_reports_the_tool_count_it_returned(self):
+        with mcp_creation({"status": "connected", "tools_count": 7}) as mcp:
+            authored = await create_integration(USER, mcp_blueprint())
+
         assert authored.needs_connection is False
-        assert "7 tools" in (authored.note or "")
+        assert authored.note == "Connected. 7 tools available."
+        assert mcp.create.await_args.args[0] == USER
+
+    async def test_a_connected_server_that_reported_no_tools_says_zero(self):
+        # A server can connect and expose nothing. "0 tools available" is the
+        # honest answer; anything invented here reads as tools the user has.
+        with mcp_creation({"status": "connected"}):
+            authored = await create_integration(USER, mcp_blueprint())
+
+        assert authored.note == "Connected. 0 tools available."
 
     async def test_reports_when_the_server_still_needs_authentication(self):
-        with (
-            patch(
-                "app.services.integrations.authoring.mcp_author.get_mcp_client",
-                AsyncMock(return_value=MagicMock()),
-            ),
-            patch(
-                "app.services.integrations.authoring.mcp_author.create_and_connect_custom_integration",
-                AsyncMock(return_value=(MagicMock(), {"status": "oauth_required"})),
-            ),
-        ):
-            authored = await create_integration(
-                USER, McpBlueprint(name="Acme", server_url="https://mcp.example.test")
-            )
+        # Not an error — the user has one more step, and the note is what tells
+        # them so.
+        with mcp_creation({"status": "oauth_required"}):
+            authored = await create_integration(USER, mcp_blueprint())
+
         assert authored.needs_connection is True
+        assert authored.note == "Connect it to finish authenticating."
+
+    async def test_a_failure_from_the_server_is_relayed_instead_of_the_generic_note(self):
+        # The caller is a chat tool: "MCP server returned 502" lets the model
+        # tell the user what went wrong, "connect it to finish" does not.
+        with mcp_creation({"status": "error", "error": "MCP server returned 502"}):
+            authored = await create_integration(USER, mcp_blueprint())
+
+        assert authored.needs_connection is True
+        assert authored.note == "MCP server returned 502"
+
+    async def test_the_wrong_blueprint_kind_names_the_author_and_the_kind(self):
+        # Unreachable through the registry, which dispatches on kind — it is the
+        # guard that makes a future author wired to the wrong kind fail loudly
+        # instead of quietly creating the wrong sort of integration.
+        with pytest.raises(TypeError) as exc_info:
+            await McpIntegrationAuthor().create(USER, cli_blueprint())
+
+        assert str(exc_info.value) == "McpIntegrationAuthor cannot author a 'cli' blueprint"
 
     @pytest.mark.parametrize(
         "unsafe",
@@ -188,3 +296,104 @@ class TestMcpAuthor:
         # applies the SSRF shape check.
         with pytest.raises(Exception):
             await create_integration(USER, McpBlueprint(name="Acme", server_url=unsafe))
+
+
+class TestIconFromHomepage:
+    """A CLI has no server URL, so the icon comes from a declared homepage.
+
+    Declared rather than derived: pulling a URL out of ``install_command`` names
+    where the bytes are hosted (github.com, registry.npmjs.org), not whose tool
+    it is, and would give npm's icon to every npm-published vendor CLI.
+    """
+
+    async def test_stores_the_favicon_fetched_from_the_homepage(self):
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+            patch(
+                "app.services.integrations.authoring.cli_author.fetch_favicon_safely",
+                AsyncMock(return_value="https://cdn.example.test/gh.png"),
+            ) as fetch,
+        ):
+            repo.create = AsyncMock()
+            await create_integration(USER, cli_blueprint(homepage="https://cli.github.com"))
+
+        fetch.assert_awaited_once_with("https://cli.github.com")
+        assert repo.create.await_args.args[0].icon_url == "https://cdn.example.test/gh.png"
+
+    async def test_no_homepage_means_no_icon(self):
+        # The blank-URL guard lives in the shared helper, not repeated here.
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+            patch(
+                "app.services.integrations.authoring.cli_author.fetch_favicon_safely",
+                AsyncMock(return_value=None),
+            ) as fetch,
+        ):
+            repo.create = AsyncMock()
+            await create_integration(USER, cli_blueprint())
+
+        fetch.assert_awaited_once_with(None)
+        assert repo.create.await_args.args[0].icon_url is None
+
+    async def test_an_unreachable_favicon_host_still_creates_the_integration(self):
+        # The helper returns None rather than raising (its own tests pin that);
+        # a missing icon must not cost the user the integration.
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+            patch(
+                "app.services.integrations.authoring.cli_author.fetch_favicon_safely",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            repo.create = AsyncMock()
+            authored = await create_integration(
+                USER, cli_blueprint(homepage="https://slow.example.test")
+            )
+
+        assert authored.integration.name == "GitHub CLI"
+        assert repo.create.await_args.args[0].icon_url is None
+
+    @pytest.mark.parametrize(
+        "unsafe",
+        ["http://127.0.0.1/logo.png", "file:///etc/passwd", "ftp://example.test/x", "not-a-url"],
+    )
+    async def test_a_malformed_or_literal_private_homepage_is_rejected_outright(self, unsafe: str):
+        # Caught by the model's cheap shape check, so the integration is never
+        # created at all.
+        with patch(
+            "app.services.integrations.authoring.cli_author.fetch_favicon_safely", AsyncMock()
+        ) as fetch:
+            with pytest.raises(ValueError, match="Invalid CLI configuration"):
+                await create_integration(USER, cli_blueprint(homepage=unsafe))
+        fetch.assert_not_awaited()
+
+    async def test_a_hostname_resolving_to_a_private_address_yields_no_icon(self):
+        # The shape check does not resolve DNS, so `localhost` passes it; the
+        # shared helper's resolving guard is what refuses the request. The
+        # integration is still created, just without an icon.
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+            patch(
+                "app.services.integrations.authoring.cli_author.fetch_favicon_safely",
+                AsyncMock(return_value=None),
+            ) as fetch,
+        ):
+            repo.create = AsyncMock()
+            authored = await create_integration(
+                USER, cli_blueprint(homepage="http://localhost:8080/")
+            )
+
+        fetch.assert_awaited_once_with("http://localhost:8080/")
+        assert authored.integration.icon_url is None

--- a/apps/api/tests/unit/services/integrations/test_authoring.py
+++ b/apps/api/tests/unit/services/integrations/test_authoring.py
@@ -25,6 +25,7 @@ from app.services.integrations.authoring import (
     McpBlueprint,
     create_integration,
     get_author,
+    register_author,
 )
 from app.services.integrations.authoring.cli_author import CliIntegrationAuthor
 from app.services.integrations.authoring.mcp_author import McpIntegrationAuthor
@@ -92,6 +93,22 @@ class TestAuthorRegistry:
     def test_both_transports_are_authorable(self):
         assert isinstance(get_author("cli"), CliIntegrationAuthor)
         assert get_author("mcp") is not None
+
+    def test_registering_an_author_is_what_makes_a_kind_creatable(self):
+        # Registration is the whole mechanism: a registry that stored anything
+        # but the author leaves `create_integration` with nothing to call, and
+        # a transport that is in fact implemented reports "No author
+        # registered".
+        original = get_author("cli")
+        assert original is not None
+        replacement = CliIntegrationAuthor()
+        try:
+            register_author(replacement)
+            assert get_author("cli") is replacement
+        finally:
+            # The registry is process-wide; put the real author back so a later
+            # test never authors through a stub.
+            register_author(original)
 
     async def test_an_unknown_kind_fails_loudly(self):
         blueprint = MagicMock()

--- a/apps/api/tests/unit/services/integrations/test_authoring.py
+++ b/apps/api/tests/unit/services/integrations/test_authoring.py
@@ -1,0 +1,190 @@
+"""Unit tests for creating an integration from a blueprint.
+
+The authoring path is reachable from a chat tool, so its inputs come from a
+model reading a vendor's docs. The tests focus on what that implies: a
+malformed blueprint must fail with a message the model can act on, and a
+half-created integration must never be left behind.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.integrations.authoring import (
+    CliBlueprint,
+    McpBlueprint,
+    create_integration,
+    get_author,
+)
+from app.services.integrations.authoring.cli_author import CliIntegrationAuthor
+
+USER = "user-1"
+
+
+def cli_blueprint(**overrides: object) -> CliBlueprint:
+    base: dict[str, object] = {
+        "name": "GitHub CLI",
+        "description": "Work with GitHub from the command line",
+        "command": "gh",
+        "install_command": "curl -fsSL https://example.test/gh.tgz | tar -xz",
+        "capabilities": ["list pull requests", "create issues"],
+        "auth_kind": "token",
+        "verify_command": "gh auth status",
+        "token_env": "GH_TOKEN",
+        "token_label": "GitHub token",
+    }
+    base.update(overrides)
+    return CliBlueprint(**base)  # type: ignore[arg-type]
+
+
+class TestAuthorRegistry:
+    def test_both_transports_are_authorable(self):
+        assert isinstance(get_author("cli"), CliIntegrationAuthor)
+        assert get_author("mcp") is not None
+
+    async def test_an_unknown_kind_fails_loudly(self):
+        blueprint = MagicMock()
+        blueprint.kind = "carrier-pigeon"
+        with pytest.raises(ValueError, match="No author registered"):
+            await create_integration(USER, blueprint)
+
+
+class TestCliAuthor:
+    async def test_persists_the_integration_and_attaches_it(self):
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration",
+                AsyncMock(),
+            ) as attach,
+        ):
+            repo.create = AsyncMock()
+            authored = await create_integration(USER, cli_blueprint())
+
+        repo.create.assert_awaited_once()
+        stored = repo.create.await_args.args[0]
+        assert stored.managed_by == "cli"
+        assert stored.source == "custom"
+        assert stored.created_by == USER
+        assert stored.cli_config is not None
+        assert stored.cli_config.command == "gh"
+        attach.assert_awaited_once()
+        assert authored.needs_connection is True
+
+    async def test_capabilities_become_the_displayed_tool_list(self):
+        # Publishing requires a non-empty tool list, and "one tool that wraps a
+        # CLI" tells a user nothing — the capabilities are the real answer.
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+        ):
+            repo.create = AsyncMock()
+            await create_integration(USER, cli_blueprint())
+
+        stored = repo.create.await_args.args[0]
+        assert [t.name for t in stored.tools] == ["list pull requests", "create issues"]
+
+    async def test_rolls_back_the_catalog_row_if_attaching_fails(self):
+        # Otherwise the marketplace shows an integration that belongs to nobody
+        # and that nobody can connect or delete.
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration",
+                AsyncMock(side_effect=RuntimeError("mongo down")),
+            ),
+        ):
+            repo.create = AsyncMock()
+            repo.delete = AsyncMock()
+            with pytest.raises(RuntimeError):
+                await create_integration(USER, cli_blueprint())
+
+        repo.delete.assert_awaited_once()
+
+    async def test_an_incoherent_auth_spec_is_rejected_with_a_usable_message(self):
+        # A model that read a vendor's docs badly gets told exactly what is
+        # missing so it can retry, rather than a stack trace.
+        with pytest.raises(ValueError, match="Invalid CLI configuration"):
+            await create_integration(USER, cli_blueprint(auth_kind="device", login_command=None))
+
+    async def test_a_no_auth_cli_still_needs_a_connect_to_install(self):
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+        ):
+            repo.create = AsyncMock()
+            authored = await create_integration(
+                USER,
+                cli_blueprint(auth_kind="none", token_env=None, token_label=None),
+            )
+        assert authored.needs_connection is True
+        assert repo.create.await_args.args[0].requires_auth is False
+
+    async def test_does_not_touch_the_sandbox(self):
+        # Creation is a catalog write. Installing here would make an ordinary
+        # chat turn wait on a cold sandbox and an npm install.
+        with (
+            patch("app.services.integrations.authoring.cli_author.integration_repository") as repo,
+            patch(
+                "app.services.integrations.authoring.cli_author.add_user_integration", AsyncMock()
+            ),
+            patch("app.services.cli.runtime.ensure_installed", AsyncMock()) as install,
+        ):
+            repo.create = AsyncMock()
+            await create_integration(USER, cli_blueprint())
+        install.assert_not_awaited()
+
+
+class TestMcpAuthor:
+    async def test_delegates_to_the_existing_custom_mcp_path(self):
+        integration = MagicMock(name="integration")
+        with (
+            patch(
+                "app.services.integrations.authoring.mcp_author.get_mcp_client",
+                AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "app.services.integrations.authoring.mcp_author.create_and_connect_custom_integration",
+                AsyncMock(return_value=(integration, {"status": "connected", "tools_count": 7})),
+            ) as create,
+        ):
+            authored = await create_integration(
+                USER, McpBlueprint(name="Acme", server_url="https://mcp.example.test")
+            )
+
+        create.assert_awaited_once()
+        assert authored.integration is integration
+        assert authored.needs_connection is False
+        assert "7 tools" in (authored.note or "")
+
+    async def test_reports_when_the_server_still_needs_authentication(self):
+        with (
+            patch(
+                "app.services.integrations.authoring.mcp_author.get_mcp_client",
+                AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "app.services.integrations.authoring.mcp_author.create_and_connect_custom_integration",
+                AsyncMock(return_value=(MagicMock(), {"status": "oauth_required"})),
+            ),
+        ):
+            authored = await create_integration(
+                USER, McpBlueprint(name="Acme", server_url="https://mcp.example.test")
+            )
+        assert authored.needs_connection is True
+
+    @pytest.mark.parametrize(
+        "unsafe",
+        ["http://127.0.0.1/mcp", "http://localhost:8080/mcp", "file:///etc/passwd", "ftp://x/y"],
+    )
+    async def test_rejects_unsafe_server_urls_from_a_chat_caller(self, unsafe: str):
+        # This path never went through the HTTP request model that normally
+        # applies the SSRF shape check.
+        with pytest.raises(Exception):
+            await create_integration(USER, McpBlueprint(name="Acme", server_url=unsafe))

--- a/apps/api/tests/unit/services/integrations/test_connect_dispatch.py
+++ b/apps/api/tests/unit/services/integrations/test_connect_dispatch.py
@@ -1,0 +1,231 @@
+"""Unit tests for the shared connect dispatch and the provider registry.
+
+This is the single place a transport is chosen, for both the authenticated
+endpoint and the login-free connect-link path. The behaviour that matters is
+that every registered transport is reachable, an unregistered one fails
+loudly, and no transport can leak an exception to the caller.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.cli_config import CliAuthSpec, CliConfig
+from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.services.integrations import connect_dispatch
+from app.services.integrations.providers import (
+    CliIntegrationProvider,
+    ComposioIntegrationProvider,
+    ConnectContext,
+    McpIntegrationProvider,
+    SelfIntegrationProvider,
+    get_provider,
+)
+
+USER = "user-1"
+
+
+def _resolved(
+    managed_by: str = "mcp",
+    *,
+    source: str = "platform",
+    available: bool = True,
+    provider: str | None = "acme",
+    cli_config: CliConfig | None = None,
+) -> MagicMock:
+    resolved = MagicMock()
+    resolved.managed_by = managed_by
+    resolved.source = source
+    resolved.name = "Acme"
+    resolved.requires_auth = False
+    resolved.cli_config = cli_config
+    resolved.mcp_config = MagicMock(server_url="https://mcp.example.test")
+    if source == "platform":
+        resolved.platform_integration = MagicMock(available=available, provider=provider)
+    else:
+        resolved.platform_integration = None
+    return resolved
+
+
+class TestProviderRegistry:
+    @pytest.mark.parametrize(
+        ("managed_by", "expected"),
+        [
+            ("mcp", McpIntegrationProvider),
+            ("composio", ComposioIntegrationProvider),
+            ("self", SelfIntegrationProvider),
+            ("cli", CliIntegrationProvider),
+        ],
+    )
+    def test_every_connectable_transport_is_registered(self, managed_by, expected):
+        assert isinstance(get_provider(managed_by), expected)
+
+    def test_internal_integrations_have_no_provider(self):
+        # They are always on and have nothing to connect; the dispatch turns
+        # this into a clear error rather than a crash.
+        assert get_provider("internal") is None
+
+
+class TestDispatch:
+    async def test_unknown_integration_returns_none_for_a_404(self):
+        with patch.object(
+            connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=None)
+        ):
+            assert await connect_dispatch.initiate_integration_connection(USER, "nope") is None
+
+    async def test_unavailable_platform_integration_is_rejected(self):
+        with patch.object(
+            connect_dispatch.IntegrationResolver,
+            "resolve",
+            AsyncMock(return_value=_resolved(available=False)),
+        ):
+            result = await connect_dispatch.initiate_integration_connection(USER, "x")
+        assert result is not None
+        assert result.status == "error"
+        assert "not available" in (result.error or "")
+
+    async def test_transport_without_a_provider_is_reported(self):
+        with patch.object(
+            connect_dispatch.IntegrationResolver,
+            "resolve",
+            AsyncMock(return_value=_resolved(managed_by="internal")),
+        ):
+            result = await connect_dispatch.initiate_integration_connection(USER, "todos")
+        assert result is not None
+        assert result.status == "error"
+        assert "Unsupported integration type" in (result.error or "")
+
+    async def test_provider_exceptions_never_escape(self):
+        # The endpoint returns this straight to a client; an unhandled exception
+        # here would be a 500 for something as ordinary as a dead MCP server.
+        provider = MagicMock()
+        provider.connect = AsyncMock(side_effect=RuntimeError("upstream exploded"))
+        with (
+            patch.object(
+                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+            ),
+            patch.object(connect_dispatch, "get_provider", return_value=provider),
+        ):
+            result = await connect_dispatch.initiate_integration_connection(USER, "x")
+        assert result is not None
+        assert result.status == "error"
+        assert "upstream exploded" in (result.error or "")
+
+    async def test_a_completed_connection_is_recorded_once(self):
+        provider = MagicMock()
+        provider.connect = AsyncMock(
+            return_value=ConnectIntegrationResponse(
+                status="connected", integration_id="x", name="Acme"
+            )
+        )
+        with (
+            patch.object(
+                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+            ),
+            patch.object(connect_dispatch, "get_provider", return_value=provider),
+            patch.object(connect_dispatch, "capture_context_event") as capture,
+        ):
+            await connect_dispatch.initiate_integration_connection(USER, "x")
+        capture.assert_called_once()
+
+    async def test_a_pending_connection_is_not_recorded_as_connected(self):
+        provider = MagicMock()
+        provider.connect = AsyncMock(
+            return_value=ConnectIntegrationResponse(
+                status="pending", integration_id="x", name="Acme"
+            )
+        )
+        with (
+            patch.object(
+                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+            ),
+            patch.object(connect_dispatch, "get_provider", return_value=provider),
+            patch.object(connect_dispatch, "capture_context_event") as capture,
+        ):
+            await connect_dispatch.initiate_integration_connection(USER, "x")
+        capture.assert_not_called()
+
+    async def test_the_pasted_secret_reaches_the_provider(self):
+        provider = MagicMock()
+        provider.connect = AsyncMock(
+            return_value=ConnectIntegrationResponse(
+                status="pending", integration_id="x", name="Acme"
+            )
+        )
+        with (
+            patch.object(
+                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+            ),
+            patch.object(connect_dispatch, "get_provider", return_value=provider),
+        ):
+            await connect_dispatch.initiate_integration_connection(
+                USER, "x", bearer_token="paste-me"
+            )
+        ctx: ConnectContext = provider.connect.await_args.args[0]
+        assert ctx.secret == "paste-me"
+        assert ctx.user_id == USER
+
+
+class TestCliProvider:
+    CONFIG = CliConfig(
+        command="link-cli",
+        install_command="npm install x",
+        auth=CliAuthSpec(
+            kind="device",
+            login_command="link-cli auth login",
+            verify_command="link-cli auth status",
+        ),
+    )
+
+    def _ctx(self, cli_config: CliConfig | None) -> ConnectContext:
+        return ConnectContext(
+            user_id=USER,
+            integration_id="stripe_link",
+            resolved=_resolved(managed_by="cli", cli_config=cli_config),
+            redirect_path="/integrations",
+        )
+
+    async def test_missing_configuration_is_an_error_not_a_crash(self):
+        result = await CliIntegrationProvider().connect(self._ctx(None))
+        assert result.status == "error"
+        assert "no CLI configuration" in (result.error or "")
+
+    @pytest.mark.parametrize(
+        ("phase", "expected_status"),
+        [
+            ("installing", "pending"),
+            ("awaiting_approval", "pending"),
+            ("needs_token", "pending"),
+            ("connected", "connected"),
+            ("failed", "error"),
+        ],
+    )
+    async def test_phase_maps_onto_the_shared_response_status(self, phase, expected_status):
+        from app.services.cli.connect import CliConnectOutcome
+
+        outcome = CliConnectOutcome(phase=phase, message="m", instructions="i")
+        with patch(
+            "app.services.integrations.providers.cli_provider.advance",
+            AsyncMock(return_value=outcome),
+        ):
+            result = await CliIntegrationProvider().connect(self._ctx(self.CONFIG))
+        assert result.status == expected_status
+        assert result.cli is not None
+        assert result.cli.phase == phase
+
+    async def test_token_prompt_copy_is_carried_to_the_client(self):
+        from app.services.cli.connect import CliConnectOutcome
+
+        outcome = CliConnectOutcome(
+            phase="needs_token", token_label="GitHub token", token_help_url="https://gh.test/t"
+        )
+        with patch(
+            "app.services.integrations.providers.cli_provider.advance",
+            AsyncMock(return_value=outcome),
+        ):
+            result = await CliIntegrationProvider().connect(self._ctx(self.CONFIG))
+        assert result.cli is not None
+        assert result.cli.token_label == "GitHub token"
+        assert result.cli.token_help_url == "https://gh.test/t"

--- a/apps/api/tests/unit/services/integrations/test_connect_dispatch.py
+++ b/apps/api/tests/unit/services/integrations/test_connect_dispatch.py
@@ -3,7 +3,9 @@
 This is the single place a transport is chosen, for both the authenticated
 endpoint and the login-free connect-link path. The behaviour that matters is
 that every registered transport is reachable, an unregistered one fails
-loudly, and no transport can leak an exception to the caller.
+loudly, no transport can leak an exception to the caller, and the context each
+transport receives carries the caller's arguments unchanged — a dropped field
+here is a connect that fails for a reason the user cannot act on.
 """
 
 from __future__ import annotations
@@ -12,17 +14,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.constants.log_tags import LogTag
 from app.models.cli_config import CliAuthSpec, CliConfig
-from app.schemas.integrations.responses import ConnectIntegrationResponse
+from app.schemas.integrations.responses import CliConnectDetail, ConnectIntegrationResponse
+from app.services.analytics_service import AnalyticsEvents
+from app.services.cli.connect import CliConnectOutcome
 from app.services.integrations import connect_dispatch
 from app.services.integrations.providers import (
     CliIntegrationProvider,
     ComposioIntegrationProvider,
     ConnectContext,
+    IntegrationProvider,
     McpIntegrationProvider,
     SelfIntegrationProvider,
     get_provider,
+    register_provider,
 )
+from tests.helpers import captured_wide_event
 
 USER = "user-1"
 
@@ -49,6 +57,47 @@ def _resolved(
     return resolved
 
 
+def _resolver(catalog: dict[str, MagicMock]) -> AsyncMock:
+    """A resolver that answers for the ids it was given and ``None`` otherwise.
+
+    Keyed rather than constant so a dispatch that looked up the wrong id
+    resolves nothing — exactly what would happen against the real catalog.
+    """
+    return AsyncMock(side_effect=lambda integration_id: catalog.get(integration_id))
+
+
+def _registry(managed_by: str, provider: IntegrationProvider | MagicMock) -> MagicMock:
+    """A ``get_provider`` stub that serves exactly one transport.
+
+    The registry is keyed on ``managed_by``; looking the wrong key up in
+    production yields ``None`` and the connect is refused, so the stub must
+    behave the same way rather than answering every key alike.
+    """
+    return MagicMock(side_effect=lambda key: provider if key == managed_by else None)
+
+
+def _provider_returning(response: ConnectIntegrationResponse) -> MagicMock:
+    provider = MagicMock()
+    provider.connect = AsyncMock(return_value=response)
+    return provider
+
+
+@pytest.fixture
+def restored_registry():
+    """Put the real transports back after a test registers over one.
+
+    ``_PROVIDERS`` is process-wide, so a stub left behind would silently serve
+    every later test in the session.
+    """
+    original = {
+        managed_by: get_provider(managed_by) for managed_by in ("mcp", "composio", "self", "cli")
+    }
+    yield
+    for provider in original.values():
+        if provider is not None:
+            register_provider(provider)
+
+
 class TestProviderRegistry:
     @pytest.mark.parametrize(
         ("managed_by", "expected"),
@@ -67,105 +116,203 @@ class TestProviderRegistry:
         # this into a clear error rather than a crash.
         assert get_provider("internal") is None
 
+    def test_registering_a_transport_is_what_makes_it_reachable(self, restored_registry):
+        # Registration is the whole mechanism: a registry that stored anything
+        # but the provider leaves the dispatch with nothing to call, and every
+        # entry point refuses a transport that is in fact implemented.
+        replacement = CliIntegrationProvider()
+        register_provider(replacement)
+        assert get_provider("cli") is replacement
+
 
 class TestDispatch:
     async def test_unknown_integration_returns_none_for_a_404(self):
         with patch.object(
-            connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=None)
+            connect_dispatch.IntegrationResolver, "resolve", _resolver({"known": _resolved()})
         ):
             assert await connect_dispatch.initiate_integration_connection(USER, "nope") is None
 
-    async def test_unavailable_platform_integration_is_rejected(self):
+    async def test_unavailable_platform_integration_is_refused_by_name(self):
+        # The user sees this string on the integration card, so it has to name
+        # the integration they clicked rather than fail anonymously.
         with patch.object(
             connect_dispatch.IntegrationResolver,
             "resolve",
-            AsyncMock(return_value=_resolved(available=False)),
+            _resolver({"acme": _resolved(available=False)}),
         ):
-            result = await connect_dispatch.initiate_integration_connection(USER, "x")
+            result = await connect_dispatch.initiate_integration_connection(USER, "acme")
         assert result is not None
         assert result.status == "error"
-        assert "not available" in (result.error or "")
+        assert result.error == "Integration acme is not available yet"
+        assert result.name == "Acme"
 
-    async def test_transport_without_a_provider_is_reported(self):
+    async def test_transport_without_a_provider_is_reported_with_the_transport_name(self):
         with patch.object(
             connect_dispatch.IntegrationResolver,
             "resolve",
-            AsyncMock(return_value=_resolved(managed_by="internal")),
+            _resolver({"todos": _resolved(managed_by="internal")}),
         ):
             result = await connect_dispatch.initiate_integration_connection(USER, "todos")
         assert result is not None
         assert result.status == "error"
-        assert "Unsupported integration type" in (result.error or "")
+        assert result.error == "Unsupported integration type: internal"
 
-    async def test_provider_exceptions_never_escape(self):
+    async def test_provider_exceptions_never_escape_and_are_recorded(self):
         # The endpoint returns this straight to a client; an unhandled exception
         # here would be a 500 for something as ordinary as a dead MCP server.
+        # What the user is told names the integration and what to do; the raw
+        # upstream text stays on the wide event, which is the only place the
+        # cause survives and the only place it is useful.
         provider = MagicMock()
         provider.connect = AsyncMock(side_effect=RuntimeError("upstream exploded"))
         with (
             patch.object(
-                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+                connect_dispatch.IntegrationResolver, "resolve", _resolver({"x": _resolved()})
             ),
-            patch.object(connect_dispatch, "get_provider", return_value=provider),
+            patch.object(connect_dispatch, "get_provider", _registry("mcp", provider)),
         ):
-            result = await connect_dispatch.initiate_integration_connection(USER, "x")
+            async with captured_wide_event() as event:
+                result = await connect_dispatch.initiate_integration_connection(USER, "x")
+
         assert result is not None
         assert result.status == "error"
-        assert "upstream exploded" in (result.error or "")
+        assert result.error == (
+            "Something went wrong connecting Acme. This is usually temporary; try again in a moment."
+        )
+        (failure,) = event["errors"]
+        assert failure == {
+            "msg": f"{LogTag.INTEGRATION} Failed to initiate connection",
+            "integration_id": "x",
+            "user_id": USER,
+            "error": "upstream exploded",
+            "error_type": "RuntimeError",
+        }
 
-    async def test_a_completed_connection_is_recorded_once(self):
-        provider = MagicMock()
-        provider.connect = AsyncMock(
-            return_value=ConnectIntegrationResponse(
-                status="connected", integration_id="x", name="Acme"
-            )
+    async def test_a_completed_connection_is_recorded_once_with_its_transport(self):
+        provider = _provider_returning(
+            ConnectIntegrationResponse(status="connected", integration_id="x", name="Acme")
         )
         with (
             patch.object(
-                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+                connect_dispatch.IntegrationResolver, "resolve", _resolver({"x": _resolved()})
             ),
-            patch.object(connect_dispatch, "get_provider", return_value=provider),
+            patch.object(connect_dispatch, "get_provider", _registry("mcp", provider)),
             patch.object(connect_dispatch, "capture_context_event") as capture,
         ):
             await connect_dispatch.initiate_integration_connection(USER, "x")
-        capture.assert_called_once()
+        # The analytics funnel is grouped by transport; the property names are
+        # the schema PostHog joins on, so neither may drift.
+        capture.assert_called_once_with(
+            AnalyticsEvents.INTEGRATION_CONNECTED,
+            {"integration_id": "x", "managed_by": "mcp"},
+        )
 
     async def test_a_pending_connection_is_not_recorded_as_connected(self):
-        provider = MagicMock()
-        provider.connect = AsyncMock(
-            return_value=ConnectIntegrationResponse(
-                status="pending", integration_id="x", name="Acme"
-            )
+        provider = _provider_returning(
+            ConnectIntegrationResponse(status="pending", integration_id="x", name="Acme")
         )
         with (
             patch.object(
-                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+                connect_dispatch.IntegrationResolver, "resolve", _resolver({"x": _resolved()})
             ),
-            patch.object(connect_dispatch, "get_provider", return_value=provider),
+            patch.object(connect_dispatch, "get_provider", _registry("mcp", provider)),
             patch.object(connect_dispatch, "capture_context_event") as capture,
         ):
             await connect_dispatch.initiate_integration_connection(USER, "x")
         capture.assert_not_called()
 
-    async def test_the_pasted_secret_reaches_the_provider(self):
-        provider = MagicMock()
-        provider.connect = AsyncMock(
-            return_value=ConnectIntegrationResponse(
-                status="pending", integration_id="x", name="Acme"
-            )
+    async def test_the_context_carries_every_caller_argument_to_the_transport(self):
+        # The transports read this and nothing else: a dropped secret sends the
+        # user back to a token dialog that already has their token, and a
+        # dropped redirect path returns them to the wrong page after OAuth.
+        resolved = _resolved()
+        provider = _provider_returning(
+            ConnectIntegrationResponse(status="pending", integration_id="x", name="Acme")
         )
         with (
             patch.object(
-                connect_dispatch.IntegrationResolver, "resolve", AsyncMock(return_value=_resolved())
+                connect_dispatch.IntegrationResolver, "resolve", _resolver({"x": resolved})
             ),
-            patch.object(connect_dispatch, "get_provider", return_value=provider),
+            patch.object(connect_dispatch, "get_provider", _registry("mcp", provider)),
         ):
             await connect_dispatch.initiate_integration_connection(
-                USER, "x", bearer_token="paste-me"
+                USER,
+                "x",
+                user_email="user@example.test",
+                redirect_path="/chat/42",
+                bearer_token="paste-me",
             )
+        assert provider.connect.await_args.args == (
+            ConnectContext(
+                user_id=USER,
+                integration_id="x",
+                resolved=resolved,
+                redirect_path="/chat/42",
+                user_email="user@example.test",
+                secret="paste-me",
+            ),
+        )
+
+    async def test_a_bare_connect_returns_the_user_to_the_integrations_page(self):
+        # The login-free connect-link path calls with neither argument: the
+        # redirect has to land somewhere real, and an unknown email must stay
+        # empty rather than become a bogus OAuth login hint.
+        resolved = _resolved()
+        provider = _provider_returning(
+            ConnectIntegrationResponse(status="pending", integration_id="x", name="Acme")
+        )
+        with (
+            patch.object(
+                connect_dispatch.IntegrationResolver, "resolve", _resolver({"x": resolved})
+            ),
+            patch.object(connect_dispatch, "get_provider", _registry("mcp", provider)),
+        ):
+            await connect_dispatch.initiate_integration_connection(USER, "x")
         ctx: ConnectContext = provider.connect.await_args.args[0]
-        assert ctx.secret == "paste-me"
-        assert ctx.user_id == USER
+        assert ctx.redirect_path == "/integrations"
+        assert ctx.user_email == ""
+        assert ctx.secret is None
+
+
+class TestDispatchWideEvent:
+    """The wide event is how a failed connect is diagnosed in production.
+
+    Nothing else records which user asked for which integration, or how the
+    attempt ended, so a renamed key or a dropped namespace is an outage that
+    cannot be investigated afterwards.
+    """
+
+    async def test_the_event_identifies_the_user_the_integration_and_the_outcome(self):
+        provider = _provider_returning(
+            ConnectIntegrationResponse(status="pending", integration_id="x", name="Acme")
+        )
+        with (
+            patch.object(
+                connect_dispatch.IntegrationResolver, "resolve", _resolver({"x": _resolved()})
+            ),
+            patch.object(connect_dispatch, "get_provider", _registry("mcp", provider)),
+        ):
+            async with captured_wide_event() as event:
+                await connect_dispatch.initiate_integration_connection(USER, "x")
+                # Read inside the boundary: closing it stamps its own
+                # ``outcome`` over whatever the dispatch recorded.
+                outcome = event["outcome"]
+
+        assert event["user"] == {"id": USER}
+        assert event["integration"] == {"id": "x", "managed_by": "mcp", "source": "platform"}
+        assert outcome == "pending"
+
+    async def test_a_refused_connect_is_recorded_as_an_error_outcome(self):
+        with patch.object(
+            connect_dispatch.IntegrationResolver,
+            "resolve",
+            _resolver({"acme": _resolved(available=False)}),
+        ):
+            async with captured_wide_event() as event:
+                await connect_dispatch.initiate_integration_connection(USER, "acme")
+                outcome = event["outcome"]
+
+        assert outcome == "error"
 
 
 class TestCliProvider:
@@ -179,18 +326,44 @@ class TestCliProvider:
         ),
     )
 
-    def _ctx(self, cli_config: CliConfig | None) -> ConnectContext:
+    def _ctx(self, cli_config: CliConfig | None, *, secret: str | None = None) -> ConnectContext:
         return ConnectContext(
             user_id=USER,
             integration_id="stripe_link",
             resolved=_resolved(managed_by="cli", cli_config=cli_config),
             redirect_path="/integrations",
+            secret=secret,
         )
 
-    async def test_missing_configuration_is_an_error_not_a_crash(self):
+    async def test_missing_configuration_is_an_error_naming_the_integration(self):
+        # Only reachable via a hand-written Mongo document, so the message has
+        # to say which document is wrong.
         result = await CliIntegrationProvider().connect(self._ctx(None))
         assert result.status == "error"
-        assert "no CLI configuration" in (result.error or "")
+        assert result.error == "stripe_link has no CLI configuration"
+
+    async def test_the_state_machine_is_driven_for_this_user_and_integration(self):
+        # advance() is the whole transport; the pasted token is the credential
+        # the user just typed, and driving the wrong (user, integration, config)
+        # would authenticate someone else's sandbox.
+        outcome = CliConnectOutcome(phase="connected", message="Signed in")
+        with patch(
+            "app.services.integrations.providers.cli_provider.advance",
+            AsyncMock(return_value=outcome),
+        ) as advance:
+            await CliIntegrationProvider().connect(self._ctx(self.CONFIG, secret="paste-me"))
+        advance.assert_awaited_once_with(USER, "stripe_link", self.CONFIG, token="paste-me")
+
+    async def test_an_empty_paste_is_not_forwarded_as_a_token(self):
+        # The connect dialog submits an empty field on the first poll; an empty
+        # string is not a credential and must not be written to the CLI's HOME.
+        outcome = CliConnectOutcome(phase="needs_token")
+        with patch(
+            "app.services.integrations.providers.cli_provider.advance",
+            AsyncMock(return_value=outcome),
+        ) as advance:
+            await CliIntegrationProvider().connect(self._ctx(self.CONFIG, secret=""))
+        assert advance.await_args.kwargs["token"] is None
 
     @pytest.mark.parametrize(
         ("phase", "expected_status"),
@@ -199,25 +372,40 @@ class TestCliProvider:
             ("awaiting_approval", "pending"),
             ("needs_token", "pending"),
             ("connected", "connected"),
-            ("failed", "error"),
         ],
     )
-    async def test_phase_maps_onto_the_shared_response_status(self, phase, expected_status):
-        from app.services.cli.connect import CliConnectOutcome
-
-        outcome = CliConnectOutcome(phase=phase, message="m", instructions="i")
+    async def test_a_phase_short_of_failure_is_progress_not_an_error(self, phase, expected_status):
+        # The client polls while `pending` and stops on `error`. Reporting
+        # progress as an error would abandon an install that was going fine,
+        # and the instructions are what the user needs to act on meanwhile.
+        outcome = CliConnectOutcome(
+            phase=phase, message="Installing link-cli", instructions="Visit https://link.test/abc"
+        )
         with patch(
             "app.services.integrations.providers.cli_provider.advance",
             AsyncMock(return_value=outcome),
         ):
             result = await CliIntegrationProvider().connect(self._ctx(self.CONFIG))
         assert result.status == expected_status
-        assert result.cli is not None
-        assert result.cli.phase == phase
+        assert result.message == "Installing link-cli"
+        assert result.error is None
+        assert result.cli == CliConnectDetail(
+            phase=phase, instructions="Visit https://link.test/abc"
+        )
+
+    async def test_a_failed_phase_surfaces_the_reason_as_the_error(self):
+        outcome = CliConnectOutcome(phase="failed", message="npm install exited 1")
+        with patch(
+            "app.services.integrations.providers.cli_provider.advance",
+            AsyncMock(return_value=outcome),
+        ):
+            result = await CliIntegrationProvider().connect(self._ctx(self.CONFIG))
+        assert result.status == "error"
+        assert result.error == "npm install exited 1"
+        assert result.message == "npm install exited 1"
+        assert result.cli == CliConnectDetail(phase="failed")
 
     async def test_token_prompt_copy_is_carried_to_the_client(self):
-        from app.services.cli.connect import CliConnectOutcome
-
         outcome = CliConnectOutcome(
             phase="needs_token", token_label="GitHub token", token_help_url="https://gh.test/t"
         )

--- a/apps/api/tests/unit/services/integrations/test_connect_dispatch.py
+++ b/apps/api/tests/unit/services/integrations/test_connect_dispatch.py
@@ -417,3 +417,85 @@ class TestCliProvider:
         assert result.cli is not None
         assert result.cli.token_label == "GitHub token"
         assert result.cli.token_help_url == "https://gh.test/t"
+
+
+class TestCliProviderDisconnect:
+    """Disconnecting a CLI has to finish even when the sandbox does not.
+
+    The durable HOME lives in the user's sandbox, so tearing it down is a
+    remote call that can fail for reasons that have nothing to do with the
+    integration. If that failure aborted the disconnect, the user would be
+    left owning an integration they cannot remove until their sandbox comes
+    back — and the record is what every other surface reads.
+    """
+
+    CONFIG = CliConfig(
+        command="link-cli",
+        install_command="npm install x",
+        auth=CliAuthSpec(
+            kind="device",
+            login_command="link-cli auth login",
+            verify_command="link-cli auth status",
+        ),
+    )
+    MODULE = "app.services.integrations.providers.cli_provider"
+
+    def _resolved(self, cli_config: CliConfig | None) -> MagicMock:
+        resolved = _resolved(managed_by="cli", cli_config=cli_config)
+        resolved.integration_id = "stripe_link"
+        return resolved
+
+    async def test_the_sandbox_state_is_torn_down_before_the_record_goes(self):
+        resolved = self._resolved(self.CONFIG)
+        with (
+            patch(f"{self.MODULE}.cli_disconnect", AsyncMock()) as teardown,
+            patch(f"{self.MODULE}.remove_user_integration", AsyncMock()) as remove,
+            patch(f"{self.MODULE}.delete_if_user_authored", AsyncMock()) as delete,
+        ):
+            await CliIntegrationProvider().disconnect(USER, resolved)
+
+        # The teardown runs the CLI's own logout and deletes its durable HOME,
+        # so it needs this user, this integration and this spec.
+        teardown.assert_awaited_once_with(USER, "stripe_link", self.CONFIG)
+        remove.assert_awaited_once_with(USER, "stripe_link")
+        delete.assert_awaited_once_with(USER, resolved)
+
+    async def test_a_failed_teardown_still_removes_the_record_and_is_recorded(self):
+        resolved = self._resolved(self.CONFIG)
+        with (
+            patch(
+                f"{self.MODULE}.cli_disconnect",
+                AsyncMock(side_effect=RuntimeError("sandbox unreachable")),
+            ),
+            patch(f"{self.MODULE}.remove_user_integration", AsyncMock()) as remove,
+            patch(f"{self.MODULE}.delete_if_user_authored", AsyncMock()) as delete,
+        ):
+            async with captured_wide_event() as event:
+                await CliIntegrationProvider().disconnect(USER, resolved)
+
+        remove.assert_awaited_once_with(USER, "stripe_link")
+        delete.assert_awaited_once_with(USER, resolved)
+        # Swallowing the failure is only defensible because it is visible here.
+        (warning,) = event["warnings"]
+        assert warning == {
+            "msg": f"{LogTag.INTEGRATION} CLI teardown failed; removing the record anyway",
+            "integration_id": "stripe_link",
+            "user_id": USER,
+            "error": "sandbox unreachable",
+            "error_type": "RuntimeError",
+        }
+
+    async def test_a_document_with_no_cli_config_is_still_disconnectable(self):
+        # Only reachable via a hand-written Mongo document, which is exactly
+        # the case where the user most needs to be able to remove it.
+        resolved = self._resolved(None)
+        with (
+            patch(f"{self.MODULE}.cli_disconnect", AsyncMock()) as teardown,
+            patch(f"{self.MODULE}.remove_user_integration", AsyncMock()) as remove,
+            patch(f"{self.MODULE}.delete_if_user_authored", AsyncMock()) as delete,
+        ):
+            await CliIntegrationProvider().disconnect(USER, resolved)
+
+        teardown.assert_not_awaited()
+        remove.assert_awaited_once_with(USER, "stripe_link")
+        delete.assert_awaited_once_with(USER, resolved)

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -285,6 +285,59 @@ class TestIntegrationResolverResolve:
 
     @patch("app.services.integrations.integration_resolver.integration_repository")
     @patch("app.services.integrations.integration_resolver.get_integration_by_id")
+    async def test_resolve_custom_cli_takes_requires_auth_from_its_own_auth_spec(
+        self, mock_get_by_id, mock_repo
+    ):
+        """A CLI's credential step is declared by its auth spec, not the
+        MCP-flavoured document field, which every authored CLI leaves at the
+        default. Trusting the document would resolve a token-authenticated CLI
+        as needing nothing, and the connect flow would skip the paste-a-token
+        step entirely."""
+        mock_get_by_id.return_value = None
+        doc = _make_custom_doc(requires_auth=False)
+        doc["managed_by"] = "cli"
+        doc["mcp_config"] = None
+        doc["cli_config"] = {
+            "command": "gh",
+            "install_command": "npm install -g gh",
+            "auth": {
+                "kind": "token",
+                "verify_command": "gh auth status",
+                "token_env": "GH_TOKEN",
+                "token_label": "GitHub token",
+            },
+        }
+        mock_repo.get = AsyncMock(return_value=Integration.model_validate(doc))
+
+        result = await IntegrationResolver.resolve(CUSTOM_INTEGRATION_ID)
+
+        assert result is not None
+        assert result.requires_auth is True
+
+    @patch("app.services.integrations.integration_resolver.integration_repository")
+    @patch("app.services.integrations.integration_resolver.get_integration_by_id")
+    async def test_resolve_custom_cli_with_no_auth_requires_none(self, mock_get_by_id, mock_repo):
+        """The other direction: a formatter-style CLI with no credentials must
+        not be reported as needing one, or the UI shows a connect dialog with
+        nothing to fill in."""
+        mock_get_by_id.return_value = None
+        doc = _make_custom_doc(requires_auth=True)
+        doc["managed_by"] = "cli"
+        doc["mcp_config"] = None
+        doc["cli_config"] = {
+            "command": "fmt",
+            "install_command": "npm install -g fmt",
+            "auth": {"kind": "none", "verify_command": "fmt --version"},
+        }
+        mock_repo.get = AsyncMock(return_value=Integration.model_validate(doc))
+
+        result = await IntegrationResolver.resolve(CUSTOM_INTEGRATION_ID)
+
+        assert result is not None
+        assert result.requires_auth is False
+
+    @patch("app.services.integrations.integration_resolver.integration_repository")
+    @patch("app.services.integrations.integration_resolver.get_integration_by_id")
     async def test_resolve_custom_with_auth_mismatch_syncs(self, mock_get_by_id, mock_repo):
         """When mcp_config.requires_auth differs from doc-level, mcp_config wins and syncs."""
         mock_get_by_id.return_value = None
@@ -1675,7 +1728,7 @@ class TestCreateAndConnectCustomIntegration:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.custom_crud.fetch_favicon_from_url",
+        "app.services.integrations.custom_crud.fetch_favicon_safely",
         new_callable=AsyncMock,
     )
     async def test_bearer_token_flow(self, mock_favicon, mock_create):
@@ -1729,7 +1782,7 @@ class TestCreateAndConnectCustomIntegration:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.custom_crud.fetch_favicon_from_url",
+        "app.services.integrations.custom_crud.fetch_favicon_safely",
         new_callable=AsyncMock,
     )
     async def test_probe_fails_returns_error(self, mock_favicon, mock_create):
@@ -1766,7 +1819,7 @@ class TestCreateAndConnectCustomIntegration:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.custom_crud.fetch_favicon_from_url",
+        "app.services.integrations.custom_crud.fetch_favicon_safely",
         new_callable=AsyncMock,
     )
     async def test_probe_detects_auth_requirement(self, mock_favicon, mock_create):
@@ -1807,7 +1860,7 @@ class TestCreateAndConnectCustomIntegration:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.custom_crud.fetch_favicon_from_url",
+        "app.services.integrations.custom_crud.fetch_favicon_safely",
         new_callable=AsyncMock,
     )
     async def test_connect_without_auth_success(self, mock_favicon, mock_create):
@@ -1845,7 +1898,7 @@ class TestCreateAndConnectCustomIntegration:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.custom_crud.fetch_favicon_from_url",
+        "app.services.integrations.custom_crud.fetch_favicon_safely",
         new_callable=AsyncMock,
     )
     async def test_connect_raises_oauth_error_triggers_auth_flow(self, mock_favicon, mock_create):
@@ -1885,7 +1938,7 @@ class TestCreateAndConnectCustomIntegration:
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.custom_crud.fetch_favicon_from_url",
+        "app.services.integrations.custom_crud.fetch_favicon_safely",
         new_callable=AsyncMock,
     )
     async def test_connect_generic_error(self, mock_favicon, mock_create):
@@ -3083,3 +3136,46 @@ class TestConnectMorePaths:
 
         assert result.status == "redirect"
         assert result.redirect_url == "https://auth.example.com"
+
+
+class TestCliDisconnectDoesNotResurrectTheRecord:
+    """Disconnecting a user-authored CLI integration must leave nothing behind.
+
+    ``_invalidate_caches`` ends in ``update_user_integration_status``, which is
+    an upsert. For a custom integration whose catalog document the disconnect
+    just deleted, falling into that branch recreates the ``user_integrations``
+    row with status "created" — invisible in the UI (the list drops rows whose
+    document is gone) but permanent: ``exists()`` stays true forever and a
+    second disconnect raises "not found".
+    """
+
+    async def test_the_user_record_is_not_recreated(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.services.integrations import integration_connection_service as module
+
+        with (
+            patch.object(module, "get_integration_by_id", return_value=None),
+            patch.object(module, "delete_cache", AsyncMock()),
+            patch.object(module, "remove_user_integration", AsyncMock()) as remove,
+            patch.object(module, "update_user_integration_status", AsyncMock()) as upsert,
+        ):
+            await module._invalidate_caches("user-1", "d8f9d534-cli", "cli")
+
+        upsert.assert_not_awaited()
+        remove.assert_not_awaited()
+
+    async def test_mcp_keeps_its_existing_behaviour(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.services.integrations import integration_connection_service as module
+
+        with (
+            patch.object(module, "get_integration_by_id", return_value=None),
+            patch.object(module, "delete_cache", AsyncMock()),
+            patch.object(module, "remove_user_integration", AsyncMock()),
+            patch.object(module, "update_user_integration_status", AsyncMock()) as upsert,
+        ):
+            await module._invalidate_caches("user-1", "custom-mcp", "mcp")
+
+        upsert.assert_not_awaited()

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -315,6 +315,7 @@ class TestIntegrationResolverHelpers:
             requires_auth=False,
             auth_type=None,
             mcp_config=mcp_cfg,
+            cli_config=None,
             platform_integration=None,
             custom_doc=None,
         )
@@ -1659,6 +1660,7 @@ class TestCreateAndConnectCustomIntegration:
             managed_by="mcp",
             source="custom",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
         )
         mock_create.return_value = integration
 
@@ -1712,6 +1714,7 @@ class TestCreateAndConnectCustomIntegration:
             managed_by="mcp",
             source="custom",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
         )
         mock_create.return_value = integration
 
@@ -1748,6 +1751,7 @@ class TestCreateAndConnectCustomIntegration:
             managed_by="mcp",
             source="custom",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
         )
         mock_create.return_value = integration
 
@@ -1788,6 +1792,7 @@ class TestCreateAndConnectCustomIntegration:
             managed_by="mcp",
             source="custom",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
         )
         mock_create.return_value = integration
 
@@ -1827,6 +1832,7 @@ class TestCreateAndConnectCustomIntegration:
             managed_by="mcp",
             source="custom",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
         )
         mock_create.return_value = integration
 
@@ -1864,6 +1870,7 @@ class TestCreateAndConnectCustomIntegration:
             managed_by="mcp",
             source="custom",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
         )
         mock_create.return_value = integration
 
@@ -1897,6 +1904,7 @@ class TestBuildIntegrationsConfig:
                 integration_id="github",
                 managed_by="mcp",
                 mcp_config=MCPConfig(server_url=SERVER_URL, requires_auth=True),
+                cli_config=None,
             ),
             _make_oauth_integration(integration_id="todos", managed_by="internal"),
         ],
@@ -1916,6 +1924,7 @@ class TestBuildIntegrationsConfig:
                 integration_id="no-auth-mcp",
                 managed_by="mcp",
                 mcp_config=MCPConfig(server_url=SERVER_URL, requires_auth=False),
+                cli_config=None,
             ),
         ],
     )
@@ -1932,6 +1941,7 @@ class TestBuildIntegrationsConfig:
                 integration_id="oauth-mcp",
                 managed_by="mcp",
                 mcp_config=MCPConfig(server_url=SERVER_URL, requires_auth=True),
+                cli_config=None,
             ),
         ],
     )
@@ -2344,6 +2354,7 @@ class TestDisconnectIntegration:
             requires_auth=False,
             auth_type=None,
             mcp_config=None,
+            cli_config=None,
             platform_integration=None,
             custom_doc={"created_by": USER_ID},
         )
@@ -2386,6 +2397,7 @@ class TestDisconnectIntegration:
             requires_auth=False,
             auth_type=None,
             mcp_config=None,
+            cli_config=None,
             platform_integration=None,
             custom_doc={"created_by": "other-user"},
         )
@@ -2438,6 +2450,7 @@ class TestDisconnectIntegration:
             requires_auth=True,
             auth_type="oauth",
             mcp_config=None,
+            cli_config=None,
             platform_integration=platform_int,
             custom_doc=None,
         )
@@ -2476,6 +2489,7 @@ class TestDisconnectIntegration:
             requires_auth=True,
             auth_type="oauth",
             mcp_config=None,
+            cli_config=None,
             platform_integration=None,
             custom_doc=None,
         )
@@ -2510,6 +2524,7 @@ class TestDisconnectIntegration:
             requires_auth=True,
             auth_type="oauth",
             mcp_config=None,
+            cli_config=None,
             platform_integration=platform_int,
             custom_doc=None,
         )
@@ -2539,6 +2554,7 @@ class TestDisconnectIntegration:
             requires_auth=True,
             auth_type="oauth",
             mcp_config=None,
+            cli_config=None,
             platform_integration=None,
             custom_doc=None,
         )
@@ -2575,6 +2591,7 @@ class TestDisconnectIntegration:
             requires_auth=True,
             auth_type="oauth",
             mcp_config=MCPConfig(server_url=SERVER_URL),
+            cli_config=None,
             platform_integration=_make_oauth_integration(
                 integration_id="perplexity", managed_by="mcp"
             ),
@@ -2604,6 +2621,7 @@ class TestDisconnectIntegration:
             requires_auth=False,
             auth_type=None,
             mcp_config=None,
+            cli_config=None,
             platform_integration=None,
             custom_doc=None,
         )

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -25,6 +25,7 @@ from app.agents.core.integration_capabilities import (
     get_user_integration_capabilities,
 )
 from app.helpers.mcp_helpers import get_api_base_url
+from app.models.cli_config import CliAuthSpec, CliConfig
 from app.models.integration_models import (
     CreateCustomIntegrationRequest,
     Integration,
@@ -48,6 +49,7 @@ from app.services.integrations.custom_crud import (
     update_custom_integration,
 )
 from app.services.integrations.integration_connection_service import (
+    McpConnectRequest,
     _handle_auth_required,
     _redirect_to_oauth,
     build_integrations_config,
@@ -84,6 +86,32 @@ USER_ID_2 = "507f1f77bcf86cd799439022"
 INTEGRATION_ID = "test-integration-123"
 CUSTOM_INTEGRATION_ID = "custom-int-uuid-456"
 SERVER_URL = "https://mcp.example.com/v1"
+
+
+def _cli_resolved(*, created_by: str) -> ResolvedIntegration:
+    """A user-authored CLI integration: `managed_by == "cli"` AND `source == "custom"`."""
+    return ResolvedIntegration(
+        integration_id=CUSTOM_INTEGRATION_ID,
+        name="Some CLI",
+        description="",
+        category="custom",
+        managed_by="cli",
+        source="custom",
+        requires_auth=True,
+        auth_type=None,
+        mcp_config=None,
+        cli_config=CliConfig(
+            command="somecli",
+            install_command="npm install -g somecli",
+            auth=CliAuthSpec(
+                kind="device",
+                login_command="somecli auth login",
+                verify_command="somecli auth status",
+            ),
+        ),
+        platform_integration=None,
+        custom_doc={"created_by": created_by},
+    )
 
 
 def _make_oauth_integration(**overrides: Any) -> OAuthIntegration:
@@ -1988,13 +2016,15 @@ class TestConnectMcpIntegration:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            server_url=SERVER_URL,
-            probe_result={},
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                server_url=SERVER_URL,
+                probe_result={},
+            )
         )
 
         assert result.status == "connected"
@@ -2017,12 +2047,14 @@ class TestConnectMcpIntegration:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=True,
-            redirect_path="/integrations",
-            is_platform=False,
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=True,
+                redirect_path="/integrations",
+                is_platform=False,
+            )
         )
 
         assert result.status == "redirect"
@@ -2045,12 +2077,14 @@ class TestConnectMcpIntegration:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=True,
-            redirect_path="/integrations",
-            is_platform=True,
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=True,
+                redirect_path="/integrations",
+                is_platform=True,
+            )
         )
 
         assert result.status == "redirect"
@@ -2086,12 +2120,14 @@ class TestConnectMcpIntegration:
         mock_token_store_cls.return_value = mock_store
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            bearer_token="my-token",
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                bearer_token="my-token",
+            )
         )
 
         assert result.status == "connected"
@@ -2120,12 +2156,14 @@ class TestConnectMcpIntegration:
         mock_token_store_cls.return_value = mock_store
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            bearer_token="bad-token",
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                bearer_token="bad-token",
+            )
         )
 
         assert result.status == "error"
@@ -2151,13 +2189,15 @@ class TestConnectMcpIntegration:
             new_callable=AsyncMock,
         ):
             result = await connect_mcp_integration(
-                user_id=USER_ID,
-                integration_id=INTEGRATION_ID,
-                integration_name="Test",
-                requires_auth=False,
-                redirect_path="/integrations",
-                server_url=SERVER_URL,
-                probe_result=None,
+                McpConnectRequest(
+                    user_id=USER_ID,
+                    integration_id=INTEGRATION_ID,
+                    integration_name="Test",
+                    requires_auth=False,
+                    redirect_path="/integrations",
+                    server_url=SERVER_URL,
+                    probe_result=None,
+                )
             )
 
         assert result.status == "redirect"
@@ -2181,13 +2221,15 @@ class TestConnectMcpIntegration:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            server_url=SERVER_URL,
-            probe_result={},
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                server_url=SERVER_URL,
+                probe_result={},
+            )
         )
 
         assert result.status == "redirect"
@@ -2207,13 +2249,15 @@ class TestConnectMcpIntegration:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            server_url=SERVER_URL,
-            probe_result={},
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                server_url=SERVER_URL,
+                probe_result={},
+            )
         )
 
         assert result.status == "connected"
@@ -2408,6 +2452,86 @@ class TestDisconnectIntegration:
 
         assert isinstance(result, IntegrationSuccessResponse)
         mock_client.disconnect.assert_awaited_once()
+        mock_remove_user.assert_awaited_once()
+
+    @patch(
+        "app.services.integrations.integration_connection_service._invalidate_caches",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.remove_user_integration",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.delete_custom_integration",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.get_mcp_client",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.cli_disconnect",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        new_callable=AsyncMock,
+    )
+    async def test_disconnect_cli_wins_over_the_custom_source_branch(
+        self,
+        mock_resolve,
+        mock_cli_disconnect,
+        mock_get_client,
+        mock_delete_custom,
+        mock_remove_user,
+        mock_invalidate,
+    ):
+        """A user-authored CLI is `source == "custom"` too, so branch order decides.
+
+        If the custom-source branch were reached first it would try to close an
+        MCP session this integration never had, and the CLI's sandbox HOME would
+        be left behind on every disconnect.
+        """
+        mock_resolve.return_value = _cli_resolved(created_by=USER_ID)
+        mock_client = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        result = await disconnect_integration(USER_ID, CUSTOM_INTEGRATION_ID)
+
+        assert isinstance(result, IntegrationSuccessResponse)
+        mock_cli_disconnect.assert_awaited_once()
+        mock_client.disconnect.assert_not_awaited()
+        mock_remove_user.assert_awaited_once()
+        mock_delete_custom.assert_awaited_once()
+
+    @patch(
+        "app.services.integrations.integration_connection_service._invalidate_caches",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.remove_user_integration",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.cli_disconnect",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        new_callable=AsyncMock,
+    )
+    async def test_disconnect_cli_teardown_failure_still_removes_the_record(
+        self, mock_resolve, mock_cli_disconnect, mock_remove_user, mock_invalidate
+    ):
+        """An unreachable sandbox must not strand the user with an integration
+        they cannot remove; the teardown is best-effort by design."""
+        mock_resolve.return_value = _cli_resolved(created_by="other-user")
+        mock_cli_disconnect.side_effect = RuntimeError("sandbox unreachable")
+
+        result = await disconnect_integration(USER_ID, CUSTOM_INTEGRATION_ID)
+
+        assert isinstance(result, IntegrationSuccessResponse)
         mock_remove_user.assert_awaited_once()
 
     @patch(
@@ -2795,14 +2919,17 @@ class TestHandleAuthRequired:
         mcp_client = AsyncMock()
 
         response = await _handle_auth_required(
-            "u1",
-            "int-1",
-            "gmail",
-            "/cb",
-            is_platform=True,
+            McpConnectRequest(
+                user_id="u1",
+                integration_id="int-1",
+                integration_name="gmail",
+                requires_auth=True,
+                redirect_path="/cb",
+                is_platform=True,
+            ),
+            mcp_client,
             detected_auth_type="bearer",
             probe_result=None,
-            mcp_client=mcp_client,
         )
 
         assert response.status == "error"
@@ -2816,14 +2943,17 @@ class TestHandleAuthRequired:
         probe = {"oauth_challenge": {"state": "s"}}
 
         response = await _handle_auth_required(
-            "u1",
-            "int-1",
-            "gmail",
-            "/cb",
-            is_platform=True,
+            McpConnectRequest(
+                user_id="u1",
+                integration_id="int-1",
+                integration_name="gmail",
+                requires_auth=True,
+                redirect_path="/cb",
+                is_platform=True,
+            ),
+            mcp_client,
             detected_auth_type="oauth",
             probe_result=probe,
-            mcp_client=mcp_client,
         )
 
         assert response.status == "redirect"
@@ -2851,12 +2981,14 @@ class TestConnectProbeDetection:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            probe_result={"requires_auth": True, "auth_type": "custom"},
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                probe_result={"requires_auth": True, "auth_type": "custom"},
+            )
         )
 
         assert result.status == "redirect"
@@ -2880,12 +3012,14 @@ class TestConnectProbeDetection:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=True,
-            redirect_path="/integrations",
-            probe_result={"requires_auth": True, "auth_type": "custom"},
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=True,
+                redirect_path="/integrations",
+                probe_result={"requires_auth": True, "auth_type": "custom"},
+            )
         )
 
         assert result.status == "redirect"
@@ -2912,11 +3046,13 @@ class TestConnectMorePaths:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=True,
-            redirect_path="/integrations",
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=True,
+                redirect_path="/integrations",
+            )
         )
 
         assert result.status == "redirect"
@@ -2935,12 +3071,14 @@ class TestConnectMorePaths:
         mock_get_client.return_value = mock_client
 
         result = await connect_mcp_integration(
-            user_id=USER_ID,
-            integration_id=INTEGRATION_ID,
-            integration_name="Test",
-            requires_auth=False,
-            redirect_path="/integrations",
-            is_platform=True,
+            McpConnectRequest(
+                user_id=USER_ID,
+                integration_id=INTEGRATION_ID,
+                integration_name="Test",
+                requires_auth=False,
+                redirect_path="/integrations",
+                is_platform=True,
+            )
         )
 
         assert result.status == "redirect"

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -57,6 +57,7 @@ from app.services.integrations.integration_connection_service import (
     connect_composio_integration,
     connect_mcp_integration,
     connect_self_integration,
+    delete_if_user_authored,
 )
 from app.services.integrations.integration_resolver import (
     IntegrationResolver,
@@ -76,6 +77,7 @@ from app.services.integrations.user_integrations import (
     get_user_integrations,
     remove_user_integration,
 )
+from tests.helpers import captured_wide_event
 
 # ---------------------------------------------------------------------------
 # Shared constants & helpers
@@ -2185,7 +2187,16 @@ class TestConnectMcpIntegration:
 
         assert result.status == "connected"
         assert result.tools_count == 1
-        mock_store.store_bearer_token.assert_awaited_once()
+        assert result.integration_id == INTEGRATION_ID
+        assert result.name == "Test"
+        assert result.message == "Integration connected successfully"
+        # The token is a per-user credential: stored under this user's store,
+        # keyed by this integration. Either one wrong and the next connect
+        # reads somebody else's token, or none at all.
+        mock_token_store_cls.assert_called_once_with(USER_ID)
+        mock_store.store_bearer_token.assert_awaited_once_with(INTEGRATION_ID, "my-token")
+        mock_client.connect.assert_awaited_once_with(INTEGRATION_ID)
+        mock_update_status.assert_awaited_once_with(USER_ID, INTEGRATION_ID, "connected")
 
     @patch(
         "app.services.integrations.integration_connection_service.invalidate_user_integration_caches",
@@ -2220,8 +2231,16 @@ class TestConnectMcpIntegration:
         )
 
         assert result.status == "error"
-        assert result.error is not None
-        mock_store.delete_credentials.assert_awaited_once()
+        # The reason is shown to the user; a generic string here would make a
+        # bad token indistinguishable from an unreachable server.
+        assert result.error == "Connection failed"
+        assert result.message == "Connection failed"
+        assert result.integration_id == INTEGRATION_ID
+        assert result.name == "Test"
+        # Rollback: a stored credential for a connection that never worked
+        # would make the next attempt skip the token prompt and fail again.
+        mock_store.delete_credentials.assert_awaited_once_with(INTEGRATION_ID)
+        mock_invalidate.assert_awaited_once_with(USER_ID)
 
     @patch(
         "app.services.integrations.integration_connection_service.get_mcp_client",
@@ -3179,3 +3198,138 @@ class TestCliDisconnectDoesNotResurrectTheRecord:
             await module._invalidate_caches("user-1", "custom-mcp", "mcp")
 
         upsert.assert_not_awaited()
+
+
+class TestDeletingOnlyWhatTheUserAuthored:
+    """Disconnect removes the user's link; it removes the catalog document only
+    when that user wrote it.
+
+    Every other case is somebody else's row. A custom integration installed
+    from the marketplace is a link to the author's document, and a platform
+    integration is shared by everyone — deleting either because one user
+    disconnected takes it away from all of them, irreversibly.
+    """
+
+    MODULE = "app.services.integrations.integration_connection_service"
+
+    def _resolved(self, *, source: str, created_by: str | None) -> ResolvedIntegration:
+        return ResolvedIntegration(
+            integration_id=CUSTOM_INTEGRATION_ID,
+            name="Some CLI",
+            description="",
+            category="custom",
+            managed_by="cli",
+            source=source,
+            requires_auth=True,
+            auth_type=None,
+            mcp_config=None,
+            cli_config=None,
+            platform_integration=None,
+            custom_doc=None if created_by is None else {"created_by": created_by},
+        )
+
+    async def test_the_author_of_a_custom_integration_deletes_its_document(self):
+        with patch(f"{self.MODULE}.delete_custom_integration", new_callable=AsyncMock) as delete:
+            await delete_if_user_authored(
+                USER_ID, self._resolved(source="custom", created_by=USER_ID)
+            )
+
+        delete.assert_awaited_once_with(USER_ID, CUSTOM_INTEGRATION_ID)
+
+    async def test_someone_elses_custom_integration_is_only_unlinked(self):
+        with patch(f"{self.MODULE}.delete_custom_integration", new_callable=AsyncMock) as delete:
+            await delete_if_user_authored(
+                USER_ID, self._resolved(source="custom", created_by="another-user")
+            )
+
+        delete.assert_not_awaited()
+
+    async def test_a_platform_integration_is_never_deleted(self):
+        # Shared by every user; there is no "my copy" of it to remove.
+        with patch(f"{self.MODULE}.delete_custom_integration", new_callable=AsyncMock) as delete:
+            await delete_if_user_authored(
+                USER_ID, self._resolved(source="platform", created_by=USER_ID)
+            )
+
+        delete.assert_not_awaited()
+
+    async def test_a_custom_row_with_no_document_is_left_alone(self):
+        # Ownership cannot be established, so the safe answer is to unlink only.
+        with patch(f"{self.MODULE}.delete_custom_integration", new_callable=AsyncMock) as delete:
+            await delete_if_user_authored(USER_ID, self._resolved(source="custom", created_by=None))
+
+        delete.assert_not_awaited()
+
+
+class TestTheBearerConnectWideEvent:
+    """The bearer flow stores a credential and then either connects or rolls
+    back. The wide event is where that outcome is read in production — nothing
+    else records which auth shape was used or how many tools came back."""
+
+    MODULE = "app.services.integrations.integration_connection_service"
+
+    def _request(self) -> McpConnectRequest:
+        return McpConnectRequest(
+            user_id=USER_ID,
+            integration_id=INTEGRATION_ID,
+            integration_name="Test",
+            requires_auth=False,
+            redirect_path="/integrations",
+            bearer_token="my-token",
+        )
+
+    async def test_a_successful_connect_records_the_shape_and_the_tool_count(self):
+        client = AsyncMock()
+        client.connect.return_value = ["t1", "t2"]
+        with (
+            patch(f"{self.MODULE}.get_mcp_client", new_callable=AsyncMock, return_value=client),
+            patch(f"{self.MODULE}.MCPTokenStore", return_value=AsyncMock()),
+            patch(f"{self.MODULE}.update_user_integration_status", new_callable=AsyncMock),
+            patch(f"{self.MODULE}.invalidate_user_integration_caches", new_callable=AsyncMock),
+        ):
+            async with captured_wide_event() as event:
+                await connect_mcp_integration(self._request())
+                integration = dict(event["integration"])
+
+        assert integration == {
+            "provider": "Test",
+            "action": "connect_mcp",
+            "auth_type": "bearer",
+            "status": "connected",
+            "tools_count": 2,
+        }
+
+    async def test_a_server_that_exposes_nothing_still_reports_a_count(self):
+        # `connect` can legitimately return an empty list; reporting None here
+        # would make "connected with no tools" unreadable in the event.
+        client = AsyncMock()
+        client.connect.return_value = []
+        with (
+            patch(f"{self.MODULE}.get_mcp_client", new_callable=AsyncMock, return_value=client),
+            patch(f"{self.MODULE}.MCPTokenStore", return_value=AsyncMock()),
+            patch(f"{self.MODULE}.update_user_integration_status", new_callable=AsyncMock),
+            patch(f"{self.MODULE}.invalidate_user_integration_caches", new_callable=AsyncMock),
+        ):
+            result = await connect_mcp_integration(self._request())
+
+        assert result.status == "connected"
+        assert result.tools_count == 0
+
+    async def test_a_failed_connect_records_the_error_status(self):
+        client = AsyncMock()
+        client.connect.side_effect = RuntimeError("bad token")
+        with (
+            patch(f"{self.MODULE}.get_mcp_client", new_callable=AsyncMock, return_value=client),
+            patch(f"{self.MODULE}.MCPTokenStore", return_value=AsyncMock()),
+            patch(f"{self.MODULE}.invalidate_user_integration_caches", new_callable=AsyncMock),
+        ):
+            async with captured_wide_event() as event:
+                await connect_mcp_integration(self._request())
+                integration = dict(event["integration"])
+
+        assert integration == {
+            "provider": "Test",
+            "action": "connect_mcp",
+            "auth_type": "bearer",
+            "status": "error",
+        }

--- a/apps/api/tests/unit/services/test_integration_service.py
+++ b/apps/api/tests/unit/services/test_integration_service.py
@@ -42,6 +42,7 @@ from app.schemas.integrations.responses import (
     CommunityIntegrationItem,
     IntegrationSuccessResponse,
 )
+from app.services.integrations.connect_dispatch import disconnect_integration
 from app.services.integrations.custom_crud import (
     create_and_connect_custom_integration,
     create_custom_integration,
@@ -56,7 +57,6 @@ from app.services.integrations.integration_connection_service import (
     connect_composio_integration,
     connect_mcp_integration,
     connect_self_integration,
-    disconnect_integration,
 )
 from app.services.integrations.integration_resolver import (
     IntegrationResolver,
@@ -2414,23 +2414,23 @@ class TestConnectSelfIntegration:
 
 class TestDisconnectIntegration:
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.remove_user_integration",
+        "app.services.integrations.providers.oauth_providers.remove_user_integration",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.delete_custom_integration",
+        "app.services.integrations.providers.oauth_providers.delete_if_user_authored",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.get_mcp_client",
+        "app.services.integrations.providers.oauth_providers.get_mcp_client",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_custom_integration_owned(
@@ -2466,19 +2466,19 @@ class TestDisconnectIntegration:
         mock_delete_custom.assert_awaited_once()
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.remove_user_integration",
+        "app.services.integrations.providers.oauth_providers.remove_user_integration",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.get_mcp_client",
+        "app.services.integrations.providers.oauth_providers.get_mcp_client",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_custom_not_owned_skips_delete(
@@ -2508,27 +2508,27 @@ class TestDisconnectIntegration:
         mock_remove_user.assert_awaited_once()
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.remove_user_integration",
+        "app.services.integrations.providers.cli_provider.remove_user_integration",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.delete_custom_integration",
+        "app.services.integrations.providers.cli_provider.delete_if_user_authored",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.get_mcp_client",
+        "app.services.integrations.providers.oauth_providers.get_mcp_client",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.cli_disconnect",
+        "app.services.integrations.providers.cli_provider.cli_disconnect",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_cli_wins_over_the_custom_source_branch(
@@ -2559,19 +2559,19 @@ class TestDisconnectIntegration:
         mock_delete_custom.assert_awaited_once()
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.remove_user_integration",
+        "app.services.integrations.providers.cli_provider.remove_user_integration",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.cli_disconnect",
+        "app.services.integrations.providers.cli_provider.cli_disconnect",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_cli_teardown_failure_still_removes_the_record(
@@ -2588,7 +2588,7 @@ class TestDisconnectIntegration:
         mock_remove_user.assert_awaited_once()
 
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_not_found_raises(self, mock_resolve):
@@ -2598,14 +2598,14 @@ class TestDisconnectIntegration:
             await disconnect_integration(USER_ID, "nonexistent")
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.get_composio_service",
+        "app.services.integrations.providers.oauth_providers.get_composio_service",
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_composio_integration(
@@ -2642,14 +2642,14 @@ class TestDisconnectIntegration:
         )
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.get_composio_service",
+        "app.services.integrations.providers.oauth_providers.get_composio_service",
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_composio_no_provider_raises(
@@ -2675,14 +2675,14 @@ class TestDisconnectIntegration:
             await disconnect_integration(USER_ID, "bad")
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.token_repository",
+        "app.services.integrations.providers.oauth_providers.token_repository",
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_self_managed_integration(
@@ -2713,11 +2713,11 @@ class TestDisconnectIntegration:
         mock_token_repo.revoke_token.assert_awaited_once_with(user_id=USER_ID, provider="google")
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_self_no_provider_raises(self, mock_resolve, mock_invalidate):
@@ -2740,19 +2740,19 @@ class TestDisconnectIntegration:
             await disconnect_integration(USER_ID, "x")
 
     @patch(
-        "app.services.integrations.integration_connection_service._invalidate_caches",
+        "app.services.integrations.connect_dispatch._invalidate_caches",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.remove_user_integration",
+        "app.services.integrations.providers.oauth_providers.remove_user_integration",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.get_mcp_client",
+        "app.services.integrations.providers.oauth_providers.get_mcp_client",
         new_callable=AsyncMock,
     )
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_platform_mcp_integration(
@@ -2784,7 +2784,7 @@ class TestDisconnectIntegration:
         mock_remove_user.assert_awaited_once()
 
     @patch(
-        "app.services.integrations.integration_connection_service.IntegrationResolver.resolve",
+        "app.services.integrations.connect_dispatch.IntegrationResolver.resolve",
         new_callable=AsyncMock,
     )
     async def test_disconnect_unsupported_managed_by_raises(self, mock_resolve):

--- a/apps/api/tests/unit/services/test_my_integrations.py
+++ b/apps/api/tests/unit/services/test_my_integrations.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.config.oauth_config import get_integration_by_id
 from app.models.integration_models import (
     IntegrationResponse,
     IntegrationTool,
@@ -23,6 +24,7 @@ from app.schemas.integrations.responses import (
 )
 from app.services.integrations.my_integrations import get_integration_tools, get_my_integrations
 from app.utils.errors import AppError
+from tests.helpers import captured_wide_event
 
 _MOD = "app.services.integrations.my_integrations"
 USER_ID = "507f1f77bcf86cd799439011"
@@ -140,6 +142,52 @@ class TestGetMyIntegrations:
         result = await get_my_integrations(USER_ID)
 
         assert result.integrations[0].tool_count == 0
+
+    async def test_a_cli_integration_counts_the_capabilities_it_declares(
+        self, mock_deps, mock_redis_cache
+    ):
+        """A CLI integration registers one tool that wraps the whole command, so
+        the tool registry can only ever say 1 — and says 0 until the category is
+        lazily registered. Neither answers "what can this do", which is what the
+        card shows; the catalog's declared capabilities do."""
+        catalog_entry = get_integration_by_id("stripe_link")
+        assert catalog_entry is not None
+        assert catalog_entry.cli_config is not None
+        assert catalog_entry.cli_config.capabilities, "the fixture needs a CLI with capabilities"
+
+        mock_deps.config.return_value = IntegrationsConfigResponse(
+            integrations=[_config_item(id="stripe_link", name="Stripe Link", managed_by="cli")]
+        )
+        mock_deps.categories.return_value = {}
+
+        result = await get_my_integrations(USER_ID)
+
+        assert result.integrations[0].tool_count == len(catalog_entry.cli_config.capabilities)
+
+    async def test_a_platform_integration_with_no_cli_config_stays_at_zero(
+        self, mock_deps, mock_redis_cache
+    ):
+        """The capability fallback must not invent a count for the OAuth and
+        Composio integrations, which are the overwhelming majority."""
+        mock_deps.config.return_value = IntegrationsConfigResponse(
+            integrations=[_config_item(id="not-in-the-catalog")]
+        )
+        mock_deps.categories.return_value = {}
+
+        result = await get_my_integrations(USER_ID)
+
+        assert result.integrations[0].tool_count == 0
+
+    async def test_the_wide_event_attributes_the_catalog_to_its_owner(
+        self, mock_deps, mock_redis_cache
+    ):
+        """This response is entirely per-user, so "the wrong integrations came
+        back" is only diagnosable if the event says whose they were."""
+        async with captured_wide_event() as event:
+            await get_my_integrations(USER_ID)
+            user = event["user"]
+
+        assert user == {"id": USER_ID}
 
     async def test_platform_status_from_connection_map(self, mock_deps, mock_redis_cache):
         mock_deps.status.return_value = {"github": True}
@@ -315,3 +363,42 @@ class TestGetIntegrationTools:
         assert response.integration_id == "ghost"
         assert response.tools == []
         assert response.count == 0
+
+
+class TestCliToolCountBeatsTheRegistry:
+    """What a CLI integration can do is its capabilities, not its tool count.
+
+    One tool wraps the whole command, so the registry's answer is 1 once the
+    category is registered. A user reading "1 tool" on a card that can create
+    payments, list balances and pay 402 endpoints has been told something false.
+    """
+
+    async def test_capabilities_win_even_when_the_registry_has_counted_the_tool(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.services.integrations import my_integrations as module
+
+        integration = module.get_integration_by_id("stripe_link")
+        assert integration is not None and integration.cli_config is not None
+        expected = len(integration.cli_config.capabilities)
+        assert expected > 1, "fixture needs a CLI integration with several capabilities"
+
+        # build_integrations_config is lru_cached and shared process-wide, so a
+        # test that ran earlier can leave a stale catalog behind. Rebuild it.
+        module.build_integrations_config.cache_clear()
+
+        with (
+            patch.object(module, "get_all_integrations_status", AsyncMock(return_value={})),
+            patch.object(
+                module,
+                "get_user_integrations",
+                AsyncMock(return_value=SimpleNamespace(integrations=[])),
+            ),
+            # The registry has counted the single wrapper tool.
+            patch.object(module, "get_tool_categories", AsyncMock(return_value={"stripe_link": 1})),
+        ):
+            result = await module.get_my_integrations.__wrapped__("user-1")
+
+        items = {i.id: i for i in result.integrations}
+        assert "stripe_link" in items, "the CLI integration is missing from the catalog"
+        assert items["stripe_link"].tool_count == expected

--- a/apps/api/tests/unit/services/test_my_integrations.py
+++ b/apps/api/tests/unit/services/test_my_integrations.py
@@ -218,6 +218,51 @@ class TestGetMyIntegrations:
         assert item.status == "created"
         assert item.tool_count == 2
 
+    async def test_an_empty_stored_tool_list_falls_back_to_the_registry_count(
+        self, mock_deps, mock_redis_cache
+    ):
+        """A user record whose tool list was never populated must not blank the
+        card. The registry keys its counts by (often capitalised) category name
+        while the catalog keys by id, so the fallback has to match them
+        case-insensitively or every such integration silently shows nothing."""
+        mock_deps.user.return_value = UserIntegrationsListResponse(
+            integrations=[
+                _user_integration(
+                    integration_id="github",
+                    integration=_integration_response(
+                        integration_id="github", name="GitHub", source="platform", tools=[]
+                    ),
+                )
+            ]
+        )
+        mock_deps.categories.return_value = {"Github": 4}
+
+        result = await get_my_integrations(USER_ID)
+
+        assert result.integrations[0].tool_count == 4
+
+    async def test_an_integration_nobody_can_count_reports_no_tools(
+        self, mock_deps, mock_redis_cache
+    ):
+        """Neither the user record nor the registry knows anything. Zero is the
+        honest answer; any invented number becomes "1 tool" on a card for an
+        integration that exposes none."""
+        mock_deps.user.return_value = UserIntegrationsListResponse(
+            integrations=[
+                _user_integration(
+                    integration_id="github",
+                    integration=_integration_response(
+                        integration_id="github", name="GitHub", source="platform", tools=[]
+                    ),
+                )
+            ]
+        )
+        mock_deps.categories.return_value = {}
+
+        result = await get_my_integrations(USER_ID)
+
+        assert result.integrations[0].tool_count == 0
+
     async def test_expired_platform_integration_carries_expired_at(
         self, mock_deps, mock_redis_cache
     ):

--- a/apps/api/tests/unit/tools/test_registry.py
+++ b/apps/api/tests/unit/tools/test_registry.py
@@ -825,11 +825,12 @@ class TestInitializedCategoryContract:
             "context": {"gather_context"},
         }
 
-    def test_the_two_destructive_built_ins_are_stamped_alone(self, registry: ToolRegistry) -> None:
-        """``execute_workflow`` starts an autonomous run and
-        ``connect_integration`` connects an external account; every sibling is
-        reversible or read-only. A mangled member name in either curated set
-        downgrades the one tool that must stop at the HIL gate to safe.
+    def test_the_destructive_built_ins_are_stamped_alone(self, registry: ToolRegistry) -> None:
+        """``execute_workflow`` starts an autonomous run, ``connect_integration``
+        connects an external account, and ``create_custom_integration`` stores an
+        install command that will later run in the user's sandbox; every sibling
+        is reversible or read-only. A mangled member name in either curated set
+        downgrades a tool that must stop at the HIL gate to safe.
         """
         workflows = {
             tool.name: tool.destructive for tool in registry._categories["workflows"].tools
@@ -853,6 +854,7 @@ class TestInitializedCategoryContract:
             "suggest_integrations": False,
             "connect_integration": True,
             "check_integrations_status": False,
+            "create_custom_integration": True,
         }
 
 

--- a/apps/api/tests/unit/utils/test_favicon_utils.py
+++ b/apps/api/tests/unit/utils/test_favicon_utils.py
@@ -16,6 +16,7 @@ from app.utils.favicon_utils import (
     _smithery_qualified_name,
     _validate_favicon_url,
     fetch_favicon_from_url,
+    fetch_favicon_safely,
     legacy_favicon_url,
 )
 
@@ -489,3 +490,49 @@ class TestFetchFaviconImpl:
         mock_legacy.return_value = "https://www.google.com/s2/favicons?domain=example.com&sz=256"
         result = await _fetch_favicon_impl("https://example.com/mcp")
         assert result == "https://www.google.com/s2/favicons?domain=example.com&sz=256"
+
+
+# --- fetch_favicon_safely: the one guarded entry point --------------------
+# Every caller that turns a URL into an integration icon goes through it, so its
+# guards are the only place those callers are protected.
+
+_SAFE_MODULE = "app.utils.favicon_utils"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   "])
+async def test_a_blank_url_never_reaches_the_network(blank):
+    with patch(f"{_SAFE_MODULE}.fetch_favicon_from_url", AsyncMock()) as fetch:
+        assert await fetch_favicon_safely(blank) is None
+    fetch.assert_not_awaited()
+
+
+async def test_a_public_url_is_fetched():
+    with (
+        patch(f"{_SAFE_MODULE}.assert_public_http_url", AsyncMock()),
+        patch(
+            f"{_SAFE_MODULE}.fetch_favicon_from_url", AsyncMock(return_value="https://cdn/x.png")
+        ),
+    ):
+        assert await fetch_favicon_safely("https://example.test") == "https://cdn/x.png"
+
+
+async def test_a_url_resolving_to_a_private_address_is_never_fetched():
+    # The callers' shape check does not resolve DNS, so this is the only layer
+    # that stops an internal hostname.
+    with (
+        patch(
+            f"{_SAFE_MODULE}.assert_public_http_url", AsyncMock(side_effect=ValueError("private"))
+        ),
+        patch(f"{_SAFE_MODULE}.fetch_favicon_from_url", AsyncMock()) as fetch,
+    ):
+        assert await fetch_favicon_safely("http://localhost:8080") is None
+    fetch.assert_not_awaited()
+
+
+async def test_a_failing_fetch_yields_no_icon_rather_than_raising():
+    # An icon is cosmetic; it must never fail the operation that wanted it.
+    with (
+        patch(f"{_SAFE_MODULE}.assert_public_http_url", AsyncMock()),
+        patch(f"{_SAFE_MODULE}.fetch_favicon_from_url", AsyncMock(return_value=None)),
+    ):
+        assert await fetch_favicon_safely("https://example.test") is None

--- a/apps/api/tests/unit/utils/test_favicon_utils.py
+++ b/apps/api/tests/unit/utils/test_favicon_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from app.constants.log_tags import LogTag
 from app.utils.favicon_utils import (
     _fetch_favicon_impl,
     _fetch_smithery_icon,
@@ -19,6 +20,8 @@ from app.utils.favicon_utils import (
     fetch_favicon_safely,
     legacy_favicon_url,
 )
+from shared.py.wide_events import log as wide_log
+from tests.helpers import captured_wide_event
 
 # ---------------------------------------------------------------------------
 # _get_domain_cache_key / _get_host_url — keyed by full host
@@ -519,14 +522,40 @@ async def test_a_public_url_is_fetched():
 async def test_a_url_resolving_to_a_private_address_is_never_fetched():
     # The callers' shape check does not resolve DNS, so this is the only layer
     # that stops an internal hostname.
+    guard = AsyncMock(side_effect=ValueError("resolves to 127.0.0.1"))
     with (
-        patch(
-            f"{_SAFE_MODULE}.assert_public_http_url", AsyncMock(side_effect=ValueError("private"))
-        ),
+        patch(f"{_SAFE_MODULE}.assert_public_http_url", guard),
         patch(f"{_SAFE_MODULE}.fetch_favicon_from_url", AsyncMock()) as fetch,
+        patch(f"{_SAFE_MODULE}.log", wide_log),
     ):
-        assert await fetch_favicon_safely("http://localhost:8080") is None
+        async with captured_wide_event() as event:
+            assert await fetch_favicon_safely("http://localhost:8080") is None
+
     fetch.assert_not_awaited()
+    # The URL that was checked must be the URL that was asked for, and the
+    # refusal has to name it — this swallows the error, so the wide event is
+    # the only place a blocked SSRF attempt is visible at all.
+    guard.assert_awaited_once_with("http://localhost:8080")
+    (warning,) = event["warnings"]
+    assert warning == {
+        "msg": f"{LogTag.TOOL} Refusing to fetch a favicon from a non-public URL",
+        "server_url": "http://localhost:8080",
+        "error": "resolves to 127.0.0.1",
+    }
+
+
+async def test_the_url_that_passed_the_guard_is_the_one_fetched():
+    # A mismatch here would check one host and fetch another, which is exactly
+    # the bypass the guard exists to prevent.
+    with (
+        patch(f"{_SAFE_MODULE}.assert_public_http_url", AsyncMock()),
+        patch(
+            f"{_SAFE_MODULE}.fetch_favicon_from_url", AsyncMock(return_value="https://cdn/x.png")
+        ) as fetch,
+    ):
+        await fetch_favicon_safely("https://vendor.example.test/docs")
+
+    fetch.assert_awaited_once_with("https://vendor.example.test/docs")
 
 
 async def test_a_failing_fetch_yields_no_icon_rather_than_raising():

--- a/apps/web/src/__tests__/cli-connect-poll-loop.test.tsx
+++ b/apps/web/src/__tests__/cli-connect-poll-loop.test.tsx
@@ -85,7 +85,6 @@ describe("useCliConnect", () => {
     renderHook(() =>
       useCliConnect({
         integrationId: "stripe_link",
-        isOpen: true,
         onConnected,
       }),
     );

--- a/apps/web/src/__tests__/cli-connect-poll-loop.test.tsx
+++ b/apps/web/src/__tests__/cli-connect-poll-loop.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+/**
+ * The CLI connect poll loop.
+ *
+ * Connecting a CLI is the only connect flow the client drives itself: it
+ * re-POSTs an idempotent endpoint until the install finishes and the user has
+ * approved a login. Three things about that loop are load-bearing and none are
+ * visible from reading a single render:
+ *
+ *   - it must stop on a terminal phase, or it hammers a sandbox whose commands
+ *     are serialised per user and starves their other tool calls;
+ *   - it must stop when abandoned (unmount), or a response from a dead run
+ *     overwrites the live one;
+ *   - it must give up eventually, because the server will happily restart an
+ *     expired device login forever.
+ *
+ * The poll interval is mocked down to a millisecond rather than driven with
+ * fake timers: `waitFor` polls on real timers, and pinning React's `act` against
+ * a faked clock deadlocks the two.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const postConnect = vi.fn();
+
+vi.mock("@/features/integrations/api/integrationsApi", () => ({
+  integrationsApi: {
+    postConnect: (...args: unknown[]) => postConnect(...args),
+  },
+}));
+vi.mock("@/features/integrations/api/queryKeys", () => ({
+  integrationKeys: { all: ["integrations"] },
+  toolKeys: { all: ["tools"] },
+}));
+// Literals, not constants: vi.mock factories are hoisted above every
+// top-level binding in this file.
+vi.mock("@/features/integrations/constants/connect", () => ({
+  CLI_CONNECT_POLL_INTERVAL_MS: 1,
+  CLI_CONNECT_POLL_MAX_ATTEMPTS: 5,
+}));
+vi.mock("@/lib/url-safety", () => ({
+  sanitizeRedirectUrl: (url: string) => url,
+}));
+// A STABLE client: react-query returns one instance for the tree, and the
+// poll callback depends on it. Handing back a fresh object per render would
+// invalidate that callback every render and restart the loop forever, which is
+// a defect in the mock, not in the hook. vi.hoisted so the binding exists by
+// the time the hoisted factory below runs.
+const { queryClient } = vi.hoisted(() => ({
+  queryClient: { invalidateQueries: () => undefined },
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => queryClient,
+}));
+
+import { CLI_CONNECT_POLL_MAX_ATTEMPTS } from "@/features/integrations/constants/connect";
+import { useCliConnect } from "@/features/integrations/hooks/useCliConnect";
+
+const pending = (phase: string, instructions: string | null = null) => ({
+  status: "pending",
+  integrationId: "stripe_link",
+  name: "Stripe Link",
+  cli: { phase, instructions },
+});
+
+const connected = () => ({
+  status: "connected",
+  integrationId: "stripe_link",
+  name: "Stripe Link",
+  cli: { phase: "connected" },
+});
+
+/** Give the loop room to tick several more times if it is going to. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 40));
+
+describe("useCliConnect", () => {
+  beforeEach(() => {
+    postConnect.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const render = (onConnected = vi.fn()) =>
+    renderHook(() =>
+      useCliConnect({
+        integrationId: "stripe_link",
+        isOpen: true,
+        onConnected,
+      }),
+    );
+
+  it("keeps polling while the install is running", async () => {
+    postConnect.mockResolvedValue(pending("installing"));
+    render();
+    await waitFor(() =>
+      expect(postConnect.mock.calls.length).toBeGreaterThan(2),
+    );
+  });
+
+  it("stops the moment the connection lands", async () => {
+    const onConnected = vi.fn();
+    postConnect.mockResolvedValue(connected());
+    render(onConnected);
+
+    await waitFor(() =>
+      expect(onConnected).toHaveBeenCalledWith("Stripe Link"),
+    );
+    const settled = postConnect.mock.calls.length;
+    await settle();
+    expect(postConnect.mock.calls.length).toBe(settled);
+  });
+
+  it("stops when the CLI asks for a token, instead of spinning on the prompt", async () => {
+    postConnect.mockResolvedValue(pending("needs_token"));
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.state.phase).toBe("needs_token"));
+    const settled = postConnect.mock.calls.length;
+    await settle();
+    expect(postConnect.mock.calls.length).toBe(settled);
+  });
+
+  it("stops polling once unmounted", async () => {
+    postConnect.mockResolvedValue(pending("awaiting_approval", "approve here"));
+    const { unmount } = render();
+
+    await waitFor(() => expect(postConnect).toHaveBeenCalled());
+    unmount();
+    const settled = postConnect.mock.calls.length;
+    await settle();
+    // One in-flight response may still land; the loop must not schedule more.
+    expect(postConnect.mock.calls.length).toBeLessThanOrEqual(settled + 1);
+  });
+
+  it("gives up rather than polling an expired login forever", async () => {
+    postConnect.mockResolvedValue(pending("awaiting_approval", "approve here"));
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.state.phase).toBe("failed"));
+    expect(postConnect.mock.calls.length).toBeLessThanOrEqual(
+      CLI_CONNECT_POLL_MAX_ATTEMPTS,
+    );
+    expect(result.current.state.error).toContain("took too long");
+  });
+
+  it("surfaces a request failure instead of retrying blindly", async () => {
+    postConnect.mockRejectedValue(new Error("network down"));
+    const { result } = render();
+
+    await waitFor(() => expect(result.current.state.phase).toBe("failed"));
+    expect(result.current.state.error).toContain("network down");
+    const settled = postConnect.mock.calls.length;
+    await settle();
+    expect(postConnect.mock.calls.length).toBe(settled);
+  });
+
+  it("exposes the approval link pulled out of the CLI's own output", async () => {
+    postConnect.mockResolvedValue(
+      pending(
+        "awaiting_approval",
+        'verification_url: "https://app.link.com/device/setup?code=abc-def"',
+      ),
+    );
+    const { result } = render();
+
+    await waitFor(() =>
+      expect(result.current.state.approvalUrl).toBe(
+        "https://app.link.com/device/setup?code=abc-def",
+      ),
+    );
+  });
+});

--- a/apps/web/src/features/integrations/api/integrationsApi.ts
+++ b/apps/web/src/features/integrations/api/integrationsApi.ts
@@ -5,6 +5,7 @@ import type { CommunityWorkflowsResponse } from "@/types/features/workflowTypes"
 import type {
   CommunityIntegration,
   CommunityIntegrationsResponse,
+  ConnectIntegrationResponse,
   CreateCustomIntegrationRequest,
   CreateCustomIntegrationResponse,
   Integration,
@@ -16,6 +17,18 @@ import type {
 
 export interface IntegrationConfigResponse {
   integrations: Integration[];
+}
+
+/**
+ * Where the backend should send the user back to after an OAuth round trip:
+ * the current page, minus the params the callback itself owns.
+ */
+function connectRedirectPath(): string {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("integration");
+  url.searchParams.delete("oauth_success");
+  url.searchParams.delete("oauth_error");
+  return url.pathname + url.search;
 }
 
 export const integrationsApi = {
@@ -83,6 +96,29 @@ export const integrationsApi = {
   },
 
   /**
+   * POST the unified connect endpoint and hand back the response untouched.
+   *
+   * The endpoint is idempotent and advances a connection one step per call, so
+   * the CLI transport polls it and needs the raw `status`/`cli` block —
+   * including the in-band `error` status, which `connectIntegration` turns
+   * into a throw. Pass `silent` when the caller renders failures itself
+   * instead of letting the api layer toast every poll tick.
+   */
+  postConnect: async (
+    integrationId: string,
+    options: { bearerToken?: string; silent?: boolean } = {},
+  ): Promise<ConnectIntegrationResponse> => {
+    return await apiService.post<ConnectIntegrationResponse>(
+      `/integrations/connect/${integrationId.toLowerCase()}`,
+      {
+        redirect_path: connectRedirectPath(),
+        bearer_token: options.bearerToken,
+      },
+      { silent: options.silent },
+    );
+  },
+
+  /**
    * Connect an integration using the unified backend endpoint.
    */
   connectIntegration: async (
@@ -92,27 +128,9 @@ export const integrationsApi = {
     if (typeof window === "undefined")
       return { status: "error", name: "Unknown" };
 
-    const url = new URL(window.location.href);
-    url.searchParams.delete("integration");
-    url.searchParams.delete("oauth_success");
-    url.searchParams.delete("oauth_error");
-    const redirectPath = url.pathname + url.search;
-
-    const response = (await apiService.post(
-      `/integrations/connect/${integrationId.toLowerCase()}`,
-      {
-        redirect_path: redirectPath,
-        bearer_token: bearerToken,
-      },
-    )) as {
-      status: "connected" | "redirect" | "error";
-      integrationId: string;
-      name: string;
-      message?: string;
-      toolsCount?: number;
-      redirectUrl?: string;
-      error?: string;
-    };
+    const response = await integrationsApi.postConnect(integrationId, {
+      bearerToken,
+    });
 
     if (response.status === "redirect" && response.redirectUrl) {
       const safeUrl = sanitizeRedirectUrl(response.redirectUrl);

--- a/apps/web/src/features/integrations/components/CliConnectModal.tsx
+++ b/apps/web/src/features/integrations/components/CliConnectModal.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { Kbd } from "@heroui/kbd";
+import { Link } from "@heroui/link";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import { Spinner } from "@heroui/spinner";
+import { KeyIcon, RedoIcon } from "@icons";
+import { useCallback, useState } from "react";
+import { useModalKeyboardSubmit } from "@/hooks/ui/useModalKeyboardSubmit";
+import { usePlatform } from "@/hooks/ui/usePlatform";
+import { toast } from "@/lib/toast";
+import { type CliConnectState, useCliConnect } from "../hooks/useCliConnect";
+import type { CliConnectPhase } from "../types";
+
+interface CliConnectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** The integration being connected, or `null` when nothing is selected. */
+  integrationId: string | null;
+  integrationName: string;
+}
+
+function subtitleFor(phase: CliConnectPhase | null, name: string): string {
+  switch (phase) {
+    case "awaiting_approval":
+      return "Approve this login to continue";
+    case "needs_token":
+      return `Paste a token to finish connecting ${name}`;
+    case "connected":
+      return `${name} is connected`;
+    case "failed":
+      return `${name} couldn't be connected`;
+    default:
+      return `Setting up ${name}`;
+  }
+}
+
+/** The tool's own output, shown exactly as it was written. */
+function OutputBlock({ text }: { text: string }) {
+  return (
+    <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-zinc-800 p-3 font-mono text-xs text-zinc-300">
+      {text}
+    </pre>
+  );
+}
+
+interface CliConnectBodyProps {
+  state: CliConnectState;
+  integrationName: string;
+  token: string;
+  onTokenChange: (token: string) => void;
+}
+
+function CliConnectBody({
+  state,
+  integrationName,
+  token,
+  onTokenChange,
+}: CliConnectBodyProps) {
+  if (state.phase === "failed") {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-danger">
+          {state.error ?? "Connection failed"}
+        </p>
+        {state.instructions && <OutputBlock text={state.instructions} />}
+      </div>
+    );
+  }
+
+  if (state.phase === "needs_token") {
+    return (
+      <div className="flex flex-col gap-2">
+        <Input
+          label={state.tokenLabel ?? "Access token"}
+          placeholder="Paste your token"
+          value={token}
+          onValueChange={onTokenChange}
+          type="password"
+          isRequired
+          autoFocus
+          startContent={<KeyIcon width={16} height={16} />}
+        />
+        {state.tokenHelpUrl && (
+          <Link href={state.tokenHelpUrl} isExternal size="sm">
+            Get a token
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  if (state.phase === "awaiting_approval") {
+    return (
+      <div className="flex flex-col gap-3">
+        {state.instructions ? (
+          <OutputBlock text={state.instructions} />
+        ) : (
+          <p className="text-sm text-zinc-400">
+            {state.message ?? "Starting login…"}
+          </p>
+        )}
+        {state.approvalUrl && (
+          <div>
+            <Button
+              as={Link}
+              href={state.approvalUrl}
+              isExternal
+              variant="flat"
+              color="primary"
+              size="sm"
+            >
+              Open approval page
+            </Button>
+          </div>
+        )}
+        <div className="flex items-center gap-2 text-sm text-zinc-400">
+          <Spinner size="sm" />
+          Waiting for you to approve
+        </div>
+      </div>
+    );
+  }
+
+  if (state.phase === "connected") {
+    return (
+      <p className="text-sm text-zinc-400">
+        {integrationName} is ready to use.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-zinc-400">
+      <Spinner size="sm" />
+      Installing {integrationName}…
+    </div>
+  );
+}
+
+/**
+ * Connect flow for integrations GAIA drives through a vendor's own tool.
+ *
+ * The connection advances a step at a time on the backend, so this stays open
+ * across the whole run: it shows what the tool is doing, relays the approval
+ * text it prints, collects a token when the vendor asks for one, and closes
+ * itself the moment the connection is live.
+ */
+export const CliConnectModal: React.FC<CliConnectModalProps> = ({
+  isOpen,
+  onClose,
+  integrationId,
+  integrationName,
+}) => {
+  const { isMac, modifierKeyName } = usePlatform();
+  const [token, setToken] = useState("");
+
+  const handleClose = useCallback(() => {
+    setToken("");
+    onClose();
+  }, [onClose]);
+
+  const handleConnected = useCallback(
+    (name: string) => {
+      toast.success(`Connected to ${name}`);
+      handleClose();
+    },
+    [handleClose],
+  );
+
+  const { state, submitToken, retry } = useCliConnect({
+    // Clearing the id while closed is what stops the flow — the hook idles on
+    // `null` instead of polling behind a hidden modal.
+    integrationId: isOpen ? integrationId : null,
+    onConnected: handleConnected,
+  });
+
+  const canSubmitToken =
+    state.phase === "needs_token" &&
+    token.trim().length > 0 &&
+    !state.isSubmittingToken;
+
+  const handleSubmitToken = useCallback(() => {
+    if (!canSubmitToken) return;
+    submitToken(token.trim());
+  }, [canSubmitToken, submitToken, token]);
+
+  useModalKeyboardSubmit({
+    isOpen,
+    loading: state.isSubmittingToken,
+    isMac,
+    handleSubmit: handleSubmitToken,
+  });
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      placement="center"
+      size="md"
+      className="shadow-none rounded-2xl"
+      backdrop="blur"
+      isDismissable={!state.isSubmittingToken}
+      isKeyboardDismissDisabled={state.isSubmittingToken}
+    >
+      <ModalContent>
+        <ModalHeader className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold">Connect {integrationName}</h2>
+          <p className="text-sm font-normal text-zinc-400">
+            {subtitleFor(state.phase, integrationName)}
+          </p>
+        </ModalHeader>
+
+        <ModalBody>
+          <CliConnectBody
+            state={state}
+            integrationName={integrationName}
+            token={token}
+            onTokenChange={setToken}
+          />
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            color="default"
+            variant="light"
+            onPress={handleClose}
+            isDisabled={state.isSubmittingToken}
+          >
+            {state.phase === "failed" ? "Close" : "Cancel"}
+          </Button>
+
+          {state.phase === "needs_token" && (
+            <Button
+              color="primary"
+              onPress={handleSubmitToken}
+              isLoading={state.isSubmittingToken}
+              isDisabled={!canSubmitToken}
+              endContent={
+                !state.isSubmittingToken && (
+                  <Kbd keys={[modifierKeyName, "enter"]} />
+                )
+              }
+            >
+              Connect
+            </Button>
+          )}
+
+          {state.phase === "failed" && (
+            <Button
+              color="primary"
+              onPress={retry}
+              startContent={<RedoIcon width={16} height={16} />}
+            >
+              Try again
+            </Button>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/apps/web/src/features/integrations/components/IntegrationsList.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationsList.tsx
@@ -8,7 +8,7 @@ import {
   integrationConnectionState,
 } from "@shared/utils";
 import type React from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import { useIntegrationModalStore } from "@/stores/integrationModalStore";
 import { useIntegrationsStore } from "@/stores/integrationsStore";
@@ -22,6 +22,7 @@ import { useIntegrationSearch } from "../hooks/useIntegrationSearch";
 import { useIntegrations } from "../hooks/useIntegrations";
 import type { Integration } from "../types";
 import { CategoryFilter } from "./CategoryFilter";
+import { CliConnectModal } from "./CliConnectModal";
 import { MarketplaceBanner } from "./MarketplaceBanner";
 
 const IntegrationRow: React.FC<{
@@ -165,12 +166,27 @@ export const IntegrationsList: React.FC<{
 
   const { filteredIntegrations } = useIntegrationSearch(integrations);
 
+  // The CLI connect flow. The integration is kept after closing so the modal
+  // still has a name to show while it animates out.
+  const [isCliModalOpen, setIsCliModalOpen] = useState(false);
+  const [cliIntegration, setCliIntegration] = useState<Integration | null>(
+    null,
+  );
+
   const handleConnect = async (integrationId: string) => {
     const integration = integrations.find((i) => i.id === integrationId);
     // API-key (bearer) integrations collect their key in the detail sidebar —
     // open it instead of connecting directly (same as clicking the row).
     if (integration?.authType === "bearer" && integration.requiresAuth) {
       onIntegrationClick?.(integrationId);
+      return;
+    }
+    // CLI integrations connect over several steps (install, approve, sometimes
+    // a token), so they need a surface to show progress on rather than a single
+    // fire-and-forget call.
+    if (integration?.managedBy === "cli") {
+      setCliIntegration(integration);
+      setIsCliModalOpen(true);
       return;
     }
     try {
@@ -353,6 +369,13 @@ export const IntegrationsList: React.FC<{
           onIntegrationClick={onIntegrationClick}
         />
       )}
+
+      <CliConnectModal
+        isOpen={isCliModalOpen}
+        onClose={() => setIsCliModalOpen(false)}
+        integrationId={cliIntegration?.id ?? null}
+        integrationName={cliIntegration?.name ?? ""}
+      />
     </div>
   );
 };

--- a/apps/web/src/features/integrations/components/IntegrationsList.tsx
+++ b/apps/web/src/features/integrations/components/IntegrationsList.tsx
@@ -8,7 +8,7 @@ import {
   integrationConnectionState,
 } from "@shared/utils";
 import type React from "react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { getToolCategoryIcon } from "@/features/chat/utils/toolIcons";
 import { useIntegrationModalStore } from "@/stores/integrationModalStore";
 import { useIntegrationsStore } from "@/stores/integrationsStore";
@@ -18,6 +18,7 @@ import {
   getUniqueCategories,
   sortCategories,
 } from "../constants/categories";
+import { useCliConnectModal } from "../hooks/useCliConnectModal";
 import { useIntegrationSearch } from "../hooks/useIntegrationSearch";
 import { useIntegrations } from "../hooks/useIntegrations";
 import type { Integration } from "../types";
@@ -166,12 +167,7 @@ export const IntegrationsList: React.FC<{
 
   const { filteredIntegrations } = useIntegrationSearch(integrations);
 
-  // The CLI connect flow. The integration is kept after closing so the modal
-  // still has a name to show while it animates out.
-  const [isCliModalOpen, setIsCliModalOpen] = useState(false);
-  const [cliIntegration, setCliIntegration] = useState<Integration | null>(
-    null,
-  );
+  const cliConnect = useCliConnectModal();
 
   const handleConnect = async (integrationId: string) => {
     const integration = integrations.find((i) => i.id === integrationId);
@@ -185,8 +181,7 @@ export const IntegrationsList: React.FC<{
     // a token), so they need a surface to show progress on rather than a single
     // fire-and-forget call.
     if (integration?.managedBy === "cli") {
-      setCliIntegration(integration);
-      setIsCliModalOpen(true);
+      cliConnect.open(integration);
       return;
     }
     try {
@@ -371,10 +366,10 @@ export const IntegrationsList: React.FC<{
       )}
 
       <CliConnectModal
-        isOpen={isCliModalOpen}
-        onClose={() => setIsCliModalOpen(false)}
-        integrationId={cliIntegration?.id ?? null}
-        integrationName={cliIntegration?.name ?? ""}
+        isOpen={cliConnect.isOpen}
+        onClose={cliConnect.close}
+        integrationId={cliConnect.integrationId}
+        integrationName={cliConnect.integrationName}
       />
     </div>
   );

--- a/apps/web/src/features/integrations/constants/connect.ts
+++ b/apps/web/src/features/integrations/constants/connect.ts
@@ -6,3 +6,10 @@
  */
 export const POST_CONNECT_POLL_INTERVAL_MS = 2000;
 export const POST_CONNECT_POLL_MAX_ATTEMPTS = 15;
+
+/**
+ * CLI-transport connects are a state machine the backend advances one step per
+ * POST, so the client re-POSTs until the status leaves `pending`. 2.5s keeps
+ * the install/approval copy fresh without hammering the endpoint.
+ */
+export const CLI_CONNECT_POLL_INTERVAL_MS = 2500;

--- a/apps/web/src/features/integrations/constants/connect.ts
+++ b/apps/web/src/features/integrations/constants/connect.ts
@@ -13,3 +13,13 @@ export const POST_CONNECT_POLL_MAX_ATTEMPTS = 15;
  * the install/approval copy fresh without hammering the endpoint.
  */
 export const CLI_CONNECT_POLL_INTERVAL_MS = 2500;
+/**
+ * Ceiling on how long the CLI connect dialog will keep polling. The server is
+ * idempotent and will happily restart an expired device login forever, so
+ * without a cap a user who opens the dialog and walks away drives an endless
+ * loop — and every tick runs a verify command in a sandbox whose commands are
+ * serialised per user, starving their other tool calls for as long as the tab
+ * is open. 240 ticks x 2.5s = 10 minutes, matching the device-code window the
+ * API allows (LOGIN_TIMEOUT_SECONDS).
+ */
+export const CLI_CONNECT_POLL_MAX_ATTEMPTS = 240;

--- a/apps/web/src/features/integrations/hooks/useCliConnect.ts
+++ b/apps/web/src/features/integrations/hooks/useCliConnect.ts
@@ -1,0 +1,245 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { sanitizeRedirectUrl } from "@/lib/url-safety";
+import { integrationsApi } from "../api/integrationsApi";
+import { integrationKeys, toolKeys } from "../api/queryKeys";
+import { CLI_CONNECT_POLL_INTERVAL_MS } from "../constants/connect";
+import type { CliConnectPhase, ConnectIntegrationResponse } from "../types";
+
+/** Phases that still need the backend to make progress on its own. */
+const POLLED_PHASES: readonly CliConnectPhase[] = [
+  "installing",
+  "awaiting_approval",
+];
+
+/** First absolute link in a block of prose, stopping at prose/markup delimiters. */
+const URL_IN_TEXT = /https?:\/\/[^\s<>"')\]]+/;
+
+/** Sentence punctuation the tool's prose leaves glued to the end of a link. */
+const TRAILING_PUNCTUATION = /[.,;:!?]+$/;
+
+export interface CliConnectState {
+  /** `null` until the first response lands. */
+  phase: CliConnectPhase | null;
+  /**
+   * The tool's own output for this phase, relayed verbatim — the approval text
+   * while waiting, the failure detail once it failed.
+   */
+  instructions: string | null;
+  /** The approval link found in `instructions`, so it can be offered as a button. */
+  approvalUrl: string | null;
+  tokenLabel: string | null;
+  tokenHelpUrl: string | null;
+  /** Backend prose, shown while the tool has produced no output of its own. */
+  message: string | null;
+  /** Set only when the connection failed. */
+  error: string | null;
+  /** True while a pasted token is in flight. */
+  isSubmittingToken: boolean;
+}
+
+const INITIAL_STATE: CliConnectState = {
+  phase: null,
+  instructions: null,
+  approvalUrl: null,
+  tokenLabel: null,
+  tokenHelpUrl: null,
+  message: null,
+  error: null,
+  isSubmittingToken: false,
+};
+
+/**
+ * Pull the approval link out of the tool's login output.
+ *
+ * Vendors word (and reword) that output freely, so the link is found by scan
+ * rather than by parsing a known format, and sanitized before it is ever
+ * offered to the user.
+ */
+function findApprovalUrl(instructions: string | null): string | null {
+  if (!instructions) return null;
+  const match = instructions.match(URL_IN_TEXT);
+  if (!match) return null;
+  return sanitizeRedirectUrl(match[0].replace(TRAILING_PUNCTUATION, ""));
+}
+
+export interface UseCliConnectOptions {
+  /**
+   * The integration to connect, or `null` to stay idle. Passing `null` stops
+   * an in-flight run, so callers close the flow by clearing this.
+   */
+  integrationId: string | null;
+  /** Runs once the tool reports a live connection, with the integration name. */
+  onConnected: (name: string) => void;
+}
+
+export interface UseCliConnectResult {
+  state: CliConnectState;
+  /** Sends a pasted token and resumes polling. */
+  submitToken: (token: string) => void;
+  /** Restarts a failed connection from the top. */
+  retry: () => void;
+}
+
+/**
+ * Resolve the phase from a connect response.
+ *
+ * The top-level status wins over `cli.phase` so a backend that reports failure
+ * or success without a matching phase can't strand the UI. A CLI connect never
+ * redirects, and a `pending` with no `cli` block leaves nothing to show or poll
+ * on, so both fall through to `failed` rather than spinning forever.
+ */
+function derivePhase(response: ConnectIntegrationResponse): CliConnectPhase {
+  if (response.status === "error") return "failed";
+  if (response.status === "connected") return "connected";
+  if (response.cli) return response.cli.phase;
+  return "failed";
+}
+
+type PollStep = (
+  integrationId: string,
+  runId: number,
+  bearerToken?: string,
+) => Promise<void>;
+
+/**
+ * Drives a `managedBy: "cli"` connection.
+ *
+ * The connect endpoint is idempotent and advances the connection one step per
+ * call, so this re-POSTs it on an interval while the phase is a waiting one and
+ * stops the moment the flow needs the user (`needs_token`) or is over
+ * (`connected`, `failed`). Every run carries a generation number: closing the
+ * flow, submitting a token, or retrying bumps it, so a response from an
+ * abandoned run is dropped instead of overwriting the live one — and the
+ * pending timer is always cleared, including on unmount.
+ */
+export function useCliConnect({
+  integrationId,
+  onConnected,
+}: UseCliConnectOptions): UseCliConnectResult {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<CliConnectState>(INITIAL_STATE);
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const runIdRef = useRef(0);
+
+  // Held in a ref so a caller's inline callback doesn't restart the flow on
+  // every render.
+  const onConnectedRef = useRef(onConnected);
+  useEffect(() => {
+    onConnectedRef.current = onConnected;
+  });
+
+  const clearPendingTick = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const step = useCallback<PollStep>(
+    async (id, runId, bearerToken) => {
+      let response: ConnectIntegrationResponse;
+      try {
+        response = await integrationsApi.postConnect(id, {
+          bearerToken,
+          // Failures are rendered inside the modal; a toast per poll tick
+          // would bury the screen.
+          silent: true,
+        });
+      } catch (error) {
+        if (runId !== runIdRef.current) return;
+        setState((previous) => ({
+          ...previous,
+          phase: "failed",
+          error: error instanceof Error ? error.message : "Connection failed",
+          isSubmittingToken: false,
+        }));
+        return;
+      }
+
+      if (runId !== runIdRef.current) return;
+
+      const cli = response.cli ?? null;
+      const phase = derivePhase(response);
+      const instructions = cli?.instructions ?? null;
+
+      setState({
+        phase,
+        instructions,
+        approvalUrl: findApprovalUrl(instructions),
+        tokenLabel: cli?.tokenLabel ?? null,
+        tokenHelpUrl: cli?.tokenHelpUrl ?? null,
+        message: response.message ?? null,
+        error:
+          phase === "failed"
+            ? (response.error ?? response.message ?? "Connection failed")
+            : null,
+        isSubmittingToken: false,
+      });
+
+      if (phase === "connected") {
+        // Invalidate rather than refetch: the list and the tool picker catch up
+        // in the background while the flow closes.
+        queryClient.invalidateQueries({ queryKey: integrationKeys.all });
+        queryClient.invalidateQueries({ queryKey: toolKeys.all });
+        onConnectedRef.current(response.name);
+        return;
+      }
+
+      if (!POLLED_PHASES.includes(phase)) return;
+
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        void step(id, runId);
+      }, CLI_CONNECT_POLL_INTERVAL_MS);
+    },
+    [queryClient],
+  );
+
+  /** Abandons the current run, then starts a fresh one. */
+  const start = useCallback(
+    (id: string, bearerToken?: string) => {
+      clearPendingTick();
+      runIdRef.current += 1;
+      void step(id, runIdRef.current, bearerToken);
+    },
+    [clearPendingTick, step],
+  );
+
+  useEffect(() => {
+    if (!integrationId) return;
+
+    setState(INITIAL_STATE);
+    start(integrationId);
+
+    return () => {
+      clearPendingTick();
+      // Bumping the generation makes any in-flight response a no-op.
+      runIdRef.current += 1;
+    };
+  }, [integrationId, start, clearPendingTick]);
+
+  const submitToken = useCallback(
+    (token: string) => {
+      if (!integrationId) return;
+      setState((previous) => ({
+        ...previous,
+        isSubmittingToken: true,
+        error: null,
+      }));
+      start(integrationId, token);
+    },
+    [integrationId, start],
+  );
+
+  const retry = useCallback(() => {
+    if (!integrationId) return;
+    setState(INITIAL_STATE);
+    start(integrationId);
+  }, [integrationId, start]);
+
+  return { state, submitToken, retry };
+}

--- a/apps/web/src/features/integrations/hooks/useCliConnect.ts
+++ b/apps/web/src/features/integrations/hooks/useCliConnect.ts
@@ -5,7 +5,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { sanitizeRedirectUrl } from "@/lib/url-safety";
 import { integrationsApi } from "../api/integrationsApi";
 import { integrationKeys, toolKeys } from "../api/queryKeys";
-import { CLI_CONNECT_POLL_INTERVAL_MS } from "../constants/connect";
+import {
+  CLI_CONNECT_POLL_INTERVAL_MS,
+  CLI_CONNECT_POLL_MAX_ATTEMPTS,
+} from "../constants/connect";
 import type { CliConnectPhase, ConnectIntegrationResponse } from "../types";
 
 /** Phases that still need the backend to make progress on its own. */
@@ -101,6 +104,8 @@ function derivePhase(response: ConnectIntegrationResponse): CliConnectPhase {
 type PollStep = (
   integrationId: string,
   runId: number,
+  /** Which tick this is, so the loop can stop instead of running forever. */
+  attempt: number,
   bearerToken?: string,
 ) => Promise<void>;
 
@@ -140,7 +145,7 @@ export function useCliConnect({
   }, []);
 
   const step = useCallback<PollStep>(
-    async (id, runId, bearerToken) => {
+    async (id, runId, attempt, bearerToken) => {
       let response: ConnectIntegrationResponse;
       try {
         response = await integrationsApi.postConnect(id, {
@@ -191,9 +196,19 @@ export function useCliConnect({
 
       if (!POLLED_PHASES.includes(phase)) return;
 
+      if (attempt + 1 >= CLI_CONNECT_POLL_MAX_ATTEMPTS) {
+        setState((previous) => ({
+          ...previous,
+          phase: "failed",
+          error:
+            "This took too long. The login may have expired — try connecting again.",
+        }));
+        return;
+      }
+
       timeoutRef.current = setTimeout(() => {
         timeoutRef.current = null;
-        void step(id, runId);
+        void step(id, runId, attempt + 1);
       }, CLI_CONNECT_POLL_INTERVAL_MS);
     },
     [queryClient],
@@ -204,7 +219,7 @@ export function useCliConnect({
     (id: string, bearerToken?: string) => {
       clearPendingTick();
       runIdRef.current += 1;
-      void step(id, runIdRef.current, bearerToken);
+      void step(id, runIdRef.current, 0, bearerToken);
     },
     [clearPendingTick, step],
   );

--- a/apps/web/src/features/integrations/hooks/useCliConnectModal.ts
+++ b/apps/web/src/features/integrations/hooks/useCliConnectModal.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import type { Integration } from "../types";
+
+/**
+ * Open/close state for the CLI connect modal.
+ *
+ * Mirrors `useBearerTokenModal`: the list component decides *that* a CLI
+ * integration should open a modal, and this owns the rest. The integration is
+ * deliberately kept after `close()` so the modal still has a name to render
+ * while it animates out — clearing it makes the title flash empty.
+ */
+export function useCliConnectModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [integration, setIntegration] = useState<Integration | null>(null);
+
+  const open = useCallback((target: Integration) => {
+    setIntegration(target);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return {
+    isOpen,
+    integrationId: integration?.id ?? null,
+    integrationName: integration?.name ?? "",
+    open,
+    close,
+  };
+}

--- a/apps/web/src/features/integrations/types/index.ts
+++ b/apps/web/src/features/integrations/types/index.ts
@@ -7,8 +7,11 @@
  * from `../types`.
  */
 
+import type { IntegrationManagedBy } from "@shared/types";
+
 export type {
   IntegrationConnectionData,
+  IntegrationManagedBy,
   IntegrationStatusRecord as IntegrationStatus,
   IntegrationToolsResponse,
   MyIntegrationsResponse,
@@ -47,7 +50,7 @@ export interface Integration {
   expiredAt?: string;
   displayPriority?: number;
   isFeatured?: boolean;
-  managedBy?: "self" | "composio" | "mcp" | "internal";
+  managedBy?: IntegrationManagedBy;
   available?: boolean;
   authType?: "oauth" | "bearer" | "none";
   source?: "platform" | "custom";
@@ -62,6 +65,54 @@ export interface Integration {
     picture: string | null;
   } | null;
   slug: string;
+}
+
+/**
+ * Where a `managedBy: "cli"` connection currently stands.
+ *
+ * `installing` and `awaiting_approval` are waiting states the client polls
+ * through; `needs_token` hands control back to the user; `connected` and
+ * `failed` are terminal.
+ */
+export type CliConnectPhase =
+  | "installing"
+  | "needs_token"
+  | "awaiting_approval"
+  | "connected"
+  | "failed";
+
+/**
+ * What the user has to see and do right now for a CLI connection.
+ *
+ * `instructions` is the tool's own output relayed verbatim — the approval text
+ * (carrying a URL and a code) while waiting, or the failure detail when the
+ * phase is `failed`. GAIA never parses or rewords it.
+ */
+export interface CliConnectDetail {
+  phase: CliConnectPhase;
+  instructions?: string | null;
+  /** Prompt copy for the paste-a-token step, e.g. "Personal access token". */
+  tokenLabel?: string | null;
+  /** Where the user can go to mint that token. */
+  tokenHelpUrl?: string | null;
+}
+
+/**
+ * The unified connect endpoint's response.
+ *
+ * `pending` is the CLI transport's steady state: the endpoint is idempotent
+ * and advances the connection one step per call, so the client re-POSTs it
+ * until the status leaves `pending`, reading `cli` for what to show meanwhile.
+ */
+export interface ConnectIntegrationResponse {
+  status: "connected" | "redirect" | "error" | "pending";
+  integrationId: string;
+  name: string;
+  message?: string | null;
+  toolsCount?: number | null;
+  redirectUrl?: string | null;
+  error?: string | null;
+  cli?: CliConnectDetail | null;
 }
 
 export interface CreateCustomIntegrationRequest {

--- a/libs/shared/ts/src/types/integrations.ts
+++ b/libs/shared/ts/src/types/integrations.ts
@@ -49,7 +49,18 @@ export interface IntegrationConnectionData {
 
 export type IntegrationAuthType = "oauth" | "bearer" | "none";
 
-export type IntegrationManagedBy = "composio" | "mcp" | "internal" | "self";
+/**
+ * Which transport owns an integration's connection. `cli` is a real vendor
+ * command-line tool GAIA drives on the user's behalf — its connect flow is a
+ * state machine the client polls rather than a single call or an OAuth
+ * redirect (see `CliConnectDetail` on the connect response).
+ */
+export type IntegrationManagedBy =
+  | "composio"
+  | "mcp"
+  | "internal"
+  | "self"
+  | "cli";
 
 export interface IntegrationTool {
   name: string;

--- a/tools/lints/plr_complexity_baseline.txt
+++ b/tools/lints/plr_complexity_baseline.txt
@@ -78,7 +78,6 @@ apps/api/app/services/chat/persistence.py	PLR0913
 apps/api/app/services/composio/proxy_client.py	PLR0913
 apps/api/app/services/hil/approvals_store.py	PLR0913
 apps/api/app/services/hil/bridge.py	PLR0913
-apps/api/app/services/integrations/custom_crud.py	PLR0912
 apps/api/app/services/mcp/langchain_adapter.py	PLR0912
 apps/api/app/services/mcp/resilient_adapter.py	PLR0912
 apps/api/app/services/mcp/resilient_adapter.py	PLR0915

--- a/tools/lints/plr_complexity_baseline.txt
+++ b/tools/lints/plr_complexity_baseline.txt
@@ -46,7 +46,6 @@ apps/api/app/agents/tools/tracked_todo_tools.py	PLR0913
 apps/api/app/agents/workspace/paths.py	PLR0911
 apps/api/app/api/v1/endpoints/bot.py	PLR0912
 apps/api/app/api/v1/endpoints/bot.py	PLR0915
-apps/api/app/api/v1/endpoints/integrations/config.py	PLR0912
 apps/api/app/api/v1/endpoints/mcp.py	PLR0912
 apps/api/app/api/v1/endpoints/mcp.py	PLR0915
 apps/api/app/api/v1/endpoints/oauth.py	PLR0911
@@ -80,8 +79,6 @@ apps/api/app/services/composio/proxy_client.py	PLR0913
 apps/api/app/services/hil/approvals_store.py	PLR0913
 apps/api/app/services/hil/bridge.py	PLR0913
 apps/api/app/services/integrations/custom_crud.py	PLR0912
-apps/api/app/services/integrations/integration_connection_service.py	PLR0911
-apps/api/app/services/integrations/integration_connection_service.py	PLR0913
 apps/api/app/services/mcp/langchain_adapter.py	PLR0912
 apps/api/app/services/mcp/resilient_adapter.py	PLR0912
 apps/api/app/services/mcp/resilient_adapter.py	PLR0915
@@ -156,7 +153,6 @@ apps/api/tests/integration/real/test_schemathesis.py	PLR0912
 apps/api/tests/unit/agents/context/test_sections.py	PLR0913
 apps/api/tests/unit/agents/test_mail_templates.py	PLR0913
 apps/api/tests/unit/agents/test_messages.py	PLR0913
-apps/api/tests/unit/api/test_integrations_config_endpoint.py	PLR0913
 apps/api/tests/unit/memory/pg_store/test_memories.py	PLR0913
 apps/api/tests/unit/memory/test_ingestion.py	PLR0913
 apps/api/tests/unit/memory/test_management.py	PLR0913


### PR DESCRIPTION
## Summary

GAIA can now use a company's real command-line tool as an integration, the same way it uses a hosted API today. The first one is **Stripe Link**: connect it and GAIA can buy things for you with a single-use payment credential that you approve on your phone, and your card is never exposed to us.

For a user nothing looks new. A CLI integration appears in Integrations like any other card, lists what it can do, and asks you to approve a login. Nothing about a command line, a sandbox, or a binary is ever shown.

The same transport works for CLIs nobody here has configured: asking GAIA in chat to "create an integration for the GitHub CLI" produces a working, connectable integration, because a CLI integration is described entirely as data.

## Why

Every platform worth integrating ships a CLI, and increasingly those CLIs are built for agents: JSON output, `--schema`, device-code login. The alternative is waiting for each vendor to publish an MCP server, or hand-writing API clients that go stale. Stripe Link in particular has no API we could wrap — the payment flow, the approval UX and the credential lifecycle all live inside `link-cli`, which is the interface Stripe maintains for agents.

## What changed

### API

- **New transport `managed_by="cli"`.** An integration is described entirely as data (`app/models/cli_config.py`): what installs it, what the command is called, how it logs in. No provider-specific code, so a CLI nobody here has seen runs on the same paths.
- **One tool per integration, taking a shell command** (`app/agents/tools/cli/cli_tool.py`) rather than a generated tool per subcommand. A CLI documents itself through `--help`, and that documentation is always right for the installed version; freezing a snapshot of it into tool schemas breaks on the vendor's next release and discards the long tail. Pipes and chaining work.
- **GAIA stores no vendor credential.** The CLI owns its own login, pointed at durable storage by `HOME`. Connection state is whatever the integration's verify command exits with — the only signal that stays correct when a token is revoked or rotated outside GAIA.
- **Connecting is an idempotent state machine with no state of its own** (`app/services/cli/connect.py`). Each poll re-reads the sandbox and takes one step. Sandboxes are recreated roughly hourly and replicas are replaceable, so nothing may be remembered.
- **Connect dispatch de-duplicated.** Choosing a transport was written out twice, and the login-free connect-link path supported fewer transports than the endpoint did. Both now go through one provider registry (`app/services/integrations/providers/`, `connect_dispatch.py`).
- **HIL classifies CLI calls by the command, not the tool name.** Every command of a CLI shares one tool name, so a name-keyed verdict would gate `gh pr list` exactly as hard as `gh repo delete`. Commands are reduced to a structural shape (`app/services/hil/command_shape.py`) and classified on that, reusing the existing cache and classifier.
- **Authoring adapter** (`app/services/integrations/authoring/`) so the agent can create MCP *or* CLI integrations from chat. The add-integration dialog in the UI stays MCP-only: pasting a server URL is data entry, describing a CLI is research.

### Web

- `CliConnectModal` + `useCliConnect` drive the connect poll and render three states: installing, approve-this-login (with the CLI's own instructions and an extracted approval link), and paste-a-token.

### Infra

- The E2B template bakes a Node runtime. Installs and launchers live under the sandbox user's own home, so a sandbox resumed from a pre-template image still installs cleanly.

---

### Where the bytes live, and why

Measured on the real template, not assumed:

| | Location | Cold cost | Why there |
| --- | --- | --- | --- |
| Node runtime | Baked into the E2B image | 0.3 s startup | Extracting it onto JuiceFS took **>600 s** and left `node` with a **12 s** startup |
| CLI package | Sandbox local disk | 20 s (npm), 5 s (tarball) | Thousands of small files; re-created per sandbox by design |
| Credentials | JuiceFS (`/workspace`) | — | A handful of small files, and the only part that must survive sandbox recreation |

A warm CLI call is **2.2 s**; a cold one pays the install once per sandbox.

### The seam that makes it safe

Every CLI invocation goes through a generated per-integration launcher. The launcher is what pins `HOME` to durable storage, which is why GAIA never has to hold a vendor token to make a CLI work, and why a sandbox recreated mid-session re-installs rather than logging the user out.

To be precise about what that is *not*: it is attribution, not isolation. All of a user's connected CLIs share one launcher directory on `PATH` and run as the same sandbox user — the same trust boundary the existing bash tool already has.

## Screenshots

| State | View |
| --- | --- |
| Installing | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/cli-integrations/01-installing.png" width="460"> |
| Awaiting approval (Stripe Link, device login) | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/cli-integrations/02-awaiting-approval.png" width="460"> |
| Paste a token (GitHub CLI, created by the agent from chat) | <img src="https://raw.githubusercontent.com/theexperiencecompany/gaia/pr-assets/cli-integrations/04-github-cli-token.png" width="460"> |

The approval pane shows the CLI's own output verbatim — GAIA never parses it, because every vendor words this differently and rewords it between releases. Lines naming GAIA's internal sandbox paths are stripped before display.

## How to verify

1. Rebuild the E2B template and point `E2B_TEMPLATE_ID` at it (see Post-merge steps), then `mise dev --agent` and `mise seed`.
2. Open `/integrations`, find **Stripe Link**, click Connect. Expect: "Installing Stripe Link…", then a Link approval URL and short phrase, then Connected once you approve in the Link app.
3. Ask GAIA in chat to create an integration for the GitHub CLI, giving it the executable, install command and that it authenticates via `GH_TOKEN`. Expect a new card in Integrations whose Connect button installs `gh` and then asks for a token.
4. Ask it to create one for Stripe Atlas. Expect a clear refusal — Atlas has no CLI and no API.
5. Failure path: disconnect, then Connect and cancel the login. Expect the dialog to say so plainly and offer Try again, not hang.

**Not verified: a completed Stripe Link purchase — and it cannot be verified from here.**

The connect flow was driven end to end against the live app and works: the CLI installs, the device login starts, and Stripe returns a real approval URL and phrase. Approving that URL then hits Stripe's own wall:

> **We're not in your region yet.** Connecting agents to your account is currently only supported in the U.S.

So the unproven step is not code — it is that Link agent connections are US-only today, and the account approving has to be a US one. Everything up to Stripe's gate is exercised; nothing past it can be, without a US Link account. Approving from a US account, or Stripe opening the region, is all that is needed — no change to this branch.

Also not verified: the HIL LLM classifier was exercised against mocks, not a live model.

## Post-merge steps

- [ ] Rebuild the E2B template: `cd apps/api && uv run python scripts/build_e2b_template.py` (adds the Node runtime; the CLI transport cannot install anything without it).
- [ ] Set `E2B_TEMPLATE_ID` in Infisical to the printed template ID.

Sandboxes already paused when this ships keep the old image until they are recreated, which happens within the hour. Those users see a CLI install fail with `npm: not found` until then; retrying after recreation succeeds.

**Rollback:** revert this PR, then point `E2B_TEMPLATE_ID` back at the previous template. A revert alone leaves the new template in place, which is harmless but unused.

## Risk

The blast radius is limited to the new transport: nothing here runs unless a user connects a CLI-backed integration, and only Stripe Link ships in that state. The realistic failure is an install that fails inside a user's sandbox, which surfaces in the connect dialog and blocks only that integration.

The one change that touches existing behaviour is the connect dispatch refactor — every transport now routes through one registry. A mistake there would break connecting an integration generally rather than subtly, and it is covered by the dispatch tests plus the existing per-transport suites.

## Notes for the reviewer

Two review passes ran over this branch before it was opened for review, and both found real defects that are fixed here rather than left for you. Worth knowing what they were, because they shape the code you are reading:

- The HIL gate failed open on an env-var prefix: `FOO=1 sh -c '<payload>'` classified as `sh`. The shape derivation now strips assignments first and refuses any wrapper anywhere in the shape.
- Disconnecting a user-authored CLI integration resurrected the row it had just deleted, via an upsert in the cache-invalidation path.
- Two users authoring the same CLI collided in the process-global tool registry; custom integrations now carry a digest of their id.
- A device login could never age out, because its age came from the log's mtime (its last write) rather than the pid file.
- An earlier commit on this branch silently deleted the E2B template's sudo-hardening — a patch matched a comment that appears twice in that file. It is restored, and verified against the live template (`sudo` absent, `hidepid=invisible` on).

One cosmetic wart: commit `6bf71a5fe0` reuses an earlier commit's subject line. The diff is correct; I did not force-push to fix the message.
