### PR TITLE
feat(workflows): author playbooks as inline $ask slots, checked against the run that writes them

### DIFF
--- a/apps/api/app/agents/prompts/playbook_prompts.py
+++ b/apps/api/app/agents/prompts/playbook_prompts.py
@@ -17,17 +17,29 @@ the finished result. Two reasons, both load-bearing:
 PLAYBOOK_CHECK_BRIEF = """<playbook_check>
 This workflow has no working playbook. When you have finished the work above (and only then), decide whether the sequence you just ran is worth freezing so future runs can replay it instead of reasoning it out again.
 
-Work through these six for yourself, against the calls you actually made. This is your own reasoning, not part of the run's result:
+Work through these five for yourself, against the calls you actually made. This is your own reasoning, not part of the run's result:
 1. Which of your calls were discovery or dead ends (finding an id, a channel, a folder, a file, recovering from an error, or an attempt that came back empty, wrong or refused that you then did differently) rather than the work itself? Those must not go in a playbook. A playbook records what WORKED: freeze the call that actually produced the result, with the arguments that made it produce one, not the first thing you tried.
-2. Which args are fixed on every run, and what does each of the others become? The placeholder vocabulary is: $now, $today, $now + 1d; $user.email, $user.name, $user.timezone; $trigger.<path>; $steps.<step_id>.<path> and $steps.<step_id>.file; $last_run.<TOOL_NAME>.<path>; $ask.<name>.
+2. Which args are fixed on every run, and what does each of the others become? The placeholder vocabulary is: $now, $today, $now + 1d; $user.email, $user.name, $user.timezone; $trigger.<path>; $steps.<step_id>.<path> and $steps.<step_id>.file; $last_run.<TOOL_NAME>.<path>. If a value genuinely cannot be frozen or built from those, write {"$ask": "what to write"} as that value and a model writes it at replay, right before that step runs. This is rare: a search query usually freezes fine, and anything about the RESULT belongs in result_brief, not in a step.
 3. What has to carry over to the next run (a cursor, a last seen id, a timestamp) so it does not redo work or repeat something someone would notice?
-4. What did you have to write or judge from content, rather than copy straight out of a result? Each of those becomes an $ask.
-5. Would this exact ORDER OF CALLS work tomorrow, unchanged? Judge the sequence, not the content: results and the words you write from them are SUPPOSED to differ every run, and that is what synthesize and $ask exist for, so changing data is never by itself a reason to answer no. Answer no only if the sequence itself would differ: the order depended on what you found, you reacted to a result by choosing different calls mid-run, or a step only made sense given today's data.
-6. Did every call you are freezing return the data the workflow needs, as it stands? If a step came back empty, with an error, or partial, and you compensated by reasoning around it, that call is not the work. A playbook replays the call, not your reasoning, so the next run would hand the user the gap you papered over. Fix its args before freezing, or decline.
+4. Would this exact ORDER OF CALLS work tomorrow, unchanged? Judge the sequence, not the content: results and the words you write from them are SUPPOSED to differ every run, and that is what result_brief and $ask exist for, so changing data is never by itself a reason to answer no. Answer no only if the sequence itself would differ: the order depended on what you found, you reacted to a result by choosing different calls mid-run, or a step only made sense given today's data.
+5. Did every call you are freezing return the data the workflow needs, as it stands? If a step came back empty, with an error, or partial, and you compensated by reasoning around it, that call is not the work. A playbook replays the call, not your reasoning, so the next run would hand the user the gap you papered over. Fix its args before freezing, or decline.
 
-If 5 and 6 are both yes, call write_playbook. Its arguments carry the shape: a description, the steps in the order you ran them, a synthesize brief, and an ask entry for each thing you had to write. A step is EITHER a tool call OR a handoff carrying the steps that subagent ran. Each handoff's result includes a record of the calls that subagent actually ran: the handoff step's nested steps are the calls in that record that did the work, with those exact names and args, minus the subagent's own discovery. Use the real tool names and argument names you actually called, since they are checked against the live tools and a playbook naming a tool that does not exist is refused.
+If 4 and 5 are both yes, call write_playbook. Its arguments carry the shape: a description, the steps in the order you ran them, and a result_brief saying how to write the user's result from the steps' results (this is where classification, judgement and summarising go). A step is EITHER a tool call OR a handoff carrying the steps that subagent ran. Each handoff's result includes a record of the calls that subagent actually ran: the handoff step's nested steps are the calls in that record that did the work, with those exact names and args, minus the subagent's own discovery. Use the real tool names and argument names you actually called, since they are checked against the live tools and a playbook naming a tool that does not exist is refused. The shape, end to end:
 
-If either 5 or 6 is no, call decline_playbook with the reason. You MUST end this run by calling exactly one of write_playbook or decline_playbook: staying silent is not a decision, and a run that was asked and called neither is a lapse, not a no.
+steps:
+  - id: unread
+    handoff: gmail
+    steps:
+      - id: inbox
+        tool: GMAIL_FETCH_MESSAGES
+        args: {query: "is:unread newer_than:1d", max_results: 25}
+  - id: background
+    tool: web_search_tool
+    args:
+      query_text: {"$ask": "one web search that would give background on the most important mail listed above"}
+result_brief: Lead with what the unread mail is about, then what the search added. Two short paragraphs.
+
+If either 4 or 5 is no, call decline_playbook with the reason. You MUST end this run by calling exactly one of write_playbook or decline_playbook: staying silent is not a decision, and a run that was asked and called neither is a lapse, not a no.
 
 Either way, keep all of this out of what you return. The result you hand back is the workflow's own output, the thing the user asked for, and nothing else. Do not narrate the check, do not list your answers, do not mention playbooks or freezing or this decision at all. Whether you called the tool is the entire record of it.
 </playbook_check>"""
@@ -67,11 +79,11 @@ PLAYBOOK_HEAL_NO_REASON = "no reason was recorded"
 #: cannot drift apart on voice.
 _PLAYBOOK_VOICE = """Write like a person. Open on the actual point, vary your sentence length, use plain words, and say what you think instead of hedging every clause. No throat-clearing openers, no "delve", "seamless", "robust", "leverage", "testament to", no reflexive "Moreover". Do not overcorrect into forced quirkiness or slang either. Natural and clear is the whole target."""
 
-#: The mid-run call: fills the ``$ask`` fields the next step needs, and nothing
+#: The mid-run call: fills the ``$ask`` slots the next step needs, and nothing
 #: else. It runs before the later steps, so it must not write the user's result
 #: or judge the run: neither can be done before the run's outcome is known.
 PLAYBOOK_ASK_PROMPT = (
-    """You are writing the fields a workflow run needs before it can continue. The run follows a written playbook, so its steps are replayed rather than reasoned out. The steps listed as ran already happened exactly as listed. The steps still to run happen after you answer, and some of them use what you write.
+    """You are writing the slots a workflow run needs before it can continue. The run follows a written playbook, so its steps are replayed rather than reasoned out. The steps listed as ran already happened exactly as listed. The steps still to run happen after you answer, and some of them use what you write.
 
 <playbook>
 {description}
@@ -89,7 +101,7 @@ PLAYBOOK_ASK_PROMPT = (
 {asks}
 </asks>
 
-Write one entry per ask above, keyed by the ask's own name. Follow each ask's instruction and respect its length budget. Write nothing else: no result for the user and no judgement of the run. Both are written after the remaining steps have run, by a separate call that sees their results.
+Write one entry per slot above, keyed by the slot's key exactly as listed. Follow each slot's instruction and respect its length budget. Write nothing else: no result for the user and no judgement of the run. Both are written after the remaining steps have run, by a separate call that sees their results.
 
 Ground every word in what is listed above. Never invent a number, a name, a link, or an outcome that is not there.
 
@@ -115,11 +127,12 @@ PLAYBOOK_NARRATION_PROMPT = (
 {asks}
 </asks>
 
-The asks section holds the fields written earlier in this run, for context only. The steps that needed them already used them.
+The asks section holds the slots written earlier in this run, for context only. The steps that needed them already used them.
 
 Produce both of these in this one pass:
 
-1. The run's result for the user, written to this brief: {synthesize}
+1. The run's result for the user, written to this brief (result_brief): {result_brief}
+   The result is the finished text the user reads, written once. Never a draft followed by a rewrite, never a note to yourself about the brief, never an aside about what you are doing: if you would change something, change it before you write, and hand back only the final version.
 2. A verdict on the run. Judge only the steps listed under ran. Each line shows the arguments the call ran with and what it returned; judge both against the playbook's description and the brief above. Answer suspect when a result is empty where the task expects items, contains an error, or contradicts the description, and also when the arguments contradict it: a wider window than the task names, a filter it does not ask for, a source it does not mention. Plenty of results do not make a wrong call right. Otherwise answer ok. Never answer suspect because some step is missing from the list. The list is complete, and a step that is not on it was not part of this run. When it is suspect, give a one line reason. Write the result either way, exactly as the data reads.
 
 Ground every word in what is listed above. Never invent a number, a name, a link, or an outcome that is not there, and if something did not happen, say that plainly instead of smoothing over it.
@@ -127,6 +140,16 @@ Ground every word in what is listed above. Never invent a number, a name, a link
 """
     + _PLAYBOOK_VOICE
 )
+
+
+#: Delivered as the run's result when every step replayed but the narration
+#: call did not return. The steps' effects are real and their results are on
+#: the record, so the user gets what ran rather than a failed run — and the
+#: playbook is not sent to heal over a call that was never its fault.
+PLAYBOOK_NARRATION_FALLBACK_TEMPLATE = """The saved steps for this workflow ran, but the summary could not be written this time ({reason}).
+
+What ran:
+{completed}"""
 
 
 PLAYBOOK_FALLBACK_TEMPLATE = """The playbook for this workflow was replayed first and it stopped partway.

--- a/apps/api/app/agents/prompts/playbook_prompts.py
+++ b/apps/api/app/agents/prompts/playbook_prompts.py
@@ -80,10 +80,12 @@ PLAYBOOK_HEAL_NO_REASON = "no reason was recorded"
 _PLAYBOOK_VOICE = """Write like a person. Open on the actual point, vary your sentence length, use plain words, and say what you think instead of hedging every clause. No throat-clearing openers, no "delve", "seamless", "robust", "leverage", "testament to", no reflexive "Moreover". Do not overcorrect into forced quirkiness or slang either. Natural and clear is the whole target."""
 
 #: The mid-run call: fills the ``$ask`` slots the next step needs, and nothing
-#: else. It runs before the later steps, so it must not write the user's result
-#: or judge the run: neither can be done before the run's outcome is known.
+#: else. One call per step that carries slots, made immediately before that
+#: step, so the slots are written from everything that has actually run. It runs
+#: before the later steps, so it must not write the user's result or judge the
+#: run: neither can be done before the run's outcome is known.
 PLAYBOOK_ASK_PROMPT = (
-    """You are writing the slots a workflow run needs before it can continue. The run follows a written playbook, so its steps are replayed rather than reasoned out. The steps listed as ran already happened exactly as listed. The steps still to run happen after you answer, and some of them use what you write.
+    """You are writing the slots the next step of a workflow run needs before it can continue. The run follows a written playbook, so its steps are replayed rather than reasoned out. The steps listed as ran already happened exactly as listed. The steps still to run happen after you answer, and the first of them uses what you write.
 
 <playbook>
 {description}
@@ -144,7 +146,7 @@ Ground every word in what is listed above. Never invent a number, a name, a link
 
 #: Delivered as the run's result when every step replayed but the narration
 #: call did not return. The steps' effects are real and their results are on
-#: the record, so the user gets what ran rather than a failed run — and the
+#: the record, so the user gets what ran rather than a failed run, and the
 #: playbook is not sent to heal over a call that was never its fault.
 PLAYBOOK_NARRATION_FALLBACK_TEMPLATE = """The saved steps for this workflow ran, but the summary could not be written this time ({reason}).
 

--- a/apps/api/app/agents/tools/playbook_tools.py
+++ b/apps/api/app/agents/tools/playbook_tools.py
@@ -6,17 +6,22 @@ write always replaces what was there and a rejected write leaves the previous
 playbook untouched.
 """
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
+import json
 from typing import Annotated, Any
 
+from langchain_core.messages import ToolMessage
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import tool
+from langgraph.prebuilt import InjectedState
+from pydantic import ValidationError
+from pydantic.v1 import ValidationError as LegacyValidationError
 
 from app.constants.log_tags import LogTag
 from app.db.repositories.playbooks import playbook_repository
 from app.db.repositories.workflows import workflow_repository
 from app.models.playbook_models import (
-    PlaybookAsk,
     PlaybookDocument,
     PlaybookRunStatus,
     PlaybookStepInput,
@@ -24,7 +29,13 @@ from app.models.playbook_models import (
 )
 from app.models.workflow_models import WorkflowUpdate
 from app.services.workflow.playbook.check import HEAL_STATUSES, declined_for_good
-from app.services.workflow.playbook.parser import dump_playbook, validate_playbook
+from app.services.workflow.playbook.evaluator import parse_result
+from app.services.workflow.playbook.parser import (
+    RecordedResult,
+    RunResults,
+    dump_playbook,
+    validate_playbook,
+)
 from app.services.workflow.playbook.workflow_hash import workflow_hash
 from app.utils.workflow_utils import (
     WorkflowConfigError,
@@ -36,6 +47,83 @@ from app.utils.workflow_utils import (
 from shared.py.wide_events import log
 
 
+def _render_location(location: tuple[int | str, ...]) -> str:
+    """One pydantic error location as the author wrote it: ``steps[0].tool``."""
+    rendered = ""
+    for part in location:
+        if isinstance(part, int):
+            rendered += f"[{part}]"
+        else:
+            rendered += f".{part}" if rendered else str(part)
+    return rendered or "arguments"
+
+
+def _explain_validation_error(error: ValidationError | LegacyValidationError) -> str:
+    """Hand a rejected call back as an answer the author can act on.
+
+    Without this, arguments that miss the schema come back as a framework-level
+    error the model cannot read, and it retries the same shape. Reported as the
+    tool's own ``error_response`` so a bad shape and a bad playbook read
+    identically: what was wrong, and that nothing was written.
+
+    Both pydantic generations are accepted because that is the signature
+    langchain's hook declares; either one reports ``loc``/``msg`` the same way.
+    """
+    problems = "; ".join(
+        f"{_render_location(item['loc'])}: {item['msg']}" for item in error.errors()
+    )
+    return json.dumps(
+        error_response(
+            "invalid_playbook",
+            "The playbook was not written. Fix these and call write_playbook again: " + problems,
+        )
+    )
+
+
+def _run_results(state: Mapping[str, Any] | None) -> RunResults | None:
+    """The authoring run's tool calls with what each one returned, in call order.
+
+    ``None`` when there is no run to read: the dev ``/dev/executor`` route and
+    the unit tests build these tools without a graph, and a playbook written
+    there is validated exactly as it was before rather than refused for a run
+    that was never recorded. An empty list is NOT the same answer — it means the
+    run really made no calls, and a playbook freezing calls is wrong.
+
+    Failed calls are kept, unlike the handoff record's successful-only lines
+    (``call_record.py``): a step frozen on a call that errored is precisely one
+    of the things the validator has to catch.
+    """
+    if state is None:
+        return None
+    messages = state.get("messages")
+    if not isinstance(messages, list):
+        return None
+    answers: dict[str, object] = {}
+    for message in messages:
+        if isinstance(message, ToolMessage) and message.tool_call_id:
+            content = message.content
+            answers[message.tool_call_id] = parse_result(
+                content if isinstance(content, str) else json.dumps(content, default=str)
+            )
+    results: list[RecordedResult] = []
+    for message in messages:
+        for call in getattr(message, "tool_calls", None) or []:
+            call_id = call.get("id")
+            name = str(call.get("name") or "")
+            # A call with no answer is one still in flight (this very
+            # write_playbook call, in every real run) — it froze nothing.
+            if not name or call_id not in answers:
+                continue
+            results.append(
+                RecordedResult(
+                    tool_name=name,
+                    args=dict(call.get("args") or {}),
+                    result=answers[call_id],
+                )
+            )
+    return results
+
+
 @tool
 async def write_playbook(
     config: RunnableConfig,
@@ -44,24 +132,30 @@ async def write_playbook(
         list[PlaybookStepInput],
         "The calls to replay, in the order you made them: only the calls that did "
         "the work, never discovery or dead ends. Writing the result is not a step; "
-        "that is what synthesize is for.",
+        "that is what result_brief is for.",
     ],
-    synthesize: Annotated[str, "How to write the run's result for the user."],
-    ask: Annotated[
-        dict[str, PlaybookAsk] | None,
-        "Named slots a model fills at replay, for text you had to write rather "
-        "than copy out of a result. Reference one as $ask.<name>.",
-    ] = None,
+    result_brief: Annotated[
+        str,
+        "How to write the run's result for the user from the steps' results. "
+        "Classification, judgement and summarising go here.",
+    ],
+    #: The run's own messages, injected by the graph and absent from the schema
+    #: the model sees. Defaulted because a tool built without a graph (the dev
+    #: executor route, the unit tests) is called with arguments only.
+    state: Annotated[dict[str, Any] | None, InjectedState] = None,
 ) -> dict[str, Any]:
     """
     Freeze this workflow run's settled tool sequence as a playbook, so later runs
     execute it instead of reasoning it out again. The playbook attaches to the
     workflow this run is executing; there is no id to supply.
 
-    The steps are checked against the real tools before anything is stored: if a
-    tool or an argument does not exist, NOTHING is written and the problems come
-    back so you can fix them and call this again. A successful write replaces the
-    workflow's previous playbook entirely, which is also how you revise one.
+    The steps are checked against the real tools AND against what this run's
+    calls actually returned before anything is stored: if a tool or an argument
+    does not exist, if a step froze a call this run never made or one that came
+    back empty, or if a $steps reference reads a field the result does not have,
+    NOTHING is written and the problems come back so you can fix them and call
+    this again. A successful write replaces the workflow's previous playbook
+    entirely, which is also how you revise one.
 
     Only write a playbook when the same order of calls would work tomorrow
     unchanged. A run whose order depends on what it finds is not a playbook.
@@ -77,9 +171,14 @@ async def write_playbook(
         if workflow is None:
             return error_response("workflow_not_found", f"No workflow {workflow_id} for this user.")
 
-        body = playbook_body_from_input(description, steps, synthesize, ask)
+        body = playbook_body_from_input(description, steps, result_brief)
 
-        validation = await validate_playbook(body, user_id)
+        results = _run_results(state)
+        # On the wide event because it is the one thing a rejected-or-accepted
+        # write cannot show from its outcome: whether the run's own results
+        # were in hand (None: no graph state reached the tool at all).
+        log.set_ns("playbook", checked_against_calls=None if results is None else len(results))
+        validation = await validate_playbook(body, user_id, results)
         if not validation.valid:
             # The issues themselves, not just how many. A refused playbook is
             # diagnosed from the reason, and a count in a structured field that
@@ -106,15 +205,17 @@ async def write_playbook(
                 updated_at=now,
                 description=body.description,
                 steps=body.steps,
-                ask=body.ask,
-                synthesize=body.synthesize,
+                result_brief=body.result_brief,
             )
         )
-        # A written playbook answers the question the declines were about.
+        # A written playbook answers the question the declines were about, and
+        # supersedes the discard that recorded why the last one was thrown away.
         await workflow_repository.update_for_user(
             workflow_id,
             user_id,
-            WorkflowUpdate(playbook_declines=0, playbook_declined_hash=None),
+            WorkflowUpdate(
+                playbook_declines=0, playbook_declined_hash=None, last_playbook_discard=None
+            ),
         )
         log.set_ns("playbook", id=stored.playbook_id, steps=len(stored.steps))
         return success_response(
@@ -126,6 +227,12 @@ async def write_playbook(
             f"{LogTag.TOOL} write_playbook: exception", error_type=type(e).__name__, exc_info=True
         )
         return error_response("write_failed", str(e))
+
+
+#: Arguments that miss the schema never reach the body above — langchain raises
+#: before the coroutine runs — so the explanation is attached to the tool rather
+#: than written as a try/except inside it.
+write_playbook.handle_validation_error = _explain_validation_error
 
 
 @tool

--- a/apps/api/app/db/repositories/playbooks.py
+++ b/apps/api/app/db/repositories/playbooks.py
@@ -51,8 +51,7 @@ class PlaybooksRepository(MongoRepository[PlaybookDocument, PlaybookUpdate]):
         body = PlaybookUpdate(
             description=playbook.description,
             steps=playbook.steps,
-            ask=playbook.ask,
-            synthesize=playbook.synthesize,
+            result_brief=playbook.result_brief,
             workflow_hash=playbook.workflow_hash,
             last_run_status=PlaybookRunStatus.NOT_RUN,
             last_run_reason=None,

--- a/apps/api/app/models/playbook_models.py
+++ b/apps/api/app/models/playbook_models.py
@@ -228,6 +228,21 @@ _ARGS_DESCRIPTION = (
 )
 
 
+#: Names a model reaches for when it means ``args``. Dropped as unknown keys,
+#: any of these would store a call with no arguments at all and pass it off as
+#: authored; refusing them by name is what keeps lenience from swallowing the
+#: one key a step cannot do without.
+_ARGS_NEAR_MISSES = ("arguments", "input", "inputs", "params", "parameters", "kwargs")
+
+
+def _refuse_args_near_miss(data: Mapping[str, Any]) -> None:
+    if "args" in data:
+        return
+    for key in _ARGS_NEAR_MISSES:
+        if key in data:
+            raise ValueError(f"a step's arguments go under 'args', not {key!r}; rename it")
+
+
 class PlaybookHandoffStepInput(BaseModel):
     """A tool call recorded inside a handoff, as the authoring tool takes it.
 
@@ -262,6 +277,7 @@ class PlaybookHandoffStepInput(BaseModel):
                     "playbooks are one level deep, so list the calls that subagent made "
                     "as the handoff's own steps"
                 )
+            _refuse_args_near_miss(data)
         return data
 
     def to_step(self) -> PlaybookStep:
@@ -288,6 +304,13 @@ class PlaybookStepInput(BaseModel):
         default_factory=list,
         description="The tool calls the handoff's subagent ran. Only a handoff carries these.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _args_spelled_right(cls, data: object) -> object:
+        if isinstance(data, Mapping):
+            _refuse_args_near_miss(data)
+        return data
 
     @model_validator(mode="after")
     def exactly_one_shape(self) -> Self:

--- a/apps/api/app/models/playbook_models.py
+++ b/apps/api/app/models/playbook_models.py
@@ -5,25 +5,37 @@ and replayed by a script-driven subagent instead of being re-reasoned from
 scratch. The document is YAML the agent reads and edits; these models are the
 parsed form the runner executes.
 
-The grammar is deliberately three keys — ``description``, ``steps``,
-``synthesize`` (plus ``ask`` when a step needs text a model has to write). It
-carries no control flow: a run whose order depends on what it finds is not
-compilable and stays on the agent path, which is the correct outcome rather
-than a gap to fill with branches.
+The grammar is deliberately three keys — ``description``, ``steps`` and
+``result_brief``. It carries no control flow: a run whose order depends on what
+it finds is not compilable and stays on the agent path, which is the correct
+outcome rather than a gap to fill with branches.
+
+Text a model has to write at replay has no section of its own: it lives inline,
+as ``{"$ask": "what to write"}`` standing where the argument's value goes. That
+is not cosmetic. A slot declared in its own table can be declared and then
+referenced by nothing — five of the eight asks ever written in production were
+dead that way, filled by a model call and thrown away — and an inline slot is
+read by exactly the step it sits in, so a dead one cannot be written.
 """
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Self
+from typing import Any, Self, TypeGuard
 import uuid
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.db.repositories.base import MongoDocument
 
-#: Cap on a single ``$ask`` field's output. Generous enough for a briefing body,
+#: The key that marks an argument value as a slot a model fills at replay,
+#: rather than as data. A ``$`` prefix because no tool takes an argument or a
+#: JSON field by that name, so the marker cannot collide with real content.
+#: ``AskSlot`` below repeats the literal because a pydantic alias has to be one.
+ASK_KEY = "$ask"
+
+#: Cap on a single ``$ask`` slot's output. Generous enough for a briefing body,
 #: small enough that a runaway prompt cannot turn one replay into a long
 #: generation — the whole point of a playbook is a bounded token cost.
 DEFAULT_ASK_MAX_TOKENS = 1024
@@ -55,6 +67,47 @@ class PlaybookRunOutcome:
     status: PlaybookRunStatus
     reason: str | None = None
     counts_toward_streak: bool = True
+
+
+class AskSlot(BaseModel):
+    """An argument value a model writes at replay, written where it is used.
+
+    ``{"$ask": "<what to write>", "max_tokens": <optional int>}`` stands in the
+    argument's place. It carries no name and no list of steps to read, because
+    it needs neither: its address is its position in the arguments, and the one
+    model call that fills it sees every step that ran before its own step.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt: str = Field(alias="$ask", min_length=1, description="What to write for this value")
+    max_tokens: int = Field(default=DEFAULT_ASK_MAX_TOKENS, ge=1, le=8192)
+
+
+def is_ask_slot(value: object) -> TypeGuard[Mapping[str, Any]]:
+    """Whether a value stands for text a model writes, rather than being data.
+
+    A ``TypeGuard`` rather than a plain ``bool`` so the callers that go on to
+    read the slot's keys — the validator naming what a bad one contains — get
+    the mapping type from the check they already make.
+    """
+    return isinstance(value, Mapping) and ASK_KEY in value
+
+
+def has_ask_slots(value: object) -> bool:
+    """Whether a value holds an ask slot at any depth, itself included."""
+    return any(True for _ in walk_ask_slots(value))
+
+
+def ask_slot_key(prefix: str, path: Sequence[str | int]) -> str:
+    """The key one slot answers to: its step, then its path inside the args.
+
+    Defined once on purpose. The runner lists these keys to the model that
+    fills them and the evaluator looks the written text back up by the same
+    key, so two spellings of the rule would be a slot that is written and then
+    never substituted — a hole reaching a real tool.
+    """
+    return ".".join([prefix, *(str(part) for part in path)])
 
 
 class PlaybookStep(BaseModel):
@@ -103,20 +156,50 @@ class PlaybookStep(BaseModel):
         return self
 
 
-class PlaybookAsk(BaseModel):
-    """A named slot the model fills.
+@dataclass(frozen=True, slots=True)
+class LocatedAsk:
+    """One ask slot and the key that addresses it."""
 
-    Every ask in a playbook resolves in ONE call that also produces the
-    synthesis, so an ask costs nothing beyond the call the run already makes.
+    key: str
+    slot: AskSlot
+
+
+def ask_slots(steps: Sequence[PlaybookStep]) -> list[LocatedAsk]:
+    """Every ask slot in a playbook, in execution order, handoff children included.
+
+    Keys are unique: step ids are unique (the validator refuses a repeat) and
+    two slots in one step sit at two different argument paths.
     """
+    located: list[LocatedAsk] = []
+    for step in steps:
+        if step.handoff:
+            located.extend(ask_slots(step.steps))
+            continue
+        prefix = step.id or step.tool or ""
+        located.extend(
+            LocatedAsk(key=ask_slot_key(prefix, path), slot=AskSlot.model_validate(value))
+            for path, value in walk_ask_slots(step.args)
+        )
+    return located
 
-    model_config = ConfigDict(extra="forbid")
 
-    prompt: str = Field(description="What to write for this field")
-    uses: list[str] = Field(
-        default_factory=list, description="Step ids whose output this ask needs to see"
-    )
-    max_tokens: int = Field(default=DEFAULT_ASK_MAX_TOKENS, ge=1, le=8192)
+def walk_ask_slots(
+    value: object, path: tuple[str | int, ...] = ()
+) -> Iterator[tuple[tuple[str | int, ...], Mapping[str, Any]]]:
+    """Every ask slot inside one value, with the argument path that addresses it.
+
+    A slot is a leaf: nothing inside one is walked, so a prompt that happens to
+    read like a nested structure is text rather than more slots.
+    """
+    if is_ask_slot(value):
+        yield path, value
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            yield from walk_ask_slots(item, (*path, str(key)))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from walk_ask_slots(item, (*path, index))
 
 
 class PlaybookBody(BaseModel):
@@ -126,8 +209,9 @@ class PlaybookBody(BaseModel):
 
     description: str = Field(description="What this playbook does, in the agent's own words")
     steps: list[PlaybookStep] = Field(min_length=1)
-    ask: dict[str, PlaybookAsk] = Field(default_factory=dict)
-    synthesize: str = Field(description="How to write the run's user-facing result")
+    result_brief: str = Field(
+        description="How to write the run's result for the user, from every step's result."
+    )
 
 
 #: The placeholder vocabulary, spelled out for the tool-boundary schema. A JSON
@@ -137,7 +221,10 @@ _ARGS_DESCRIPTION = (
     "The call's arguments, exactly as the tool takes them. A value may be a "
     "placeholder resolved at replay: $now, $today, $now + 1d; $user.email, "
     "$user.name, $user.timezone; $trigger.<path>; $steps.<step_id>.<path>; "
-    "$last_run.<TOOL_NAME>.<path>; $ask.<name>."
+    "$last_run.<TOOL_NAME>.<path>. $ask is not a placeholder; if a value "
+    "genuinely cannot be frozen or built from $now/$today/$user/$trigger/"
+    '$steps/$last_run, write {"$ask": "what to write"} as that value and a '
+    "model fills it at replay."
 )
 
 
@@ -148,13 +235,34 @@ class PlaybookHandoffStepInput(BaseModel):
     plain tool calls. Modelling that here instead of reusing ``PlaybookStep``
     keeps the tool's JSON Schema free of the self-``$ref`` that several
     function-calling providers mishandle.
-    """
 
-    model_config = ConfigDict(extra="forbid")
+    Unknown keys are dropped rather than refused. A model that adds a ``goal``
+    or a ``note`` to a step it otherwise wrote correctly has said everything the
+    playbook needs; refusing the whole write over a stray key threw away 17 of
+    the 57 authoring attempts made in production.
+    """
 
     id: str = Field(description="Referencable name for this call, e.g. $steps.<id>.field")
     tool: str = Field(description="Exact name of the tool this step calls")
     args: dict[str, Any] = Field(default_factory=dict, description=_ARGS_DESCRIPTION)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _flat_or_refused(cls, data: object) -> object:
+        # Lenient about unknown keys, but not about these two: a child that
+        # carries its own ``steps`` or ``handoff`` is the author nesting a
+        # delegation a level deeper than a playbook goes, and dropping that
+        # silently would store a playbook that runs a fraction of what the
+        # author wrote and pass it off as the whole sequence.
+        if isinstance(data, Mapping):
+            nested = sorted(key for key in ("steps", "handoff") if key in data)
+            if nested:
+                raise ValueError(
+                    f"a handoff's child is one tool call and cannot carry {' or '.join(nested)}: "
+                    "playbooks are one level deep, so list the calls that subagent made "
+                    "as the handoff's own steps"
+                )
+        return data
 
     def to_step(self) -> PlaybookStep:
         return PlaybookStep(id=self.id, tool=self.tool, args=self.args)
@@ -162,9 +270,11 @@ class PlaybookHandoffStepInput(BaseModel):
 
 class PlaybookStepInput(BaseModel):
     """One top-level step as the authoring tool takes it: a tool call, or a
-    handoff carrying the plain tool calls that subagent ran."""
+    handoff carrying the plain tool calls that subagent ran.
 
-    model_config = ConfigDict(extra="forbid")
+    Lenient about unknown keys for the same reason as the handoff child above;
+    the shape rule below is the only one worth failing a write over.
+    """
 
     id: str = Field(default="", description="Referencable name, e.g. $steps.<id>.field")
     tool: str | None = Field(
@@ -208,15 +318,13 @@ class PlaybookStepInput(BaseModel):
 def playbook_body_from_input(
     description: str,
     steps: Sequence[PlaybookStepInput],
-    synthesize: str,
-    ask: dict[str, PlaybookAsk] | None,
+    result_brief: str,
 ) -> PlaybookBody:
     """Turn the tool boundary's flat arguments into the stored playbook body."""
     return PlaybookBody(
         description=description,
         steps=[step.to_step() for step in steps],
-        ask=ask or {},
-        synthesize=synthesize,
+        result_brief=result_brief,
     )
 
 
@@ -258,8 +366,7 @@ class PlaybookUpdate(BaseModel):
 
     description: str | None = None
     steps: list[PlaybookStep] | None = None
-    ask: dict[str, PlaybookAsk] | None = None
-    synthesize: str | None = None
+    result_brief: str | None = None
     workflow_hash: str | None = None
     last_run_status: PlaybookRunStatus | None = None
     last_run_reason: str | None = None

--- a/apps/api/app/models/workflow_models.py
+++ b/apps/api/app/models/workflow_models.py
@@ -718,6 +718,26 @@ class GeneratedPromptResult(TypedDict):
 # Repository persistence models (Wave E migration)
 
 
+class PlaybookDiscard(BaseModel):
+    """The last playbook the worker dropped for this workflow, and why.
+
+    A discard is otherwise silent data loss: the warning line ages out of log
+    retention long before anyone asks why a workflow went back to running at
+    full agent cost, and nothing on the workflow itself says it ever had a
+    shortcut. ``wf_0d05167369cf`` lost a working playbook exactly that way.
+    """
+
+    playbook_id: str
+    revision: int
+    #: The worker's own reason string — ``stale_workflow_hash``,
+    #: ``heal_attempts_exhausted``, ``suspect_streak_exhausted``.
+    reason: str
+    at: datetime
+    #: Whatever the discarding call site named beside the reason (the heal
+    #: attempt count, the suspect streak), rendered so one shape stores them all.
+    details: dict[str, str] = Field(default_factory=dict)
+
+
 class WorkflowDocument(Workflow, MongoDocument):
     """A workflow as stored in MongoDB.
 
@@ -741,6 +761,9 @@ class WorkflowDocument(Workflow, MongoDocument):
     #: an edit to the workflow changes the hash and asks again.
     playbook_declines: int = 0
     playbook_declined_hash: str | None = None
+    #: Why the worker last dropped this workflow's playbook, so a workflow that
+    #: quietly went back to full agent cost can say what happened to it.
+    last_playbook_discard: PlaybookDiscard | None = None
 
 
 class WorkflowCreatorInfo(BaseModel):
@@ -801,3 +824,4 @@ class WorkflowUpdate(BaseModel):
     created_by: str | None = None
     playbook_declines: int | None = None
     playbook_declined_hash: str | None = None
+    last_playbook_discard: PlaybookDiscard | None = None

--- a/apps/api/app/services/workflow/playbook/evaluator.py
+++ b/apps/api/app/services/workflow/playbook/evaluator.py
@@ -23,6 +23,7 @@ import json
 import re
 from typing import Any
 
+from app.models.playbook_models import ASK_KEY, ask_slot_key, is_ask_slot
 from app.models.workflow_execution_models import RECORD_CUT_MARKER, RecordedCall
 from app.services.workflow.playbook.placeholders import PLACEHOLDER_TOKEN
 from app.utils.errors import AppError
@@ -40,16 +41,20 @@ _OFFSET_UNITS: dict[str, str] = {
 _USER_FIELDS = ("email", "name", "timezone")
 
 #: Addresses the file a step offloaded its result to, rather than the result.
-_FILE_FIELD = "file"
+#: Public because the validator has to exempt it: the offload file exists only
+#: at replay, so checking it against the authoring run's result would refuse a
+#: reference that is correct.
+STEP_FILE_FIELD = "file"
 
 
 @dataclass
 class PlaceholderError(AppError):
     """A placeholder this run cannot resolve, named so the failure says which one.
 
-    Raised for ``$steps`` / ``$trigger`` / ``$user`` / ``$ask``: every one of
-    them addresses something this run was supposed to have, so a miss means the
-    playbook is stale and the run must stop rather than proceed with a gap.
+    Raised for ``$steps`` / ``$trigger`` / ``$user``, and for an ask slot no
+    model wrote: every one of them addresses something this run was supposed to
+    have, so a miss means the playbook is stale and the run must stop rather
+    than proceed with a gap.
     """
 
 
@@ -89,6 +94,8 @@ class RunContext:
     steps: Mapping[str, StepResult] = field(default_factory=dict)
     #: Previous run's results keyed by TOOL NAME (see the module docstring).
     last_run: Mapping[str, object] = field(default_factory=dict)
+    #: What the mid-run model call wrote, keyed the way ``ask_slot_key`` spells
+    #: a slot's address. Read by ``fill_ask_slots``, never by ``resolve_value``.
     asks: Mapping[str, str] = field(default_factory=dict)
 
 
@@ -103,6 +110,46 @@ def last_run_index(trace: Sequence[RecordedCall]) -> dict[str, object]:
     for call in trace:
         index[call.tool_name] = parse_result(call.result_digest)
     return index
+
+
+def fill_ask_slots(
+    args: Mapping[str, Any], asks: Mapping[str, str], key_prefix: str
+) -> dict[str, Any]:
+    """One step's arguments with every inline ask slot replaced by its written text.
+
+    Pure, and deliberately a separate pass ahead of :func:`resolve_args`: a slot
+    becomes an ordinary string first, and is then scanned for placeholders like
+    any other value. That is what keeps ``$ask`` a value in the grammar rather
+    than a second grammar with its own resolution rules.
+
+    ``key_prefix`` is the step's id (its tool name when it has no id); together
+    with the argument path it spells the key the ask call answered under.
+    """
+    return {
+        str(key): _fill_value(value, asks, key_prefix, (str(key),)) for key, value in args.items()
+    }
+
+
+def _fill_value(
+    value: object, asks: Mapping[str, str], prefix: str, path: tuple[str | int, ...]
+) -> object:
+    if is_ask_slot(value):
+        key = ask_slot_key(prefix, path)
+        if key not in asks:
+            raise PlaceholderError(
+                message=f"{key} was never written",
+                why="the run's ask call produced no text for that slot",
+                fix="write one entry per slot listed, keyed exactly as the slot is listed",
+            )
+        return asks[key]
+    if isinstance(value, Mapping):
+        return {
+            str(key): _fill_value(item, asks, prefix, (*path, str(key)))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_fill_value(item, asks, prefix, (*path, index)) for index, item in enumerate(value)]
+    return value
 
 
 def resolve_args(args: Mapping[str, Any], context: RunContext) -> dict[str, Any]:
@@ -153,6 +200,16 @@ def resolve_value(value: object, context: RunContext) -> object:
     ``max_results: $steps.x.count`` stays an int); a placeholder embedded in a
     larger string is interpolated into it.
     """
+    if is_ask_slot(value):
+        # fill_ask_slots runs first and leaves none behind, so reaching one here
+        # means a step was resolved without being filled — the text a model was
+        # supposed to write is missing, and the slot's dict must not be sent as
+        # an argument in its place.
+        raise PlaceholderError(
+            message=f"an {ASK_KEY} slot was not filled before resolution",
+            why="the run resolved this step's arguments without first filling its ask slots",
+            fix="fill the step's ask slots before resolving its arguments",
+        )
     if isinstance(value, Mapping):
         return {str(key): resolve_value(item, context) for key, item in value.items()}
     if isinstance(value, list):
@@ -190,12 +247,10 @@ def _resolve_token(match: re.Match[str], context: RunContext) -> object:
 
     if root == "user":
         return _resolve_user(token, path, context.user)
-    if root == "ask":
-        return _resolve_ask(token, path, context.asks)
     if root == "trigger":
         return _resolve_required(token, context.trigger, path, "the trigger payload")
     if root == "steps":
-        return _resolve_step(token, path, context.steps)
+        return resolve_step(token, path, context.steps)
     return _resolve_last_run(token, path, context.last_run)
 
 
@@ -232,17 +287,14 @@ def _resolve_user(token: str, path: str, user: PlaybookUser) -> str:
     return value
 
 
-def _resolve_ask(token: str, path: str, asks: Mapping[str, str]) -> str:
-    if path in asks:
-        return asks[path]
-    raise PlaceholderError(
-        message=f"{token} was never written",
-        why="the run's one model call produced no text for that ask",
-        fix="declare the ask in the playbook, or stop addressing it",
-    )
+def resolve_step(token: str, path: str, steps: Mapping[str, StepResult]) -> object:
+    """One ``$steps.<id>.<path>`` reference against the results in hand.
 
-
-def _resolve_step(token: str, path: str, steps: Mapping[str, StepResult]) -> object:
+    Public because the validator resolves the same references against the run
+    that is AUTHORING the playbook, using the results that run already has. Two
+    path walkers would be two answers to "does this reference resolve", and the
+    validator's would be the one that never runs in production.
+    """
     step_id, _, rest = path.partition(".")
     result = steps.get(step_id)
     if result is None:
@@ -251,7 +303,7 @@ def _resolve_step(token: str, path: str, steps: Mapping[str, StepResult]) -> obj
             why=f"no earlier step in this replay is named {step_id!r}",
             fix="reference a step that runs before this one, or rewrite the playbook",
         )
-    if rest == _FILE_FIELD and result.file is not None:
+    if rest == STEP_FILE_FIELD and result.file is not None:
         return result.file
     return _resolve_required(token, result.value, rest, f"step {step_id!r}'s result")
 

--- a/apps/api/app/services/workflow/playbook/parser.py
+++ b/apps/api/app/services/workflow/playbook/parser.py
@@ -332,16 +332,7 @@ def _check_recorded_call(step: PlaybookStep, tool_name: str, path: str, walk: _W
     """
     matched = _matched_call(step, walk)
     if matched is None:
-        ran = sum(1 for call in walk.results or () if call.tool_name == tool_name)
-        problem = (
-            f"{tool_name} did not run in this run; a playbook freezes calls "
-            "that ran and produced their result — run it, or drop the step"
-            if ran == 0
-            else f"{tool_name} ran {ran} time(s) in this run and earlier steps froze every "
-            "one of them; a step cannot replay a call the run did not make — drop this "
-            "step, or run it again"
-        )
-        walk.issues.append(PlaybookIssue(where=path, problem=problem))
+        walk.issues.append(PlaybookIssue(where=path, problem=_unmatched_problem(tool_name, walk)))
         return
     index, call = matched
     walk.consumed.add(index)
@@ -350,6 +341,33 @@ def _check_recorded_call(step: PlaybookStep, tool_name: str, path: str, walk: _W
     refusal = _result_refusal(tool_name, call)
     if refusal is not None:
         walk.issues.append(PlaybookIssue(where=path, problem=refusal))
+
+
+def _unmatched_problem(tool_name: str, walk: _Walk) -> str:
+    """Why no recorded call answers to this step, told apart by what the run
+    did make: nothing, calls all frozen already, or calls with other args."""
+    same_tool = [
+        (index, call)
+        for index, call in enumerate(walk.results or ())
+        if call.tool_name == tool_name
+    ]
+    if not same_tool:
+        return (
+            f"{tool_name} did not run in this run; a playbook freezes calls "
+            "that ran and produced their result — run it, or drop the step"
+        )
+    left = [call for index, call in same_tool if index not in walk.consumed]
+    if not left:
+        return (
+            f"{tool_name} ran {len(same_tool)} time(s) in this run and earlier steps froze "
+            "every one of them; a step cannot replay a call the run did not make — drop "
+            "this step, or run it again"
+        )
+    return (
+        f"{tool_name} ran {len(same_tool)} time(s) in this run, but never with these args "
+        f"(the last call used {_rendered_args(left[-1].args)}); freeze the call that ran, "
+        "with the args that produced its result, or run it with these args"
+    )
 
 
 def _matched_call(step: PlaybookStep, walk: _Walk) -> tuple[int, RecordedResult] | None:
@@ -362,28 +380,25 @@ def _matched_call(step: PlaybookStep, walk: _Walk) -> tuple[int, RecordedResult]
     structural (``_agrees``) rather than per-arg, because the deciding
     difference between two calls is routinely nested inside an arg that also
     carries a placeholder — treating that whole arg as a wildcard matches on the
-    parts that say nothing. The LAST call wins, both among the calls that agree
-    and as the fallback when none does: a run that repeats a tool settles on its
-    final call, which is the one worth freezing.
+    parts that say nothing. Among the calls that agree the LAST wins: a run
+    that repeats a tool settles on its final call, which is the one worth
+    freezing. A step that agrees with none is not matched at all — handing it
+    an unrelated call's result would validate a shape its own args do not
+    produce, and approve ``$steps`` references into that shape.
 
     A call already frozen by an earlier step is not offered again: the run made
     it once, and a playbook listing it twice would replay it twice.
     """
-    calls = [
-        (index, call)
-        for index, call in enumerate(walk.results or ())
-        if call.tool_name == step.tool and index not in walk.consumed
-    ]
-    if not calls:
-        return None
     agreeing = [
         (index, call)
-        for index, call in calls
-        if all(
+        for index, call in enumerate(walk.results or ())
+        if call.tool_name == step.tool
+        and index not in walk.consumed
+        and all(
             key in call.args and _agrees(value, call.args[key]) for key, value in step.args.items()
         )
     ]
-    return (agreeing or calls)[-1]
+    return agreeing[-1] if agreeing else None
 
 
 def _agrees(step_value: object, recorded_value: object) -> bool:

--- a/apps/api/app/services/workflow/playbook/parser.py
+++ b/apps/api/app/services/workflow/playbook/parser.py
@@ -6,6 +6,13 @@ at something the document already declared. Its messages are read back by the
 authoring agent, so each one names the offending step and says what would be
 valid rather than reporting "invalid".
 
+Given the authoring run's own results it asks a second, sharper question: did
+these calls actually happen, and did they return what the document claims to
+read? A playbook freezes calls that ran, so the run writing it holds every
+answer — ``pb_c7d357db77dd`` froze ``$steps.fetch_msgs.threadId`` on a tool that
+returns no ``threadId`` and broke on its first replay, with the real result
+sitting in the same conversation.
+
 ``dump_playbook`` renders a body as YAML. That rendering is for humans and for
 the agent reading its own playbook back; the structured body is the only stored
 form, so nothing ever parses the YAML again.
@@ -17,12 +24,25 @@ import json
 import re
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 import yaml
 
-from app.agents.core.subagents.call_record import ARG_TRUNCATION_MARKER
+from app.agents.core.subagents.call_record import ARG_TRUNCATION_MARKER, is_error_envelope
 from app.agents.tools.core.registry import ToolRegistry, get_tool_registry
-from app.models.playbook_models import PlaybookAsk, PlaybookBody, PlaybookStep
+from app.models.playbook_models import (
+    AskSlot,
+    PlaybookBody,
+    PlaybookStep,
+    has_ask_slots,
+    walk_ask_slots,
+)
+from app.models.workflow_execution_models import largest_list_len
+from app.services.workflow.playbook.evaluator import (
+    STEP_FILE_FIELD,
+    PlaceholderError,
+    StepResult,
+    resolve_step,
+)
 from app.services.workflow.playbook.placeholders import placeholder_tokens
 from app.services.workflow.playbook.tool_space import (
     ToolSpace,
@@ -40,6 +60,35 @@ _JSON_TYPE_TO_PYTHON: dict[str, tuple[type, ...]] = {
     "object": (dict,),
     "null": (type(None),),
 }
+
+
+#: Most keys a refusal lists back from a result. Enough to recognise the shape
+#: the tool actually returns, short enough that a wide envelope does not bury
+#: the sentence that says what is wrong.
+_MAX_LISTED_KEYS = 12
+
+#: Longest rendering of a matched call's args inside a message. The args are
+#: there to say WHICH call came back empty, not to reproduce it.
+_ARGS_IN_MESSAGE_MAX_CHARS = 200
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedResult:
+    """One call the authoring run made, with what it actually returned.
+
+    ``result`` is parsed the way the replay parses a result (JSON when it is
+    JSON, the raw text otherwise), so a check here reads exactly the value a
+    ``$steps`` placeholder would resolve against at replay.
+    """
+
+    tool_name: str
+    args: Mapping[str, Any]
+    result: object
+
+
+#: The authoring run's calls, in call order. The order IS part of the matching
+#: rule — the last call wins — so a mapping keyed by tool name would lose it.
+RunResults = Sequence[RecordedResult]
 
 
 class PlaybookIssue(BaseModel):
@@ -67,9 +116,10 @@ def dump_playbook(body: PlaybookBody) -> str:
         "description": body.description,
         "steps": [_dump_step(step) for step in body.steps],
     }
-    if body.ask:
-        document["ask"] = {name: ask.model_dump() for name, ask in body.ask.items()}
-    document["synthesize"] = body.synthesize
+    # Args are dumped as authored, so an inline ask slot renders as a nested
+    # ``$ask:`` mapping right where its value belongs — which is exactly how the
+    # agent should read it back when it revises the playbook.
+    document["result_brief"] = body.result_brief
     # sort_keys=False and sort_keys=None are byte-identical to PyYAML (it only
     # tests truthiness), so that mutation is provably equivalent and exempt.
     return yaml.safe_dump(document, sort_keys=False, allow_unicode=True)  # pragma: no mutate
@@ -90,41 +140,34 @@ def _dump_step(step: PlaybookStep) -> dict[str, Any]:
     return node
 
 
-async def validate_playbook(body: PlaybookBody, user_id: str) -> PlaybookValidation:
+async def validate_playbook(
+    body: PlaybookBody, user_id: str, results: RunResults | None = None
+) -> PlaybookValidation:
     """Check a parsed playbook against the tools it would actually reach.
 
     Three classes of problem, all fatal for a replay: a tool that does not
     exist, an arg the tool does not take (or takes with another type), and a
-    reference to a step or ask the document never declares before that point.
+    reference to a step the document never declares before that point.
 
     ``user_id`` is required because "does this tool exist" has no user-independent
     answer: a handoff's children run in that subagent's space, and an MCP
     integration's tools live on that user's own client.
+
+    ``results`` are the calls the run writing this playbook actually made. With
+    them a fourth class of problem is answerable here rather than on the first
+    replay: a step naming a tool that never ran, a step freezing a call that
+    came back empty or errored, and a ``$steps`` reference into a shape the
+    tool does not return. Without them nothing changes — the dev executor route
+    and any caller with no run behind it get exactly the checks above.
     """
     registry = await get_tool_registry()
-    walk = _Walk(
-        asks=body.ask,
-        all_step_ids=_step_ids(body.steps),
-        user_id=user_id,
-        registry=registry,
-    )
+    walk = _Walk(user_id=user_id, registry=registry, results=results)
     await _check_steps(
         body.steps,
         "steps",
         ToolSpace(tools=registry.get_tool_dict(), runtime=None, subagent_id=None),
         walk,
     )
-
-    for name, ask in body.ask.items():
-        for step_id in ask.uses:
-            if step_id not in walk.declared_steps:
-                walk.issues.append(
-                    PlaybookIssue(
-                        where=f"ask.{name}.uses",
-                        problem=f"no step is declared with id {step_id!r}",
-                    )
-                )
-
     return PlaybookValidation(valid=not walk.issues, issues=walk.issues)
 
 
@@ -132,24 +175,18 @@ async def validate_playbook(body: PlaybookBody, user_id: str) -> PlaybookValidat
 class _Walk:
     """What one pass over the document accumulates, in document order."""
 
-    asks: Mapping[str, PlaybookAsk]
-    all_step_ids: set[str]
     user_id: str
     registry: ToolRegistry
     declared_steps: set[str] = field(default_factory=set)
     issues: list[PlaybookIssue] = field(default_factory=list)
-    #: Set at the first step that addresses any ``$ask``: the runner fills EVERY
-    #: ask there, in one model call, from the steps that have run by then.
-    asks_filled_at: str | None = None
-
-
-def _step_ids(steps: Sequence[PlaybookStep]) -> set[str]:
-    ids: set[str] = set()
-    for step in steps:
-        if step.id:
-            ids.add(step.id)
-        ids |= _step_ids(step.steps)
-    return ids
+    #: The authoring run's calls, or ``None`` when there is no run to check
+    #: against. ``None`` and an empty run are different: an empty run means
+    #: every tool step froze a call that never happened.
+    results: RunResults | None = None
+    #: What each declared step returned in that run, filled as the walk passes
+    #: the step. A ``$steps`` reference is checked against this, so it can only
+    #: ever read a step that ran before it — the same rule the replay enforces.
+    step_results: dict[str, StepResult] = field(default_factory=dict)
 
 
 async def _check_steps(
@@ -208,12 +245,8 @@ def _check_tool_step(step: PlaybookStep, path: str, space: ToolSpace, walk: _Wal
         walk.issues.append(PlaybookIssue(where=path, problem=denial))
         return
 
-    # The evaluator's own scanner, so a placeholder embedded in text
-    # ("Email $steps.mail.to") is checked exactly as a whole-value one is.
-    tokens = list(placeholder_tokens(step.args))
-    if walk.asks_filled_at is None and any(token.group("root") == "ask" for token in tokens):
-        walk.asks_filled_at = step.id or path
-        _check_asks_fillable(walk)
+    if walk.results is not None:
+        _check_recorded_call(step, tool_name, path, space, walk)
 
     schema: dict[str, Any] = space.tools[tool_name].args
     for key, value in step.args.items():
@@ -244,54 +277,201 @@ def _check_tool_step(step: PlaybookStep, path: str, space: ToolSpace, walk: _Wal
                 )
             )
             continue
+        # The evaluator's own scanner, so a placeholder embedded in text
+        # ("Email $steps.mail.to") is checked exactly as a whole-value one is.
         arg_tokens = list(placeholder_tokens(value))
         for token in arg_tokens:
             _check_placeholder(token, where, walk)
-        if not arg_tokens:
+        slots = [slot for _, slot in walk_ask_slots(value)]
+        if slots and not step.id:
+            # A slot is addressed by its step's id; without one it falls back to
+            # the tool name, and two id-less steps of the same tool would then
+            # share a key and receive one text between them.
+            walk.issues.append(
+                PlaybookIssue(
+                    where=where,
+                    problem=f"a step carrying an $ask slot needs an id; give this "
+                    f"{step.tool} step one so the slot has an address of its own",
+                )
+            )
+        for slot in slots:
+            _check_ask_slot(slot, where, walk)
+        # An arg that is (or contains) a reference has no fixed type to check:
+        # what the tool receives is whatever the placeholder resolves to or the
+        # text a model writes, neither of which exists yet.
+        if not arg_tokens and not slots:
             _check_value_type(value, arg_schema, where, walk.issues)
 
 
-def _check_asks_fillable(walk: _Walk) -> None:
-    """Every ask reads only steps that ran before the asks are filled.
+def _check_recorded_call(
+    step: PlaybookStep, tool_name: str, path: str, space: ToolSpace, walk: _Walk
+) -> None:
+    """Check one tool step against the call it froze in the run writing it.
 
-    The runner narrates once, at the first step addressing any ``$ask``, and the
-    narration sees only the steps completed by then. An ask whose ``uses`` names
-    a later step would be written from nothing, silently. An id no step declares
-    at all is reported after the walk, not here.
+    Matching the step back to a recorded call is also what makes the ``$steps``
+    references checkable: the matched result is what later steps read from.
+
+    A handoff's children are exempt from "did not run". The record a handoff
+    appends (``call_record.py``) carries the subagent's tool names and args but
+    NOT their outputs, so this run's results hold nothing for them and their
+    absence is evidence of nothing.
     """
-    for name, ask in walk.asks.items():
-        for step_id in ask.uses:
-            if step_id in walk.declared_steps or step_id not in walk.all_step_ids:
-                continue
+    call = _matched_call(step, walk)
+    if call is None:
+        if space.subagent_id is None:
             walk.issues.append(
                 PlaybookIssue(
-                    where=f"ask.{name}.uses",
-                    problem=f"ask {name!r} reads step {step_id!r}, but the asks are filled at "
-                    f"step {walk.asks_filled_at!r} (the first to address $ask), before "
-                    f"{step_id!r} runs; move {step_id!r} ahead of {walk.asks_filled_at!r} "
-                    "or drop it from uses",
+                    where=path,
+                    problem=f"{tool_name} did not run in this run; a playbook freezes calls "
+                    "that ran and produced their result — run it, or drop the step",
                 )
             )
+        return
+    if step.id:
+        walk.step_results[step.id] = StepResult(value=call.result)
+    refusal = _result_refusal(tool_name, call)
+    if refusal is not None:
+        walk.issues.append(PlaybookIssue(where=path, problem=refusal))
+
+
+def _matched_call(step: PlaybookStep, walk: _Walk) -> RecordedResult | None:
+    """The recorded call this step froze, or ``None`` when the tool never ran.
+
+    A step's literal args are the only evidence of WHICH call it froze: a tool
+    called three times with different queries left three results, and checking
+    the step against the wrong one reports a shape the author never claimed. An
+    arg holding a placeholder or an ``$ask`` slot is a wildcard — the value it
+    stands for does not exist until replay, so it cannot disagree with
+    anything. The LAST call wins, both among the calls that agree and as the
+    fallback when none does: a run that repeats a tool settles on its final
+    call, which is the one worth freezing.
+    """
+    calls = [call for call in (walk.results or ()) if call.tool_name == step.tool]
+    if not calls:
+        return None
+    literals = {
+        key: value
+        for key, value in step.args.items()
+        if not any(True for _ in placeholder_tokens(value)) and not has_ask_slots(value)
+    }
+    agreeing = [
+        call
+        for call in calls
+        if all(key in call.args and call.args[key] == value for key, value in literals.items())
+    ]
+    return (agreeing or calls)[-1]
+
+
+def _result_refusal(tool_name: str, call: RecordedResult) -> str | None:
+    """Why the call this step froze is not worth freezing, or ``None``.
+
+    The error envelope is tested first: a tool that reports its own failure
+    often does so with an empty list beside it, and "returned no items" would
+    name the symptom while the message says the cause.
+    """
+    if is_error_envelope(call.result):
+        return (
+            f"{tool_name} failed in this run ({_envelope_error(call.result)}); a playbook "
+            "freezes calls that succeeded — fix the call and run it again, or drop the step"
+        )
+    # None means the result carries no list at all (a single object, a string),
+    # which says nothing about emptiness; only a list of length zero does.
+    if largest_list_len(call.result) == 0:
+        return (
+            f"{tool_name} returned no items in this run (args: {_rendered_args(call.args)}); "
+            "freeze a call that produced data — widen the args or decline the playbook"
+        )
+    return None
+
+
+def _envelope_error(result: object) -> str:
+    """What a failed tool said about its own failure, as one phrase."""
+    if isinstance(result, dict):
+        reported = result.get("error") or result.get("message")
+        if reported:
+            return str(reported)[:_ARGS_IN_MESSAGE_MAX_CHARS]
+    return "the call reported success: false"
+
+
+def _rendered_args(args: Mapping[str, Any]) -> str:
+    rendered = json.dumps(dict(args), default=str, ensure_ascii=False)
+    if len(rendered) <= _ARGS_IN_MESSAGE_MAX_CHARS:
+        return rendered
+    return rendered[:_ARGS_IN_MESSAGE_MAX_CHARS] + "..."
+
+
+def _check_step_reference(token: str, path: str, where: str, walk: _Walk) -> None:
+    """Resolve one ``$steps`` reference against what that step returned in this run.
+
+    Through the evaluator's own resolver, so an accepted reference is one the
+    replay can actually resolve rather than one a second path-walker agreed
+    with. ``.file`` is exempt: the offloaded file exists only at replay, and the
+    authoring run's result has no path to it.
+    """
+    step_id, _, rest = path.partition(".")
+    if rest == STEP_FILE_FIELD:
+        return
+    result = walk.step_results.get(step_id)
+    if result is None:
+        # The step is declared but its own call was never matched (a handoff
+        # child, or a tool this run did not call — both already reported).
+        return
+    try:
+        resolve_step(token, path, walk.step_results)
+    except PlaceholderError as error:
+        walk.issues.append(
+            PlaybookIssue(where=where, problem=error.message + _shape_hint(result.value))
+        )
+
+
+def _shape_hint(value: object) -> str:
+    """The keys the result does have, so the author can address one of them."""
+    if not isinstance(value, Mapping):
+        return ""
+    keys = sorted(str(key) for key in value)
+    listed = ", ".join(keys[:_MAX_LISTED_KEYS])
+    if len(keys) > _MAX_LISTED_KEYS:
+        listed += ", ..."
+    return f"; its result has keys: {listed}"
+
+
+def _check_ask_slot(slot: Mapping[str, Any], where: str, walk: _Walk) -> None:
+    """One inline ask slot, checked as the model wrote it.
+
+    The whole slot vocabulary is two keys, so the message names both rather than
+    relaying pydantic: the author reading this back has to know what a valid
+    slot looks like, not which field raised.
+    """
+    try:
+        AskSlot.model_validate(slot)
+    except ValidationError:
+        walk.issues.append(
+            PlaybookIssue(
+                where=where,
+                problem="an $ask slot takes only '$ask' (what to write) and an optional "
+                f"max_tokens 1..8192; got {sorted(slot)}",
+            )
+        )
 
 
 def _check_placeholder(match: re.Match[str], where: str, walk: _Walk) -> None:
     # The tokenizer only matches known roots; any other ``$word`` is literal text.
     token = match.group(0)
     root = match.group("root")
-    name = match.group("path").lstrip(".").partition(".")[0]
-    if root == "steps" and name not in walk.declared_steps:
+    path = match.group("path").lstrip(".")
+    name = path.partition(".")[0]
+    if root != "steps":
+        return
+    if name not in walk.declared_steps:
         walk.issues.append(
             PlaybookIssue(
                 where=where,
                 problem=f"{token} points at a step that no earlier node declares",
             )
         )
-    elif root == "ask" and name not in walk.asks:
-        walk.issues.append(
-            PlaybookIssue(
-                where=where, problem=f"{token} points at an ask the playbook never declares"
-            )
-        )
+        return
+    if walk.results is not None:
+        _check_step_reference(token, path, where, walk)
 
 
 def _check_value_type(

--- a/apps/api/app/services/workflow/playbook/parser.py
+++ b/apps/api/app/services/workflow/playbook/parser.py
@@ -24,6 +24,7 @@ import json
 import re
 from typing import Any
 
+from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field, ValidationError
 import yaml
 
@@ -33,7 +34,7 @@ from app.models.playbook_models import (
     AskSlot,
     PlaybookBody,
     PlaybookStep,
-    has_ask_slots,
+    is_ask_slot,
     walk_ask_slots,
 )
 from app.models.workflow_execution_models import largest_list_len
@@ -43,7 +44,7 @@ from app.services.workflow.playbook.evaluator import (
     StepResult,
     resolve_step,
 )
-from app.services.workflow.playbook.placeholders import placeholder_tokens
+from app.services.workflow.playbook.placeholders import PLACEHOLDER_TOKEN, placeholder_tokens
 from app.services.workflow.playbook.tool_space import (
     ToolSpace,
     handoff_tool_space,
@@ -249,6 +250,7 @@ def _check_tool_step(step: PlaybookStep, path: str, space: ToolSpace, walk: _Wal
         _check_recorded_call(step, tool_name, path, space, walk)
 
     schema: dict[str, Any] = space.tools[tool_name].args
+    _check_required_args(step, tool_name, path, space, walk)
     for key, value in step.args.items():
         where = f"{path}.args.{key}"
         # ensure_ascii=False, or the marker's ellipsis leaves json.dumps as
@@ -337,29 +339,67 @@ def _check_recorded_call(
 def _matched_call(step: PlaybookStep, walk: _Walk) -> RecordedResult | None:
     """The recorded call this step froze, or ``None`` when the tool never ran.
 
-    A step's literal args are the only evidence of WHICH call it froze: a tool
-    called three times with different queries left three results, and checking
-    the step against the wrong one reports a shape the author never claimed. An
-    arg holding a placeholder or an ``$ask`` slot is a wildcard — the value it
-    stands for does not exist until replay, so it cannot disagree with
-    anything. The LAST call wins, both among the calls that agree and as the
-    fallback when none does: a run that repeats a tool settles on its final
-    call, which is the one worth freezing.
+    A step's args are the only evidence of WHICH call it froze: a tool called
+    three times with different queries left three results, and checking the step
+    against the wrong one reports a shape the author never claimed. Agreement is
+    structural (``_agrees``) rather than per-arg, because the deciding
+    difference between two calls is routinely nested inside an arg that also
+    carries a placeholder — treating that whole arg as a wildcard matches on the
+    parts that say nothing. The LAST call wins, both among the calls that agree
+    and as the fallback when none does: a run that repeats a tool settles on its
+    final call, which is the one worth freezing.
     """
     calls = [call for call in (walk.results or ()) if call.tool_name == step.tool]
     if not calls:
         return None
-    literals = {
-        key: value
-        for key, value in step.args.items()
-        if not any(True for _ in placeholder_tokens(value)) and not has_ask_slots(value)
-    }
     agreeing = [
         call
         for call in calls
-        if all(key in call.args and call.args[key] == value for key, value in literals.items())
+        if all(
+            key in call.args and _agrees(value, call.args[key]) for key, value in step.args.items()
+        )
     ]
     return (agreeing or calls)[-1]
+
+
+def _agrees(step_value: object, recorded_value: object) -> bool:
+    """Whether a step's authored value could be the recorded call's value.
+
+    Anything that does not exist until replay agrees with everything: an
+    ``$ask`` slot, and a string that is nothing but a placeholder token. A
+    string that merely *embeds* a token ("Email $steps.mail.to") agrees with any
+    string, since the text it renders to is unknowable here but its type is not.
+
+    Containers are compared through, which is the whole point: a mapping agrees
+    when every key the step authored is present and agrees (recorded keys the
+    step omitted are fine — the model may have left a default unwritten), and a
+    list agrees elementwise at the same length. Everything else is equality.
+    """
+    if is_ask_slot(step_value):
+        return True
+    if isinstance(step_value, str):
+        if PLACEHOLDER_TOKEN.fullmatch(step_value):
+            return True
+        if PLACEHOLDER_TOKEN.search(step_value):
+            return isinstance(recorded_value, str)
+        return step_value == recorded_value
+    if isinstance(step_value, Mapping):
+        return isinstance(recorded_value, Mapping) and all(
+            key in recorded_value and _agrees(item, recorded_value[key])
+            for key, item in step_value.items()
+        )
+    if isinstance(step_value, list):
+        return (
+            isinstance(recorded_value, list)
+            and len(step_value) == len(recorded_value)
+            # strict= can never fire: the length check above short-circuits first,
+            # so no mutation of it is observable (same construct as trigger_dispatch_tasks).
+            and all(
+                _agrees(item, other)
+                for item, other in zip(step_value, recorded_value, strict=True)  # pragma: no mutate
+            )
+        )
+    return step_value == recorded_value
 
 
 def _result_refusal(tool_name: str, call: RecordedResult) -> str | None:
@@ -433,6 +473,43 @@ def _shape_hint(value: object) -> str:
     if len(keys) > _MAX_LISTED_KEYS:
         listed += ", ..."
     return f"; its result has keys: {listed}"
+
+
+def _check_required_args(
+    step: PlaybookStep, tool_name: str, path: str, space: ToolSpace, walk: _Walk
+) -> None:
+    """A missing required arg is a call that fails at replay before it starts.
+
+    Nothing else catches it: the per-arg checks walk the args the step HAS, and
+    a run-result match agrees with an empty mapping trivially.
+    """
+    tool = space.tools[tool_name]
+    for name in sorted(_required_args(tool) - set(step.args)):
+        walk.issues.append(
+            PlaybookIssue(
+                where=f"{path}.args",
+                problem=f"{tool_name} requires {name!r} and this step does not set it; "
+                f"it takes: {', '.join(sorted(tool.args)) or 'nothing'}",
+            )
+        )
+
+
+def _required_args(tool: BaseTool) -> set[str]:
+    """The arg names a tool cannot be called without, from its own call schema.
+
+    ``tool.args`` is only the property map; the ``required`` list lives one
+    level up, on the schema that ``tool_call_schema`` renders. langchain hands
+    that back as a v2 model for decorated tools, a v1 model for legacy ones and
+    a raw JSON document for MCP tools; all three spell ``required`` the same way.
+    """
+    schema = tool.tool_call_schema
+    if isinstance(schema, dict):
+        rendered: Mapping[str, Any] = schema
+    elif issubclass(schema, BaseModel):
+        rendered = schema.model_json_schema()
+    else:
+        rendered = schema.schema()
+    return set(rendered.get("required") or [])
 
 
 def _check_ask_slot(slot: Mapping[str, Any], where: str, walk: _Walk) -> None:

--- a/apps/api/app/services/workflow/playbook/parser.py
+++ b/apps/api/app/services/workflow/playbook/parser.py
@@ -188,6 +188,10 @@ class _Walk:
     #: the step. A ``$steps`` reference is checked against this, so it can only
     #: ever read a step that ran before it — the same rule the replay enforces.
     step_results: dict[str, StepResult] = field(default_factory=dict)
+    #: Positions in ``results`` that a step has already frozen. A recorded call
+    #: is one call; two steps matched to it would replay it twice and double a
+    #: side effect the run performed once.
+    consumed: set[int] = field(default_factory=set)
 
 
 async def _check_steps(
@@ -318,17 +322,22 @@ def _check_recorded_call(
     NOT their outputs, so this run's results hold nothing for them and their
     absence is evidence of nothing.
     """
-    call = _matched_call(step, walk)
-    if call is None:
+    matched = _matched_call(step, walk)
+    if matched is None:
         if space.subagent_id is None:
-            walk.issues.append(
-                PlaybookIssue(
-                    where=path,
-                    problem=f"{tool_name} did not run in this run; a playbook freezes calls "
-                    "that ran and produced their result — run it, or drop the step",
-                )
+            ran = sum(1 for call in walk.results or () if call.tool_name == tool_name)
+            problem = (
+                f"{tool_name} did not run in this run; a playbook freezes calls "
+                "that ran and produced their result — run it, or drop the step"
+                if ran == 0
+                else f"{tool_name} ran {ran} time(s) in this run and earlier steps froze every "
+                "one of them; a step cannot replay a call the run did not make — drop this "
+                "step, or run it again"
             )
+            walk.issues.append(PlaybookIssue(where=path, problem=problem))
         return
+    index, call = matched
+    walk.consumed.add(index)
     if step.id:
         walk.step_results[step.id] = StepResult(value=call.result)
     refusal = _result_refusal(tool_name, call)
@@ -336,8 +345,9 @@ def _check_recorded_call(
         walk.issues.append(PlaybookIssue(where=path, problem=refusal))
 
 
-def _matched_call(step: PlaybookStep, walk: _Walk) -> RecordedResult | None:
-    """The recorded call this step froze, or ``None`` when the tool never ran.
+def _matched_call(step: PlaybookStep, walk: _Walk) -> tuple[int, RecordedResult] | None:
+    """The recorded call this step froze, with its position, or ``None`` when
+    no call of that tool is left for it.
 
     A step's args are the only evidence of WHICH call it froze: a tool called
     three times with different queries left three results, and checking the step
@@ -348,13 +358,20 @@ def _matched_call(step: PlaybookStep, walk: _Walk) -> RecordedResult | None:
     parts that say nothing. The LAST call wins, both among the calls that agree
     and as the fallback when none does: a run that repeats a tool settles on its
     final call, which is the one worth freezing.
+
+    A call already frozen by an earlier step is not offered again: the run made
+    it once, and a playbook listing it twice would replay it twice.
     """
-    calls = [call for call in (walk.results or ()) if call.tool_name == step.tool]
+    calls = [
+        (index, call)
+        for index, call in enumerate(walk.results or ())
+        if call.tool_name == step.tool and index not in walk.consumed
+    ]
     if not calls:
         return None
     agreeing = [
-        call
-        for call in calls
+        (index, call)
+        for index, call in calls
         if all(
             key in call.args and _agrees(value, call.args[key]) for key, value in step.args.items()
         )

--- a/apps/api/app/services/workflow/playbook/parser.py
+++ b/apps/api/app/services/workflow/playbook/parser.py
@@ -195,7 +195,12 @@ class _Walk:
 
 
 async def _check_steps(
-    steps: Sequence[PlaybookStep], path: str, space: ToolSpace, walk: _Walk
+    steps: Sequence[PlaybookStep],
+    path: str,
+    space: ToolSpace,
+    walk: _Walk,
+    *,
+    in_handoff: bool = False,
 ) -> None:
     """Walk the steps in document order, so a reference can only resolve
     backwards: ``declared_steps`` holds exactly what ran before this node.
@@ -207,7 +212,7 @@ async def _check_steps(
     for index, step in enumerate(steps):
         here = f"{path}[{index}]"
         if step.tool:
-            _check_tool_step(step, here, space, walk)
+            _check_tool_step(step, here, space, walk, in_handoff=in_handoff)
         else:
             handoff = step.handoff
             if handoff is None:
@@ -223,7 +228,9 @@ async def _check_steps(
                     )
                 )
             else:
-                await _check_steps(step.steps, f"{here}.steps", handoff_tool_space(subagent), walk)
+                await _check_steps(
+                    step.steps, f"{here}.steps", handoff_tool_space(subagent), walk, in_handoff=True
+                )
         if step.id:
             # The runner keys its record on the id, so a second step with the
             # same id would overwrite the first's result for every later $steps.
@@ -239,7 +246,9 @@ async def _check_steps(
             walk.declared_steps.add(step.id)
 
 
-def _check_tool_step(step: PlaybookStep, path: str, space: ToolSpace, walk: _Walk) -> None:
+def _check_tool_step(
+    step: PlaybookStep, path: str, space: ToolSpace, walk: _Walk, *, in_handoff: bool
+) -> None:
     if step.tool is None:
         # exactly_one_shape forbids a tool-less step reaching here; this guard
         # narrows the type where mypy cannot see the validator.
@@ -250,8 +259,14 @@ def _check_tool_step(step: PlaybookStep, path: str, space: ToolSpace, walk: _Wal
         walk.issues.append(PlaybookIssue(where=path, problem=denial))
         return
 
-    if walk.results is not None:
-        _check_recorded_call(step, tool_name, path, space, walk)
+    # A handoff's children are not matched at all. The record a handoff appends
+    # (``call_record.py``) carries the subagent's tool names and args but NOT
+    # their outputs, so the run's results hold nothing for them — and matching
+    # them anyway would let a child consume a top-level call of the same tool.
+    # Said by the walk, not read off the space: a subagent without a config
+    # yields a space whose subagent_id is None, and a child is still a child.
+    if walk.results is not None and not in_handoff:
+        _check_recorded_call(step, tool_name, path, walk)
 
     schema: dict[str, Any] = space.tools[tool_name].args
     _check_required_args(step, tool_name, path, space, walk)
@@ -309,32 +324,24 @@ def _check_tool_step(step: PlaybookStep, path: str, space: ToolSpace, walk: _Wal
             _check_value_type(value, arg_schema, where, walk.issues)
 
 
-def _check_recorded_call(
-    step: PlaybookStep, tool_name: str, path: str, space: ToolSpace, walk: _Walk
-) -> None:
-    """Check one tool step against the call it froze in the run writing it.
+def _check_recorded_call(step: PlaybookStep, tool_name: str, path: str, walk: _Walk) -> None:
+    """Check one top-level tool step against the call it froze in the run writing it.
 
     Matching the step back to a recorded call is also what makes the ``$steps``
     references checkable: the matched result is what later steps read from.
-
-    A handoff's children are exempt from "did not run". The record a handoff
-    appends (``call_record.py``) carries the subagent's tool names and args but
-    NOT their outputs, so this run's results hold nothing for them and their
-    absence is evidence of nothing.
     """
     matched = _matched_call(step, walk)
     if matched is None:
-        if space.subagent_id is None:
-            ran = sum(1 for call in walk.results or () if call.tool_name == tool_name)
-            problem = (
-                f"{tool_name} did not run in this run; a playbook freezes calls "
-                "that ran and produced their result — run it, or drop the step"
-                if ran == 0
-                else f"{tool_name} ran {ran} time(s) in this run and earlier steps froze every "
-                "one of them; a step cannot replay a call the run did not make — drop this "
-                "step, or run it again"
-            )
-            walk.issues.append(PlaybookIssue(where=path, problem=problem))
+        ran = sum(1 for call in walk.results or () if call.tool_name == tool_name)
+        problem = (
+            f"{tool_name} did not run in this run; a playbook freezes calls "
+            "that ran and produced their result — run it, or drop the step"
+            if ran == 0
+            else f"{tool_name} ran {ran} time(s) in this run and earlier steps froze every "
+            "one of them; a step cannot replay a call the run did not make — drop this "
+            "step, or run it again"
+        )
+        walk.issues.append(PlaybookIssue(where=path, problem=problem))
         return
     index, call = matched
     walk.consumed.add(index)

--- a/apps/api/app/services/workflow/playbook/parser.py
+++ b/apps/api/app/services/workflow/playbook/parser.py
@@ -434,7 +434,9 @@ def _envelope_error(result: object) -> str:
 
 
 def _rendered_args(args: Mapping[str, Any]) -> str:
-    rendered = json.dumps(dict(args), default=str, ensure_ascii=False)
+    # ensure_ascii=False and ensure_ascii=None are byte-identical to json (it
+    # only tests truthiness), so that mutation is provably equivalent and exempt.
+    rendered = json.dumps(dict(args), default=str, ensure_ascii=False)  # pragma: no mutate
     if len(rendered) <= _ARGS_IN_MESSAGE_MAX_CHARS:
         return rendered
     return rendered[:_ARGS_IN_MESSAGE_MAX_CHARS] + "..."
@@ -489,7 +491,7 @@ def _check_required_args(
             PlaybookIssue(
                 where=f"{path}.args",
                 problem=f"{tool_name} requires {name!r} and this step does not set it; "
-                f"it takes: {', '.join(sorted(tool.args)) or 'nothing'}",
+                f"it takes: {', '.join(sorted(tool.args))}",
             )
         )
 

--- a/apps/api/app/services/workflow/playbook/placeholders.py
+++ b/apps/api/app/services/workflow/playbook/placeholders.py
@@ -10,6 +10,10 @@ A ``$word`` whose root is not one of the namespaces below is NOT a token: it is
 literal text on both sides — the validator does not check it and the evaluator
 leaves it untouched. A recorded ``bash`` step legitimately says ``echo $HOME``,
 and refusing every ``$identifier`` at write time would refuse that playbook.
+``$ask`` is deliberately absent: text a model writes at replay is no longer a
+reference into a table but an inline ``{"$ask": ...}`` value standing where the
+argument goes, so ``$ask.anything`` in a string is now plain text like any other
+unknown root.
 """
 
 from collections.abc import Iterator, Mapping
@@ -17,7 +21,7 @@ import re
 
 #: The placeholder namespaces a playbook may address.
 PLACEHOLDER_ROOTS: frozenset[str] = frozenset(
-    {"now", "today", "user", "trigger", "steps", "last_run", "ask"}
+    {"now", "today", "user", "trigger", "steps", "last_run"}
 )
 
 #: Longest root first so ``last_run`` is never matched as a shorter alternative.

--- a/apps/api/app/services/workflow/playbook/runner.py
+++ b/apps/api/app/services/workflow/playbook/runner.py
@@ -5,11 +5,13 @@ Each step runs inside a real agent graph (``create_agent``) driven by
 makes a replay use the same machinery an agentic run uses — the pregel runtime,
 the stream writer, the metadata copy, the middleware stack and the HIL gate —
 rather than a hand-supplied imitation of it. What a replay does NOT do is think.
-It makes at most two model calls: one mid-run that fills the ``$ask`` slots
-(only when a step has one), and one at the end that writes the user-facing
-result and judges the run. They are separate because the result and the verdict
-can only be written once every step has run; a verdict written mid-run judges
-steps that have not happened yet.
+Its model calls are one ask call per step that carries a ``$ask`` slot, plus the
+narration at the end that writes the user-facing result and judges the run. Each
+ask call fires immediately before its own step, so a slot whose instruction
+depends on an earlier step's result is written from that result rather than from
+a run that has not reached it yet. The narration is separate from all of them
+because the result and the verdict can only be written once every step has run;
+a verdict written mid-run judges steps that have not happened yet.
 
 A step is its own graph invocation because a playbook step addresses the results
 of the steps before it (``$steps.x.y``), so the call to emit is not known until
@@ -132,14 +134,14 @@ FALLBACK_LINE_MAX_CHARS = 1_500
 
 
 class PlaybookAskAnswer(BaseModel):
-    """One ``$ask`` slot, written by the mid-run ask call."""
+    """One ``$ask`` slot, written by an ask call."""
 
     name: str = Field(description="The slot's key, exactly as listed in <asks>")
     text: str = Field(description="What to write for that slot")
 
 
 class PlaybookAskFill(BaseModel):
-    """What the mid-run call produces: every ask, and nothing else."""
+    """What one ask call produces: the slots its own step needs, and nothing else."""
 
     asks: list[PlaybookAskAnswer] = Field(default_factory=list)
 
@@ -179,8 +181,9 @@ class PlaybookRunResult(BaseModel):
     #: One line per step that actually ran, so a fallback run can be told what it
     #: must not do again.
     completed: list[str] = Field(default_factory=list)
-    #: How many real model calls the replay made: the ask fill (only when a step
-    #: needed one) and the end-of-run narration. A call that raised is not counted.
+    #: How many real model calls the replay made: one ask fill per step that
+    #: carried a slot, plus the end-of-run narration. A call that raised is not
+    #: counted.
     llm_calls: int = 0
     #: Why a run that completed (``ok=True``) is not trusted: a step came back
     #: empty where the previous run had items, or the narration judged the
@@ -218,6 +221,8 @@ class _Run:
     steps: dict[str, StepResult] = field(default_factory=dict)
     completed: list[str] = field(default_factory=list)
     asks: dict[str, str] = field(default_factory=dict)
+    #: The most recent ask call's answers, as the model returned them. ``asks``
+    #: is the accumulation across every such call and is what steps read.
     ask_fill: PlaybookAskFill | None = None
     narration: PlaybookNarration | None = None
     #: Real model calls that returned; the replay's cost line.
@@ -367,9 +372,9 @@ async def _run_tool_step(
     tool_name = step.tool or ""
     position = run.position
 
-    if run.ask_fill is None and has_ask_slots(step.args):
+    if has_ask_slots(step.args):
         failure = await _fill_asks_or_fail(
-            playbook, run, pending=_labels(playbook.steps)[position - 1 :]
+            playbook, step, run, pending=_labels(playbook.steps)[position - 1 :]
         )
         if failure is not None:
             return failure
@@ -640,7 +645,7 @@ def _context(run: _Run) -> RunContext:
 
 
 async def _fill_asks_or_fail(
-    playbook: PlaybookDocument, run: _Run, *, pending: Sequence[str]
+    playbook: PlaybookDocument, step: PlaybookStep, run: _Run, *, pending: Sequence[str]
 ) -> _StepFailure | None:
     """Run the ask fill; a raise becomes the failure that stops the run.
 
@@ -648,7 +653,7 @@ async def _fill_asks_or_fail(
     never ran and what had completed by the time the model call died.
     """
     try:
-        await _fill_asks(playbook, run, pending=pending)
+        await _fill_asks(playbook, step, run, pending=pending)
     except Exception as exc:
         return _model_call_failure(playbook, run, _ASK_FILL_LABEL, exc)
     return None
@@ -682,17 +687,21 @@ def _model_call_failure(
 
 
 async def _fill_asks(
-    playbook: PlaybookDocument, run: _Run, *, pending: Sequence[str]
+    playbook: PlaybookDocument, step: PlaybookStep, run: _Run, *, pending: Sequence[str]
 ) -> PlaybookAskFill:
-    """The mid-run model call: every ask slot in the playbook, and nothing else.
+    """The model call for one step's ask slots, made just before that step runs.
 
-    It fires the first time a step carries a slot, which can be before the last
-    step. ``pending`` names the steps that have not run yet, so the model knows
-    what its answers are about to be used for. The result and the verdict are
-    deliberately not written here: they would describe a run whose outcome is
-    not known yet.
+    Scoped to ``step`` rather than the whole playbook because a slot's
+    instruction may only be answerable from what ran before it ("summarise the
+    events fetched above"): filling every slot at the first one would write a
+    later step's argument from a run that had not reached it. ``ask_slots`` is
+    called with the single step so the keys are spelled by the one rule the
+    evaluator looks them back up by. ``pending`` names the steps that have not
+    run yet, so the model knows what its answers are about to be used for. The
+    result and the verdict are deliberately not written here: they would
+    describe a run whose outcome is not known yet.
     """
-    located = ask_slots(playbook.steps)
+    located = ask_slots([step])
     config = metered_config(playbook.user_id)
     fill: PlaybookAskFill = await ainvoke_llm(
         background_structured_runnable(PlaybookAskFill, config=config),
@@ -707,7 +716,9 @@ async def _fill_asks(
     )
     run.llm_calls += 1
     run.ask_fill = fill
-    run.asks = {answer.name: answer.text for answer in fill.asks}
+    # Accumulated, never replaced: an earlier step's filled slots are still
+    # part of the arguments its record shows, and the narration reads them all.
+    run.asks.update({answer.name: answer.text for answer in fill.asks})
     missing = sorted({ask.key for ask in located} - set(run.asks))
     if missing:
         log.warning(
@@ -755,7 +766,7 @@ def _labels(steps: Sequence[PlaybookStep]) -> list[str]:
 
 
 def _render_asks(located: Sequence[LocatedAsk]) -> str:
-    """The slots to write, as the mid-run call is shown them.
+    """The slots to write, as one ask call is shown them.
 
     One line per slot, keyed exactly as the runner will look the answer back up.
     There is no "works from" line: a slot is filled from everything listed as
@@ -767,13 +778,13 @@ def _render_asks(located: Sequence[LocatedAsk]) -> str:
     for ask in located:
         lines.append(f"- {ask.key}: {ask.slot.prompt}")
         # A per-slot cap cannot be enforced through the API when one call writes
-        # every slot, so it is stated to the model as the budget it is.
+        # several slots, so it is stated to the model as the budget it is.
         lines.append(f"  budget: about {ask.slot.max_tokens} tokens")
     return "\n".join(lines)
 
 
 def _render_filled_asks(asks: Mapping[str, str]) -> str:
-    """The asks as the mid-run call wrote them, for the end-of-run call to read."""
+    """The asks as the ask calls wrote them, for the end-of-run call to read."""
     if not asks:
         return "none"
     return "\n".join(f"- {name}: {text}" for name, text in asks.items())

--- a/apps/api/app/services/workflow/playbook/runner.py
+++ b/apps/api/app/services/workflow/playbook/runner.py
@@ -5,15 +5,15 @@ Each step runs inside a real agent graph (``create_agent``) driven by
 makes a replay use the same machinery an agentic run uses — the pregel runtime,
 the stream writer, the metadata copy, the middleware stack and the HIL gate —
 rather than a hand-supplied imitation of it. What a replay does NOT do is think.
-It makes at most two model calls: one mid-run that fills the ``$ask`` fields
-(only when a step needs one), and one at the end that writes the user-facing
+It makes at most two model calls: one mid-run that fills the ``$ask`` slots
+(only when a step has one), and one at the end that writes the user-facing
 result and judges the run. They are separate because the result and the verdict
 can only be written once every step has run; a verdict written mid-run judges
 steps that have not happened yet.
 
 A step is its own graph invocation because a playbook step addresses the results
-of the steps before it (``$steps.x.y``, ``$ask.z``), so the call to emit is not
-known until its predecessor has answered.
+of the steps before it (``$steps.x.y``), so the call to emit is not known until
+its predecessor has answered.
 
 Two properties are load-bearing:
 
@@ -43,14 +43,24 @@ from app.agents.middleware.factory import (
     SubagentStackOptions,
     create_middleware_stack,
 )
-from app.agents.prompts.playbook_prompts import PLAYBOOK_ASK_PROMPT, PLAYBOOK_NARRATION_PROMPT
+from app.agents.prompts.playbook_prompts import (
+    PLAYBOOK_ASK_PROMPT,
+    PLAYBOOK_NARRATION_FALLBACK_TEMPLATE,
+    PLAYBOOK_NARRATION_PROMPT,
+)
 from app.agents.tools.core.registry import ToolRegistry, get_tool_registry
 from app.agents.workspace.offload import read_offload
 from app.constants.hil import HIL_STATUS_KWARG
 from app.constants.log_tags import LogTag
 from app.db.repositories.workflow_executions import workflow_executions_repository
 from app.models.agent_models import AgentConfigurable
-from app.models.playbook_models import PlaybookAsk, PlaybookDocument, PlaybookStep
+from app.models.playbook_models import (
+    LocatedAsk,
+    PlaybookDocument,
+    PlaybookStep,
+    ask_slots,
+    has_ask_slots,
+)
 from app.models.workflow_execution_models import (
     RecordedCall,
     build_result_digest,
@@ -64,6 +74,7 @@ from app.services.workflow.playbook.evaluator import (
     PlaybookUser,
     RunContext,
     StepResult,
+    fill_ask_slots,
     last_run_index,
     parse_result,
     resolve_args,
@@ -114,12 +125,17 @@ _NARRATION_LABEL = "narration"
 #: exists only so a tool whose result loops the graph cannot run away.
 _REPLAY_RECURSION_LIMIT = 8
 
+#: A completed line as a BRIEF quotes it back — the agent's fallback note and the
+#: narration fallback the user reads. Both say what ran and roughly what came
+#: back; neither needs the whole payload the narration itself was shown.
+FALLBACK_LINE_MAX_CHARS = 1_500
+
 
 class PlaybookAskAnswer(BaseModel):
-    """One ``$ask`` field, written by the mid-run ask call."""
+    """One ``$ask`` slot, written by the mid-run ask call."""
 
-    name: str = Field(description="The ask's name, exactly as the playbook declares it")
-    text: str = Field(description="What to write for that field")
+    name: str = Field(description="The slot's key, exactly as listed in <asks>")
+    text: str = Field(description="What to write for that slot")
 
 
 class PlaybookAskFill(BaseModel):
@@ -174,6 +190,11 @@ class PlaybookRunResult(BaseModel):
     #: the narration's own verdict. The worker weighs them differently, so it
     #: needs to know which one spoke. ``None`` exactly when ``suspect`` is.
     suspect_source: Literal["record", "narration"] | None = None
+    #: Why the end-of-run call did not write the result, on a run where every
+    #: step ran anyway (``ok=True``, ``text`` the fallback record of what ran).
+    #: The steps are the workflow; only the sentence about them is missing, so
+    #: this is a delivered run, not a playbook to heal.
+    narration_failed: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -242,7 +263,15 @@ async def run_playbook(
     space = ToolSpace(tools=registry.get_tool_dict(), runtime=None, subagent_id=None)
 
     failure = await _run_steps(playbook, playbook.steps, run, space)
-    if failure is None and run.suspect is not None:
+    if failure is not None:
+        return PlaybookRunResult(
+            ok=False,
+            trace=run.trace,
+            completed=run.completed,
+            failure=_failure_text(failure, run.completed),
+            llm_calls=run.llm_calls,
+        )
+    if run.suspect is not None:
         # Stopped on the record's word: no narration, nothing to deliver. The
         # agent finishes this fire from the list of what ran.
         return PlaybookRunResult(
@@ -253,16 +282,10 @@ async def run_playbook(
             suspect=run.suspect,
             suspect_source="record",
         )
-    if failure is None:
-        failure = await _narrate_or_fail(playbook, run)
-    if failure is not None:
-        return PlaybookRunResult(
-            ok=False,
-            trace=run.trace,
-            completed=run.completed,
-            failure=_failure_text(failure, run.completed),
-            llm_calls=run.llm_calls,
-        )
+
+    narration_failure = await _narrate_or_fail(playbook, run)
+    if narration_failure is not None:
+        return _narration_fallback(run, narration_failure)
 
     narration = run.narration
     if narration is None:
@@ -344,7 +367,7 @@ async def _run_tool_step(
     tool_name = step.tool or ""
     position = run.position
 
-    if run.ask_fill is None and playbook.ask and _addresses_ask(step):
+    if run.ask_fill is None and has_ask_slots(step.args):
         failure = await _fill_asks_or_fail(
             playbook, run, pending=_labels(playbook.steps)[position - 1 :]
         )
@@ -356,7 +379,10 @@ async def _run_tool_step(
         return _StepFailure(position, tool_name, denial)
 
     try:
-        args = resolve_args(step.args, _context(run))
+        # Slots first, then placeholders: filling turns a slot into an ordinary
+        # string, which resolution then scans like any other authored value.
+        filled = fill_ask_slots(step.args, run.asks, key_prefix=step.id or tool_name)
+        args = resolve_args(filled, _context(run))
     except PlaceholderError as exc:
         return _StepFailure(position, tool_name, exc.message)
 
@@ -613,21 +639,6 @@ def _context(run: _Run) -> RunContext:
     )
 
 
-def _addresses_ask(step: PlaybookStep) -> bool:
-    """Whether this step's arguments address a ``$ask`` field."""
-    return any("$ask." in text for text in _strings(step.args))
-
-
-def _strings(value: object) -> list[str]:
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, Mapping):
-        return [text for item in value.values() for text in _strings(item)]
-    if isinstance(value, list):
-        return [text for item in value for text in _strings(item)]
-    return []
-
-
 async def _fill_asks_or_fail(
     playbook: PlaybookDocument, run: _Run, *, pending: Sequence[str]
 ) -> _StepFailure | None:
@@ -644,10 +655,11 @@ async def _fill_asks_or_fail(
 
 
 async def _narrate_or_fail(playbook: PlaybookDocument, run: _Run) -> _StepFailure | None:
-    """Run the narration; a raise becomes the failure that stops the run.
+    """Run the narration; a raise comes back as the reason it wrote nothing.
 
-    Positioned at the last step, so the report still says every step had
-    completed by the time the model call died.
+    Positioned at the last step, so the reason still says every step had
+    completed by the time the model call died. The caller turns it into a
+    completed run, not a stopped one — see ``_narration_fallback``.
     """
     try:
         await _narrate(playbook, run)
@@ -672,14 +684,15 @@ def _model_call_failure(
 async def _fill_asks(
     playbook: PlaybookDocument, run: _Run, *, pending: Sequence[str]
 ) -> PlaybookAskFill:
-    """The mid-run model call: every ask, and only the asks.
+    """The mid-run model call: every ask slot in the playbook, and nothing else.
 
-    It fires the first time a step addresses a ``$ask``, which can be before the
-    last step. ``pending`` names the steps that have not run yet, so the model
-    knows what its fields are about to be used for. The result and the verdict
-    are deliberately not written here: they would describe a run whose outcome
-    is not known yet.
+    It fires the first time a step carries a slot, which can be before the last
+    step. ``pending`` names the steps that have not run yet, so the model knows
+    what its answers are about to be used for. The result and the verdict are
+    deliberately not written here: they would describe a run whose outcome is
+    not known yet.
     """
+    located = ask_slots(playbook.steps)
     config = metered_config(playbook.user_id)
     fill: PlaybookAskFill = await ainvoke_llm(
         background_structured_runnable(PlaybookAskFill, config=config),
@@ -687,7 +700,7 @@ async def _fill_asks(
             description=playbook.description,
             completed="\n".join(run.completed) or "nothing yet",
             remaining="\n".join(pending),
-            asks=_render_asks(playbook.ask, run.completed),
+            asks=_render_asks(located),
         ),
         label="playbook_ask_fill",
         config=config,
@@ -695,10 +708,10 @@ async def _fill_asks(
     run.llm_calls += 1
     run.ask_fill = fill
     run.asks = {answer.name: answer.text for answer in fill.asks}
-    missing = sorted(set(playbook.ask) - set(run.asks))
+    missing = sorted({ask.key for ask in located} - set(run.asks))
     if missing:
         log.warning(
-            f"{LogTag.WORKFLOW} Playbook ask fill wrote nothing for declared asks",
+            f"{LogTag.WORKFLOW} Playbook ask fill wrote nothing for some slots",
             playbook_id=playbook.playbook_id,
             workflow_id=playbook.workflow_id,
             missing_asks=missing,
@@ -719,7 +732,7 @@ async def _narrate(playbook: PlaybookDocument, run: _Run) -> PlaybookNarration:
             description=playbook.description,
             completed="\n".join(run.completed) or "nothing",
             asks=_render_filled_asks(run.asks),
-            synthesize=playbook.synthesize,
+            result_brief=playbook.result_brief,
         ),
         label="playbook_narration",
         config=config,
@@ -741,18 +754,21 @@ def _labels(steps: Sequence[PlaybookStep]) -> list[str]:
     return labels
 
 
-def _render_asks(asks: Mapping[str, PlaybookAsk], completed: Sequence[str]) -> str:
-    if not asks:
+def _render_asks(located: Sequence[LocatedAsk]) -> str:
+    """The slots to write, as the mid-run call is shown them.
+
+    One line per slot, keyed exactly as the runner will look the answer back up.
+    There is no "works from" line: a slot is filled from everything listed as
+    already run, because it has no way to name a subset of it.
+    """
+    if not located:
         return "none"
     lines: list[str] = []
-    for name, ask in asks.items():
-        lines.append(f"- {name}: {ask.prompt}")
-        # A per-field cap cannot be enforced through the API when one call writes
-        # every field, so it is stated to the model as the budget it is.
-        lines.append(f"  budget: about {ask.max_tokens} tokens")
-        seen = [line for line in completed if any(line.startswith(f"{u} (") for u in ask.uses)]
-        if seen:
-            lines.append(f"  works from: {'; '.join(seen)}")
+    for ask in located:
+        lines.append(f"- {ask.key}: {ask.slot.prompt}")
+        # A per-slot cap cannot be enforced through the API when one call writes
+        # every slot, so it is stated to the model as the budget it is.
+        lines.append(f"  budget: about {ask.slot.max_tokens} tokens")
     return "\n".join(lines)
 
 
@@ -761,6 +777,39 @@ def _render_filled_asks(asks: Mapping[str, str]) -> str:
     if not asks:
         return "none"
     return "\n".join(f"- {name}: {text}" for name, text in asks.items())
+
+
+def completed_block(completed: Sequence[str]) -> str:
+    """What ran, one bounded line each, as a brief quotes it back to a reader."""
+    return "\n".join(f"- {_bounded_line(line)}" for line in completed) or "- nothing"
+
+
+def _bounded_line(line: str) -> str:
+    return line if len(line) <= FALLBACK_LINE_MAX_CHARS else line[:FALLBACK_LINE_MAX_CHARS] + "..."
+
+
+def _narration_fallback(run: _Run, failure: _StepFailure) -> PlaybookRunResult:
+    """Every step ran and only the sentence about them could not be written.
+
+    Prod: 13 of 15 failed replays were exactly this — every tool step complete,
+    the narration call alone raising. Reporting that as a stopped run gave the
+    user nothing and sent the next fire to a ~20-call heal run against a frozen
+    sequence that had just done its job. The steps' own record is a worse result
+    than the narration's sentence and a far better one than silence.
+
+    ``suspect`` stays unset: the narration is what produces a verdict, and it
+    never spoke. An unwritten verdict is not a clean one.
+    """
+    return PlaybookRunResult(
+        ok=True,
+        text=PLAYBOOK_NARRATION_FALLBACK_TEMPLATE.format(
+            reason=failure.reason, completed=completed_block(run.completed)
+        ),
+        trace=run.trace,
+        completed=run.completed,
+        llm_calls=run.llm_calls,
+        narration_failed=failure.reason,
+    )
 
 
 def _failure_text(failure: _StepFailure, completed: Sequence[str]) -> str:

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -801,6 +801,45 @@ async def _notify_replay_finished(
         )
 
 
+async def _deliver_replay(
+    fire: _Fire,
+    playbook: PlaybookDocument,
+    conversation_id: str,
+    result: PlaybookRunResult,
+) -> tuple[str, list[RecordedCall], str]:
+    """Write a trusted replay's turn and tell the user; the other outcomes leave
+    the conversation to the agent run that takes over, so one fire shows one
+    result instead of a half-run followed by a real one."""
+    workflow, workflow_id, user = fire.workflow, fire.workflow_id, fire.user
+    log.set_ns(
+        "playbook",
+        mode="replay",
+        reason="workflow_hash_match",
+        playbook_id=playbook.playbook_id,
+        llm_calls=result.llm_calls,
+        outcome=PlaybookRunStatus.SUCCESS.value,
+    )
+    if result.narration_failed is not None:
+        log.warning(
+            f"{LogTag.WORKER} Playbook replayed but the narration failed; "
+            "delivered the steps' record instead",
+            workflow_id=workflow_id,
+            playbook_id=playbook.playbook_id,
+            reason=result.narration_failed,
+        )
+    await add_playbook_run_messages(
+        conversation_id=conversation_id,
+        user_id=workflow.user_id,
+        workflow=workflow,
+        response=result.text,
+        trace=result.trace,
+        playbook=playbook,
+    )
+    await _notify_replay_finished(workflow, user, conversation_id, result.text)
+    summary = REPLAY_SUMMARY if result.narration_failed is None else REPLAY_NARRATION_FAILED_SUMMARY
+    return conversation_id, result.trace, summary
+
+
 async def _finish_after_replay(
     fire: _Fire,
     playbook: PlaybookDocument,
@@ -853,38 +892,7 @@ async def _finish_after_replay(
         )
 
     if status is PlaybookRunStatus.SUCCESS:
-        log.set_ns(
-            "playbook",
-            mode="replay",
-            reason="workflow_hash_match",
-            playbook_id=playbook.playbook_id,
-            llm_calls=result.llm_calls,
-            outcome=status.value,
-        )
-        if result.narration_failed is not None:
-            log.warning(
-                f"{LogTag.WORKER} Playbook replayed but the narration failed; "
-                "delivered the steps' record instead",
-                workflow_id=workflow_id,
-                playbook_id=playbook.playbook_id,
-                reason=result.narration_failed,
-            )
-        # Only a trusted replay writes the turn. The others leave the
-        # conversation to the agent run that takes over, so the user sees one
-        # result for one fire instead of a half-run followed by a real one.
-        await add_playbook_run_messages(
-            conversation_id=conversation_id,
-            user_id=workflow.user_id,
-            workflow=workflow,
-            response=result.text,
-            trace=result.trace,
-            playbook=playbook,
-        )
-        await _notify_replay_finished(workflow, user, conversation_id, result.text)
-        summary = (
-            REPLAY_SUMMARY if result.narration_failed is None else REPLAY_NARRATION_FAILED_SUMMARY
-        )
-        return conversation_id, result.trace, summary
+        return await _deliver_replay(fire, playbook, conversation_id, result)
 
     disabled = False
     if status is PlaybookRunStatus.SUSPECT and updated is not None:

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -44,6 +44,7 @@ from app.core.websocket_manager import get_websocket_manager
 from app.db.repositories.playbooks import playbook_repository
 from app.db.repositories.todos import todo_repository
 from app.db.repositories.users import user_repository
+from app.db.repositories.workflows import workflow_repository
 from app.decorators import enforce_daily_cost_budget
 from app.decorators.rate_limiting import enforce_tiered_limit
 from app.models.chat_models import MessageModel, ToolDataEntry
@@ -66,9 +67,11 @@ from app.models.user_models import AuthenticatedUser
 from app.models.workflow_execution_models import RecordedCall
 from app.models.workflow_models import (
     CreateWorkflowRequest,
+    PlaybookDiscard,
     TriggerConfig,
     TriggerType,
     Workflow,
+    WorkflowUpdate,
 )
 from app.services.analytics_service import AnalyticsEvents, capture_event
 from app.services.limit_upsell import LimitHitOrigin, mark_run_origin
@@ -96,7 +99,11 @@ from app.services.workflow.execution_service import (
 from app.services.workflow.notifications import send_workflow_completion_notification
 from app.services.workflow.playbook.check import HEAL_STATUSES, distrust_fresh_playbook
 from app.services.workflow.playbook.evaluator import PlaybookUser
-from app.services.workflow.playbook.runner import PlaybookRunResult, run_playbook
+from app.services.workflow.playbook.runner import (
+    PlaybookRunResult,
+    completed_block,
+    run_playbook,
+)
 from app.services.workflow.playbook.workflow_hash import workflow_hash
 from app.services.workflow.run_trace import build_trace
 from app.services.workflow.scheduler import WorkflowScheduler, workflow_scheduler
@@ -533,20 +540,10 @@ def _origin_for(trigger_type: str) -> LimitHitOrigin:
     )
 
 
-#: A completed line as the fallback agent reads it. The narration reads the
-#: full result (its own bound); the agent needs to know what ran and roughly
-#: what came back, not the whole payload again in its brief.
-FALLBACK_LINE_MAX_CHARS = 1_500
-
-
-def _bounded_line(line: str) -> str:
-    return line if len(line) <= FALLBACK_LINE_MAX_CHARS else line[:FALLBACK_LINE_MAX_CHARS] + "..."
-
-
 def _fallback_note(result: PlaybookRunResult) -> str:
     """The replay that did not hold, stopped or untrusted, addressed to the agent
     that has to finish the run."""
-    completed = "\n".join(f"- {_bounded_line(line)}" for line in result.completed) or "- nothing"
+    completed = completed_block(result.completed)
     if result.ok:
         body = PLAYBOOK_SUSPECT_FALLBACK_TEMPLATE.format(
             reason=result.suspect or "no reason was recorded", completed=completed
@@ -565,6 +562,9 @@ def _fallback_note(result: PlaybookRunResult) -> str:
 AGENT_RUN_SUMMARY = "Ran the full workflow"
 HEAL_RUN_SUMMARY = "Ran the full workflow and repaired its saved shortcut"
 REPLAY_SUMMARY = "Ran from the saved shortcut"
+#: Same run, minus the sentence describing it: the steps all ran, so the record
+#: must not read like a failure, and it must not read like a normal replay either.
+REPLAY_NARRATION_FAILED_SUMMARY = "Ran from the saved shortcut; the summary could not be written"
 REPLAY_STOPPED_SUMMARY = "The saved shortcut stopped partway, so GAIA ran the rest itself"
 REPLAY_FLAGGED_SUMMARY = (
     "The saved shortcut's result looked wrong ({reason}), so GAIA ran the workflow itself"
@@ -604,6 +604,31 @@ async def _discard_playbook(
         reason=reason,
         **details,
     )
+    # The log says why to whoever is reading Loki this week; the workflow says
+    # why to whoever asks in six months why their shortcut is gone. Failing to
+    # write it costs that answer and nothing else, so it never fails the fire.
+    try:
+        await workflow_repository.update_for_user(
+            workflow_id,
+            user_id,
+            WorkflowUpdate(
+                last_playbook_discard=PlaybookDiscard(
+                    playbook_id=playbook.playbook_id,
+                    revision=playbook.revision,
+                    reason=reason,
+                    at=datetime.now(UTC),
+                    details={key: str(value) for key, value in details.items()},
+                )
+            ),
+        )
+    except Exception as e:
+        log.warning(
+            f"{LogTag.WORKER} Playbook discard not recorded on the workflow",
+            workflow_id=workflow_id,
+            playbook_id=playbook.playbook_id,
+            reason=reason,
+            error_type=type(e).__name__,
+        )
 
 
 @dataclass(frozen=True)
@@ -836,6 +861,14 @@ async def _finish_after_replay(
             llm_calls=result.llm_calls,
             outcome=status.value,
         )
+        if result.narration_failed is not None:
+            log.warning(
+                f"{LogTag.WORKER} Playbook replayed but the narration failed; "
+                "delivered the steps' record instead",
+                workflow_id=workflow_id,
+                playbook_id=playbook.playbook_id,
+                reason=result.narration_failed,
+            )
         # Only a trusted replay writes the turn. The others leave the
         # conversation to the agent run that takes over, so the user sees one
         # result for one fire instead of a half-run followed by a real one.
@@ -848,19 +881,22 @@ async def _finish_after_replay(
             playbook=playbook,
         )
         await _notify_replay_finished(workflow, user, conversation_id, result.text)
-        return conversation_id, result.trace, REPLAY_SUMMARY
+        summary = (
+            REPLAY_SUMMARY if result.narration_failed is None else REPLAY_NARRATION_FAILED_SUMMARY
+        )
+        return conversation_id, result.trace, summary
 
     disabled = False
     if status is PlaybookRunStatus.SUSPECT and updated is not None:
         disabled = updated.suspect_streak >= PLAYBOOK_SUSPECT_STREAK_LIMIT
         if disabled:
-            await playbook_repository.delete_for_workflow(workflow_id, workflow.user_id)
-            log.warning(
-                f"{LogTag.WORKER} Playbook disabled after repeated suspect replays",
-                workflow_id=workflow_id,
-                playbook_id=playbook.playbook_id,
-                reason=reason,
+            await _discard_playbook(
+                workflow_id,
+                workflow.user_id,
+                playbook,
+                reason="suspect_streak_exhausted",
                 suspect_streak=updated.suspect_streak,
+                suspect_reason=reason,
             )
     if status is PlaybookRunStatus.FAILED:
         log.set_ns(

--- a/apps/api/tests/contracts/test_playbooks_repository.py
+++ b/apps/api/tests/contracts/test_playbooks_repository.py
@@ -38,7 +38,7 @@ def make_doc(**overrides) -> PlaybookDocument:
         "workflow_hash": "hash-1",
         "description": "first",
         "steps": [{"id": "one", "tool": "list_events", "args": {"calendar_id": "primary"}}],
-        "synthesize": "s",
+        "result_brief": "s",
         "created_at": now,
         "updated_at": now,
     }

--- a/apps/api/tests/unit/agents/tools/test_playbook_tools.py
+++ b/apps/api/tests/unit/agents/tools/test_playbook_tools.py
@@ -7,12 +7,13 @@ production would reject it.
 """
 
 from datetime import UTC, datetime
+import json
 from typing import Annotated, Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from langchain_core.messages import AIMessage, ToolMessage
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool, tool
-from pydantic import ValidationError
 import pytest
 import yaml
 
@@ -25,7 +26,6 @@ from app.agents.tools.playbook_tools import (
 from app.constants.agents import PLAYBOOK_DECLINE_LIMIT
 from app.constants.log_tags import LogTag
 from app.models.playbook_models import (
-    PlaybookAsk,
     PlaybookBody,
     PlaybookDocument,
     PlaybookRunStatus,
@@ -33,6 +33,7 @@ from app.models.playbook_models import (
     playbook_body_from_input,
 )
 from app.models.workflow_models import (
+    PlaybookDiscard,
     TriggerConfig,
     TriggerType,
     WorkflowDocument,
@@ -40,6 +41,7 @@ from app.models.workflow_models import (
 )
 from app.services.workflow.playbook.parser import (
     PlaybookValidation,
+    RunResults,
     dump_playbook,
     validate_playbook,
 )
@@ -149,7 +151,7 @@ def _existing(store: _FakePlaybookStore) -> PlaybookDocument:
         workflow_hash="stale",
         description="Old",
         steps=[{"id": "one", "tool": "list_events", "args": {"calendar_id": "primary"}}],
-        synthesize="Old synthesis.",
+        result_brief="Old synthesis.",
         last_run_status=PlaybookRunStatus.SUCCESS,
         created_at=now,
         updated_at=now,
@@ -165,7 +167,7 @@ NEW_STEPS: list[dict[str, Any]] = [
 NEW_ARGS: dict[str, Any] = {
     "description": "Read the day's events",
     "steps": NEW_STEPS,
-    "synthesize": "Say what is on today.",
+    "result_brief": "Say what is on today.",
 }
 
 #: Exactly what read_playbook renders for the playbook ``_existing`` stores.
@@ -178,7 +180,7 @@ OLD_YAML = (
     "  tool: list_events\n"
     "  args:\n"
     "    calendar_id: primary\n"
-    "synthesize: Old synthesis.\n"
+    "result_brief: Old synthesis.\n"
 )
 
 
@@ -207,31 +209,56 @@ def workflows() -> MagicMock:
 
 @pytest.mark.unit
 class TestWritePlaybook:
-    async def test_a_step_the_schema_does_not_know_never_reaches_the_tool(
+    async def test_a_step_carrying_keys_the_schema_never_asked_for_is_still_written(
         self, store: _FakePlaybookStore, workflows: MagicMock
     ) -> None:
-        # Regression: the playbook used to arrive as one YAML string, so an
-        # invented key like `goal` got all the way to the parser. The bound
-        # schema now refuses it before the tool body runs.
-        before = _existing(store)
+        """A stray ``goal``/``task``/``note`` beside a correct call is dropped,
+        not refused.
+
+        Measured in production: 17 of 57 authoring attempts were thrown away
+        whole because the model annotated a step it had otherwise written
+        correctly. If this fails, the step input has gone back to forbidding
+        extras and the same writes start being rejected again.
+        """
+        _existing(store)
+        annotated = [
+            {
+                "id": "agenda",
+                "tool": "list_events",
+                "args": {"calendar_id": "primary"},
+                "goal": "read the events",
+                "task": "agenda",
+                "note": "runs every morning",
+            }
+        ]
         with (
             patch(f"{TOOLS_MODULE}.playbook_repository", store),
             patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
             patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_FakeRegistry()),
-            pytest.raises(ValidationError, match="goal"),
         ):
-            await write_playbook.ainvoke(
-                {**NEW_ARGS, "steps": [{"id": "agenda", "goal": "read the events"}]},
-                config=_config(),
+            result = await write_playbook.ainvoke(
+                {**NEW_ARGS, "steps": annotated}, config=_config()
             )
 
-        assert store.documents[(WORKFLOW_ID, USER_ID)] == before
+        assert result["success"] is True
+        stored = store.documents[(WORKFLOW_ID, USER_ID)]
+        assert stored.steps[0].model_dump(exclude_defaults=True) == {
+            "id": "agenda",
+            "tool": "list_events",
+            "args": {"calendar_id": "primary"},
+        }
 
-    async def test_a_tool_step_nested_under_a_handoff_child_is_refused(
+    async def test_a_tool_step_nested_under_a_handoff_child_is_refused_not_dropped(
         self, store: _FakePlaybookStore, workflows: MagicMock
     ) -> None:
-        # Playbooks are depth-1: a handoff's children are plain tool calls, and
-        # the flat input model is what makes deeper nesting unrepresentable.
+        """Playbooks are depth-1: a handoff's children are plain tool calls.
+
+        The child model drops unknown keys, so without its own rule a third
+        level would vanish silently and the stored playbook would run a fraction
+        of what the author wrote. If this fails, either a grandchild is being
+        stored (a level the runner cannot execute) or it is being discarded
+        without a word to the author.
+        """
         deeper = [
             {
                 "handoff": "gmail",
@@ -249,10 +276,23 @@ class TestWritePlaybook:
             patch(f"{TOOLS_MODULE}.playbook_repository", store),
             patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
             patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_FakeRegistry()),
-            pytest.raises(ValidationError),
+            patch(
+                f"{PARSER_MODULE}.resolve_subagent_tools",
+                AsyncMock(
+                    return_value=SubagentTools(
+                        tools=_FakeRegistry().get_tool_dict(), initial_tool_ids=[]
+                    )
+                ),
+            ),
         ):
-            await write_playbook.ainvoke({**NEW_ARGS, "steps": deeper}, config=_config())
+            result = await write_playbook.ainvoke({**NEW_ARGS, "steps": deeper}, config=_config())
 
+        assert isinstance(result, str), "refused at the boundary, through handle_validation_error"
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert parsed["error"] == "invalid_playbook"
+        assert "steps[0].steps[0]: " in parsed["message"]
+        assert "one level deep" in parsed["message"]
         assert store.documents == {}
 
     async def test_playbook_failing_validation_writes_nothing(
@@ -301,8 +341,12 @@ class TestWritePlaybook:
                 "handoff": "gmail",
                 "steps": [{"id": "mail", "tool": "list_events", "args": {"calendar_id": "$now"}}],
             },
+            {
+                "id": "written",
+                "tool": "list_events",
+                "args": {"calendar_id": {"$ask": "which calendar the agenda came from"}},
+            },
         ]
-        ask = {"subject": {"prompt": "one subject line", "uses": ["agenda", "mail"]}}
         with (
             patch(f"{TOOLS_MODULE}.playbook_repository", store),
             patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
@@ -319,17 +363,14 @@ class TestWritePlaybook:
                 ),
             ),
         ):
-            result = await write_playbook.ainvoke(
-                {**NEW_ARGS, "steps": steps, "ask": ask}, config=_config()
-            )
+            result = await write_playbook.ainvoke({**NEW_ARGS, "steps": steps}, config=_config())
 
         assert result["success"] is True
         stored = store.documents[(WORKFLOW_ID, USER_ID)]
         expected = playbook_body_from_input(
             description="Read the day's events",
             steps=[PlaybookStepInput.model_validate(step) for step in steps],
-            synthesize="Say what is on today.",
-            ask={"subject": PlaybookAsk.model_validate(ask["subject"])},
+            result_brief="Say what is on today.",
         )
         assert PlaybookBody.model_validate(yaml.safe_load(dump_playbook(stored))) == expected
 
@@ -518,6 +559,34 @@ class TestDeclinePlaybook:
         assert result["success"] is True
         assert workflows.workflow.playbook_declines == 0
         assert workflows.workflow.playbook_declined_hash is None
+
+    async def test_a_write_clears_the_discard_the_worker_recorded(
+        self, store: _FakePlaybookStore
+    ) -> None:
+        """The discard says why this workflow's LAST playbook was thrown away.
+        Left behind after a successful write it describes a document that no
+        longer exists, and the workflow reads as having lost a shortcut it now
+        has."""
+        workflows = _FakeWorkflowStore()
+        workflows.workflow = workflows.workflow.model_copy(
+            update={
+                "last_playbook_discard": PlaybookDiscard(
+                    playbook_id="pb_old",
+                    revision=1,
+                    reason="stale_workflow_hash",
+                    at=datetime.now(UTC),
+                )
+            }
+        )
+        with (
+            patch(f"{TOOLS_MODULE}.playbook_repository", store),
+            patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
+            patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_FakeRegistry()),
+        ):
+            result = await write_playbook.ainvoke(NEW_ARGS, config=_config())
+
+        assert result["success"] is True
+        assert workflows.workflow.last_playbook_discard is None
 
     async def test_declining_an_unknown_workflow_is_refused(
         self, store: _FakePlaybookStore
@@ -868,9 +937,11 @@ class TestPlaybookStorageDetails:
         """
         seen: list[tuple[PlaybookBody, str]] = []
 
-        async def spying_validate(body: PlaybookBody, user_id: str) -> PlaybookValidation:
+        async def spying_validate(
+            body: PlaybookBody, user_id: str, results: RunResults | None = None
+        ) -> PlaybookValidation:
             seen.append((body, user_id))
-            return await validate_playbook(body, user_id)
+            return await validate_playbook(body, user_id, results)
 
         with (
             patch(f"{TOOLS_MODULE}.playbook_repository", store),
@@ -886,8 +957,7 @@ class TestPlaybookStorageDetails:
                 playbook_body_from_input(
                     description="Read the day's events",
                     steps=[PlaybookStepInput.model_validate(step) for step in NEW_STEPS],
-                    synthesize="Say what is on today.",
-                    ask=None,
+                    result_brief="Say what is on today.",
                 ),
                 USER_ID,
             )
@@ -999,7 +1069,12 @@ class TestPlaybookWideEvents:
             tool={"name": "write_playbook", "action": "write"}, workflow_id=WORKFLOW_ID
         )
         stored = store.documents[(WORKFLOW_ID, USER_ID)]
-        log.set_ns.assert_called_once_with("playbook", id=stored.playbook_id, steps=1)
+        # No graph state reaches a direct ainvoke, so the run check records
+        # None — the field that tells prod whether InjectedState was filled.
+        assert log.set_ns.call_args_list == [
+            call("playbook", checked_against_calls=None),
+            call("playbook", id=stored.playbook_id, steps=1),
+        ]
 
     async def test_a_rejected_write_is_recorded_with_how_many_problems(
         self, store: _FakePlaybookStore, workflows: MagicMock
@@ -1016,7 +1091,9 @@ class TestPlaybookWideEvents:
             )
 
         assert log.warning.call_args.kwargs["issues"] == 1
-        log.set_ns.assert_not_called()
+        # The run check is stamped before the verdict, so a refusal still says
+        # what it was checked against; nothing about a stored playbook follows.
+        assert log.set_ns.call_args_list == [call("playbook", checked_against_calls=None)]
 
     async def test_a_read_records_the_tool_and_the_workflow(
         self, store: _FakePlaybookStore
@@ -1062,3 +1139,276 @@ class TestPlaybookWideEvents:
             await disable_playbook.ainvoke({"reason": "nothing to disable"}, config=_config())
 
         log.set_ns.assert_not_called()
+
+
+@pytest.mark.unit
+class TestWritePlaybookBoundary:
+    """The tool's own schema and what a call that misses it gets back.
+
+    The schema is the only place the model learns the shape, and the boundary
+    error is the only thing it has to work from when the shape is wrong. In
+    production 36 of 57 authoring attempts were rejected, and a framework-level
+    error the model could not read is why it retried the same shape.
+    """
+
+    def test_the_schema_asks_for_three_things_and_no_ask_section(self) -> None:
+        """``ask`` was a separate table the model had to reason about, and five
+        of the eight asks ever written were referenced by no step. The slot now
+        lives inside the argument, so there is nothing at the top level to get
+        wrong; a reappearing ``ask`` property is that mistake coming back.
+        """
+        schema = write_playbook.tool_call_schema.model_json_schema()
+
+        assert schema["required"] == ["description", "steps", "result_brief"]
+        assert "ask" not in schema["properties"]
+        # The workflow is resolved from the run's config server-side.
+        assert "workflow_id" not in schema["properties"]
+
+    def test_the_step_schema_does_not_forbid_extra_keys(self) -> None:
+        """``additionalProperties: false`` is what a provider renders as "no
+        other keys allowed", and it is what turned a step annotated with a
+        ``goal`` into a refused write. Its absence is the leniency, expressed
+        where the model actually reads it."""
+        schema = write_playbook.tool_call_schema.model_json_schema()
+
+        step = schema["$defs"][PlaybookStepInput.__name__]
+        assert step.get("additionalProperties") is not False
+        child_name = step["properties"]["steps"]["items"]["$ref"].rsplit("/", 1)[-1]
+        assert schema["$defs"][child_name].get("additionalProperties") is not False
+
+    @pytest.mark.parametrize(
+        ("arguments", "expected_location"),
+        [
+            (
+                {"steps": NEW_STEPS, "result_brief": "Say what is on today."},
+                "description",
+            ),
+            (
+                {
+                    **NEW_ARGS,
+                    "steps": [
+                        {"id": "agenda", "tool": "list_events", "handoff": "gmail", "args": {}}
+                    ],
+                },
+                "steps[0]",
+            ),
+        ],
+        ids=["missing-description", "both-tool-and-handoff"],
+    )
+    async def test_arguments_that_miss_the_schema_come_back_as_a_readable_refusal(
+        self,
+        store: _FakePlaybookStore,
+        workflows: MagicMock,
+        arguments: dict[str, Any],
+        expected_location: str,
+    ) -> None:
+        """langchain raises before the coroutine runs, so without the tool's
+        ``handle_validation_error`` hook the model gets a framework traceback
+        rather than the tool's own envelope. If this fails, a shape mistake stops
+        being recoverable: the model cannot tell what to fix, and nothing says
+        the playbook was not written.
+        """
+        with (
+            patch(f"{TOOLS_MODULE}.playbook_repository", store),
+            patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
+            patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_FakeRegistry()),
+        ):
+            result = await write_playbook.ainvoke(arguments, config=_config())
+
+        assert isinstance(result, str), "the hook hands the model a string, not a raised error"
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert parsed["error"] == "invalid_playbook"
+        assert parsed["message"].startswith(
+            "The playbook was not written. Fix these and call write_playbook again: "
+        )
+        assert f"{expected_location}: " in parsed["message"]
+        assert store.documents == {}
+
+
+@pytest.mark.unit
+class TestReadPlaybookYaml:
+    async def test_the_yaml_carries_the_result_brief_and_no_ask_section(
+        self, store: _FakePlaybookStore
+    ) -> None:
+        """The YAML is the document the agent reads before revising, so it has to
+        be the shape write_playbook takes. A stray top-level ``ask:`` would teach
+        the agent to write back a section the tool no longer has."""
+        now = datetime.now(UTC)
+        store.documents[(WORKFLOW_ID, USER_ID)] = PlaybookDocument(
+            playbook_id="pb_slots",
+            workflow_id=WORKFLOW_ID,
+            user_id=USER_ID,
+            workflow_hash="h",
+            description="Read the day's events",
+            steps=[
+                {
+                    "id": "agenda",
+                    "tool": "list_events",
+                    "args": {"calendar_id": {"$ask": "which calendar to read"}},
+                }
+            ],
+            result_brief="Say what is on today.",
+            created_at=now,
+            updated_at=now,
+        )
+        with patch(f"{TOOLS_MODULE}.playbook_repository", store):
+            result = await read_playbook.ainvoke({}, config=_config())
+
+        document = yaml.safe_load(result["data"]["yaml"])
+        assert document["result_brief"] == "Say what is on today."
+        assert "ask" not in document
+        assert document["steps"][0]["args"]["calendar_id"] == {"$ask": "which calendar to read"}
+
+
+@tool("GMAIL_FETCH_MESSAGES")
+async def gmail_fetch_messages(query: Annotated[str, "Search query"]) -> dict[str, Any]:
+    """Fetch messages. Named as the real Composio tool is, because the playbook
+    this class is about froze $steps.<id>.threadId on it."""
+    return {}
+
+
+@tool("GMAIL_REPLY")
+async def gmail_reply(
+    thread_id: Annotated[str, "Thread to reply on"], body: Annotated[str, "Reply body"]
+) -> dict[str, Any]:
+    """Reply on a thread."""
+    return {}
+
+
+class _GmailRegistry:
+    """The two tools the authoring-run fixtures below call."""
+
+    def get_tool_dict(self) -> dict[str, BaseTool]:
+        return {"GMAIL_FETCH_MESSAGES": gmail_fetch_messages, "GMAIL_REPLY": gmail_reply}
+
+
+def _run_state(*calls: tuple[str, dict[str, Any], object]) -> dict[str, Any]:
+    """Graph state whose messages are the run's calls and the answers to them.
+
+    Built as real messages rather than as a results list, because reading the
+    run out of ``state["messages"]`` — pairing each AIMessage tool call with the
+    ToolMessage that answers its id — is half of what is under test.
+    """
+    messages: list[Any] = []
+    for index, (name, args, result) in enumerate(calls):
+        call_id = f"call_{index}"
+        messages.append(
+            AIMessage(content="", tool_calls=[{"name": name, "args": args, "id": call_id}])
+        )
+        messages.append(ToolMessage(content=json.dumps(result), tool_call_id=call_id, name=name))
+    return {"messages": messages}
+
+
+FETCH_STEP: dict[str, Any] = {
+    "id": "fetch",
+    "tool": "GMAIL_FETCH_MESSAGES",
+    "args": {"query": "is:unread"},
+}
+
+
+@pytest.mark.unit
+class TestWritePlaybookAgainstTheAuthoringRun:
+    """The run's own results, injected as state, decide the write.
+
+    ``pb_c7d357db77dd`` froze ``$steps.fetch_msgs.threadId`` on a tool that does
+    not return one and broke on its first replay; two more were frozen from
+    calls that came back empty. In every case the result was in this same
+    conversation when write_playbook was called.
+    """
+
+    async def test_a_step_freezing_a_field_the_run_never_returned_is_refused_with_the_keys(
+        self, store: _FakePlaybookStore, workflows: MagicMock
+    ) -> None:
+        """The exact production failure. The refusal has to list what the result
+        DOES carry, or the author is told to fix something without being told
+        what it could have written instead."""
+        state = _run_state(
+            ("GMAIL_FETCH_MESSAGES", {"query": "is:unread"}, {"messages": [{"id": "m1"}]}),
+            ("GMAIL_REPLY", {"thread_id": "t1", "body": "hi"}, {"sent": [{"id": "1"}]}),
+        )
+        steps = [
+            FETCH_STEP,
+            {
+                "id": "reply",
+                "tool": "GMAIL_REPLY",
+                "args": {"thread_id": "$steps.fetch.threadId", "body": "hi"},
+            },
+        ]
+        with (
+            patch(f"{TOOLS_MODULE}.playbook_repository", store),
+            patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
+            patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_GmailRegistry()),
+        ):
+            result = await write_playbook.ainvoke(
+                {**NEW_ARGS, "steps": steps, "state": state}, config=_config()
+            )
+
+        assert result["success"] is False
+        assert (
+            "steps[1].args.thread_id: $steps.fetch.threadId is not in step 'fetch''s result"
+            in (result["message"])
+        )
+        assert "its result has keys: messages" in result["message"]
+        assert store.documents == {}
+
+    async def test_a_step_freezing_a_call_that_returned_nothing_is_refused(
+        self, store: _FakePlaybookStore, workflows: MagicMock
+    ) -> None:
+        """A frozen call that found no items replays into a workflow that
+        delivers nothing and is marked SUSPECT one fire later."""
+        state = _run_state(("GMAIL_FETCH_MESSAGES", {"query": "is:unread"}, {"messages": []}))
+        with (
+            patch(f"{TOOLS_MODULE}.playbook_repository", store),
+            patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
+            patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_GmailRegistry()),
+        ):
+            result = await write_playbook.ainvoke(
+                {**NEW_ARGS, "steps": [FETCH_STEP], "state": state}, config=_config()
+            )
+
+        assert result["success"] is False
+        assert "GMAIL_FETCH_MESSAGES returned no items in this run" in result["message"]
+        assert store.documents == {}
+
+    async def test_a_playbook_that_matches_what_the_run_returned_is_written(
+        self, store: _FakePlaybookStore, workflows: MagicMock
+    ) -> None:
+        """The checks must accept the shape the run actually produced. A refusal
+        here would refuse every playbook, which is worse than the bug."""
+        state = _run_state(
+            (
+                "GMAIL_FETCH_MESSAGES",
+                {"query": "is:unread"},
+                {"messages": [{"id": "m1", "threadId": "t1"}]},
+            ),
+            ("GMAIL_REPLY", {"thread_id": "t1", "body": "hi"}, {"sent": [{"id": "1"}]}),
+        )
+        steps = [
+            FETCH_STEP,
+            {
+                "id": "reply",
+                "tool": "GMAIL_REPLY",
+                "args": {"thread_id": "$steps.fetch.messages.0.threadId", "body": "hi"},
+            },
+        ]
+        with (
+            patch(f"{TOOLS_MODULE}.playbook_repository", store),
+            patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
+            patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_GmailRegistry()),
+        ):
+            result = await write_playbook.ainvoke(
+                {**NEW_ARGS, "steps": steps, "state": state}, config=_config()
+            )
+
+        assert result["success"] is True
+        assert len(store.documents[(WORKFLOW_ID, USER_ID)].steps) == 2
+
+    def test_the_run_state_is_injected_and_never_shown_to_the_model(self) -> None:
+        """``state`` is filled by the graph. If it appeared in the schema the
+        model would be asked to write its own transcript back as an argument,
+        and the checks would read whatever it invented."""
+        schema = write_playbook.tool_call_schema.model_json_schema()
+
+        assert "state" not in schema["properties"]
+        assert schema["required"] == ["description", "steps", "result_brief"]

--- a/apps/api/tests/unit/agents/tools/test_playbook_tools.py
+++ b/apps/api/tests/unit/agents/tools/test_playbook_tools.py
@@ -14,10 +14,13 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 from langchain_core.messages import AIMessage, ToolMessage
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool, tool
+from pydantic import ValidationError
 import pytest
 import yaml
 
 from app.agents.tools.playbook_tools import (
+    _explain_validation_error,
+    _run_results,
     decline_playbook,
     disable_playbook,
     read_playbook,
@@ -1177,11 +1180,11 @@ class TestWritePlaybookBoundary:
         assert schema["$defs"][child_name].get("additionalProperties") is not False
 
     @pytest.mark.parametrize(
-        ("arguments", "expected_location"),
+        ("arguments", "expected_problems"),
         [
             (
                 {"steps": NEW_STEPS, "result_brief": "Say what is on today."},
-                "description",
+                "description: Field required",
             ),
             (
                 {
@@ -1190,17 +1193,21 @@ class TestWritePlaybookBoundary:
                         {"id": "agenda", "tool": "list_events", "handoff": "gmail", "args": {}}
                     ],
                 },
-                "steps[0]",
+                "steps[0]: Value error, step agenda: set exactly one of 'tool' or 'handoff'",
+            ),
+            (
+                {"steps": NEW_STEPS},
+                "description: Field required; result_brief: Field required",
             ),
         ],
-        ids=["missing-description", "both-tool-and-handoff"],
+        ids=["missing-description", "both-tool-and-handoff", "two-problems"],
     )
     async def test_arguments_that_miss_the_schema_come_back_as_a_readable_refusal(
         self,
         store: _FakePlaybookStore,
         workflows: MagicMock,
         arguments: dict[str, Any],
-        expected_location: str,
+        expected_problems: str,
     ) -> None:
         """langchain raises before the coroutine runs, so without the tool's
         ``handle_validation_error`` hook the model gets a framework traceback
@@ -1219,11 +1226,23 @@ class TestWritePlaybookBoundary:
         parsed = json.loads(result)
         assert parsed["success"] is False
         assert parsed["error"] == "invalid_playbook"
-        assert parsed["message"].startswith(
+        assert parsed["message"] == (
             "The playbook was not written. Fix these and call write_playbook again: "
+            + expected_problems
         )
-        assert f"{expected_location}: " in parsed["message"]
         assert store.documents == {}
+
+    def test_a_refusal_with_no_field_to_point_at_names_the_arguments_as_a_whole(self) -> None:
+        """A pydantic error on the call as a whole carries no location. Rendered
+        as the empty string the model reads ": Input should be..." and has
+        nothing to act on; the arguments themselves are what is wrong."""
+        with pytest.raises(ValidationError) as raised:
+            write_playbook.tool_call_schema.model_validate("not a mapping")
+
+        assert json.loads(_explain_validation_error(raised.value))["message"] == (
+            "The playbook was not written. Fix these and call write_playbook again: "
+            "arguments: Input should be a valid dictionary or instance of write_playbook"
+        )
 
 
 @pytest.mark.unit
@@ -1412,3 +1431,97 @@ class TestWritePlaybookAgainstTheAuthoringRun:
 
         assert "state" not in schema["properties"]
         assert schema["required"] == ["description", "steps", "result_brief"]
+
+
+@pytest.mark.unit
+class TestTheRunTheWriteIsCheckedAgainst:
+    """Reading the run out of the graph state: each recorded call paired with
+    the message that answered it. What this drops never reaches the validator,
+    and what it invents is checked against a call that never happened."""
+
+    def test_a_call_is_recorded_with_its_arguments_and_what_came_back(self) -> None:
+        """A tool answering in content blocks rather than a string is the normal
+        shape for several providers. Dropped or blanked, the step it belongs to
+        is refused as "did not run in this run"."""
+        state = {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "GMAIL_FETCH_MESSAGES", "args": {"query": "is:unread"}, "id": "c1"}
+                    ],
+                ),
+                ToolMessage(
+                    content=[
+                        {"type": "text", "text": "one", "at": datetime(2026, 9, 1, tzinfo=UTC)}
+                    ],
+                    tool_call_id="c1",
+                ),
+            ]
+        }
+
+        results = _run_results(state)
+
+        assert [recorded.tool_name for recorded in results] == ["GMAIL_FETCH_MESSAGES"]
+        assert results[0].args == {"query": "is:unread"}
+        assert results[0].result == [
+            {"type": "text", "text": "one", "at": "2026-09-01 00:00:00+00:00"}
+        ]
+
+    def test_a_call_with_no_tool_name_is_not_a_call_a_step_could_have_frozen(self) -> None:
+        """A nameless call matches no step's tool. Kept, it becomes a recorded
+        result under a name no playbook can ever address."""
+        state = {
+            "messages": [
+                AIMessage(content="", tool_calls=[{"name": "", "args": {}, "id": "c1"}]),
+                ToolMessage(content=json.dumps({"ok": True}), tool_call_id="c1"),
+            ]
+        }
+
+        assert _run_results(state) == []
+
+    def test_a_call_still_in_flight_is_skipped_and_the_ones_beside_it_are_kept(self) -> None:
+        """``write_playbook`` itself is unanswered in every real run. Stopping at
+        it throws away the calls the playbook is being written from."""
+        state = {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "write_playbook", "args": {}, "id": "c0"},
+                        {
+                            "name": "GMAIL_FETCH_MESSAGES",
+                            "args": {"query": "is:unread"},
+                            "id": "c1",
+                        },
+                    ],
+                ),
+                ToolMessage(content=json.dumps({"messages": [{"id": "m1"}]}), tool_call_id="c1"),
+            ]
+        }
+
+        results = _run_results(state)
+
+        assert [recorded.tool_name for recorded in results] == ["GMAIL_FETCH_MESSAGES"]
+
+    async def test_a_write_records_how_many_of_the_runs_calls_it_was_checked_against(
+        self, store: _FakePlaybookStore, workflows: MagicMock
+    ) -> None:
+        """``None`` and ``0`` are different answers — no graph state reached the
+        tool at all, versus a run that genuinely made no calls — and this count
+        is the only field that tells them apart in production."""
+        state = _run_state(
+            ("GMAIL_FETCH_MESSAGES", {"query": "is:unread"}, {"messages": [{"id": "m1"}]}),
+            ("GMAIL_REPLY", {"thread_id": "t1", "body": "hi"}, {"sent": [{"id": "1"}]}),
+        )
+        with (
+            patch(f"{TOOLS_MODULE}.playbook_repository", store),
+            patch(f"{TOOLS_MODULE}.workflow_repository", workflows),
+            patch(f"{PARSER_MODULE}.get_tool_registry", return_value=_GmailRegistry()),
+            patch(f"{TOOLS_MODULE}.log") as log,
+        ):
+            await write_playbook.ainvoke(
+                {**NEW_ARGS, "steps": [FETCH_STEP], "state": state}, config=_config()
+            )
+
+        assert log.set_ns.call_args_list[0] == call("playbook", checked_against_calls=2)

--- a/apps/api/tests/unit/db/repositories/test_playbooks.py
+++ b/apps/api/tests/unit/db/repositories/test_playbooks.py
@@ -38,7 +38,7 @@ def _doc(**overrides: Any) -> PlaybookDocument:
         "workflow_hash": "hash-1",
         "description": "first",
         "steps": [{"id": "one", "tool": "list_events", "args": {"calendar_id": "primary"}}],
-        "synthesize": "s",
+        "result_brief": "s",
         "created_at": NOW,
         "updated_at": NOW,
     }
@@ -166,8 +166,7 @@ class TestUpsertForWorkflow:
         assert [step["tool"] for step in set_fields.pop("steps")] == ["list_events"]
         assert set_fields == {
             "description": "first",
-            "ask": {},
-            "synthesize": "s",
+            "result_brief": "s",
             "workflow_hash": "hash-1",
             "last_run_status": PlaybookRunStatus.NOT_RUN,
             "last_run_reason": None,

--- a/apps/api/tests/unit/models/test_playbook_models.py
+++ b/apps/api/tests/unit/models/test_playbook_models.py
@@ -1,0 +1,186 @@
+"""Unit tests for `app.models.playbook_models` — the inline `$ask` slot.
+
+The slot key is the address a written value is looked up by: the runner lists
+it to the model that fills it and the evaluator substitutes by it, so a key
+derived differently on either side is a hole reaching a real tool. The input
+models are the tool boundary, lenient where a stray key is harmless and strict
+exactly where silence would store less than the author wrote.
+"""
+
+from typing import Any
+
+from pydantic import ValidationError
+import pytest
+
+from app.models.playbook_models import (
+    DEFAULT_ASK_MAX_TOKENS,
+    AskSlot,
+    PlaybookHandoffStepInput,
+    PlaybookStep,
+    PlaybookStepInput,
+    ask_slots,
+)
+
+
+class TestAskSlotKeys:
+    """The key one slot answers to.
+
+    The runner lists these keys to the model that writes the values and the
+    evaluator substitutes by the same key. A key derived differently on either
+    side is a slot that is written and never substituted, so the raw slot dict
+    reaches a real tool.
+    """
+
+    def test_a_nested_argument_path_is_spelled_out_from_the_step_id(self) -> None:
+        steps = [
+            PlaybookStep(
+                id="send",
+                tool="send_mail",
+                args={"body": [{"text": {"$ask": "the opening line"}}]},
+            )
+        ]
+
+        located = ask_slots(steps)
+
+        assert [item.key for item in located] == ["send.body.0.text"]
+        assert located[0].slot.prompt == "the opening line"
+
+    def test_a_step_without_an_id_is_addressed_by_its_tool_name(self) -> None:
+        steps = [
+            PlaybookStep(tool="web_search_tool", args={"query_text": {"$ask": "what to look up"}})
+        ]
+
+        assert [item.key for item in ask_slots(steps)] == ["web_search_tool.query_text"]
+
+    def test_a_slot_inside_a_handoff_child_is_keyed_by_the_child_not_the_handoff(self) -> None:
+        """A handoff's children are what actually call tools, and the evaluator
+        fills args per child step. Keying by the handoff would look the value up
+        under a prefix no step ever passes."""
+        steps = [
+            PlaybookStep(
+                id="mail",
+                handoff="gmail",
+                steps=[
+                    PlaybookStep(
+                        id="fetch",
+                        tool="GMAIL_FETCH_MESSAGES",
+                        args={"query": {"$ask": "what to search the inbox for"}},
+                    )
+                ],
+            )
+        ]
+
+        located = ask_slots(steps)
+
+        assert [item.key for item in located] == ["fetch.query"]
+
+    def test_slots_come_back_in_execution_order(self) -> None:
+        steps = [
+            PlaybookStep(id="first", tool="a", args={"x": {"$ask": "one"}}),
+            PlaybookStep(
+                id="handed",
+                handoff="gmail",
+                steps=[PlaybookStep(id="second", tool="b", args={"y": {"$ask": "two"}})],
+            ),
+            PlaybookStep(id="third", tool="c", args={"z": {"$ask": "three"}}),
+        ]
+
+        assert [item.key for item in ask_slots(steps)] == ["first.x", "second.y", "third.z"]
+
+
+class TestPlaybookStepInput:
+    def test_unknown_keys_are_dropped_instead_of_refusing_the_write(self) -> None:
+        """17 of 57 production authoring attempts were thrown away whole for a
+        ``goal`` beside an otherwise correct call."""
+        step = PlaybookStepInput.model_validate(
+            {"id": "agenda", "tool": "list_events", "goal": "read", "note": "daily"}
+        )
+
+        assert step.to_step().model_dump(exclude_defaults=True) == {
+            "id": "agenda",
+            "tool": "list_events",
+        }
+
+    @pytest.mark.parametrize(
+        "step",
+        [
+            {"id": "agenda", "tool": "list_events", "handoff": "gmail"},
+            {"id": "agenda"},
+        ],
+        ids=["both", "neither"],
+    )
+    def test_a_node_is_a_tool_call_or_a_handoff_and_never_both_or_neither(
+        self, step: dict[str, Any]
+    ) -> None:
+        """The one rule still worth failing a write over: a malformed node means
+        the runner would silently skip a step instead of running it."""
+        with pytest.raises(ValidationError, match="exactly one of"):
+            PlaybookStepInput.model_validate(step)
+
+
+class TestPlaybookHandoffStepInput:
+    @pytest.mark.parametrize(
+        ("child", "named"),
+        [
+            (
+                {"id": "mail", "tool": "list_events", "steps": [{"id": "x", "tool": "y"}]},
+                "steps",
+            ),
+            ({"id": "mail", "tool": "list_events", "handoff": "todos"}, "handoff"),
+            (
+                {"id": "mail", "tool": "list_events", "handoff": "todos", "steps": []},
+                "handoff or steps",
+            ),
+        ],
+        ids=["steps", "handoff", "both"],
+    )
+    def test_a_child_that_nests_a_level_deeper_is_refused_by_name(
+        self, child: dict[str, Any], named: str
+    ) -> None:
+        """The child model drops unknown keys, and ``steps``/``handoff`` ARE
+        unknown to it. Without this rule a grandchild delegation is discarded
+        silently and the stored playbook runs less than the author wrote while
+        reporting success. The message has to name which key, or the author
+        cannot tell nesting from a typo."""
+        with pytest.raises(ValidationError, match=f"cannot carry {named}"):
+            PlaybookHandoffStepInput.model_validate(child)
+
+    def test_a_stray_annotation_on_a_child_is_still_dropped(self) -> None:
+        """The refusal above is exactly two keys wide: a ``goal`` on a child is
+        the same harmless annotation it is on a top-level step."""
+        child = PlaybookHandoffStepInput.model_validate(
+            {"id": "mail", "tool": "list_events", "goal": "read the agenda"}
+        )
+
+        assert child.to_step().model_dump(exclude_defaults=True) == {
+            "id": "mail",
+            "tool": "list_events",
+        }
+
+
+class TestAskSlot:
+    def test_the_prompt_is_read_from_the_dollar_ask_key(self) -> None:
+        assert AskSlot.model_validate({"$ask": "what to write"}).prompt == "what to write"
+        assert AskSlot.model_validate({"$ask": "what to write"}).max_tokens == (
+            DEFAULT_ASK_MAX_TOKENS
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            {"$ask": "what to write", "uses": ["agenda"]},
+            {"$ask": "what to write", "prompt": "again"},
+            {"$ask": ""},
+            {"$ask": "what to write", "max_tokens": 0},
+            {"$ask": "what to write", "max_tokens": 8193},
+        ],
+        ids=["legacy-uses", "aliased-name", "empty-prompt", "zero-budget", "over-budget"],
+    )
+    def test_a_slot_that_is_not_exactly_a_prompt_and_a_budget_is_refused(
+        self, value: dict[str, Any]
+    ) -> None:
+        """The parser reports a bad slot to the author from this failure, and
+        the budget bound is what keeps one replay from turning into an unbounded
+        generation — the whole point of freezing a sequence is a bounded cost."""
+        with pytest.raises(ValidationError):
+            AskSlot.model_validate(value)

--- a/apps/api/tests/unit/models/test_playbook_models.py
+++ b/apps/api/tests/unit/models/test_playbook_models.py
@@ -74,6 +74,18 @@ class TestAskSlotKeys:
 
         assert [item.key for item in located] == ["fetch.query"]
 
+    def test_a_step_with_neither_a_name_nor_a_tool_is_keyed_by_its_path_alone(self) -> None:
+        """``exactly_one_shape`` forbids this step, so it only exists if one is
+        conjured past validation (``model_construct``) — a stored document read
+        back, say. The prefix then falls back to nothing, and the key is the
+        argument path on its own; anything else spells a step name that no step
+        answers to, and the written text is never substituted."""
+        shapeless = PlaybookStep.model_construct(
+            id="", tool=None, handoff=None, steps=[], args={"query": {"$ask": "what to look up"}}
+        )
+
+        assert [item.key for item in ask_slots([shapeless])] == [".query"]
+
     def test_slots_come_back_in_execution_order(self) -> None:
         steps = [
             PlaybookStep(id="first", tool="a", args={"x": {"$ask": "one"}}),
@@ -142,8 +154,13 @@ class TestPlaybookHandoffStepInput:
         silently and the stored playbook runs less than the author wrote while
         reporting success. The message has to name which key, or the author
         cannot tell nesting from a typo."""
-        with pytest.raises(ValidationError, match=f"cannot carry {named}"):
+        with pytest.raises(ValidationError) as raised:
             PlaybookHandoffStepInput.model_validate(child)
+
+        assert (
+            f"a handoff's child is one tool call and cannot carry {named}: playbooks are "
+            "one level deep, so list the calls that subagent made as the handoff's own steps"
+        ) in str(raised.value)
 
     def test_a_stray_annotation_on_a_child_is_still_dropped(self) -> None:
         """The refusal above is exactly two keys wide: a ``goal`` on a child is
@@ -156,6 +173,52 @@ class TestPlaybookHandoffStepInput:
             "id": "mail",
             "tool": "list_events",
         }
+
+
+class TestArgsSpelledRight:
+    """``args`` under another name is dropped as unknown, and the step then
+    stores a call with no arguments at all while reporting a successful write."""
+
+    @pytest.mark.parametrize(
+        "near_miss",
+        ["arguments", "input", "inputs", "params", "parameters", "kwargs"],
+    )
+    @pytest.mark.parametrize(
+        "model",
+        [PlaybookStepInput, PlaybookHandoffStepInput],
+        ids=["top-level", "handoff-child"],
+    )
+    def test_arguments_under_another_name_are_refused_by_that_name(
+        self, model: type[PlaybookStepInput] | type[PlaybookHandoffStepInput], near_miss: str
+    ) -> None:
+        with pytest.raises(ValidationError) as raised:
+            model.model_validate({"id": "mail", "tool": "send_email", near_miss: {"to": "a@b.com"}})
+
+        assert f"a step's arguments go under 'args', not {near_miss!r}; rename it" in str(
+            raised.value
+        )
+
+    @pytest.mark.parametrize(
+        "model",
+        [PlaybookStepInput, PlaybookHandoffStepInput],
+        ids=["top-level", "handoff-child"],
+    )
+    def test_a_stray_alias_beside_real_args_is_dropped_not_refused(
+        self, model: type[PlaybookStepInput] | type[PlaybookHandoffStepInput]
+    ) -> None:
+        """The refusal is about arguments going missing. With ``args`` present
+        nothing is lost, so the extra key is the same harmless annotation any
+        other unknown key is."""
+        step = model.model_validate(
+            {
+                "id": "mail",
+                "tool": "send_email",
+                "args": {"to": "a@b.com"},
+                "arguments": {"to": "z@z.com"},
+            }
+        )
+
+        assert step.args == {"to": "a@b.com"}
 
 
 class TestAskSlot:

--- a/apps/api/tests/unit/models/test_workflow_models.py
+++ b/apps/api/tests/unit/models/test_workflow_models.py
@@ -7,7 +7,13 @@ in test_timezone.py / test_cron_utils.py; here we assert the composition.
 
 from datetime import UTC, datetime
 
-from app.models.workflow_models import TriggerConfig, TriggerType
+from app.models.workflow_models import (
+    PlaybookDiscard,
+    TriggerConfig,
+    TriggerType,
+    WorkflowDocument,
+    WorkflowUpdate,
+)
 
 BASE = datetime(2025, 1, 1, 0, 0, tzinfo=UTC)  # midnight UTC
 
@@ -71,3 +77,47 @@ class TestTriggerConfigUpdateNextRun:
         tc.update_next_run(base_time=BASE)
         # Same base + zone => same next_run => no change on the second call.
         assert tc.update_next_run(base_time=BASE) is False
+
+
+def _stored_workflow(**overrides: object) -> WorkflowDocument:
+    return WorkflowDocument(
+        id="wf_1",
+        user_id="u_1",
+        title="Daily agenda",
+        steps=[],
+        trigger_config=TriggerConfig(type=TriggerType.MANUAL),
+        **overrides,
+    )
+
+
+class TestThePlaybookDiscardAWorkflowRemembers:
+    """The discard record is the only durable answer to "where did my shortcut
+    go" — the worker's warning line ages out of log retention long before the
+    question is asked."""
+
+    DISCARD = PlaybookDiscard(
+        playbook_id="pb_1",
+        revision=3,
+        reason="suspect_streak_exhausted",
+        at=datetime(2025, 6, 1, 12, 0, tzinfo=UTC),
+        details={"suspect_streak": "3"},
+    )
+
+    def test_it_survives_the_round_trip_through_a_stored_workflow(self) -> None:
+        stored = _stored_workflow(last_playbook_discard=self.DISCARD)
+
+        restored = WorkflowDocument.model_validate(stored.model_dump())
+
+        assert restored.last_playbook_discard == self.DISCARD
+
+    def test_a_workflow_that_never_lost_one_says_nothing(self) -> None:
+        assert _stored_workflow().last_playbook_discard is None
+
+    def test_the_update_carries_it_as_a_set_field(self) -> None:
+        """``$set`` is built from the fields the caller actually set, so a discard
+        written through anything but this field never reaches Mongo."""
+        update = WorkflowUpdate(last_playbook_discard=self.DISCARD)
+
+        assert update.model_dump(exclude_unset=True) == {
+            "last_playbook_discard": self.DISCARD.model_dump()
+        }

--- a/apps/api/tests/unit/services/workflow/test_playbook_check.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_check.py
@@ -24,6 +24,7 @@ from app.agents.prompts.playbook_prompts import (
     PLAYBOOK_HEAL_ALREADY_RAN,
     PLAYBOOK_HEAL_BRIEF,
     PLAYBOOK_HEAL_NO_REASON,
+    PLAYBOOK_NARRATION_PROMPT,
     PLAYBOOK_SUSPECT_FALLBACK_TEMPLATE,
 )
 from app.agents.tools.playbook_tools import write_playbook
@@ -82,7 +83,7 @@ def _playbook(status: PlaybookRunStatus, reason: str | None = None) -> PlaybookD
         workflow_hash="h",
         description="d",
         steps=[PlaybookStep(id="s1", tool="create_todo", args={})],
-        synthesize="s",
+        result_brief="s",
         last_run_status=status,
         last_run_reason=reason,
         created_at=now,
@@ -425,14 +426,59 @@ def test_the_check_names_both_decision_tools_so_the_executor_can_act():
 def test_the_check_asks_whether_every_frozen_call_actually_returned_the_data():
     # Regression: a playbook froze a call that came back empty, because the
     # agent had reasoned around the gap and the sequence still "worked". The
-    # sixth question makes an empty, errored or partial result a reason to fix
-    # the args or decline, and the decision rule has to read against it.
-    assert "6." in PLAYBOOK_CHECK_BRIEF
-    assert "these six" in PLAYBOOK_CHECK_BRIEF
+    # last question makes an empty, errored or partial result a reason to fix
+    # the args or decline, and the decision rule has to read against it. The
+    # numbering moved when the old ask question was dropped, so the rule and the
+    # question it names have to be re-pinned together.
+    assert "5." in PLAYBOOK_CHECK_BRIEF
+    assert "these five" in PLAYBOOK_CHECK_BRIEF
     assert "came back empty, with an error, or partial" in PLAYBOOK_CHECK_BRIEF
-    assert "If 5 and 6 are both yes, call write_playbook" in PLAYBOOK_CHECK_BRIEF
-    assert "If either 5 or 6 is no, call decline_playbook" in PLAYBOOK_CHECK_BRIEF
+    assert "If 4 and 5 are both yes, call write_playbook" in PLAYBOOK_CHECK_BRIEF
+    assert "If either 4 or 5 is no, call decline_playbook" in PLAYBOOK_CHECK_BRIEF
     assert "exactly one of write_playbook or decline_playbook" in PLAYBOOK_CHECK_BRIEF
+    # Six questions would mean the deleted ask question came back.
+    assert "6." not in PLAYBOOK_CHECK_BRIEF
+
+
+def test_the_narration_is_told_the_result_is_final_text_written_once():
+    """Seen on a live replay: the narration wrote a draft, then "hmm, the brief
+    is strict about exactly 3 bullets. Let me redo:", then the rewrite — all
+    inside the ``result`` field, which is delivered to the user verbatim. The
+    structured output cannot separate a draft from the answer, so the prompt
+    has to forbid the draft. If this fails, that self-talk ships again."""
+    rendered = PLAYBOOK_NARRATION_PROMPT.format(
+        description="d", completed="c", asks="none", result_brief="three bullets"
+    )
+    assert "written once" in rendered
+    assert "Never a draft followed by a rewrite" in rendered
+    assert "hand back only the final version" in rendered
+
+
+def test_the_check_teaches_the_inline_ask_slot_and_no_ask_section():
+    """The slot is only reachable if the placeholder question names it.
+
+    An ask used to be a top-level table, and five of the eight ever written in
+    production were referenced by no step at all — declared, filled by a model
+    call, thrown away. If this fails, the brief is either teaching the dead
+    section again or has stopped teaching the slot, and the model has nowhere to
+    put a value it genuinely cannot freeze.
+    """
+    assert '{"$ask":' in PLAYBOOK_CHECK_BRIEF
+    assert "cannot be frozen or built from" in PLAYBOOK_CHECK_BRIEF
+    assert "synthesize" not in PLAYBOOK_CHECK_BRIEF
+    assert "ask entry" not in PLAYBOOK_CHECK_BRIEF
+
+
+def test_the_check_shows_a_literal_example_of_the_shape_it_asks_for():
+    """Prose about the shape is what the schema already says; the example is
+    what shows a handoff carrying its child, a slot sitting inside an argument,
+    and the result_brief at the end. If it goes missing the model is back to
+    inferring the layout from a sentence, which is how the 63% rejection rate
+    happened."""
+    assert "result_brief:" in PLAYBOOK_CHECK_BRIEF
+    assert "GMAIL_FETCH_MESSAGES" in PLAYBOOK_CHECK_BRIEF
+    assert "handoff: gmail" in PLAYBOOK_CHECK_BRIEF
+    assert "tool: web_search_tool" in PLAYBOOK_CHECK_BRIEF
 
 
 def test_the_heal_brief_names_the_tools_the_executor_needs():
@@ -488,7 +534,7 @@ def test_the_tools_own_schema_carries_the_step_shape():
     """
     schema = write_playbook.tool_call_schema.model_json_schema()
 
-    assert {"description", "steps", "synthesize", "ask"} <= set(schema["properties"])
+    assert {"description", "steps", "result_brief"} == set(schema["properties"])
     # The workflow is resolved from the run's config server-side. Exposing it as
     # an argument is what let a live run hallucinate "inbox-triage" as an id.
     assert "workflow_id" not in schema["properties"]
@@ -502,7 +548,13 @@ def test_the_tools_own_schema_carries_the_step_shape():
     # no self-$ref for a provider to mishandle.
     assert "steps" not in child["properties"]
 
-    with pytest.raises(ValidationError, match="goal"):
+    # A key the schema never asked for is dropped, not refused: the shape rule
+    # is the only thing worth failing a write over.
+    step_input = PlaybookStepInput.model_validate(
+        {"id": "agenda", "tool": "list_events", "goal": "read the events"}
+    )
+    assert not hasattr(step_input, "goal")
+    with pytest.raises(ValidationError, match="exactly one of"):
         PlaybookStepInput.model_validate({"id": "agenda", "goal": "read the events"})
 
 
@@ -542,7 +594,7 @@ def _frozen(*tools: str, handoff: str | None = None) -> PlaybookDocument:
         workflow_hash="h",
         description="triage",
         steps=steps,
-        synthesize="say",
+        result_brief="say",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
     )

--- a/apps/api/tests/unit/services/workflow/test_playbook_evaluator.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_evaluator.py
@@ -379,6 +379,12 @@ def test_a_slot_that_reached_resolution_unfilled_stops_the_run() -> None:
         resolve_value({"$ask": "Write a subject line"}, _context())
     _assert_actionable(caught.value, "$ask")
     assert caught.value.message == "an $ask slot was not filled before resolution"
+    # The whole triple: this is a bug in the run's own order, and the two lines
+    # that say which order was skipped are the only thing pointing at it.
+    assert caught.value.why == (
+        "the run resolved this step's arguments without first filling its ask slots"
+    )
+    assert caught.value.fix == "fill the step's ask slots before resolving its arguments"
 
 
 def test_dollar_ask_in_a_string_is_literal_text_not_a_placeholder() -> None:

--- a/apps/api/tests/unit/services/workflow/test_playbook_evaluator.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_evaluator.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.models.playbook_models import ask_slot_key
 from app.models.workflow_execution_models import RECORD_CUT_MARKER, RecordedCall
 from app.services.workflow.playbook.evaluator import (
     PlaceholderError,
@@ -19,6 +20,7 @@ from app.services.workflow.playbook.evaluator import (
     RunContext,
     StepResult,
     _resolve_time,
+    fill_ask_slots,
     last_run_index,
     resolve_args,
     resolve_value,
@@ -111,9 +113,16 @@ def test_steps_resolve_by_id_and_by_file() -> None:
     assert resolve_value("$steps.inbox.file", context) == "/workspace/inbox.json"
 
 
-def test_ask_resolves_the_text_the_model_wrote() -> None:
-    context = _context(asks={"body": "Here is your morning digest."})
-    assert resolve_value("$ask.body", context) == "Here is your morning digest."
+def test_fill_ask_slots_substitutes_the_text_the_model_wrote_by_key() -> None:
+    """A slot is addressed by its step and its argument path, and comes out as
+    the plain text the ask call wrote. Substituting under any other key would
+    leave the slot's dict standing where a tool argument belongs."""
+    filled = fill_ask_slots(
+        {"to": "a@b.com", "subject": {"$ask": "Write a subject line"}},
+        {"mail.subject": "Here is your morning digest."},
+        key_prefix="mail",
+    )
+    assert filled == {"to": "a@b.com", "subject": "Here is your morning digest."}
 
 
 def test_last_run_resolves_a_cursor_from_the_previous_run() -> None:
@@ -330,14 +339,56 @@ def test_unknown_user_field_is_rejected_and_names_the_real_ones() -> None:
     assert caught.value.fix == "address one of those fields"
 
 
-def test_missing_ask_names_the_placeholder() -> None:
-    """An ask the model never wrote must stop the run by name, not send an empty string."""
+def test_a_slot_the_ask_call_never_wrote_stops_the_run_by_its_key() -> None:
+    """A slot the model never wrote must stop the run naming the key it was
+    listed under, not send the slot's dict or an empty string to the tool."""
     with pytest.raises(PlaceholderError) as caught:
-        resolve_value("$ask.body", _context(asks={"subject": "hi"}))
-    _assert_actionable(caught.value, "$ask.body")
-    assert caught.value.message == "$ask.body was never written"
-    assert caught.value.why == "the run's one model call produced no text for that ask"
-    assert caught.value.fix == "declare the ask in the playbook, or stop addressing it"
+        fill_ask_slots(
+            {"subject": {"$ask": "Write a subject line"}},
+            {"mail.body": "hi"},
+            key_prefix="mail",
+        )
+    _assert_actionable(caught.value, "mail.subject")
+    assert caught.value.message == "mail.subject was never written"
+    assert caught.value.why == "the run's ask call produced no text for that slot"
+    assert caught.value.fix == (
+        "write one entry per slot listed, keyed exactly as the slot is listed"
+    )
+
+
+def test_fill_ask_slots_reaches_a_slot_nested_in_a_list_inside_a_dict() -> None:
+    """Slots hide wherever an argument nests, and the key spells the whole path.
+
+    Filling only top-level arguments would leave the raw ``{"$ask": ...}`` dict
+    inside a structured payload, and the tool would receive it as data.
+    """
+    args = {"message": {"blocks": [{"text": {"$ask": "Write the digest body"}}]}}
+    key = ask_slot_key("send", ("message", "blocks", 0, "text"))
+    assert key == "send.message.blocks.0.text"
+
+    filled = fill_ask_slots(args, {key: "Three meetings today."}, key_prefix="send")
+
+    assert filled == {"message": {"blocks": [{"text": "Three meetings today."}]}}
+
+
+def test_a_slot_that_reached_resolution_unfilled_stops_the_run() -> None:
+    """``fill_ask_slots`` runs before ``resolve_args`` and leaves none behind, so
+    a slot met here means the step was resolved without being filled. Passing
+    the slot's dict through would send a tool ``{"$ask": ...}`` as an argument."""
+    with pytest.raises(PlaceholderError) as caught:
+        resolve_value({"$ask": "Write a subject line"}, _context())
+    _assert_actionable(caught.value, "$ask")
+    assert caught.value.message == "an $ask slot was not filled before resolution"
+
+
+def test_dollar_ask_in_a_string_is_literal_text_not_a_placeholder() -> None:
+    """``$ask`` left the placeholder vocabulary when asks moved inline: a slot is
+    a value, not a reference into a table. Resolving ``$ask.body`` as a token
+    again would either raise on a perfectly good literal or substitute text
+    where the author wrote characters."""
+    context = _context(asks={"mail.body": "Here is your digest."})
+    assert resolve_value("$ask.body", context) == "$ask.body"
+    assert resolve_value("Sent $ask.body today", context) == "Sent $ask.body today"
 
 
 def test_a_step_placeholder_with_no_field_resolves_to_the_whole_result() -> None:

--- a/apps/api/tests/unit/services/workflow/test_playbook_parser.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_parser.py
@@ -1990,6 +1990,107 @@ result_brief: x
             "$steps.agenda.threadId is not in step 'agenda''s result" + expected_hint
         ]
 
+    async def test_an_unknown_arg_is_answered_with_the_tools_whole_arg_list(self) -> None:
+        """The list is what the author rewrites from, so it has to be the real
+        one: every arg, sorted, comma-separated. A one-arg tool cannot show the
+        separator, which is how a broken join went unnoticed."""
+        body = _body(
+            """
+description: A misspelt recipient field
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+      recipient: c@d.com
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            (
+                "steps[0].args.recipient",
+                "send_email takes no arg 'recipient'; it takes: retries, subject, to",
+            )
+        ]
+
+    async def test_a_call_the_run_made_once_cannot_be_frozen_twice(self) -> None:
+        """Two steps with one tool and the same args both matched the single
+        recorded call, and the replay then sent the mail twice for a run that
+        sent it once. The second step must be refused, and the message must say
+        how many times the tool really ran so the author can tell a duplicate
+        from a call that was dropped from the record."""
+        body = _body(
+            """
+description: The same mail, listed twice
+steps:
+  - id: first
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+  - id: again
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [_call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "1"}]})]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            (
+                "steps[1]",
+                "send_email ran 1 time(s) in this run and earlier steps froze every one of "
+                "them; a step cannot replay a call the run did not make — drop this step, "
+                "or run it again",
+            )
+        ]
+
+    async def test_a_tool_the_run_called_twice_can_be_frozen_twice(self) -> None:
+        """The refusal above is about cardinality, not repetition: a run that
+        genuinely made the call twice left two records, and two steps may each
+        take one. A third step has nothing left and says so with the count."""
+        body = _body(
+            """
+description: Two mails, then one too many
+steps:
+  - id: first
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+  - id: second
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+  - id: third
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [
+            _call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "1"}]}),
+            _call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "2"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[2]"]
+        assert result.issues[0].problem.startswith("send_email ran 2 time(s) in this run")
+
     async def test_a_reference_deeper_than_one_field_is_still_read_from_its_step(self) -> None:
         """``$steps.agenda.organizer.email`` names the step ``agenda`` and the
         path ``organizer.email``. Split from the other end the step is called

--- a/apps/api/tests/unit/services/workflow/test_playbook_parser.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_parser.py
@@ -2054,6 +2054,37 @@ result_brief: x
             )
         ]
 
+    async def test_a_handoff_child_never_takes_a_top_level_call_of_the_same_tool(self) -> None:
+        """The run's results hold nothing for a subagent's calls (the handoff
+        record carries their args, not their outputs), so a child is not matched
+        at all. Matching it anyway let a child consume the one recorded top-level
+        call of the same tool, and the real top-level step behind it was refused
+        as a call the run never made."""
+        body = _body(
+            """
+description: The subagent listed events, then the executor did too
+steps:
+  - id: delegated
+    handoff: calendar_agent
+    steps:
+      - id: theirs
+        tool: list_events
+        args:
+          calendar_id: primary
+  - id: mine
+    tool: list_events
+    args:
+      calendar_id: primary
+result_brief: x
+"""
+        )
+        results = [_call("list_events", {"calendar_id": "primary"}, {"events": [{"id": "e1"}]})]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()), _handoff_space():
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
     async def test_a_tool_the_run_called_twice_can_be_frozen_twice(self) -> None:
         """The refusal above is about cardinality, not repetition: a run that
         genuinely made the call twice left two records, and two steps may each

--- a/apps/api/tests/unit/services/workflow/test_playbook_parser.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_parser.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any
 from unittest.mock import AsyncMock, call, patch
 
 from langchain_core.tools import BaseTool, tool
-from pydantic import Field, ValidationError
+from pydantic import Field, ValidationError, v1
 import pytest
 import yaml
 
@@ -1342,6 +1342,69 @@ result_brief: x
 
         assert result.issues == []
 
+    @pytest.mark.parametrize(
+        "tool_kind",
+        ["json-document", "pydantic-v1"],
+    )
+    async def test_a_required_arg_is_read_from_every_schema_shape_langchain_hands_back(
+        self, tool_kind: str
+    ) -> None:
+        """Decorated tools carry a v2 model, MCP tools a raw JSON document and
+        legacy tools a v1 model. ``required`` is spelled the same way on all
+        three, but each is read through a different branch, and a branch that
+        reads nothing would quietly stop refusing calls that cannot run."""
+
+        class _JsonExec(BaseTool):
+            name: str = "run_query"
+            description: str = "Run a query"
+
+            def _run(self, **kwargs: Any) -> dict[str, Any]:
+                return {}
+
+        json_document: dict[str, Any] = {
+            "type": "object",
+            "properties": {"code": {"type": "string"}, "lang": {"type": "string"}},
+            "required": ["code"],
+        }
+
+        class _LegacyArgs(v1.BaseModel):
+            code: str
+            lang: str = ""
+
+        class _LegacyExec(BaseTool):
+            name: str = "run_query"
+            description: str = "Run a query"
+            args_schema: type[v1.BaseModel] = _LegacyArgs
+
+            def _run(self, **kwargs: Any) -> dict[str, Any]:
+                return {}
+
+        exec_tool: BaseTool = (
+            _JsonExec(args_schema=json_document) if tool_kind == "json-document" else _LegacyExec()
+        )
+        body = _body(
+            """
+description: Run a query with only the optional argument
+steps:
+  - id: query
+    tool: run_query
+    args:
+      lang: sql
+result_brief: x
+"""
+        )
+        with patch(
+            f"{MODULE}.get_tool_registry", return_value=_FakeRegistry({"run_query": exec_tool})
+        ):
+            result = await validate_playbook(body, USER_ID)
+
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            (
+                "steps[0].args",
+                "run_query requires 'code' and this step does not set it; it takes: code, lang",
+            )
+        ]
+
     async def test_a_deep_step_reference_resolves_against_the_step_id(self) -> None:
         """``$steps.agenda.organizer.email`` names step ``agenda``, not
         ``agenda.organizer``. Splitting from the wrong end rejects a playbook
@@ -1883,6 +1946,49 @@ result_brief: x
             "$steps.agenda.threadId is not in step 'agenda''s result"
             "; its result has keys: messages, nextPage"
         )
+
+    @pytest.mark.parametrize(
+        ("key_count", "expected_hint"),
+        [
+            (12, "; its result has keys: " + ", ".join(f"k{i:02d}" for i in range(12))),
+            (13, "; its result has keys: " + ", ".join(f"k{i:02d}" for i in range(12)) + ", ..."),
+        ],
+        ids=["exactly-the-cap", "one-over-the-cap"],
+    )
+    async def test_the_keys_hint_lists_up_to_the_cap_and_marks_the_rest(
+        self, key_count: int, expected_hint: str
+    ) -> None:
+        """A wide result must not bury the sentence that says what is wrong, so
+        the hint stops at the cap and says there is more. Exactly at the cap
+        there is nothing more to say, and the marker must not appear."""
+        body = _body(
+            """
+description: Reply on a field that does not exist
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+  - id: mail
+    tool: send_email
+    args:
+      to: $steps.agenda.threadId
+      subject: hi
+result_brief: x
+"""
+        )
+        wide = {f"k{i:02d}": i for i in range(key_count)}
+        results = [
+            _call("list_events", {"calendar_id": "primary"}, wide),
+            _call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "1"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.problem for issue in result.issues] == [
+            "$steps.agenda.threadId is not in step 'agenda''s result" + expected_hint
+        ]
 
     async def test_a_reference_deeper_than_one_field_is_still_read_from_its_step(self) -> None:
         """``$steps.agenda.organizer.email`` names the step ``agenda`` and the

--- a/apps/api/tests/unit/services/workflow/test_playbook_parser.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_parser.py
@@ -19,7 +19,6 @@ import yaml
 from app.agents.core.subagents.call_record import ARG_TRUNCATION_MARKER
 from app.models.mcp_config import SubAgentConfig
 from app.models.playbook_models import (
-    PlaybookAsk,
     PlaybookBody,
     PlaybookHandoffStepInput,
     PlaybookStep,
@@ -27,7 +26,11 @@ from app.models.playbook_models import (
     playbook_body_from_input,
 )
 from app.models.subagent_models import Subagent
-from app.services.workflow.playbook.parser import dump_playbook, validate_playbook
+from app.services.workflow.playbook.parser import (
+    RecordedResult,
+    dump_playbook,
+    validate_playbook,
+)
 from app.services.workflow.playbook.tool_space import SubagentTools
 
 MODULE = "app.services.workflow.playbook.parser"
@@ -117,13 +120,10 @@ steps:
     tool: send_email
     args:
       to: $user.email
-      subject: Agenda for $today
+      subject:
+        $ask: Write the agenda as a short note
       retries: 2
-ask:
-  body:
-    prompt: Write the agenda as a short note
-    uses: [agenda]
-synthesize: Say what was sent.
+result_brief: Say what was sent.
 """
 
 
@@ -190,7 +190,7 @@ class TestPlaybookGrammar:
                             "steps": [{"id": "inner", "tool": "send_email"}],
                         }
                     ],
-                    "synthesize": "x",
+                    "result_brief": "x",
                 }
             )
         assert "both_shapes" in str(exc.value)
@@ -201,7 +201,7 @@ class TestPlaybookGrammar:
                 {
                     "description": "Empty handoff",
                     "steps": [{"id": "delegate", "handoff": "mail_agent"}],
-                    "synthesize": "x",
+                    "result_brief": "x",
                 }
             )
         assert "mail_agent" in str(exc.value)
@@ -213,7 +213,7 @@ class TestPlaybookGrammar:
                     "description": "Extra key",
                     "version": 3,
                     "steps": [{"id": "one", "tool": "send_email"}],
-                    "synthesize": "x",
+                    "result_brief": "x",
                 }
             )
         assert "version" in str(exc.value)
@@ -221,7 +221,7 @@ class TestPlaybookGrammar:
     def test_a_playbook_with_no_steps_is_rejected(self) -> None:
         with pytest.raises(ValidationError):
             PlaybookBody.model_validate(
-                {"description": "Nothing to do", "steps": [], "synthesize": "x"}
+                {"description": "Nothing to do", "steps": [], "result_brief": "x"}
             )
 
 
@@ -246,7 +246,7 @@ steps:
   - id: one
     tool: list_events
     args: {{"query": "newsletters {ARG_TRUNCATION_MARKER}"}}
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -270,7 +270,7 @@ steps:
     args:
       query: "newsletters {ARG_TRUNCATION_MARKER}"
       bogus: "x"
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -303,7 +303,7 @@ steps:
   - id: one
     tool: send_owl
     args: {}
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -322,7 +322,7 @@ steps:
       to: a@b.com
       subject: hi
       bcc: c@d.com
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -342,7 +342,7 @@ steps:
       to: a@b.com
       subject: hi
       retries: soon
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -365,7 +365,7 @@ steps:
     tool: list_events
     args:
       calendar_id: primary
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -391,7 +391,7 @@ steps:
         args:
           to: $steps.agenda.organizer
           subject: hi
-synthesize: x
+result_brief: x
 """
         )
         with (
@@ -416,7 +416,7 @@ steps:
         tool: send_email
         args:
           to: a@b.com
-synthesize: x
+result_brief: x
 """
         )
         with (
@@ -443,7 +443,7 @@ steps:
         tool: exec
         args:
           code: "1"
-synthesize: x
+result_brief: x
 """
         )
         mcp_only = {"exec": _mcp_exec_tool()}
@@ -476,7 +476,7 @@ steps:
         args:
           to: a@b.com
           subject: hi
-synthesize: x
+result_brief: x
 """
         )
         with (
@@ -505,7 +505,7 @@ steps:
         tool: list_events
         args:
           calendar_id: primary
-synthesize: x
+result_brief: x
 """
         )
         with (
@@ -516,23 +516,31 @@ synthesize: x
 
         assert result.issues == []
 
-    async def test_undeclared_ask_reference_is_rejected(self) -> None:
+    async def test_a_dollar_ask_string_is_literal_text_and_is_type_checked_as_one(self) -> None:
+        """``$ask`` left the placeholder vocabulary when asks moved inline, so
+        ``$ask.headline`` is characters like ``$HOME`` is. It must neither be
+        refused as an undeclared reference nor exempt the argument from the type
+        check the way a real placeholder does — an author who writes it into an
+        integer arg has written a string there."""
         body = _body(
             """
-description: Reads an ask nobody declared
+description: A dollar-ask string is just text
 steps:
   - id: mail
     tool: send_email
     args:
       to: a@b.com
       subject: $ask.headline
-synthesize: x
+      retries: $ask.count
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID)
-        assert result.valid is False
-        assert "$ask.headline" in result.issues[0].problem
+
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            ("steps[0].args.retries", "expected integer, got str")
+        ]
 
     async def test_an_unknown_dollar_word_is_literal_text_not_a_placeholder(self) -> None:
         """Only the closed namespaces are placeholders. A recorded ``bash`` step
@@ -546,7 +554,7 @@ steps:
     args:
       to: $sender.email
       subject: echo $HOME $1
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -556,25 +564,45 @@ synthesize: x
     async def test_a_placeholder_embedded_in_text_is_checked_like_a_whole_one(self) -> None:
         """The evaluator interpolates ``$x`` inside a larger string, so the
         validator has to read it there too. It only looked at values that
-        START with ``$``, so ``"Sent $ask.headline"`` was accepted and then
-        replayed against an ask the playbook never declares."""
+        START with ``$``, so ``"Sent $steps.headline.text"`` was accepted and
+        then replayed against a step the playbook never declares."""
         body = _body(
             """
-description: Embedded undeclared ask
+description: Embedded undeclared step reference
 steps:
   - id: mail
     tool: send_email
     args:
       to: a@b.com
-      subject: Sent $ask.headline about today
-synthesize: x
+      subject: Sent $steps.headline.text about today
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID)
         assert result.valid is False
         assert result.issues[0].where == "steps[0].args.subject"
-        assert "$ask.headline" in result.issues[0].problem
+        assert "$steps.headline.text" in result.issues[0].problem
+
+    async def test_an_embedded_dollar_ask_is_literal_text_too(self) -> None:
+        """The embedded scan reads every ``$word`` in a string; ``$ask`` is no
+        longer one of the roots it knows, so text mentioning it must pass rather
+        than being refused as a reference to a table that no longer exists."""
+        body = _body(
+            """
+description: Text that mentions an ask
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: Sent $ask.headline about today
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+        assert result.issues == []
 
     async def test_an_embedded_reference_to_an_undeclared_step_is_refused(self) -> None:
         body = _body(
@@ -586,7 +614,7 @@ steps:
     args:
       to: a@b.com
       subject: Found $steps.agenda.count events
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -608,7 +636,7 @@ steps:
     args:
       to: a@b.com
       subject: Found $steps.agenda.count events on $today
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -624,154 +652,18 @@ steps:
     tool: list_events
     args:
       calendar_id: $last_run.LIST_EVENTS.calendar_id
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID)
         assert result.issues == []
 
-    async def test_ask_uses_an_undeclared_step_is_rejected(self) -> None:
-        body = _body(
-            """
-description: Ask reading a step that does not exist
-steps:
-  - id: agenda
-    tool: list_events
-    args:
-      calendar_id: primary
-ask:
-  body:
-    prompt: Write it up
-    uses: [inbox]
-synthesize: x
-"""
-        )
-        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
-            result = await validate_playbook(body, USER_ID)
-        assert result.valid is False
-        assert result.issues[0].where == "ask.body.uses"
-
-    async def test_an_ask_reading_a_step_that_runs_after_the_asks_are_filled_is_refused(
-        self,
-    ) -> None:
-        """The runner narrates at the FIRST step addressing any ``$ask``, from the
-        steps completed by then. ``uses`` was only checked against the steps the
-        whole document declares, so an ask reading a later step validated and
-        was then written from nothing at replay, silently."""
-        body = _body(
-            """
-description: Summarise the agenda before fetching it
-steps:
-  - id: mail
-    tool: send_email
-    args:
-      to: a@b.com
-      subject: $ask.summary
-  - id: calendar
-    tool: list_events
-    args:
-      calendar_id: primary
-ask:
-  summary:
-    prompt: Summarise the agenda
-    uses: [calendar]
-synthesize: x
-"""
-        )
-        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
-            result = await validate_playbook(body, USER_ID)
-
-        assert result.valid is False
-        # Whole message, not fragments of it: the author is told which ask, where
-        # the asks are filled, which step runs too late, and both ways out.
-        assert [(issue.where, issue.problem) for issue in result.issues] == [
-            (
-                "ask.summary.uses",
-                "ask 'summary' reads step 'calendar', but the asks are filled at step 'mail' "
-                "(the first to address $ask), before 'calendar' runs; move 'calendar' ahead "
-                "of 'mail' or drop it from uses",
-            )
-        ]
-
-    async def test_every_ask_is_filled_at_the_first_ask_step_not_only_the_one_addressed(
-        self,
-    ) -> None:
-        """One model call writes every ask. An ask whose own reference comes
-        late enough is still written at the first ``$ask`` step, before the step
-        it reads has run."""
-        body = _body(
-            """
-description: Two asks, one filled too early
-steps:
-  - id: mail
-    tool: send_email
-    args:
-      to: a@b.com
-      subject: $ask.greeting
-  - id: calendar
-    tool: list_events
-    args:
-      calendar_id: primary
-  - id: followup
-    tool: send_email
-    args:
-      to: a@b.com
-      subject: $ask.summary
-ask:
-  greeting:
-    prompt: Say hello
-  summary:
-    prompt: Summarise the agenda
-    uses: [calendar]
-synthesize: x
-"""
-        )
-        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
-            result = await validate_playbook(body, USER_ID)
-
-        assert result.valid is False
-        assert [issue.where for issue in result.issues] == ["ask.summary.uses"]
-        assert "'mail'" in result.issues[0].problem
-
-    async def test_an_ask_is_checked_past_the_uses_entries_that_are_already_fine(self) -> None:
-        """``uses`` is checked entry by entry, not up to the first acceptable one.
-
-        Stopping at the first entry that already ran would clear the whole ask,
-        and the later step behind it would be written from nothing at replay.
-        """
-        body = _body(
-            """
-description: An ask reading one earlier step and one later one
-steps:
-  - id: inbox
-    tool: list_events
-    args:
-      calendar_id: primary
-  - id: mail
-    tool: send_email
-    args:
-      to: a@b.com
-      subject: $ask.summary
-  - id: calendar
-    tool: list_events
-    args:
-      calendar_id: work
-ask:
-  summary:
-    prompt: Summarise both
-    uses: [inbox, calendar]
-synthesize: x
-"""
-        )
-        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
-            result = await validate_playbook(body, USER_ID)
-
-        assert result.valid is False
-        assert [issue.where for issue in result.issues] == ["ask.summary.uses"]
-        assert "'calendar'" in result.issues[0].problem
-
-    async def test_an_ask_reading_only_earlier_steps_is_accepted(self) -> None:
+    async def test_an_ask_slot_standing_where_an_argument_goes_is_accepted(self) -> None:
+        """The whole point of the inline shape: a value a model writes at replay
+        sits in the argument that needs it, in whichever step needs it, and the
+        validator lets it through. Refusing it would make the only way to author
+        written text an unwritable playbook."""
         body = _body(
             """
 description: Summarise the agenda after fetching it
@@ -784,12 +676,10 @@ steps:
     tool: send_email
     args:
       to: a@b.com
-      subject: $ask.summary
-ask:
-  summary:
-    prompt: Summarise the agenda
-    uses: [calendar]
-synthesize: x
+      subject:
+        $ask: Summarise the agenda
+        max_tokens: 200
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -797,30 +687,156 @@ synthesize: x
 
         assert result.issues == []
 
-    async def test_an_ask_reading_a_step_nobody_declares_is_reported_once(self) -> None:
-        """The ordering check must not double up with the existence check."""
+    async def test_a_slot_nested_inside_a_structured_arg_is_accepted(self) -> None:
+        """Slots reach as deep as arguments nest; a payload-shaped arg carrying
+        one must validate exactly like a top-level one."""
+        registry = _schema_registry(query_rows={"filter": {"type": "object"}})
         body = _body(
             """
-description: Ask reading a ghost step
+description: A slot inside a payload
+steps:
+  - id: rows
+    tool: query_rows
+    args:
+      filter:
+        note:
+          $ask: Say why this run matters
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.issues == []
+
+    async def test_a_slot_carrying_a_key_the_vocabulary_has_no_room_for_is_refused(self) -> None:
+        """The slot vocabulary is two keys. A model that adds ``goal`` has
+        written an instruction the runner will never read, so the refusal names
+        the argument it sits in and spells out what a slot may hold — one issue,
+        not a pydantic dump the author has to decode."""
+        body = _body(
+            """
+description: A slot with an extra key
 steps:
   - id: mail
     tool: send_email
     args:
       to: a@b.com
-      subject: $ask.summary
-ask:
-  summary:
-    prompt: Summarise
-    uses: [inbox]
-synthesize: x
+      subject:
+        $ask: Write a subject
+        goal: sound friendly
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID)
 
+        assert result.valid is False
         assert [(issue.where, issue.problem) for issue in result.issues] == [
-            ("ask.summary.uses", "no step is declared with id 'inbox'")
+            (
+                "steps[0].args.subject",
+                "an $ask slot takes only '$ask' (what to write) and an optional "
+                "max_tokens 1..8192; got ['$ask', 'goal']",
+            )
         ]
+
+    async def test_a_slot_on_a_step_with_no_id_is_refused_so_keys_cannot_collide(
+        self,
+    ) -> None:
+        """A slot's key is its step's id plus the arg path; with no id the tool
+        name stands in, so two id-less steps of one tool would share a key and
+        the second would silently receive the first's text. Refusing at
+        authoring time is the only place the author can still add the id."""
+        body = _body(
+            """
+description: Two searches, neither named
+steps:
+  - tool: list_events
+    args:
+      calendar_id:
+        $ask: which calendar to read
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.valid is False
+        assert [issue.where for issue in result.issues] == ["steps[0].args.calendar_id"]
+        assert "needs an id" in result.issues[0].problem
+        assert "list_events" in result.issues[0].problem
+
+    async def test_a_slot_with_an_empty_prompt_is_refused(self) -> None:
+        """A slot with nothing to say is a model call with no instruction; the
+        text it writes would be whatever the run happened to look like."""
+        body = _body(
+            """
+description: A slot with no instruction
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject:
+        $ask: ""
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.valid is False
+        assert [issue.where for issue in result.issues] == ["steps[0].args.subject"]
+        assert "$ask" in result.issues[0].problem
+
+    async def test_a_slot_whose_max_tokens_is_out_of_range_is_refused(self) -> None:
+        """The budget is what keeps one replay's token cost bounded; a slot
+        asking for more than the cap must be refused at authoring time rather
+        than turning a playbook into an open-ended generation."""
+        body = _body(
+            """
+description: A slot with a runaway budget
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject:
+        $ask: Write a subject
+        max_tokens: 999999
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.valid is False
+        assert [issue.where for issue in result.issues] == ["steps[0].args.subject"]
+        assert "max_tokens 1..8192" in result.issues[0].problem
+
+    async def test_an_arg_holding_a_slot_is_not_type_checked(self) -> None:
+        """A slot is a dict now and the model's text at replay, exactly as a
+        placeholder is a string now and whatever it resolves to later. Type-
+        checking the unfilled slot would refuse every typed argument a model is
+        meant to write."""
+        body = _body(
+            """
+description: A written count
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+      retries:
+        $ask: How many retries this deserves
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.issues == []
 
     async def test_a_duplicate_step_id_is_refused_by_name(self) -> None:
         """The runner records results by id, so a second ``agenda`` overwrites
@@ -840,7 +856,7 @@ steps:
         tool: list_events
         args:
           calendar_id: work
-synthesize: x
+result_brief: x
 """
         )
         with (
@@ -877,7 +893,7 @@ steps:
         args:
           to: a@b.com
           subject: hi
-synthesize: x
+result_brief: x
 """
         )
         registry = _registry()
@@ -908,7 +924,7 @@ steps:
     args:
       to: a@b.com
       subject: 2026-03-14
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -937,7 +953,7 @@ steps:
     args:
       to: a@b.com
       subject: Synced $steps.XERO_SYNC.organizer
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -962,7 +978,7 @@ steps:
     tool: query_rows
     args:
       cursor: tok_1
-synthesize: x
+result_brief: x
 """
         )
         refused = _body(
@@ -973,7 +989,7 @@ steps:
     tool: query_rows
     args:
       cursor: 7
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1003,7 +1019,7 @@ steps:
     tool: query_rows
     args:
       cursor: {value}
-synthesize: x
+result_brief: x
 """
             )
             with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1023,7 +1039,7 @@ steps:
     tool: query_rows
     args:
       cursor: 7
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1045,7 +1061,7 @@ steps:
     tool: query_rows
     args:
       limit: [1, 2]
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1072,7 +1088,7 @@ steps:
     tool: query_rows
     args:
       limit: nope
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1096,7 +1112,7 @@ steps:
       to: a@b.com
       subject: hi
       retries: true
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -1124,7 +1140,7 @@ steps:
       to: a@b.com
       subject: hi
       retries: $steps.agenda.count
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -1143,7 +1159,7 @@ steps:
     tool: query_rows
     args:
       ids: [$steps.nowhere.id]
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1163,7 +1179,7 @@ steps:
     args:
       filter:
         owner: $steps.nowhere.id
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1183,7 +1199,7 @@ steps:
     args:
       bcc: c@d.com
       cc: e@f.com
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -1203,7 +1219,7 @@ steps:
     tool: send_email
     args:
       bcc: c@d.com
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
@@ -1223,7 +1239,7 @@ steps:
     tool: ping
     args:
       loud: true
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=registry):
@@ -1248,12 +1264,299 @@ steps:
     args:
       to: $steps.agenda.organizer.email
       subject: hi
-synthesize: x
+result_brief: x
 """
         )
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID)
         assert result.issues == []
+
+
+def _call(tool_name: str, args: dict[str, Any], result: object) -> RecordedResult:
+    """One call as the authoring run made it, with what came back."""
+    return RecordedResult(tool_name=tool_name, args=args, result=result)
+
+
+@pytest.mark.unit
+class TestValidateAgainstTheRunThatIsWritingIt:
+    """The checks that read the authoring run's own results.
+
+    Every case here was a playbook production accepted and then broke on:
+    ``pb_c7d357db77dd`` froze a field its tool does not return, and two more
+    were frozen from calls that came back empty. The run had every answer in
+    hand at write time, and nothing looked at it.
+    """
+
+    async def test_a_step_is_matched_to_the_call_whose_literal_args_agree(self) -> None:
+        """A tool called twice left two results. If the step is matched to the
+        wrong one, this playbook is refused for an emptiness that belongs to the
+        other calendar entirely."""
+        body = _body(
+            """
+description: Read the work calendar
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: work
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "work"}, {"events": [{"id": "e1"}]}),
+            _call("list_events", {"calendar_id": "primary"}, {"events": []}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_an_arg_holding_a_placeholder_matches_any_recorded_value(self) -> None:
+        """A placeholder has no value until replay, so it cannot disagree with a
+        recorded arg. Treated as a literal it would agree with nothing and the
+        step would be checked against the last call — here, the empty one."""
+        body = _body(
+            """
+description: Mail the digest
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: $user.email
+      subject: one
+result_brief: x
+"""
+        )
+        results = [
+            _call("send_email", {"to": "a@b.com", "subject": "one"}, {"sent": [{"id": "1"}]}),
+            _call("send_email", {"to": "z@z.com", "subject": "two"}, {"sent": []}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_a_step_agreeing_with_no_call_falls_back_to_the_last_one(self) -> None:
+        """A step whose args match nothing recorded still has to be checked
+        against something; the run's final call is the one it settled on. If the
+        fallback picks the first instead, the empty call goes unreported."""
+        body = _body(
+            """
+description: Read a third calendar
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: other
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "work"}, {"events": [{"id": "e1"}]}),
+            _call("list_events", {"calendar_id": "primary"}, {"events": []}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[0]"]
+        assert result.issues[0].problem.startswith("list_events returned no items in this run")
+        assert '{"calendar_id": "primary"}' in result.issues[0].problem
+
+    async def test_a_tool_the_run_never_called_is_refused(self) -> None:
+        """A playbook freezes calls that ran. A step for a tool this run never
+        touched was invented, and its args have never been proven to work."""
+        body = _body(
+            """
+description: Mail an agenda that was never mailed
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [_call("list_events", {"calendar_id": "primary"}, {"events": [{"id": "e1"}]})]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[0]"]
+        assert result.issues[0].problem == (
+            "send_email did not run in this run; a playbook freezes calls that ran and "
+            "produced their result — run it, or drop the step"
+        )
+
+    async def test_a_call_that_returned_no_items_is_refused(self) -> None:
+        """Two production playbooks were frozen from a call that returned zero
+        items and were marked SUSPECT one fire later. The list is nested under an
+        envelope, so the check has to look past the top level."""
+        body = _body(
+            """
+description: Read an empty calendar
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+result_brief: x
+"""
+        )
+        results = [_call("list_events", {"calendar_id": "primary"}, {"data": {"events": []}})]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[0]"]
+        assert "widen the args or decline the playbook" in result.issues[0].problem
+
+    async def test_a_call_that_reported_its_own_failure_is_refused_by_its_error(self) -> None:
+        """A tool that catches its own failure answers with a success-shaped
+        message carrying an error envelope. Freezing that call freezes a step
+        that has never once worked, and the refusal has to name the error the
+        author has to fix."""
+        body = _body(
+            """
+description: Mail from an expired token
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "send_email",
+                {"to": "a@b.com", "subject": "hi"},
+                {"success": False, "error": "Gmail token expired"},
+            )
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[0]"]
+        assert "Gmail token expired" in result.issues[0].problem
+
+    async def test_a_reference_to_a_field_the_result_lacks_is_refused_with_its_keys(self) -> None:
+        """``pb_c7d357db77dd`` exactly: a field frozen on a tool that does not
+        return it. The keys are the whole point of the message — without them the
+        author is told what is wrong and not what it could have written."""
+        body = _body(
+            """
+description: Reply on a thread id that does not exist
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+  - id: mail
+    tool: send_email
+    args:
+      to: $steps.agenda.threadId
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "list_events",
+                {"calendar_id": "primary"},
+                {"messages": [{"id": "m1"}], "nextPage": "abc"},
+            ),
+            _call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "1"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[1].args.to"]
+        assert result.issues[0].problem == (
+            "$steps.agenda.threadId is not in step 'agenda''s result"
+            "; its result has keys: messages, nextPage"
+        )
+
+    async def test_a_reference_the_recorded_result_resolves_is_accepted(self) -> None:
+        """The check has to accept the shape the run actually produced, nested
+        list index included; a refusal here refuses a playbook that replays."""
+        body = _body(
+            """
+description: Reply to the first message
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+  - id: mail
+    tool: send_email
+    args:
+      to: $steps.agenda.messages.0.id
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "primary"}, {"messages": [{"id": "m1"}]}),
+            _call("send_email", {"to": "m1", "subject": "hi"}, {"sent": [{"id": "1"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_a_reference_to_a_steps_offload_file_is_exempt(self) -> None:
+        """``$steps.<id>.file`` addresses the workspace path a step offloaded its
+        result to, which exists only at replay. Checked against the authoring
+        run's result it is always absent, and every offloading playbook would be
+        refused."""
+        body = _body(
+            """
+description: Mail the offloaded agenda
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: $steps.agenda.file
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "primary"}, {"messages": [{"id": "m1"}]}),
+            _call("send_email", {"to": "a@b.com", "subject": "x"}, {"sent": [{"id": "1"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_without_results_the_verdict_is_the_one_it_was_before(self) -> None:
+        """No results is not an empty run. The dev executor route and every
+        caller with no graph behind it pass nothing, and must get exactly the
+        registry checks they got before — while a run that genuinely made no
+        calls is refused."""
+        body = _body(VALID_YAML)
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            without = await validate_playbook(body, USER_ID)
+            empty_run = await validate_playbook(body, USER_ID, [])
+
+        assert without.valid is True
+        assert without.issues == []
+        assert [issue.where for issue in empty_run.issues] == ["steps[0]", "steps[1]"]
 
 
 @pytest.mark.unit
@@ -1272,21 +1575,39 @@ steps:
     tool: list_events
     args:
       calendar_id: primary
-synthesize: x
+result_brief: x
 """
         )
         rendered = dump_playbook(body)
         assert "Résumé für das Team" in rendered
 
-    def test_keys_stay_in_authored_order(self) -> None:
-        """Alphabetising would put ``description`` after ``ask`` and scatter each
-        step's ``id``/``tool``/``args``, so the document stops reading like the
-        sequence it describes."""
+    def test_keys_stay_in_authored_order_with_the_result_brief_last(self) -> None:
+        """Alphabetising would put ``description`` after ``result_brief`` and
+        scatter each step's ``id``/``tool``/``args``, so the document stops
+        reading like the sequence it describes. ``result_brief`` comes last
+        because it is written from what every step above it returned."""
         body = _body(VALID_YAML)
         rendered = dump_playbook(body)
         assert rendered.index("description:") < rendered.index("steps:")
-        assert rendered.index("steps:") < rendered.index("ask:")
+        assert rendered.index("steps:") < rendered.index("result_brief:")
         assert rendered.index("id: agenda") < rendered.index("args:")
+
+    def test_the_document_carries_no_ask_section_of_its_own(self) -> None:
+        """Asks stopped being a section when they moved inline. Rendering one
+        anyway would teach the agent reading its playbook back to author the
+        shape whose dead entries this change exists to make impossible."""
+        rendered = dump_playbook(_body(VALID_YAML))
+        assert set(yaml.safe_load(rendered)) == {"description", "steps", "result_brief"}
+
+    def test_an_ask_slot_renders_inside_the_argument_it_stands_in(self) -> None:
+        """The agent revises the playbook from this YAML, so a slot has to read
+        where its value belongs. Rendered anywhere else — or flattened to a
+        marker — the agent could not tell which argument a model writes."""
+        rendered = dump_playbook(_body(VALID_YAML))
+
+        mail = yaml.safe_load(rendered)["steps"][1]
+        assert mail["args"]["subject"] == {"$ask": "Write the agenda as a short note"}
+        assert "$ask: Write the agenda as a short note" in rendered
 
 
 def _messages(exc: pytest.ExceptionInfo[ValidationError]) -> list[str]:
@@ -1436,26 +1757,34 @@ class TestAuthoredPlaybookBecomesTheStoredOne:
         assert step.tool == "send_email"
         assert step.args == {"to": "team@example.com", "subject": "Agenda"}
 
-    def test_the_declared_asks_reach_the_stored_body(self) -> None:
-        ask = PlaybookAsk(prompt="Write the digest.", uses=["events"])
+    def test_an_ask_slot_written_into_an_arg_reaches_the_stored_body(self) -> None:
+        """A slot is ordinary argument data all the way through the conversion.
 
+        The tool boundary no longer has an ``ask`` parameter to drop, so a slot
+        lost here would be lost silently: the playbook stores and replays, and
+        the step simply sends nothing where the written text belonged.
+        """
         body = playbook_body_from_input(
             description="Mail the agenda",
-            steps=[PlaybookStepInput(id="events", tool="list_events", args={"calendar_id": "x"})],
-            synthesize="Say how many events there were.",
-            ask={"body": ask},
+            steps=[
+                PlaybookStepInput(id="events", tool="list_events", args={"calendar_id": "x"}),
+                PlaybookStepInput(
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "a@b.com", "subject": {"$ask": "Write the digest."}},
+                ),
+            ],
+            result_brief="Say how many events there were.",
         )
 
-        assert body.ask == {"body": ask}
-        assert [step.tool for step in body.steps] == ["list_events"]
+        assert body.steps[1].args["subject"] == {"$ask": "Write the digest."}
+        assert body.result_brief == "Say how many events there were."
 
-    def test_a_playbook_with_no_asks_stores_an_empty_mapping(self) -> None:
-        """``None`` is what the tool boundary sends for "no asks", and it is not storable."""
-        body = playbook_body_from_input(
-            description="Mail the agenda",
-            steps=[PlaybookStepInput(id="events", tool="list_events", args={"calendar_id": "x"})],
-            synthesize="Say how many events there were.",
-            ask=None,
+    def test_an_ask_slot_inside_a_handoff_child_survives_the_conversion(self) -> None:
+        """A handoff's children are converted through their own model, so a slot
+        in one has a second chance to be dropped on the way to the stored body."""
+        child = PlaybookHandoffStepInput(
+            id="mail", tool="send_email", args={"subject": {"$ask": "Write the digest."}}
         )
 
-        assert body.ask == {}
+        assert child.to_step().args == {"subject": {"$ask": "Write the digest."}}

--- a/apps/api/tests/unit/services/workflow/test_playbook_parser.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_parser.py
@@ -1527,10 +1527,14 @@ result_brief: x
 
         assert result.issues == []
 
-    async def test_a_step_agreeing_with_no_call_falls_back_to_the_last_one(self) -> None:
-        """A step whose args match nothing recorded still has to be checked
-        against something; the run's final call is the one it settled on. If the
-        fallback picks the first instead, the empty call goes unreported."""
+    async def test_a_step_agreeing_with_no_call_is_refused_with_the_args_that_did_run(
+        self,
+    ) -> None:
+        """A step whose args match no recorded call is not a call the run made.
+        Handing it the run's last call anyway validated that call's result as
+        the step's own, so a `$steps` reference could be approved against a shape
+        the replayed args will never return. The refusal shows the args the run
+        actually used so the author can freeze the real call."""
         body = _body(
             """
 description: Read a third calendar
@@ -1550,9 +1554,52 @@ result_brief: x
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID, results)
 
-        assert [issue.where for issue in result.issues] == ["steps[0]"]
-        assert result.issues[0].problem.startswith("list_events returned no items in this run")
-        assert '{"calendar_id": "primary"}' in result.issues[0].problem
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            (
+                "steps[0]",
+                "list_events ran 2 time(s) in this run, but never with these args (the last "
+                'call used {"calendar_id": "primary"}); freeze the call that ran, with the '
+                "args that produced its result, or run it with these args",
+            )
+        ]
+
+    async def test_the_refusal_shows_the_args_of_the_last_call_still_unfrozen(self) -> None:
+        """Four calls, the first already frozen by an earlier step. The one to
+        show is the LAST still-unfrozen call — the run's final attempt — not the
+        first, not the second, and not the one another step already took."""
+        body = _body(
+            """
+description: Freeze the work calendar, then a calendar nobody read
+steps:
+  - id: work
+    tool: list_events
+    args:
+      calendar_id: work
+  - id: other
+    tool: list_events
+    args:
+      calendar_id: other
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "work"}, {"events": [{"id": "e1"}]}),
+            _call("list_events", {"calendar_id": "primary"}, {"events": [{"id": "e2"}]}),
+            _call("list_events", {"calendar_id": "shared"}, {"events": [{"id": "e3"}]}),
+            _call("list_events", {"calendar_id": "personal"}, {"events": [{"id": "e4"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            (
+                "steps[1]",
+                "list_events ran 4 time(s) in this run, but never with these args (the last "
+                'call used {"calendar_id": "personal"}); freeze the call that ran, with the '
+                "args that produced its result, or run it with these args",
+            )
+        ]
 
     async def test_a_literal_nested_beside_a_placeholder_still_picks_the_call(self) -> None:
         """The two calls differ only inside ``filters``, which also carries a
@@ -1860,7 +1907,7 @@ result_brief: x
         results = [
             _call(
                 "list_events",
-                {"query": "café ☕", "after": datetime(2026, 9, 1)},
+                {"calendar_id": "primary", "query": "café ☕", "after": datetime(2026, 9, 1)},
                 {"events": []},
             )
         ]
@@ -1870,15 +1917,15 @@ result_brief: x
 
         assert result.issues[0].problem == (
             "list_events returned no items in this run "
-            '(args: {"query": "café ☕", "after": "2026-09-01 00:00:00"}); '
+            '(args: {"calendar_id": "primary", "query": "café ☕", "after": "2026-09-01 00:00:00"}); '
             "freeze a call that produced data — widen the args or decline the playbook"
         )
 
     @pytest.mark.parametrize(
         ("filler", "rendered"),
         [
-            (191, '{"q": "' + "x" * 191 + '"}'),
-            (192, '{"q": "' + "x" * 192 + '"...'),
+            (165, '{"calendar_id": "primary", "q": "' + "x" * 165 + '"}'),
+            (166, '{"calendar_id": "primary", "q": "' + "x" * 166 + '"...'),
         ],
         ids=["exactly-at-the-cap", "one-character-over"],
     )
@@ -1899,7 +1946,9 @@ steps:
 result_brief: x
 """
         )
-        results = [_call("list_events", {"q": "x" * filler}, {"events": []})]
+        results = [
+            _call("list_events", {"calendar_id": "primary", "q": "x" * filler}, {"events": []})
+        ]
 
         with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
             result = await validate_playbook(body, USER_ID, results)

--- a/apps/api/tests/unit/services/workflow/test_playbook_parser.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_parser.py
@@ -8,6 +8,7 @@ The grammar itself is enforced by the models, since the structured tool schema
 is the only way a playbook is ever authored — nothing parses YAML back.
 """
 
+from datetime import datetime
 from typing import Annotated, Any
 from unittest.mock import AsyncMock, call, patch
 
@@ -245,7 +246,7 @@ description: Copied from the record
 steps:
   - id: one
     tool: list_events
-    args: {{"query": "newsletters {ARG_TRUNCATION_MARKER}"}}
+    args: {{"calendar_id": "primary", "query": "newsletters {ARG_TRUNCATION_MARKER}"}}
 result_brief: x
 """
         )
@@ -268,6 +269,7 @@ steps:
   - id: one
     tool: list_events
     args:
+      calendar_id: primary
       query: "newsletters {ARG_TRUNCATION_MARKER}"
       bogus: "x"
 result_brief: x
@@ -1197,6 +1199,8 @@ steps:
   - id: one
     tool: send_email
     args:
+      to: a@b.com
+      subject: hi
       bcc: c@d.com
       cc: e@f.com
 result_brief: x
@@ -1246,6 +1250,97 @@ result_brief: x
             result = await validate_playbook(body, USER_ID)
         assert result.valid is False
         assert "it takes: nothing" in result.issues[0].problem
+
+    async def test_a_required_arg_the_step_never_sets_is_refused_by_name(self) -> None:
+        """Nothing else catches this: the per-arg checks walk the args the step
+        HAS, so a call missing a required one is accepted here and fails at
+        replay before it starts."""
+        body = _body(
+            """
+description: Mail with half the arguments
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert [(issue.where, issue.problem) for issue in result.issues] == [
+            (
+                "steps[0].args",
+                "send_email requires 'subject' and this step does not set it; "
+                "it takes: retries, subject, to",
+            )
+        ]
+
+    async def test_every_missing_required_arg_is_named_in_sorted_order(self) -> None:
+        """Naming one at a time costs the author a round trip each, and the
+        order has to be the same every run or the message is not diffable."""
+        body = _body(
+            """
+description: Mail with no arguments at all
+steps:
+  - id: mail
+    tool: send_email
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert [issue.problem for issue in result.issues] == [
+            "send_email requires 'subject' and this step does not set it; "
+            "it takes: retries, subject, to",
+            "send_email requires 'to' and this step does not set it; "
+            "it takes: retries, subject, to",
+        ]
+
+    @pytest.mark.parametrize(
+        "authored",
+        ["$user.email", {"$ask": "who this goes to"}],
+        ids=["placeholder", "ask-slot"],
+    )
+    async def test_a_required_arg_filled_at_replay_still_counts_as_set(
+        self, authored: object
+    ) -> None:
+        """The arg is present; only its value is deferred. Refusing it would
+        refuse every playbook that addresses the user or writes its own text."""
+        body = PlaybookBody.model_validate(
+            {
+                "description": "Mail the agenda",
+                "steps": [
+                    {"id": "mail", "tool": "send_email", "args": {"to": authored, "subject": "hi"}}
+                ],
+                "result_brief": "x",
+            }
+        )
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.issues == []
+
+    async def test_a_tool_that_requires_nothing_is_not_asked_for_anything(self) -> None:
+        """An MCP schema with no ``required`` list is not a tool that requires
+        every arg; a step calling it with none is complete."""
+        registry = _schema_registry(ping={})
+        body = _body(
+            """
+description: Ping
+steps:
+  - id: one
+    tool: ping
+result_brief: x
+"""
+        )
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID)
+
+        assert result.issues == []
 
     async def test_a_deep_step_reference_resolves_against_the_step_id(self) -> None:
         """``$steps.agenda.organizer.email`` names step ``agenda``, not
@@ -1312,6 +1407,37 @@ result_brief: x
 
         assert result.issues == []
 
+    async def test_a_non_string_arg_picks_the_call_that_used_that_value(self) -> None:
+        """Numbers agree by equality like anything else. Matched the other way
+        round the step is checked against the call it is NOT, and this playbook
+        is refused for the emptiness of a run it never froze."""
+        body = _body(
+            """
+description: Mail with two retries
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+      retries: 2
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "send_email",
+                {"to": "a@b.com", "subject": "hi", "retries": 2},
+                {"sent": [{"id": "1"}]},
+            ),
+            _call("send_email", {"to": "a@b.com", "subject": "hi", "retries": 5}, {"sent": []}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
     async def test_an_arg_holding_a_placeholder_matches_any_recorded_value(self) -> None:
         """A placeholder has no value until replay, so it cannot disagree with a
         recorded arg. Treated as a literal it would agree with nothing and the
@@ -1365,6 +1491,169 @@ result_brief: x
         assert result.issues[0].problem.startswith("list_events returned no items in this run")
         assert '{"calendar_id": "primary"}' in result.issues[0].problem
 
+    async def test_a_literal_nested_beside_a_placeholder_still_picks_the_call(self) -> None:
+        """The two calls differ only inside ``filters``, which also carries a
+        placeholder. Treating the whole arg as a wildcard matches the last call
+        and refuses this playbook for the spam folder's emptiness."""
+        body = _body(
+            """
+description: Read the inbox
+steps:
+  - id: mail
+    tool: search_mail
+    args:
+      filters:
+        label: INBOX
+        after: $today
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "search_mail",
+                {"filters": {"label": "INBOX", "after": "2026-09-01"}},
+                {"messages": [{"id": "m1"}]},
+            ),
+            _call(
+                "search_mail",
+                {"filters": {"label": "SPAM", "after": "2026-09-01"}},
+                {"messages": []},
+            ),
+        ]
+
+        registry = _schema_registry(search_mail={"filters": {"type": "object"}})
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_a_key_the_recorded_call_lacks_disagrees_with_it(self) -> None:
+        """The last call never sent ``label`` at all, so it is not the call this
+        step froze — an arg the step names and the record omits is a
+        disagreement, not something to shrug at."""
+        body = _body(
+            """
+description: Read the inbox
+steps:
+  - id: mail
+    tool: search_mail
+    args:
+      filters:
+        label: INBOX
+        after: $today
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "search_mail",
+                {"filters": {"label": "INBOX", "after": "2026-09-01"}},
+                {"messages": [{"id": "m1"}]},
+            ),
+            _call("search_mail", {"filters": {"after": "2026-09-01"}}, {"messages": []}),
+        ]
+
+        registry = _schema_registry(search_mail={"filters": {"type": "object"}})
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_an_ask_slot_nested_in_an_arg_matches_any_recorded_value(self) -> None:
+        """Text a model writes at replay does not exist yet, so it agrees with
+        whatever sat in that position — while the literal beside it still
+        decides which call this is."""
+        body = _body(
+            """
+description: Read the inbox
+steps:
+  - id: mail
+    tool: search_mail
+    args:
+      filters:
+        label: INBOX
+        after:
+          $ask: Which day to read from
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "search_mail",
+                {"filters": {"label": "INBOX", "after": "2026-09-01"}},
+                {"messages": [{"id": "m1"}]},
+            ),
+            _call(
+                "search_mail",
+                {"filters": {"label": "SPAM", "after": "2026-08-01"}},
+                {"messages": []},
+            ),
+        ]
+
+        registry = _schema_registry(search_mail={"filters": {"type": "object"}})
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_a_list_arg_agrees_at_its_own_length_only(self) -> None:
+        """A placeholder element stands for one value, not for any number of
+        them, so a recorded list of another length is a different call."""
+        body = _body(
+            """
+description: Tag the inbox
+steps:
+  - id: tagged
+    tool: tag_mail
+    args:
+      labels:
+        - INBOX
+        - $today
+result_brief: x
+"""
+        )
+        results = [
+            _call("tag_mail", {"labels": ["INBOX", "2026-09-01"]}, {"tagged": [{"id": "m1"}]}),
+            _call("tag_mail", {"labels": ["INBOX", "2026-09-01", "SPAM"]}, {"tagged": []}),
+        ]
+
+        registry = _schema_registry(tag_mail={"labels": {"type": "array"}})
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
+    async def test_a_key_the_step_left_out_does_not_break_agreement(self) -> None:
+        """The model writes the args it meant, not every default the tool
+        filled in; a recorded key the step never mentions cannot be evidence
+        that this is some other call."""
+        body = _body(
+            """
+description: Read the inbox
+steps:
+  - id: mail
+    tool: search_mail
+    args:
+      filters:
+        label: INBOX
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "search_mail",
+                {"filters": {"label": "INBOX", "after": "2026-09-01"}},
+                {"messages": [{"id": "m1"}]},
+            ),
+            _call("search_mail", {"filters": {"label": "SPAM"}}, {"messages": []}),
+        ]
+
+        registry = _schema_registry(search_mail={"filters": {"type": "object"}})
+        with patch(f"{MODULE}.get_tool_registry", return_value=registry):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues == []
+
     async def test_a_tool_the_run_never_called_is_refused(self) -> None:
         """A playbook freezes calls that ran. A step for a tool this run never
         touched was invented, and its args have never been proven to work."""
@@ -1412,7 +1701,10 @@ result_brief: x
             result = await validate_playbook(body, USER_ID, results)
 
         assert [issue.where for issue in result.issues] == ["steps[0]"]
-        assert "widen the args or decline the playbook" in result.issues[0].problem
+        assert result.issues[0].problem == (
+            'list_events returned no items in this run (args: {"calendar_id": "primary"}); '
+            "freeze a call that produced data — widen the args or decline the playbook"
+        )
 
     async def test_a_call_that_reported_its_own_failure_is_refused_by_its_error(self) -> None:
         """A tool that catches its own failure answers with a success-shaped
@@ -1443,7 +1735,116 @@ result_brief: x
             result = await validate_playbook(body, USER_ID, results)
 
         assert [issue.where for issue in result.issues] == ["steps[0]"]
-        assert "Gmail token expired" in result.issues[0].problem
+        assert result.issues[0].problem == (
+            "send_email failed in this run (Gmail token expired); a playbook freezes "
+            "calls that succeeded — fix the call and run it again, or drop the step"
+        )
+
+    @pytest.mark.parametrize(
+        ("envelope", "said"),
+        [
+            ({"success": False, "message": "Gmail token expired"}, "Gmail token expired"),
+            ({"success": False}, "the call reported success: false"),
+        ],
+        ids=["message-key", "said-nothing"],
+    )
+    async def test_a_failure_with_no_error_key_is_named_by_whatever_it_did_say(
+        self, envelope: dict[str, Any], said: str
+    ) -> None:
+        """Tools spell their failure two ways — an ``error`` and a bare
+        ``message`` — and some say only ``success: false``. The refusal is the
+        author's only account of why the call failed, so it has to read the
+        second spelling and say so plainly when there is no third."""
+        body = _body(
+            """
+description: Mail from a failing tool
+steps:
+  - id: mail
+    tool: send_email
+    args:
+      to: a@b.com
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [_call("send_email", {"to": "a@b.com", "subject": "hi"}, envelope)]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[0]"]
+        assert result.issues[0].problem == (
+            f"send_email failed in this run ({said}); a playbook freezes "
+            "calls that succeeded — fix the call and run it again, or drop the step"
+        )
+
+    async def test_the_args_naming_the_empty_call_are_rendered_as_they_were_sent(self) -> None:
+        """The args are there to say WHICH call came back empty. Escaped to
+        ASCII the author cannot recognise their own query, and a value that is
+        not JSON (a datetime the tool was handed) must render rather than crash
+        the whole validation."""
+        body = _body(
+            """
+description: Read an empty calendar
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+result_brief: x
+"""
+        )
+        results = [
+            _call(
+                "list_events",
+                {"query": "café ☕", "after": datetime(2026, 9, 1)},
+                {"events": []},
+            )
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues[0].problem == (
+            "list_events returned no items in this run "
+            '(args: {"query": "café ☕", "after": "2026-09-01 00:00:00"}); '
+            "freeze a call that produced data — widen the args or decline the playbook"
+        )
+
+    @pytest.mark.parametrize(
+        ("filler", "rendered"),
+        [
+            (191, '{"q": "' + "x" * 191 + '"}'),
+            (192, '{"q": "' + "x" * 192 + '"...'),
+        ],
+        ids=["exactly-at-the-cap", "one-character-over"],
+    )
+    async def test_long_args_are_cut_at_the_cap_and_marked(
+        self, filler: int, rendered: str
+    ) -> None:
+        """200 characters of args, then an ellipsis. The cap is inclusive: a
+        rendering that lands exactly on it is complete and must not be marked as
+        cut, or the author goes looking for args that were never dropped."""
+        body = _body(
+            """
+description: Read an empty calendar
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+result_brief: x
+"""
+        )
+        results = [_call("list_events", {"q": "x" * filler}, {"events": []})]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert result.issues[0].problem == (
+            f"list_events returned no items in this run (args: {rendered}); "
+            "freeze a call that produced data — widen the args or decline the playbook"
+        )
 
     async def test_a_reference_to_a_field_the_result_lacks_is_refused_with_its_keys(self) -> None:
         """``pb_c7d357db77dd`` exactly: a field frozen on a tool that does not
@@ -1481,6 +1882,74 @@ result_brief: x
         assert result.issues[0].problem == (
             "$steps.agenda.threadId is not in step 'agenda''s result"
             "; its result has keys: messages, nextPage"
+        )
+
+    async def test_a_reference_deeper_than_one_field_is_still_read_from_its_step(self) -> None:
+        """``$steps.agenda.organizer.email`` names the step ``agenda`` and the
+        path ``organizer.email``. Split from the other end the step is called
+        ``agenda.organizer``, nothing in the run answers to it, and a reference
+        into a shape the tool does not return is waved through."""
+        body = _body(
+            """
+description: Reply to the organizer
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+  - id: mail
+    tool: send_email
+    args:
+      to: $steps.agenda.organizer.email
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "primary"}, {"organizer": {"name": "Ada"}}),
+            _call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "1"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[1].args.to"]
+        assert result.issues[0].problem == (
+            "$steps.agenda.organizer.email is not in step 'agenda''s result"
+            "; its result has keys: organizer"
+        )
+
+    async def test_a_result_with_no_keys_to_offer_ends_the_refusal_where_it_is(self) -> None:
+        """The keys are a hint, not a sentence: a result that is a bare list has
+        none to give, and the refusal has to stop rather than trail off into an
+        empty ``has keys:``."""
+        body = _body(
+            """
+description: Reply on a thread id a list cannot carry
+steps:
+  - id: agenda
+    tool: list_events
+    args:
+      calendar_id: primary
+  - id: mail
+    tool: send_email
+    args:
+      to: $steps.agenda.threadId
+      subject: hi
+result_brief: x
+"""
+        )
+        results = [
+            _call("list_events", {"calendar_id": "primary"}, ["m1", "m2"]),
+            _call("send_email", {"to": "a@b.com", "subject": "hi"}, {"sent": [{"id": "1"}]}),
+        ]
+
+        with patch(f"{MODULE}.get_tool_registry", return_value=_registry()):
+            result = await validate_playbook(body, USER_ID, results)
+
+        assert [issue.where for issue in result.issues] == ["steps[1].args.to"]
+        assert result.issues[0].problem == (
+            "$steps.agenda.threadId is not in step 'agenda''s result"
         )
 
     async def test_a_reference_the_recorded_result_resolves_is_accepted(self) -> None:

--- a/apps/api/tests/unit/services/workflow/test_playbook_runner.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_runner.py
@@ -8,7 +8,7 @@ runner no longer calls the gate itself.
 
 A replay makes one model call when the playbook has no asks (the end-of-run
 result and verdict) and two when it has asks (an ask fill mid-run, before the step
-that needs it, then the same end-of-run call), no matter how many ``$ask`` fields
+that needs it, then the same end-of-run call), no matter how many ``$ask`` slots
 there are. The scripted model's turns are not model calls and never reach a provider.
 """
 
@@ -37,7 +37,11 @@ from app.agents.middleware.factory import (
 from app.agents.workspace.offload import mark_offload
 from app.constants.hil import HIL_STATUS_KWARG
 from app.constants.log_tags import LogTag
-from app.models.playbook_models import PlaybookAsk, PlaybookDocument, PlaybookStep
+from app.models.playbook_models import (
+    DEFAULT_ASK_MAX_TOKENS,
+    PlaybookDocument,
+    PlaybookStep,
+)
 from app.models.workflow_execution_models import (
     RECORD_CUT_MARKER,
     RESULT_DIGEST_MAX_CHARS,
@@ -180,14 +184,11 @@ class _FakeSubagent:
     config = _FakeSubagentConfig()
 
 
-def _playbook(
-    steps: list[PlaybookStep], ask: dict[str, PlaybookAsk] | None = None
-) -> PlaybookDocument:
+def _playbook(steps: list[PlaybookStep]) -> PlaybookDocument:
     return PlaybookDocument(
         description="Mail the day's agenda",
         steps=steps,
-        ask=ask or {},
-        synthesize="Say how many events there were and that the mail went out.",
+        result_brief="Say how many events there were and that the mail went out.",
         workflow_id="wf_1",
         user_id="u_1",
         workflow_hash="hash_1",
@@ -200,9 +201,22 @@ def _narration(result: str = "Twelve events, mail sent.") -> PlaybookNarration:
     return PlaybookNarration(result=result)
 
 
-def _ask_fill(**asks: str) -> PlaybookAskFill:
+def _slot(prompt: str, max_tokens: int | None = None) -> dict[str, Any]:
+    """An ask slot as it is authored: the instruction, standing in the argument.
+
+    Written as a plain dict rather than through ``AskSlot`` because that is what
+    a stored playbook holds and what the runner has to recognise.
+    """
+    slot: dict[str, Any] = {"$ask": prompt}
+    if max_tokens is not None:
+        slot["max_tokens"] = max_tokens
+    return slot
+
+
+def _ask_fill(asks: dict[str, str] | None = None) -> PlaybookAskFill:
+    """What the one mid-run call answers, keyed by each slot's ``<step>.<arg>`` key."""
     return PlaybookAskFill(
-        asks=[PlaybookAskAnswer(name=name, text=text) for name, text in asks.items()]
+        asks=[PlaybookAskAnswer(name=name, text=text) for name, text in (asks or {}).items()]
     )
 
 
@@ -420,15 +434,14 @@ async def test_one_ask_call_covers_two_asks_and_one_result_call_follows() -> Non
             PlaybookStep(
                 id="mail",
                 tool="send_email",
-                args={"to": "$ask.recipient", "body": "$ask.body"},
+                args={
+                    "to": _slot("Who should get this?"),
+                    "body": _slot("Write the digest."),
+                },
             ),
-        ],
-        ask={
-            "recipient": PlaybookAsk(prompt="Who should get this?", uses=["events"]),
-            "body": PlaybookAsk(prompt="Write the digest.", uses=["events"]),
-        },
+        ]
     )
-    ask_fill = _ask_fill(recipient="team@example.com", body="Twelve events today.")
+    ask_fill = _ask_fill({"mail.to": "team@example.com", "mail.body": "Twelve events today."})
 
     result, llm = await _run(playbook, registry, ask_fill=ask_fill)
 
@@ -440,11 +453,17 @@ async def test_one_ask_call_covers_two_asks_and_one_result_call_follows() -> Non
     # Both fields reach the end call as separate lines: run together they read
     # as one field whose text is the other's, which is what it writes from.
     assert _prompt_block(_result_prompt(llm), "asks") == (
-        "- recipient: team@example.com\n- body: Twelve events today."
+        "- mail.to: team@example.com\n- mail.body: Twelve events today."
     )
 
 
-async def test_a_playbook_with_no_asks_still_makes_exactly_one_call() -> None:
+async def test_a_playbook_with_no_slots_makes_exactly_one_model_call() -> None:
+    """A playbook with nothing to write pays for the narration and nothing else.
+
+    The ask fill is the replay's one optional cost. A second call on a playbook
+    that has no slot to fill is a model call bought for nothing, on every fire
+    of every workflow that never needed one.
+    """
     recorder = _Recorder()
     registry = _FakeRegistry(_tools(recorder))
 
@@ -701,9 +720,14 @@ async def test_a_step_that_raises_is_logged_with_its_error_type() -> None:
     }
 
 
-async def test_a_narration_that_raises_stops_the_run_with_every_step_on_record() -> None:
-    """The narration is the last thing a finished replay does; a raise there
-    dropped a trace in which EVERY step had already run."""
+async def test_a_narration_that_raises_after_every_step_is_still_a_completed_run() -> None:
+    """The steps ARE the workflow; the narration is the sentence about them.
+
+    Prod: 13 of 15 failed replays had every tool step complete and only this
+    call raise. Reported as a stopped run, the user got nothing and the next
+    fire spent a full heal run on a sequence that had just worked. A run that
+    ran everything is a run that finished, and it delivers what it did.
+    """
     recorder = _Recorder()
     registry = _FakeRegistry(_tools(recorder))
     playbook = _playbook(AGENDA_STEPS)
@@ -715,16 +739,23 @@ async def test_a_narration_that_raises_stops_the_run_with_every_step_on_record()
             seams=_Seams(llm=AsyncMock(side_effect=TimeoutError("model"))),
         )
 
-    assert result.ok is False
+    assert result.ok is True
+    assert result.failure is None
     assert [call.tool_name for call in result.trace] == ["list_events", "send_email"]
+    assert result.narration_failed == "the narration raised TimeoutError: model"
+    # The delivered text has to stand in for the summary nobody wrote: why it is
+    # missing, and every step that ran, so the user is not told a blank page.
+    assert result.narration_failed in result.text
+    for line in result.completed:
+        assert f"- {line}" in result.text
     assert len(result.completed) == 2
-    assert result.failure is not None
-    assert result.failure.startswith(
-        "Playbook stopped at step 2 (narration): the narration raised TimeoutError: model."
-    )
+    # No verdict was written, so there is none to report: the narration is what
+    # judges a run, and it never spoke.
+    assert result.suspect is None
+    assert result.suspect_source is None
     assert result.llm_calls == 0
-    # Which of the run's two model calls died, and on what: the failure text
-    # says it to the agent, the event says it to whoever is watching the fleet.
+    # The call still died, and the fleet still hears about it — the run being
+    # deliverable is not the same as the model call being fine.
     assert log.exception.call_args.args == (f"{LogTag.WORKFLOW} Playbook model call raised",)
     assert log.exception.call_args.kwargs == {
         "playbook_id": playbook.playbook_id,
@@ -732,6 +763,37 @@ async def test_a_narration_that_raises_stops_the_run_with_every_step_on_record()
         "call": "narration",
         "error_type": "TimeoutError",
     }
+
+
+async def test_a_narration_failure_still_counts_the_ask_call_that_did_return() -> None:
+    """``llm_calls`` is the replay's cost line: the ask fill was billed, the
+    narration that raised was not."""
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder))
+    playbook = _playbook(
+        [
+            PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
+            PlaybookStep(
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Write the body")},
+            ),
+        ]
+    )
+
+    result, _ = await _run(
+        playbook,
+        registry,
+        seams=_Seams(
+            llm=AsyncMock(
+                side_effect=[_ask_fill({"mail.body": "Here it is."}), RuntimeError("boom")]
+            )
+        ),
+    )
+
+    assert result.ok is True
+    assert result.narration_failed == "the narration raised RuntimeError: boom"
+    assert result.llm_calls == 1
 
 
 async def test_a_mid_run_ask_fill_that_raises_stops_before_the_step_that_needed_it() -> None:
@@ -743,10 +805,11 @@ async def test_a_mid_run_ask_fill_that_raises_stops_before_the_step_that_needed_
         [
             PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
             PlaybookStep(
-                id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Write the body")},
             ),
-        ],
-        ask={"body": PlaybookAsk(prompt="Write the body", uses=["events"])},
+        ]
     )
 
     result, _ = await _run(
@@ -847,16 +910,17 @@ class TestNarrationCall:
             [
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.")},
                 ),
-            ],
-            ask={"body": PlaybookAsk(prompt="Write the digest.", uses=["events"])},
+            ]
         )
 
         result, llm = await _run(
             playbook,
             registry,
-            ask_fill=_ask_fill(body="Twelve today."),
+            ask_fill=_ask_fill({"mail.body": "Twelve today."}),
             seams=_Seams(runnable=runnable),
         )
 
@@ -904,12 +968,30 @@ class TestNarrationCall:
             'mail (send_email {"to":"team@example.com"}) -> sent',
         ]
         assert playbook.description in prompt
-        assert playbook.synthesize in prompt
+        assert playbook.result_brief in prompt
         assert "\n".join(result.completed) in prompt
         # Narrated at the end, so nothing is outstanding: the prompt has no
         # still-to-run section at all, rather than an empty one the model could
         # read as "some steps are missing".
         assert "<still_to_run>" not in prompt
+
+    async def test_the_end_call_is_given_the_result_brief_as_the_brief_to_write_to(self) -> None:
+        """The brief is the only instruction on HOW to write the user's result.
+
+        It is where classification, judgement and summarising live now that a
+        playbook has no ask table to hide them in, so a narration prompt that
+        drops it produces a competent summary of the wrong thing on every fire.
+        """
+        recorder = _Recorder()
+        registry = _FakeRegistry(_tools(recorder))
+        playbook = _playbook(AGENDA_STEPS)
+
+        result, llm = await _run(playbook, registry)
+
+        assert result.ok is True, result.failure
+        assert f"written to this brief (result_brief): {playbook.result_brief}" in _result_prompt(
+            llm
+        )
 
     async def test_a_mid_run_ask_fill_is_told_what_has_not_happened_yet(self) -> None:
         """An ask written before the last step has to know what it is for.
@@ -923,14 +1005,17 @@ class TestNarrationCall:
         playbook = _playbook(
             [
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.summary"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Summarise the day.")},
                 ),
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
-            ],
-            ask={"summary": PlaybookAsk(prompt="Summarise the day.", uses=[])},
+            ]
         )
 
-        result, llm = await _run(playbook, registry, ask_fill=_ask_fill(summary="A quiet day."))
+        result, llm = await _run(
+            playbook, registry, ask_fill=_ask_fill({"mail.body": "A quiet day."})
+        )
 
         assert result.ok is True, result.failure
         prompt = _ask_prompt(llm)
@@ -939,34 +1024,39 @@ class TestNarrationCall:
         # "the run did nothing" rather than "the run has not started".
         assert _prompt_block(prompt, "ran") == "nothing yet"
 
-    async def test_the_prompt_states_every_declared_ask_and_its_budget(self) -> None:
-        """One call fills every ask, so the per-ask instruction can only travel in its prompt."""
+    async def test_the_prompt_states_every_slot_and_its_budget(self) -> None:
+        """One call fills every slot, so the per-slot instruction and its budget
+        can only travel in this prompt. The budget is the slot's own, not the
+        default: a slot that asks for a line and is shown the 1024-token default
+        gets a page, and the argument that carries it is the one that grows."""
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
-        ask = PlaybookAsk(prompt="Write the digest.", uses=["events"])
         playbook = _playbook(
             [
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.", 256)},
                 ),
-            ],
-            ask={"body": ask},
+            ]
         )
 
-        result, llm = await _run(playbook, registry, ask_fill=_ask_fill(body="Twelve today."))
+        result, llm = await _run(
+            playbook, registry, ask_fill=_ask_fill({"mail.body": "Twelve today."})
+        )
 
         assert result.ok is True, result.failure
         prompt = _ask_prompt(llm)
-        assert f"- body: {ask.prompt}" in prompt
-        assert f"budget: about {ask.max_tokens} tokens" in prompt
+        assert "- mail.body: Write the digest." in prompt
+        assert "budget: about 256 tokens" in prompt
 
-    async def test_an_ask_the_model_ignored_is_named_on_the_wide_event(self) -> None:
-        """A silently unwritten ask produces a run that reads as fine and is not.
+    async def test_a_slot_the_model_ignored_is_named_on_the_wide_event(self) -> None:
+        """A silently unwritten slot produces a run that reads as fine and is not.
 
-        The step addressing it fails with a placeholder error far from the cause,
-        so the only way to see that the model skipped a field it was asked for is
-        this warning.
+        The step carrying it fails when its arguments are filled, far from the
+        cause, so the only way to see that the model skipped a slot it was
+        listed is this warning, which names the slot by its key.
         """
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
@@ -974,20 +1064,21 @@ class TestNarrationCall:
             [
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.")},
                 ),
-            ],
-            ask={"body": PlaybookAsk(prompt="Write the digest.", uses=["events"])},
+            ]
         )
 
         with patch(f"{MODULE}.log") as log:
             result, _ = await _run(playbook, registry, ask_fill=_ask_fill())
 
         assert result.ok is False
-        assert "$ask.body" in (result.failure or "")
+        assert "mail.body was never written" in (result.failure or "")
         assert log.warning.call_count == 1
-        assert "wrote nothing for declared asks" in log.warning.call_args.args[0]
-        assert log.warning.call_args.kwargs["missing_asks"] == ["body"]
+        assert "wrote nothing for some slots" in log.warning.call_args.args[0]
+        assert log.warning.call_args.kwargs["missing_asks"] == ["mail.body"]
         assert log.warning.call_args.kwargs["playbook_id"] == playbook.playbook_id
         assert log.warning.call_args.kwargs["workflow_id"] == "wf_1"
 
@@ -1089,14 +1180,15 @@ async def test_a_run_that_stops_after_the_ask_fill_still_reports_the_call_it_mad
     playbook = _playbook(
         [
             PlaybookStep(
-                id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.summary"}
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Summarise the day.")},
             ),
             PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
-        ],
-        ask={"summary": PlaybookAsk(prompt="Summarise the day.", uses=[])},
+        ]
     )
 
-    result, llm = await _run(playbook, registry, ask_fill=_ask_fill(summary="A quiet day."))
+    result, llm = await _run(playbook, registry, ask_fill=_ask_fill({"mail.body": "A quiet day."}))
 
     assert result.ok is False
     assert llm.await_count == 1
@@ -1223,7 +1315,9 @@ class TestNarrationSections:
             [
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.")},
                 ),
                 PlaybookStep(
                     handoff="calendar_agent",
@@ -1231,14 +1325,13 @@ class TestNarrationSections:
                         PlaybookStep(id="more", tool="list_events", args={"calendar_id": "second"})
                     ],
                 ),
-            ],
-            ask={"body": PlaybookAsk(prompt="Write the digest.", uses=[])},
+            ]
         )
 
         result, llm = await _run(
             playbook,
             registry,
-            ask_fill=_ask_fill(body="Twelve today."),
+            ask_fill=_ask_fill({"mail.body": "Twelve today."}),
             seams=_Seams(subagent=_FakeSubagent()),
         )
 
@@ -1249,7 +1342,7 @@ class TestNarrationSections:
             "mail (send_email)\nhandoff to calendar_agent\nmore (list_events)"
         )
 
-    async def test_a_playbook_with_no_asks_says_so_rather_than_leaving_it_blank(self) -> None:
+    async def test_a_playbook_with_no_slots_says_so_rather_than_leaving_it_blank(self) -> None:
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
 
@@ -1258,63 +1351,74 @@ class TestNarrationSections:
         assert result.ok is True, result.failure
         assert _prompt_block(str(llm.await_args.args[1]), "asks") == "none"
 
-    async def test_each_ask_arrives_with_its_budget_and_the_steps_it_works_from(self) -> None:
-        """An ask names the steps it is written from, and they must reach the model.
+    async def test_a_slot_is_listed_with_its_budget_and_nothing_it_cannot_have(self) -> None:
+        """A slot is two lines and no more.
 
-        Without them the model writes the field from the whole run, which is the
-        difference between "the digest of the calendar" and "a summary of
-        everything that happened".
+        It has no set of steps to read: it is written from everything listed as
+        already run, because an inline slot has no way to name a subset of it.
+        The block is pinned whole, so a third line reappearing — a works-from
+        naming steps the slot cannot address — fails here rather than silently
+        narrowing what the model writes from.
         """
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
-        ask = PlaybookAsk(prompt="Write the digest.", uses=["events", "mail"])
         playbook = _playbook(
             [
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
                 PlaybookStep(id="mail", tool="send_email", args={"to": "$trigger.to"}),
                 PlaybookStep(
-                    id="note", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="note",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.")},
                 ),
-            ],
-            ask={"body": ask},
+            ]
         )
 
-        result, llm = await _run(playbook, registry, ask_fill=_ask_fill(body="Twelve today."))
+        result, llm = await _run(
+            playbook, registry, ask_fill=_ask_fill({"note.body": "Twelve today."})
+        )
 
         assert result.ok is True, result.failure
         assert _prompt_block(_ask_prompt(llm), "asks") == "\n".join(
             [
-                f"- body: {ask.prompt}",
-                f"  budget: about {ask.max_tokens} tokens",
-                '  works from: events (list_events {"calendar_id":"primary"}) -> {"count": 12}; mail (send_email {"to":"team@example.com"}) -> sent',
+                "- note.body: Write the digest.",
+                f"  budget: about {DEFAULT_ASK_MAX_TOKENS} tokens",
             ]
         )
         # One step per line: run together, two calls read as one call whose
-        # result is the other's, and the field is written from that.
+        # result is the other's, and the slot is written from that.
         assert _prompt_block(_ask_prompt(llm), "ran") == (
             'events (list_events {"calendar_id":"primary"}) -> {"count": 12}\n'
             'mail (send_email {"to":"team@example.com"}) -> sent'
         )
 
-    async def test_an_ask_inside_a_list_argument_still_triggers_the_ask_fill(self) -> None:
-        """Placeholders are found wherever they are, not only at the top level.
+    async def test_a_slot_inside_a_list_argument_still_triggers_the_ask_fill(self) -> None:
+        """Slots are found wherever they are, not only at the top level.
 
-        A step whose ``$ask`` sits inside a list would otherwise run before the
-        model ever wrote the field, and fail on a placeholder that was going to
-        be filled one line later.
+        A step whose slot sits inside a list would otherwise run before the
+        model ever wrote it, and send the slot's own dict as the argument. The
+        key names the position: the list index is part of the address.
         """
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
         playbook = _playbook(
-            [PlaybookStep(id="notes", tool="file_notes", args={"items": ["intro", "$ask.body"]})],
-            ask={"body": PlaybookAsk(prompt="Write the digest.", uses=[])},
+            [
+                PlaybookStep(
+                    id="notes",
+                    tool="file_notes",
+                    args={"items": ["intro", _slot("Write the digest.")]},
+                )
+            ]
         )
 
-        result, llm = await _run(playbook, registry, ask_fill=_ask_fill(body="Twelve today."))
+        result, llm = await _run(
+            playbook, registry, ask_fill=_ask_fill({"notes.items.1": "Twelve today."})
+        )
 
         assert result.ok is True, result.failure
         assert llm.await_count == 2
         assert recorder.calls[0][1]["items"] == ["intro", "Twelve today."]
+        assert "- notes.items.1: Write the digest." in _ask_prompt(llm)
 
 
 # --- when each model call happens ------------------------------------------
@@ -1323,8 +1427,8 @@ class TestNarrationSections:
 class TestCallOrder:
     """When the two model calls fire, relative to the steps.
 
-    Seen live on "write a note ($ask.note), then create_todo with it": one call
-    filled the ask AND wrote the result AND judged the run, before create_todo
+    Seen live on "write a note (an $ask slot), then create_todo with it": one call
+    filled the slot AND wrote the result AND judged the run, before create_todo
     ran. The verdict said "the create_todo step had not run, so no todo was
     created", the replay was distrusted and the agent redid the fire. The ask
     has to be written before the step that needs it; the result and the verdict
@@ -1333,18 +1437,19 @@ class TestCallOrder:
 
     ASK_STEPS: ClassVar[list[PlaybookStep]] = [
         PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
-        PlaybookStep(id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}),
+        PlaybookStep(
+            id="mail",
+            tool="send_email",
+            args={"to": "$trigger.to", "body": {"$ask": "Write the digest."}},
+        ),
     ]
-    ASK: ClassVar[dict[str, PlaybookAsk]] = {
-        "body": PlaybookAsk(prompt="Write the digest.", uses=["events"])
-    }
 
     async def test_the_ask_call_precedes_its_step_and_the_result_call_follows_the_last(
         self,
     ) -> None:
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
-        answers = [_ask_fill(body="Twelve today."), _narration()]
+        answers = [_ask_fill({"mail.body": "Twelve today."}), _narration()]
         tools_run_before_each_call: list[list[str]] = []
 
         async def model(runnable: object, prompt: object, **kwargs: object) -> object:
@@ -1352,7 +1457,7 @@ class TestCallOrder:
             return answers[len(tools_run_before_each_call) - 1]
 
         result, llm = await _run(
-            _playbook(self.ASK_STEPS, ask=self.ASK),
+            _playbook(self.ASK_STEPS),
             registry,
             seams=_Seams(llm=AsyncMock(side_effect=model)),
         )
@@ -1376,7 +1481,7 @@ class TestCallOrder:
         registry = _FakeRegistry(_tools(recorder))
 
         result, llm = await _run(
-            _playbook(self.ASK_STEPS, ask=self.ASK), registry, ask_fill=_ask_fill(body="x")
+            _playbook(self.ASK_STEPS), registry, ask_fill=_ask_fill({"mail.body": "x"})
         )
 
         assert result.ok is True, result.failure
@@ -1387,15 +1492,15 @@ class TestCallOrder:
         assert _prompt_block(_ask_prompt(llm), "still_to_run") == "mail (send_email)"
 
     async def test_the_ask_calls_answers_resolve_the_later_steps_arguments(self) -> None:
-        """``$ask.<name>`` is read from the ask call, not from the result call,
-        which returns no asks at all."""
+        """A slot's text is read from the ask call, not from the result call,
+        which writes no slots at all."""
         recorder = _Recorder()
         registry = _FakeRegistry(_tools(recorder))
 
         result, _ = await _run(
-            _playbook(self.ASK_STEPS, ask=self.ASK),
+            _playbook(self.ASK_STEPS),
             registry,
-            ask_fill=_ask_fill(body="Written by the ask call."),
+            ask_fill=_ask_fill({"mail.body": "Written by the ask call."}),
             narration=_narration("Written by the result call."),
         )
 
@@ -1408,13 +1513,13 @@ class TestCallOrder:
         registry = _FakeRegistry(_tools(recorder))
 
         result, llm = await _run(
-            _playbook(self.ASK_STEPS, ask=self.ASK),
+            _playbook(self.ASK_STEPS),
             registry,
-            ask_fill=_ask_fill(body="Twelve today."),
+            ask_fill=_ask_fill({"mail.body": "Twelve today."}),
         )
 
         assert result.ok is True, result.failure
-        assert _prompt_block(_result_prompt(llm), "asks") == "- body: Twelve today."
+        assert _prompt_block(_result_prompt(llm), "asks") == "- mail.body: Twelve today."
 
 
 # --- what a stopped run reports --------------------------------------------
@@ -1805,12 +1910,13 @@ class TestNonStringResults:
         assert "twelve events" in result.trace[0].result_digest
 
 
-async def test_a_handoff_child_can_address_an_ask() -> None:
+async def test_a_handoff_child_can_carry_a_slot() -> None:
     """The ask fill a child triggers is the parent playbook's, not the handoff's.
 
     A handoff's children are run against the same playbook, so a child that
-    needs a ``$ask`` fills it from the whole playbook. Filling it from anything
-    else has nothing to write the field from.
+    carries a slot fills it from the whole playbook. Filling it from anything
+    else has nothing to write from. The key is the CHILD's id, not the
+    handoff's: a key built from the handoff would name a step with no arguments.
     """
     recorder = _Recorder()
     registry = _FakeRegistry(_tools(recorder), spaces={"calendar": ["list_events"]})
@@ -1819,17 +1925,20 @@ async def test_a_handoff_child_can_address_an_ask() -> None:
             PlaybookStep(
                 handoff="calendar_agent",
                 steps=[
-                    PlaybookStep(id="more", tool="list_events", args={"calendar_id": "$ask.which"})
+                    PlaybookStep(
+                        id="more",
+                        tool="list_events",
+                        args={"calendar_id": _slot("Which calendar?")},
+                    )
                 ],
             )
-        ],
-        ask={"which": PlaybookAsk(prompt="Which calendar?", uses=[])},
+        ]
     )
 
     result, llm = await _run(
         playbook,
         registry,
-        ask_fill=_ask_fill(which="primary"),
+        ask_fill=_ask_fill({"more.calendar_id": "primary"}),
         seams=_Seams(subagent=_FakeSubagent()),
     )
 
@@ -2004,17 +2113,18 @@ class TestSuspectVerdict:
         playbook = _playbook(
             [
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.")},
                 ),
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
-            ],
-            ask={"body": PlaybookAsk(prompt="Write the digest.", uses=[])},
+            ]
         )
 
         result, llm = await _run(
             playbook,
             registry,
-            ask_fill=_ask_fill(body="Twelve today."),
+            ask_fill=_ask_fill({"mail.body": "Twelve today."}),
             seams=_Seams(find_previous=_previous_run(self.PREVIOUS_HAD_THREE)),
         )
 
@@ -2268,10 +2378,11 @@ class TestSuspectVerdict:
             [
                 PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
                 PlaybookStep(
-                    id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                    id="mail",
+                    tool="send_email",
+                    args={"to": "$trigger.to", "body": _slot("Write the digest.")},
                 ),
-            ],
-            ask={"body": PlaybookAsk(prompt="Write the digest.", uses=["events"])},
+            ]
         )
         narration = PlaybookNarration(
             result="Twelve events, but the mail did not go out.",
@@ -2280,7 +2391,10 @@ class TestSuspectVerdict:
         )
 
         result, llm = await _run(
-            playbook, registry, ask_fill=_ask_fill(body="Twelve today."), narration=narration
+            playbook,
+            registry,
+            ask_fill=_ask_fill({"mail.body": "Twelve today."}),
+            narration=narration,
         )
 
         assert result.ok is True, result.failure
@@ -2338,10 +2452,10 @@ async def test_a_replay_that_finished_without_a_narration_refuses_to_report_a_re
     assert str(raised.value) == "playbook replay finished every step without a narration"
 
 
-async def test_the_asks_are_filled_once_however_many_steps_address_them() -> None:
-    """The fill is remembered, so the second step reads what the first wrote.
+async def test_the_slots_are_filled_once_however_many_steps_carry_them() -> None:
+    """The fill is remembered, so the third step reads what the one call wrote.
 
-    Forgetting it costs another model call mid-run and lets one field be
+    Forgetting it costs another model call mid-run and lets one instruction be
     answered two different ways inside a single replay: the mail says one thing
     and the note filed about it says another.
     """
@@ -2351,22 +2465,204 @@ async def test_the_asks_are_filled_once_however_many_steps_address_them() -> Non
         [
             PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
             PlaybookStep(
-                id="mail", tool="send_email", args={"to": "$trigger.to", "body": "$ask.body"}
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Write the digest.")},
             ),
             PlaybookStep(
-                id="note", tool="send_email", args={"to": "$user.email", "body": "$ask.body"}
+                id="note",
+                tool="send_email",
+                args={"to": "$user.email", "body": _slot("Write the digest.")},
             ),
-        ],
-        ask={"body": PlaybookAsk(prompt="Write the digest.", uses=["events"])},
+        ]
     )
 
-    result, llm = await _run(playbook, registry, ask_fill=_ask_fill(body="Twelve today."))
+    result, llm = await _run(
+        playbook,
+        registry,
+        ask_fill=_ask_fill({"mail.body": "Twelve today.", "note.body": "Twelve today."}),
+    )
 
     assert result.ok is True, result.failure
     assert llm.await_count == 2
     assert result.llm_calls == 2
     assert recorder.calls[1][1]["body"] == "Twelve today."
     assert recorder.calls[2][1]["body"] == "Twelve today."
+
+
+# --- one fill, every slot ---------------------------------------------------
+
+
+async def test_one_ask_call_fills_every_slot_including_a_later_steps_and_a_childs() -> None:
+    """One mid-run call writes every slot the playbook holds, wherever it sits.
+
+    Slots are addressed by key, so a later step's slot and a slot inside a
+    handoff's recorded child are written by the same call that the first slot
+    triggered. A fill that covered only the step that triggered it would cost a
+    model call per step with a slot, and each one would answer the same playbook
+    from a different half of the run.
+    """
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder), spaces={"calendar": ["list_events"]})
+    playbook = _playbook(
+        [
+            PlaybookStep(
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Write the digest.")},
+            ),
+            PlaybookStep(
+                id="note",
+                tool="send_email",
+                args={"to": "$user.email", "body": _slot("Write the note.")},
+            ),
+            PlaybookStep(
+                handoff="calendar_agent",
+                steps=[
+                    PlaybookStep(
+                        id="more",
+                        tool="list_events",
+                        args={"calendar_id": _slot("Which calendar?")},
+                    )
+                ],
+            ),
+        ]
+    )
+
+    result, llm = await _run(
+        playbook,
+        registry,
+        ask_fill=_ask_fill(
+            {
+                "mail.body": "Twelve events today.",
+                "note.body": "Filed for the record.",
+                "more.calendar_id": "second",
+            }
+        ),
+        seams=_Seams(subagent=_FakeSubagent()),
+    )
+
+    assert result.ok is True, result.failure
+    assert llm.await_count == 2
+    assert result.llm_calls == 2
+    assert recorder.calls[0][1]["body"] == "Twelve events today."
+    assert recorder.calls[1][1]["body"] == "Filed for the record."
+    assert recorder.calls[2][1]["calendar_id"] == "second"
+    # Listed in execution order, handoff children included, keyed by
+    # ``<step id>.<argument path>`` — the key the answers are looked back up by.
+    assert _prompt_block(_ask_prompt(llm), "asks").splitlines()[::2] == [
+        "- mail.body: Write the digest.",
+        "- note.body: Write the note.",
+        "- more.calendar_id: Which calendar?",
+    ]
+
+
+async def test_the_ask_fill_fires_at_the_first_step_with_a_slot_and_not_again() -> None:
+    """One fill, at the first step that carries a slot — not one per such step.
+
+    A run whose first and third steps both carry slots still makes exactly one
+    fill call, before anything has run. A second fill mid-run buys another model
+    call and lets one instruction be answered two different ways inside a single
+    replay.
+    """
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder))
+    playbook = _playbook(
+        [
+            PlaybookStep(
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Write the digest.")},
+            ),
+            PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
+            PlaybookStep(
+                id="note",
+                tool="send_email",
+                args={"to": "$user.email", "body": _slot("Write the note.")},
+            ),
+        ]
+    )
+    answers = [_ask_fill({"mail.body": "Twelve today.", "note.body": "Filed."}), _narration()]
+    tools_run_before_each_call: list[list[str]] = []
+
+    async def model(runnable: object, prompt: object, **kwargs: object) -> object:
+        tools_run_before_each_call.append([name for name, _ in recorder.calls])
+        return answers[len(tools_run_before_each_call) - 1]
+
+    result, llm = await _run(playbook, registry, seams=_Seams(llm=AsyncMock(side_effect=model)))
+
+    assert result.ok is True, result.failure
+    # The fill ran before step 1, and the only call after it is the end-of-run
+    # one: the third step's slot did not trigger a second fill.
+    assert tools_run_before_each_call == [[], ["send_email", "list_events", "send_email"]]
+    assert llm.await_count == 2
+    assert result.llm_calls == 2
+    assert recorder.calls[2][1]["body"] == "Filed."
+
+
+async def test_a_slot_is_filled_before_the_placeholder_beside_it_is_resolved() -> None:
+    """Filling runs first, so a slot and a ``$steps`` reference in one argument
+    both arrive resolved.
+
+    The order is load-bearing in both directions: resolution first would meet the
+    slot's own dict and stop the run, and a fill that did not leave an ordinary
+    string behind would send the placeholder next to it as literal text.
+    """
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder))
+    playbook = _playbook(
+        [
+            PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
+            PlaybookStep(
+                id="notes",
+                tool="file_notes",
+                args={
+                    "items": [_slot("Write the digest."), "Found $steps.events.count events"],
+                },
+            ),
+        ]
+    )
+
+    result, _ = await _run(
+        playbook, registry, ask_fill=_ask_fill({"notes.items.0": "Twelve today."})
+    )
+
+    assert result.ok is True, result.failure
+    assert recorder.calls[1][1]["items"] == ["Twelve today.", "Found 12 events"]
+
+
+async def test_a_fill_that_omits_a_slot_stops_the_run_at_that_step_naming_the_key() -> None:
+    """A slot with no text is a hole in a real tool call, so the step must not run.
+
+    The report names the key the model was listed, which is the only thing that
+    says which of the slots came back empty, and it lists the steps that DID run
+    so the agent finishing the fire does not repeat their side effects.
+    """
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder))
+    playbook = _playbook(
+        [
+            PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
+            PlaybookStep(
+                id="mail",
+                tool="send_email",
+                args={"to": "$trigger.to", "body": _slot("Write the digest.")},
+            ),
+        ]
+    )
+
+    result, _ = await _run(
+        playbook, registry, ask_fill=_ask_fill({"mail.elsewhere": "Twelve today."})
+    )
+
+    assert result.ok is False
+    assert result.failure is not None
+    assert result.failure.startswith(
+        "Playbook stopped at step 2 (send_email): mail.body was never written."
+    )
+    # The step never ran; the one before it did, and the report says so.
+    assert [name for name, _ in recorder.calls] == ["list_events"]
+    assert result.completed == ['events (list_events {"calendar_id":"primary"}) -> {"count": 12}']
 
 
 async def test_a_refusal_carrying_content_blocks_is_quoted_rather_than_lost() -> None:
@@ -2611,8 +2907,8 @@ class TestGuardsOnStatesTheModelsRuleOut:
         assert failure.position == 1
         assert failure.reason == "no tool named '' exists"
 
-    def test_a_playbook_with_no_asks_renders_them_as_a_word(self) -> None:
-        assert _render_asks({}, []) == "none"
+    def test_a_playbook_with_no_slots_renders_them_as_a_word(self) -> None:
+        assert _render_asks([]) == "none"
 
     def test_a_record_verdict_is_reported_as_the_records(self) -> None:
         run = _bare_run()

--- a/apps/api/tests/unit/services/workflow/test_playbook_runner.py
+++ b/apps/api/tests/unit/services/workflow/test_playbook_runner.py
@@ -7,9 +7,9 @@ which is the only way to tell that a replay still gates every call now that the
 runner no longer calls the gate itself.
 
 A replay makes one model call when the playbook has no asks (the end-of-run
-result and verdict) and two when it has asks (an ask fill mid-run, before the step
-that needs it, then the same end-of-run call), no matter how many ``$ask`` slots
-there are. The scripted model's turns are not model calls and never reach a provider.
+result and verdict), plus one ask fill for each step that carries ``$ask`` slots,
+made immediately before that step so the slots are written from what has actually
+run. The scripted model's turns are not model calls and never reach a provider.
 """
 
 from collections.abc import Iterator
@@ -214,15 +214,15 @@ def _slot(prompt: str, max_tokens: int | None = None) -> dict[str, Any]:
 
 
 def _ask_fill(asks: dict[str, str] | None = None) -> PlaybookAskFill:
-    """What the one mid-run call answers, keyed by each slot's ``<step>.<arg>`` key."""
+    """What one ask call answers, keyed by each slot's ``<step>.<arg>`` key."""
     return PlaybookAskFill(
         asks=[PlaybookAskAnswer(name=name, text=text) for name, text in (asks or {}).items()]
     )
 
 
-def _ask_prompt(llm: AsyncMock) -> str:
-    """The prompt the mid-run ask call was given: always the FIRST model call."""
-    return str(llm.await_args_list[0].args[1])
+def _ask_prompt(llm: AsyncMock, index: int = 0) -> str:
+    """The prompt an ask call was given; the ask calls come before the end-of-run one."""
+    return str(llm.await_args_list[index].args[1])
 
 
 def _result_prompt(llm: AsyncMock) -> str:
@@ -265,8 +265,10 @@ async def _run(
     """Run the playbook with mocked seams; hands back the result and the LLM mock.
 
     ``narration`` is what the end-of-run call returns; ``ask_fill`` is what the
-    mid-run ask call returns, and giving one makes the model answer the ask call
-    first and the narration second, in that order. ``runnable``,
+    ask call returns, and giving one makes the model answer the ask call first
+    and the narration second, in that order — so it fits a playbook whose slots
+    all sit on one step. A playbook with slots on several steps makes an ask
+    call per step and scripts them through ``seams.llm`` instead. ``runnable``,
     ``find_previous`` and ``llm`` let a test hold on to the seam it is asserting
     about: how a model call is built, what the previous execution's trace was
     looked up with, and what the model calls do.
@@ -2452,55 +2454,124 @@ async def test_a_replay_that_finished_without_a_narration_refuses_to_report_a_re
     assert str(raised.value) == "playbook replay finished every step without a narration"
 
 
-async def test_the_slots_are_filled_once_however_many_steps_carry_them() -> None:
-    """The fill is remembered, so the third step reads what the one call wrote.
+#: Two slotted steps around a fetch: the mail's body is written from the events,
+#: and the note's body is written from what the mail actually went out as.
+TWO_SLOTTED_STEPS = [
+    PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
+    PlaybookStep(
+        id="mail",
+        tool="send_email",
+        args={"to": "$trigger.to", "body": _slot("Write the digest.")},
+    ),
+    PlaybookStep(
+        id="note",
+        tool="send_email",
+        args={"to": "$user.email", "body": _slot("Note what the mail said.")},
+    ),
+]
 
-    Forgetting it costs another model call mid-run and lets one instruction be
-    answered two different ways inside a single replay: the mail says one thing
-    and the note filed about it says another.
+
+async def test_each_slotted_step_gets_its_own_ask_call_listing_only_its_slots() -> None:
+    """Two steps carrying slots, two ask calls, and neither is shown the other's.
+
+    The keys are what say which step a call is answering for, so a call listed
+    both steps' keys is a call being asked to write an argument for a step that
+    is still several results away.
     """
     recorder = _Recorder()
     registry = _FakeRegistry(_tools(recorder))
-    playbook = _playbook(
-        [
-            PlaybookStep(id="events", tool="list_events", args={"calendar_id": "primary"}),
-            PlaybookStep(
-                id="mail",
-                tool="send_email",
-                args={"to": "$trigger.to", "body": _slot("Write the digest.")},
-            ),
-            PlaybookStep(
-                id="note",
-                tool="send_email",
-                args={"to": "$user.email", "body": _slot("Write the digest.")},
-            ),
+    fills = AsyncMock(
+        side_effect=[
+            _ask_fill({"mail.body": "Twelve today."}),
+            _ask_fill({"note.body": "Told the team about twelve."}),
+            _narration(),
         ]
     )
 
-    result, llm = await _run(
-        playbook,
-        registry,
-        ask_fill=_ask_fill({"mail.body": "Twelve today.", "note.body": "Twelve today."}),
-    )
+    result, llm = await _run(_playbook(TWO_SLOTTED_STEPS), registry, seams=_Seams(llm=fills))
 
     assert result.ok is True, result.failure
-    assert llm.await_count == 2
-    assert result.llm_calls == 2
+    assert llm.await_count == 3
+    assert result.llm_calls == 3
+    assert _prompt_block(_ask_prompt(llm, 0), "asks").splitlines()[::2] == [
+        "- mail.body: Write the digest."
+    ]
+    assert _prompt_block(_ask_prompt(llm, 1), "asks").splitlines()[::2] == [
+        "- note.body: Note what the mail said."
+    ]
     assert recorder.calls[1][1]["body"] == "Twelve today."
-    assert recorder.calls[2][1]["body"] == "Twelve today."
+    assert recorder.calls[2][1]["body"] == "Told the team about twelve."
 
 
-# --- one fill, every slot ---------------------------------------------------
+async def test_a_later_steps_slot_is_written_from_the_steps_that_already_ran() -> None:
+    """The bug this split fixes: a slot answered before the run reached it.
+
+    One call at the first slotted step wrote every slot in the playbook, so the
+    note's "what the mail said" was answered with nothing listed under ran — the
+    mail had not gone out yet — and that text reached a real tool. Its call now
+    fires at its own step, with the fetch and the mail both listed as run.
+    """
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder))
+    fills = AsyncMock(
+        side_effect=[
+            _ask_fill({"mail.body": "Twelve today."}),
+            _ask_fill({"note.body": "Told the team about twelve."}),
+            _narration(),
+        ]
+    )
+
+    result, llm = await _run(_playbook(TWO_SLOTTED_STEPS), registry, seams=_Seams(llm=fills))
+
+    assert result.ok is True, result.failure
+    assert _prompt_block(_ask_prompt(llm, 0), "ran") == (
+        'events (list_events {"calendar_id":"primary"}) -> {"count": 12}'
+    )
+    assert _prompt_block(_ask_prompt(llm, 1), "ran") == (
+        'events (list_events {"calendar_id":"primary"}) -> {"count": 12}\n'
+        'mail (send_email {"to":"team@example.com","body":"Twelve today."}) -> sent'
+    )
 
 
-async def test_one_ask_call_fills_every_slot_including_a_later_steps_and_a_childs() -> None:
-    """One mid-run call writes every slot the playbook holds, wherever it sits.
+async def test_a_fill_that_omits_a_later_steps_key_stops_the_run_at_that_step() -> None:
+    """Each call is checked against its own step's slots, not the playbook's.
 
-    Slots are addressed by key, so a later step's slot and a slot inside a
-    handoff's recorded child are written by the same call that the first slot
-    triggered. A fill that covered only the step that triggered it would cost a
-    model call per step with a slot, and each one would answer the same playbook
-    from a different half of the run.
+    A step whose call came back without its key must not run: the argument would
+    still hold the slot's own dict. Checked at the later step because that is
+    where the earlier fill's answers no longer stand in for it — the run has
+    already spent a call, so "some slot was written" says nothing about this one.
+    """
+    recorder = _Recorder()
+    registry = _FakeRegistry(_tools(recorder))
+    fills = AsyncMock(
+        side_effect=[_ask_fill({"mail.body": "Twelve today."}), _ask_fill({"note.elsewhere": "x"})]
+    )
+
+    with patch(f"{MODULE}.log") as log:
+        result, llm = await _run(_playbook(TWO_SLOTTED_STEPS), registry, seams=_Seams(llm=fills))
+
+    assert result.ok is False
+    assert result.failure is not None
+    assert result.failure.startswith(
+        "Playbook stopped at step 3 (send_email): note.body was never written."
+    )
+    # The step never ran, and the mail before it did: the fill that answered
+    # that step's own slot is not undone by the one that failed.
+    assert [name for name, _ in recorder.calls] == ["list_events", "send_email"]
+    assert llm.await_count == 2
+    assert log.warning.call_args.kwargs["missing_asks"] == ["note.body"]
+
+
+# --- one fill per slotted step ----------------------------------------------
+
+
+async def test_a_handoff_childs_slot_is_filled_by_its_own_call_like_any_other() -> None:
+    """A child inside a handoff is a step, so it gets a step's ask call.
+
+    Its slot is not swept up by the call the first top-level slot triggered:
+    the child runs last, and a fill made before the two steps ahead of it would
+    write its argument from a run that had not reached it. The keys stay the
+    child's own, so the answers still land where the evaluator looks for them.
     """
     recorder = _Recorder()
     registry = _FakeRegistry(_tools(recorder), spaces={"calendar": ["list_events"]})
@@ -2529,41 +2600,45 @@ async def test_one_ask_call_fills_every_slot_including_a_later_steps_and_a_child
         ]
     )
 
+    fills = AsyncMock(
+        side_effect=[
+            _ask_fill({"mail.body": "Twelve events today."}),
+            _ask_fill({"note.body": "Filed for the record."}),
+            _ask_fill({"more.calendar_id": "second"}),
+            _narration(),
+        ]
+    )
+
     result, llm = await _run(
         playbook,
         registry,
-        ask_fill=_ask_fill(
-            {
-                "mail.body": "Twelve events today.",
-                "note.body": "Filed for the record.",
-                "more.calendar_id": "second",
-            }
-        ),
-        seams=_Seams(subagent=_FakeSubagent()),
+        seams=_Seams(subagent=_FakeSubagent(), llm=fills),
     )
 
     assert result.ok is True, result.failure
-    assert llm.await_count == 2
-    assert result.llm_calls == 2
+    assert llm.await_count == 4
+    assert result.llm_calls == 4
     assert recorder.calls[0][1]["body"] == "Twelve events today."
     assert recorder.calls[1][1]["body"] == "Filed for the record."
     assert recorder.calls[2][1]["calendar_id"] == "second"
-    # Listed in execution order, handoff children included, keyed by
+    # One call per slotted step, in execution order, each keyed by
     # ``<step id>.<argument path>`` — the key the answers are looked back up by.
-    assert _prompt_block(_ask_prompt(llm), "asks").splitlines()[::2] == [
+    assert [
+        _prompt_block(_ask_prompt(llm, index), "asks").splitlines()[0] for index in range(3)
+    ] == [
         "- mail.body: Write the digest.",
         "- note.body: Write the note.",
         "- more.calendar_id: Which calendar?",
     ]
 
 
-async def test_the_ask_fill_fires_at_the_first_step_with_a_slot_and_not_again() -> None:
-    """One fill, at the first step that carries a slot — not one per such step.
+async def test_each_fill_fires_at_its_own_step_and_no_earlier() -> None:
+    """A run whose first and third steps carry slots makes one fill at each.
 
-    A run whose first and third steps both carry slots still makes exactly one
-    fill call, before anything has run. A second fill mid-run buys another model
-    call and lets one instruction be answered two different ways inside a single
-    replay.
+    The first fires before anything has run, which is all its step can be
+    written from. The second fires after the two steps in front of it, which is
+    the whole point: written at the first one it would answer from a run that
+    had not fetched anything yet.
     """
     recorder = _Recorder()
     registry = _FakeRegistry(_tools(recorder))
@@ -2582,7 +2657,11 @@ async def test_the_ask_fill_fires_at_the_first_step_with_a_slot_and_not_again() 
             ),
         ]
     )
-    answers = [_ask_fill({"mail.body": "Twelve today.", "note.body": "Filed."}), _narration()]
+    answers = [
+        _ask_fill({"mail.body": "Twelve today."}),
+        _ask_fill({"note.body": "Filed."}),
+        _narration(),
+    ]
     tools_run_before_each_call: list[list[str]] = []
 
     async def model(runnable: object, prompt: object, **kwargs: object) -> object:
@@ -2592,11 +2671,13 @@ async def test_the_ask_fill_fires_at_the_first_step_with_a_slot_and_not_again() 
     result, llm = await _run(playbook, registry, seams=_Seams(llm=AsyncMock(side_effect=model)))
 
     assert result.ok is True, result.failure
-    # The fill ran before step 1, and the only call after it is the end-of-run
-    # one: the third step's slot did not trigger a second fill.
-    assert tools_run_before_each_call == [[], ["send_email", "list_events", "send_email"]]
-    assert llm.await_count == 2
-    assert result.llm_calls == 2
+    assert tools_run_before_each_call == [
+        [],
+        ["send_email", "list_events"],
+        ["send_email", "list_events", "send_email"],
+    ]
+    assert llm.await_count == 3
+    assert result.llm_calls == 3
     assert recorder.calls[2][1]["body"] == "Filed."
 
 
@@ -2845,7 +2926,7 @@ async def test_the_ask_fill_adds_to_the_runs_llm_count_rather_than_resetting_it(
         patch(f"{MODULE}.background_structured_runnable", MagicMock()),
         patch(f"{MODULE}.ainvoke_llm", AsyncMock(return_value=fill)),
     ):
-        await _fill_asks(playbook, run, pending=[])
+        await _fill_asks(playbook, playbook.steps[0], run, pending=[])
 
     assert run.llm_calls == 6
     assert run.ask_fill is fill

--- a/apps/api/tests/unit/tools/test_executor_tool.py
+++ b/apps/api/tests/unit/tools/test_executor_tool.py
@@ -964,7 +964,7 @@ def _failed_playbook() -> PlaybookDocument:
         workflow_hash="h",
         description="d",
         steps=[PlaybookStep(id="events", tool="list_events", args={})],
-        synthesize="s",
+        result_brief="s",
         last_run_status=PlaybookRunStatus.FAILED,
         last_run_reason="stopped at step 2 (send_email)",
         created_at=now,

--- a/apps/api/tests/unit/workers/test_workflow_tasks_playbook.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks_playbook.py
@@ -37,26 +37,27 @@ from app.models.playbook_models import (
 )
 from app.models.workflow_execution_models import RecordedCall
 from app.models.workflow_models import (
+    PlaybookDiscard,
     TriggerConfig,
     TriggerType,
     Workflow,
     WorkflowStep,
 )
 from app.services.workflow.execution_service import WorkflowFireQueued
+from app.services.workflow.playbook.check import HEAL_STATUSES
 from app.services.workflow.playbook.evaluator import PlaybookUser
-from app.services.workflow.playbook.runner import PlaybookRunResult
+from app.services.workflow.playbook.runner import FALLBACK_LINE_MAX_CHARS, PlaybookRunResult
 from app.services.workflow.playbook.workflow_hash import workflow_hash
 from app.utils.timezone import Timezone
 from app.workers.tasks.workflow_tasks import (
     AGENT_RUN_SUMMARY,
-    FALLBACK_LINE_MAX_CHARS,
     HEAL_RUN_SUMMARY,
     OVERLAPPED_SUMMARY,
     REPLAY_FLAGGED_SUMMARY,
+    REPLAY_NARRATION_FAILED_SUMMARY,
     REPLAY_STOPPED_SUMMARY,
     REPLAY_SUMMARY,
     SHORTCUT_DISCARDED_SUMMARY,
-    _bounded_line,
     _fallback_note,
     _notify_replay_finished,
     _resolve_workflow_user,
@@ -109,7 +110,7 @@ def _playbook(workflow: Workflow, *, stale: bool = False) -> PlaybookDocument:
         ),
         description="Mail the day's agenda",
         steps=[PlaybookStep(id="events", tool="list_events", args={})],
-        synthesize="Say what happened.",
+        result_brief="Say what happened.",
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
     )
@@ -131,6 +132,7 @@ class _Harness:
         self.record_run_outcome = AsyncMock(return_value=None)
         self.increment_heal_attempts = AsyncMock(return_value=None)
         self.delete_for_workflow = AsyncMock(return_value=True)
+        self.update_workflow = AsyncMock(return_value=None)
         self.add_messages = AsyncMock()
         self.platform_delivery = AsyncMock()
         self.completion_notification = AsyncMock()
@@ -178,6 +180,10 @@ class _Harness:
                 f"{MODULE}.playbook_repository.increment_heal_attempts",
                 self.increment_heal_attempts,
             ),
+            patch(
+                f"{MODULE}.workflow_repository.update_for_user",
+                self.update_workflow,
+            ),
             patch(f"{MODULE}.add_playbook_run_messages", self.add_messages),
             patch(f"{MODULE}.deliver_result_to_platforms", self.platform_delivery),
             patch(
@@ -191,6 +197,13 @@ class _Harness:
     def summary(self) -> str:
         """What the execution record says this fire did."""
         return str(self.complete_execution.await_args.kwargs["summary"])
+
+    def discard_record(self) -> PlaybookDiscard:
+        """What this fire wrote onto the workflow about the shortcut it dropped."""
+        self.update_workflow.assert_awaited_once()
+        update = self.update_workflow.await_args.args[2]
+        assert update.last_playbook_discard is not None
+        return update.last_playbook_discard
 
     def delivered_text(self) -> str:
         """What the user reads in the conversation for this fire's replay."""
@@ -591,13 +604,13 @@ class TestSuspectReplay:
         warnings = [
             call
             for call in harness.log.warning.call_args_list
-            if "disabled" in str(call.args[0]).lower()
+            if call.kwargs.get("reason") == "suspect_streak_exhausted"
         ]
         assert len(warnings) == 1
         kwargs = warnings[0].kwargs
         assert kwargs["workflow_id"] == workflow.id
         assert kwargs["playbook_id"] == playbook.playbook_id
-        assert kwargs["reason"] == self.REASON
+        assert kwargs["suspect_reason"] == self.REASON
 
     async def test_a_streak_below_the_limit_keeps_the_playbook(self) -> None:
         workflow = _workflow()
@@ -1668,9 +1681,11 @@ class TestTheFallbackBriefTheAgentReads:
 
     def test_a_line_at_the_bound_is_left_whole_and_the_next_one_is_cut(self) -> None:
         at_bound = "a" * FALLBACK_LINE_MAX_CHARS
+        result = PlaybookRunResult(ok=False, completed=[at_bound, at_bound + "a"], failure="boom")
 
-        assert _bounded_line(at_bound) == at_bound
-        assert _bounded_line(at_bound + "a") == at_bound + "..."
+        note = _fallback_note(result)
+
+        assert f"- {at_bound}\n- {at_bound}..." in note
 
     def test_a_stopped_replay_that_did_nothing_says_so_in_both_slots(self) -> None:
         result = PlaybookRunResult(ok=False, text="", trace=[], completed=[], failure=None)
@@ -2079,11 +2094,12 @@ class TestAnUntrustedReplayHandsOverWithItsRecord:
         await _fire(harness)
 
         harness.log.warning.assert_any_call(
-            f"{LogTag.WORKER} Playbook disabled after repeated suspect replays",
+            f"{LogTag.WORKER} Playbook discarded",
             workflow_id="wf_1",
             playbook_id="pb_1",
-            reason=reason,
+            reason="suspect_streak_exhausted",
             suspect_streak=PLAYBOOK_SUSPECT_STREAK_LIMIT,
+            suspect_reason=reason,
         )
         assert harness.playbook_event()["disabled"] is True
         harness.increment_heal_attempts.assert_not_awaited()
@@ -2447,3 +2463,164 @@ class TestTheScheduleZoneIsTheFallbackForABlankProfile:
             resolved = await _resolve_workflow_user(workflow, "u_1")
 
         assert resolved["timezone"] == Timezone.utc().value
+
+
+def _narration_failed_replay(reason: str) -> tuple[str, PlaybookRunResult]:
+    """A replay whose steps all ran and whose end-of-run summary raised."""
+    return (
+        "conv_1",
+        PlaybookRunResult(
+            ok=True,
+            text=f"The saved steps ran, but the summary could not be written ({reason}).",
+            completed=["events (list_events) -> 12 events"],
+            trace=[RecordedCall(tool_name="list_events")],
+            narration_failed=reason,
+            llm_calls=0,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+class TestANarrationFailureIsADeliveredRunNotAFailedOne:
+    """Prod: 13 of 15 failed playbooks had every step complete and only the
+    end-of-run summary raise. Marked FAILED, the user got nothing and the next
+    fire spent a ~20-call heal run repairing a sequence that had just worked."""
+
+    REASON = "the narration raised TimeoutError: model"
+
+    async def test_the_frozen_sequence_is_recorded_as_a_success(self) -> None:
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=_playbook(workflow))
+        harness.playbook_run = AsyncMock(return_value=_narration_failed_replay(self.REASON))
+
+        await _fire(harness)
+
+        harness.record_run_outcome.assert_awaited_once_with(
+            workflow.id,
+            workflow.user_id,
+            PlaybookRunOutcome(PlaybookRunStatus.SUCCESS, reason=None, counts_toward_streak=True),
+            playbook_id="pb_1",
+            revision=0,
+        )
+        # SUCCESS is what keeps the next fire on the replay: a heal status there
+        # would send it to the agent with the heal brief, at full agent cost.
+        assert PlaybookRunStatus.SUCCESS not in HEAL_STATUSES
+        harness.chat.assert_not_awaited()
+        harness.delete_for_workflow.assert_not_awaited()
+        harness.increment_heal_attempts.assert_not_awaited()
+
+    async def test_the_user_reads_the_record_of_what_ran(self) -> None:
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=_playbook(workflow))
+        _, result = _narration_failed_replay(self.REASON)
+        harness.playbook_run = AsyncMock(return_value=("conv_1", result))
+
+        await _fire(harness)
+
+        assert harness.delivered_text() == result.text
+        assert harness.platform_delivery.await_args.kwargs["notification_text"] == result.text
+
+    async def test_the_execution_record_says_the_summary_is_the_part_that_is_missing(
+        self,
+    ) -> None:
+        """The run is not a plain replay and not a stopped one; the workflows
+        page has to say which of the two it was."""
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=_playbook(workflow))
+        harness.playbook_run = AsyncMock(return_value=_narration_failed_replay(self.REASON))
+
+        await _fire(harness)
+
+        assert harness.summary() == REPLAY_NARRATION_FAILED_SUMMARY
+
+    async def test_the_dead_model_call_is_still_named_on_the_wide_event(self) -> None:
+        """Delivering the run is not the same as the call being fine: a fleet-wide
+        narration outage has to stay visible even though no fire failed."""
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=_playbook(workflow))
+        harness.playbook_run = AsyncMock(return_value=_narration_failed_replay(self.REASON))
+
+        await _fire(harness)
+
+        harness.log.warning.assert_any_call(
+            f"{LogTag.WORKER} Playbook replayed but the narration failed; "
+            "delivered the steps' record instead",
+            workflow_id="wf_1",
+            playbook_id="pb_1",
+            reason=self.REASON,
+        )
+
+
+@pytest.mark.asyncio
+class TestADiscardedShortcutLeavesARecordOnTheWorkflow:
+    """``wf_0d05167369cf`` lost a working playbook and nothing said why: the log
+    line ages out, and the workflow itself never knew it had one."""
+
+    async def test_a_stale_shortcut_records_the_hash_reason(self) -> None:
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=_playbook(workflow, stale=True))
+
+        await _fire(harness)
+
+        discard = harness.discard_record()
+        assert (discard.playbook_id, discard.revision) == ("pb_1", 0)
+        assert discard.reason == "stale_workflow_hash"
+        assert discard.details == {}
+        assert harness.update_workflow.await_args.args[:2] == ("wf_1", "u_1")
+
+    async def test_an_exhausted_heal_records_the_attempts_it_spent(self) -> None:
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(
+            return_value=_distrusted(workflow, attempts=PLAYBOOK_HEAL_ATTEMPT_LIMIT)
+        )
+
+        await _fire(harness)
+
+        discard = harness.discard_record()
+        assert discard.reason == "heal_attempts_exhausted"
+        assert discard.details == {"heal_attempts": str(PLAYBOOK_HEAL_ATTEMPT_LIMIT)}
+
+    async def test_a_streak_that_ran_out_records_the_streak_and_what_flagged_it(self) -> None:
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        playbook = _playbook(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=playbook)
+        harness.playbook_run = AsyncMock(return_value=_suspect_replay("the mail body was empty"))
+        harness.record_run_outcome = AsyncMock(
+            return_value=_recorded(playbook, streak=PLAYBOOK_SUSPECT_STREAK_LIMIT)
+        )
+
+        await _fire(harness)
+
+        discard = harness.discard_record()
+        assert discard.reason == "suspect_streak_exhausted"
+        assert discard.details == {
+            "suspect_streak": str(PLAYBOOK_SUSPECT_STREAK_LIMIT),
+            "suspect_reason": "the mail body was empty",
+        }
+
+    async def test_a_write_that_fails_is_named_and_never_fails_the_fire(self) -> None:
+        """The record is an explanation, not a precondition: losing it costs the
+        answer six months from now, never the run happening today."""
+        workflow = _workflow()
+        harness = _Harness(workflow)
+        harness.get_for_workflow = AsyncMock(return_value=_playbook(workflow, stale=True))
+        harness.update_workflow = AsyncMock(side_effect=ConnectionError("mongo away"))
+
+        await _fire(harness)
+
+        harness.chat.assert_awaited_once()
+        assert harness.summary() == SHORTCUT_DISCARDED_SUMMARY
+        harness.log.warning.assert_any_call(
+            f"{LogTag.WORKER} Playbook discard not recorded on the workflow",
+            workflow_id="wf_1",
+            playbook_id="pb_1",
+            reason="stale_workflow_hash",
+            error_type="ConnectionError",
+        )

--- a/apps/api/tests/unit/workers/test_workflow_tasks_playbook.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks_playbook.py
@@ -2571,6 +2571,10 @@ class TestADiscardedShortcutLeavesARecordOnTheWorkflow:
         assert (discard.playbook_id, discard.revision) == ("pb_1", 0)
         assert discard.reason == "stale_workflow_hash"
         assert discard.details == {}
+        # Stamped in UTC, not on the worker's local clock: a naive timestamp
+        # read back six months later says the wrong hour and cannot be compared
+        # with anything else in the record.
+        assert discard.at.tzinfo is UTC
         assert harness.update_workflow.await_args.args[:2] == ("wf_1", "u_1")
 
     async def test_an_exhausted_heal_records_the_attempts_it_spent(self) -> None:


### PR DESCRIPTION
## Summary

A playbook is the frozen tool-call sequence a workflow writes for itself after a run it judges repeatable, so later fires replay it instead of reasoning from scratch. Authoring one is now much more likely to succeed on the first try: text a model has to write at replay is declared inline in the argument that needs it (`{"$ask": "what to write"}`) instead of in a separate table the model kept getting wrong, and a playbook is checked against the results of the run that is writing it, so a step that froze a field the tool never returns is refused with the tool's actual keys. A replay whose steps all ran but whose final summary call failed is now delivered as the steps' record rather than marked failed and sent back to the agent, and when the worker throws a playbook away the workflow keeps a record of why.

## Why

Over 57 `write_playbook` calls in production, 36 were rejected (63%). Twelve sent the `ask` section as `{name: "string"}` where the schema wanted `{name: {prompt, uses, max_tokens}}` — `dict[str, PlaybookAsk]` renders as `object → additionalProperties → $ref`, a shape the model writes wrong while it writes `steps` (an array of the same kind of `$ref`) right every time. Seventeen added a `goal`, `task` or `note` to a step and were refused whole by `extra="forbid"`. Five of the eight asks ever written were referenced by no step and were silently never filled: the model used `ask` for "classify each email", which is a result-time instruction, and it went nowhere. Nine workflows tried to write a playbook and ended with none.

Separately, 13 of the 15 failed playbooks had every tool step succeed and only the narration call raise; each of those cost the user a failed run and cost the next fire a full agentic heal (~20 LLM calls) to "repair" a body that was never wrong. One workflow (`wf_0d05167369cf`) lost a working playbook and nothing recorded why. And `pb_c7d357db77dd` froze `$steps.fetch_msgs.threadId` on `GMAIL_FETCH_MESSAGES`, which does not return `threadId`, and broke on its first replay — with the real result sitting in the authoring run's context the whole time.

## What changed

### API

- **Inline `$ask` slots.** `PlaybookBody.ask` and the `$ask.<name>` placeholder are gone. A value that a model must write is `{"$ask": "<prompt>", "max_tokens": N}` in the argument itself; its key is `<step_id>.<arg_path>`, and each step that carries a slot gets one model call right before it runs, written from everything that has run by then (`playbook_models.py`, `evaluator.py::fill_ask_slots`, `runner.py`). A dead slot cannot be written because there is nowhere to put one but inside a step. `synthesize` is `result_brief`, and the check brief says plainly that classification, judgement and summarising belong there.
- **Lenient where a stray key is harmless, strict where silence would lose work.** `PlaybookStepInput` and `PlaybookHandoffStepInput` no longer forbid extra keys. A handoff child carrying its own `steps`/`handoff` is refused by name (otherwise a third nesting level would be dropped silently and the stored playbook would run less than the author wrote). A step carrying a slot must have an `id`, so two id-less steps of one tool cannot share a slot key. A misspelt `args` key (`arguments`, `input`, `params`, …) is refused by name rather than dropped, and a step that omits a required tool argument is refused with the tool's argument list.
- **Readable refusals at the tool boundary.** A pydantic error on the `write_playbook` call comes back as the tool's own `{"success": false, "error": "invalid_playbook", "message": "... steps[0].tool: Field required"}` envelope via `handle_validation_error`, the same shape the registry check already used, instead of a framework traceback.
- **Validation against the authoring run.** `write_playbook` takes the executor's graph state (`InjectedState`, hidden from the tool schema) and hands the run's recorded calls to `validate_playbook`. A step is matched to the last call of its tool whose recorded args agree with the step's args structurally: slots and whole-value placeholders match anything, an embedded placeholder matches any string, a mapping must contain every authored key, a list must agree elementwise at the same length. A step that agrees with no recorded call is refused with the args the run actually used, never matched to an unrelated call. A recorded call can be frozen by one step only, so a duplicated step is refused with how many times the tool really ran. A tool that never ran, a result with zero items or an error envelope, or a `$steps.<id>.<path>` the matched result cannot resolve is refused, the last with the result's top-level keys. Handoff children are not result-checked: the handoff record carries only the subagent's args, never its outputs. The wide event carries `playbook.checked_against_calls` so a missing state is visible rather than a silent no-op.
- **Narration failure is not a failed run.** When every step replayed and only the narration raised, the run is `ok` with `PLAYBOOK_NARRATION_FALLBACK_TEMPLATE` (the reason and one line per step that ran) as the delivered text and `narration_failed` on the result; the worker records `SUCCESS`, does not send the next fire to heal, and marks the execution summary "Ran from the saved shortcut; the summary could not be written". An ask-fill failure still stops the run, since the steps after it cannot run.
- **Discards leave a record.** Every `delete_for_workflow` in the worker goes through `_discard_playbook`, which now writes `WorkflowDocument.last_playbook_discard = {playbook_id, revision, reason, at, details}` for `heal_attempts_exhausted`, `stale_workflow_hash` and `suspect_streak_exhausted`. A successful `write_playbook` clears it.
- **Prompts.** The check brief is five questions (the one that said "what did you have to write or judge from content becomes an $ask" is gone — it is what taught the model to put classification in `ask`), carries the slot as a footnote under placeholders with "this is rare", and shows one literal example of a valid call. The narration prompt says the result is final text written once, never a draft followed by a rewrite: a live replay delivered a draft, "hmm, the brief is strict… Let me redo:", and the rewrite as one message.

There is deliberately no read-time migration for the old document shape. The stored playbooks were all one to two days old and 17 of 19 were failed, suspect or never run; they are re-authored under the new schema on the workflow's next good run.

| | Before | After |
| --- | --- | --- |
| `ask` in the tool schema | `object → additionalProperties → $ref` | a value inside `args`; no schema of its own |
| `goal`/`task`/`note` on a step | write refused | key dropped, step stored |
| `arguments:`/`input:` instead of `args:` | write refused (extras forbidden) | refused by name, with the fix |
| step omits a required tool arg | stored, fails at replay | refused at write, with the tool's args |
| `steps` on a handoff child | dropped silently (after lenience) | refused by name |
| pydantic error at the boundary | raw traceback to the model | `invalid_playbook` envelope naming the location |
| `$steps.x.missing_field` | discovered on first replay | refused at write, with the result's keys |
| all steps ran, narration raised | run failed, playbook FAILED, next fire heals | run delivered, playbook SUCCESS, next fire replays |
| playbook discarded | log line only | `last_playbook_discard` on the workflow |

## How to verify

1. Start the API and the ARQ worker with the dev bypass and a real model (`mise dev:arq --agent`, or the `driving-gaia` skill's two processes).
2. Create a manual workflow whose prompt is one web search and a short summary, e.g. "Search the web for the latest Pydantic release notes and summarise breaking changes in 3 bullets. Use only web search." `POST /api/v1/workflows/{id}/execute`.
3. Expect the execution trace to end in `write_playbook` with `{"success": true, ...}` on the first call, and the stored document in `GAIA.playbooks` to have `result_brief`, no `ask` key, and the search query frozen as a literal. In `apps/api/logs/structured-*.json` the worker's wide event for that fire carries `"playbook": {"checked_against_calls": 3, ...}` — a number, not `null`, is the proof the run's results reached the validator.
4. Wait a minute (the previous fire's result delivery holds the workflow's conversation lock for ~40 s after the job returns, and a replay that meets a held lock is recorded as `skipped` rather than queued — that is existing behaviour, not this change) and execute again. Expect `status: success`, one trace entry with `replayed: true`, a duration of a few seconds, and exactly one `playbook_narration` row in `llm_calls`. The delivered text should be the result only, with no draft or self-commentary.
5. Failure path: from a chat turn, ask the executor to write a playbook whose step references `$steps.<id>.no_such_field`; expect the tool to answer `invalid_playbook` and name the keys the result actually has. The unit tests in `tests/unit/services/workflow/test_playbook_parser.py::TestValidateAgainstTheRunThatIsWritingIt` cover the same cases without a model.

**Not verified:** the narration-failure fallback and the discard record were exercised only by the worker unit tests with mocked seams, not by inducing a live failure. `tests/contracts/test_playbooks_repository.py` needs real Mongo and Redis and only skips locally.

## Post-merge steps

1. Right after the deploy, clear the stored playbooks once more. The collection was emptied before this landed, but production keeps authoring old-shape documents until it runs this code, and those fail to load under the new models. From the backend container (see the `gaia-prod` read-only probe recipe): dry-run `db.playbooks.count_documents({})`, then `db.playbooks.delete_many({})`. Every affected workflow re-authors on its next good run; a fire in between simply runs agentically.

**Rollback:** revert this PR, then clear `GAIA.playbooks` again — documents written under the new shape (`result_brief`, inline `$ask`) do not load under the old models either.

## Metrics

| Metric | Before | After | How measured |
| --- | --- | --- | --- |
| `write_playbook` acceptance | 21 / 57 (37%) | 2 / 2 first-call | production `workflow_executions` traces (Aug 31 – Sep 2) vs. two live runs on this branch |
| replay vs agentic run, same workflow | 33.0 s / 10 LLM calls / $0.0235 | 3.0 s / 1 LLM call / $0.0004 | `llm_calls` ledger attributed by user and time window, one workflow, one model (`deepseek-v4-flash`); a throwaway script, not committed |

The replay figures are the existing replay path, not something this PR speeds up; they are here because the authoring rate is what gates whether a workflow ever reaches it.

## Risk

The write-time validation is the widest net: a matching rule that is too strict refuses playbooks the old code would have accepted, and the workflow just keeps running agentically, so the failure is invisible except as a `write_playbook` rejection in the trace and a flat playbook count. The "tool did not run in this run" refusal is the most likely place for that — it is correct for a first authoring, and the heal brief tells the agent to re-run the corrected call, but a heal run that reasons its way to a fix without re-executing a step will be refused. Watch the rejection reasons in the executor traces for the first days; loosening that single check is a one-line change. The narration fallback changes what a user receives when the model call fails — a factual list of what ran, not a summary — which is more than they got before (nothing) but is deliberately plain.
