### PR TITLE
fix(workflows): escape the literal example in the signal-matching prompt

### DIFF
--- a/apps/api/app/agents/prompts/workflow_prompts.py
+++ b/apps/api/app/agents/prompts/workflow_prompts.py
@@ -235,7 +235,7 @@ If a match is found, update that todo's canvas with the new signal information u
 update_tracked_todo_canvas (mode "append" or "section"; do not read the canvas and rewrite the
 whole thing). Be verbose, this is GAIA's working memory: include email addresses, thread IDs,
 event IDs, timestamps; quote the key sentences (not whole emails); update Current State; add a
-Timeline entry "- {date}: {what happened}".
+Timeline entry "- {{date}}: {{what happened}}".
 
 This matching step only MATCHES and UPDATES existing tracked todos: do not create a new one
 just because a signal arrived. (Creating still follows the normal rule, only when the run

--- a/apps/api/tests/unit/agents/prompts/test_prompt_placeholders_are_identifiers.py
+++ b/apps/api/tests/unit/agents/prompts/test_prompt_placeholders_are_identifiers.py
@@ -1,0 +1,73 @@
+"""Every ``{placeholder}`` in a prompt that is ``str.format``-ed must be a kwarg name.
+
+A literal example inside the prose, ``"- {date}: {what happened}"``, is not an
+example to the formatter: it is two placeholders nobody passes, and the call
+raises ``KeyError``. That shipped: every calendar-triggered workflow run for a
+user with tracked todos failed with ``KeyError: 'date'``, 54 times in one day,
+and the failure read as a data problem because the message was one bare word.
+
+A placeholder that is not a Python identifier (a space, a quote, a colon)
+cannot be satisfied by any ``.format(**kwargs)`` call, so it is always a
+literal that forgot its ``{{`` ``}}``. Only constants that actually reach a
+``.format(`` call are checked: prompts handed to the model verbatim may carry
+JSON examples in single braces, and those are fine.
+"""
+
+import importlib
+import pathlib
+import re
+from string import Formatter
+
+import pytest
+
+APP_ROOT = pathlib.Path(__file__).resolve().parents[4] / "app"
+PROMPTS_PACKAGE = "app.agents.prompts"
+FORMAT_CALL = re.compile(r"\b([A-Z][A-Z0-9_]+)\.format\(")
+
+
+def _formatted_constant_names() -> set[str]:
+    """Names that appear as ``NAME.format(`` anywhere under ``app/``."""
+    names: set[str] = set()
+    for path in APP_ROOT.rglob("*.py"):
+        names.update(FORMAT_CALL.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def _prompt_constants() -> dict[str, str]:
+    package = importlib.import_module(PROMPTS_PACKAGE)
+    modules = (
+        importlib.import_module(f"{PROMPTS_PACKAGE}.{path.stem}")
+        for path in pathlib.Path(package.__path__[0]).glob("*.py")
+    )
+    return {
+        name: value
+        for module in modules
+        for name, value in vars(module).items()
+        if name.isupper() and isinstance(value, str)
+    }
+
+
+def _non_identifier_placeholders(template: str) -> list[str]:
+    fields = (field for _, field, _, _ in Formatter().parse(template) if field)
+    # ``a.b`` and ``a[0]`` are legal attribute/index forms; only the root must be a name.
+    return sorted(
+        {field for field in fields if not field.split(".")[0].split("[")[0].isidentifier()}
+    )
+
+
+FORMATTED_PROMPTS = sorted(_formatted_constant_names() & set(_prompt_constants()))
+
+
+def test_the_guard_found_the_prompts_it_is_meant_to_check() -> None:
+    # If the scan ever finds nothing, the test below passes for free.
+    assert "SIGNAL_MATCHING_INSTRUCTIONS" in FORMATTED_PROMPTS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", FORMATTED_PROMPTS)
+def test_every_placeholder_in_a_formatted_prompt_is_a_kwarg_name(name: str) -> None:
+    offenders = _non_identifier_placeholders(_prompt_constants()[name])
+    assert offenders == [], (
+        f"{name} is str.format-ed but holds placeholders no kwarg can satisfy; "
+        f"a literal example in the prose needs doubled braces: {offenders!r}"
+    )

--- a/apps/api/tests/unit/helpers/test_message_helpers.py
+++ b/apps/api/tests/unit/helpers/test_message_helpers.py
@@ -249,6 +249,44 @@ class TestFormatWorkflowExecutionMessage:
 # ---------------------------------------------------------------------------
 
 
+class TestSignalMatchingSectionRenders:
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_an_integration_fire_with_tracked_todos_renders_the_signal_section(
+        self,
+    ) -> None:
+        """Production: every ``calendar_event_starting_soon`` fire for a user with
+        tracked todos failed with ``KeyError: 'date'`` (54 in one day). The signal
+        matching instructions carry a literal example, ``"- {date}: {what happened}"``,
+        and ``str.format`` read it as two placeholders. The example must reach the
+        agent verbatim, braces and all, and the section must render at all.
+        """
+        selected = SelectedWorkflowData(
+            id="wf_meeting",
+            title="Meeting Reminder",
+            description="Remind me before meetings",
+            steps=[{"title": "Remind", "category": "calendar", "description": "send the reminder"}],
+        )
+        trigger_ctx = {
+            "type": "googlecalendar",
+            "trigger_type": "integration",
+            "tracked_todos_context": "- todo_1: Ship the launch post (Key Details: thread abc)",
+            "triggered_at": "2026-09-03T10:00:00Z",
+        }
+
+        with patch(
+            "app.helpers.message_helpers.WorkflowService.get_workflow",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await format_workflow_execution_message(
+                selected, user_id="u1", trigger_context=trigger_ctx
+            )
+
+        assert "Ship the launch post" in result
+        assert "- {date}: {what happened}" in result
+
+
 class TestFormatCalendarEventContext:
     def test_timed_event_with_content(self) -> None:
         event = SelectedCalendarEventData(


### PR DESCRIPTION
## Summary

Every calendar-triggered workflow run (meeting reminders, meeting briefings) for a user who has tracked todos has been failing before the agent starts, with the one-word error `'date'`. The workflow instruction prompt carried a literal example inside its prose that Python's `str.format` read as placeholders. The example is now escaped and reaches the agent as written, and a test refuses the next one.

## Why

```
'date' failures per day:   Aug 29: 4   Aug 30: 6   Aug 31: 29   Sep 1: 47   Sep 2: 54    (33 distinct workflows)
```

All `trigger_type=integration`, all `calendar_event_starting_soon` — the `calendar:meeting_reminder` and `calendar:meeting_prep` system workflows. The curve tracks the number of users with tracked todos, because the failing section only renders for them.

## The bug

**Symptom** — `workflow_executions.error_message` is the bare string `'date'`; the run has an empty trace and lasts ~2.8 s. Users get no reminder and no briefing.

**Reproduce** — on master, call `format_workflow_execution_message` with a `trigger_context` that has `tracked_todos_context` set. It raises `KeyError: 'date'`.

**Root cause** — `apps/api/app/agents/prompts/workflow_prompts.py:238` (landed in `88d9a76a21`, Aug 25):

```
Timeline entry "- {date}: {what happened}".
```

`apps/api/app/helpers/message_helpers.py:177` runs `SIGNAL_MATCHING_INSTRUCTIONS.format(tracked_todos_context=…)` on that constant. `{date}` and `{what happened}` are placeholders to the formatter, nothing supplies them, and the first one raises. The error message is `str(KeyError('date'))`, which is just `'date'` — why it read as a data problem for a week.

**The fix** — `{{date}}: {{what happened}}`. The rendered prompt now contains the example verbatim.

**Regression tests** —
- `test_an_integration_fire_with_tracked_todos_renders_the_signal_section` drives the real `format_workflow_execution_message` with a tracked-todos trigger context and asserts the literal `- {date}: {what happened}` is in the output. Seen red on master (`KeyError: 'date'` at `message_helpers.py:177`), green after.
- `test_every_placeholder_in_a_formatted_prompt_is_a_kwarg_name` finds every prompt constant with a `NAME.format(` call site under `app/` and refuses any placeholder that is not a Python identifier — a `{what happened}` can never be a kwarg, so it is always a literal that forgot its braces. Seen red on the old prompt (`['what happened']`), green after. It deliberately does not check prompts that are never formatted; those carry JSON examples in single braces on purpose.

**Why the suite missed it** — no test rendered the signal-matching section at all: the existing `format_workflow_execution_message` tests never set `tracked_todos_context`, so the `.format` on that constant never ran.

## How to verify

1. On master, run `uv run pytest tests/unit/helpers/test_message_helpers.py -k signal_section` — expect `KeyError: 'date'`.
2. On this branch, the same command passes; `uv run pytest tests/unit/agents/prompts/test_prompt_placeholders_are_identifiers.py` passes and lists `SIGNAL_MATCHING_INSTRUCTIONS` among the prompts it checked.
3. After deploy: `workflow_executions` with `error_message: "'date'"` stops accruing (it was ~2 per hour at the top of each hour).

**Not verified:** not driven against a live calendar trigger; the fix is a two-character escape in a string constant, exercised through the real message builder in the test.

## Risk

The only behaviour change is that the agent now sees the intended example text instead of the run dying. If the escape were wrong the tests above would not pass.
