### PR TITLE
fix(web): name the company in the footer and stop the fade covering the headings

### DIFF
--- a/apps/web/src/components/navigation/Footer.tsx
+++ b/apps/web/src/components/navigation/Footer.tsx
@@ -52,8 +52,11 @@ export default function Footer() {
             wallpaper's edge never reads as a hard line against the last
             section. The via-stop holds the background color a beat longer
             before easing out, so the transition reads as a soft glow instead
-            of a straight ramp. */}
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-48 bg-linear-to-b from-background via-background/50 to-transparent" />
+            of a straight ramp. z-0 (not a higher layer) keeps the fade in the
+            same paint step as the wallpaper, above it by DOM order but below
+            the content below — otherwise its lower half washes over the link
+            column headings, which sit inside the fade's 12rem band. */}
+        <div className="pointer-events-none absolute inset-x-0 top-0 z-0 h-48 bg-linear-to-b from-background via-background/50 to-transparent" />
 
         {/* Film-grain over the wallpaper — breaks up gradient banding in the
             glow and gives the footer a tactile, printed feel. */}
@@ -118,14 +121,18 @@ export default function Footer() {
               href="https://twitter.com/madebyexp"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="The Experience Company"
+              className="flex items-center gap-2 text-sm text-zinc-200 transition-colors hover:text-primary"
             >
+              {/* Sized to the text's line box so the mark and the wordmark
+                  share one height instead of the mark towering over it. */}
               <Image
                 src="/brand/experience_logo_white.svg"
-                alt="The Experience Company"
-                width={44}
-                height={44}
+                alt=""
+                width={20}
+                height={20}
+                className="h-5 w-5"
               />
+              The Experience Company Inc.
             </Link>
 
             <div className="flex items-center gap-4 sm:justify-self-end">


### PR DESCRIPTION
## Summary

The footer's bottom bar showed the Experience Company mark with no name next to it, and the gradient that softens the footer's top edge was painting on top of the link-column headings. This adds the company name beside the mark, sizes the mark to match that text, and puts the gradient back underneath the content.

## Why

Two things a visitor sees on every marketing page: an unlabelled logo that only makes sense if you already know the company, and "Product / Resources / Company / Legal" headings sitting under a translucent wash that dims them against the rest of the column.

## What changed

### Web

- `Footer.tsx` bottom bar: the mark is now a labelled link reading "The Experience Company Inc.". The logo drops from 44px to a 20px box so it shares the text's line height, and since the visible text labels the link the image becomes decorative (`alt=""`, redundant `aria-label` removed).
- `Footer.tsx` top fade: `z-10` → `z-0`.

---

## The bug

**Symptom** — The four footer column headings render dimmer than they should, as if faded, while the links beneath them are full brightness.

**Reproduce** — Load any landing page and scroll to the footer. The headings sit in a band that is visibly washed out relative to the links below them.

**Root cause** — `Footer.tsx:59`. The top fade-out is `absolute top-0 h-48` with `z-10`. The content wrapper below it deliberately carries no `z-index` — a stacking context there would isolate the halftone wordmark's `mix-blend-overlay` and leave it blending against an empty backdrop instead of the wallpaper. So the fade lands in a strictly higher paint layer than all of the content. Its 12rem height against the content's `pt-24` means its lower half covers exactly the heading row.

**The fix** — `z-0` rather than adding a z-index to the content. That puts the fade in the same paint step as the wallpaper image, where DOM order decides: image, then fade, then content. The wordmark's blending is untouched.

**Regression test** — None. This is a paint-order bug with no non-visual assertion that would catch it; jsdom does not compute stacking contexts, and neither the class string nor the DOM shape changes in a way a component test could meaningfully pin.

**Why the suite missed it** — There is no visual-regression tier covering the footer, and the class change is invisible to every other tier.

---

## Screenshots

Not captured — the browser automation in my session could not reach the dev server (Chrome returned `ERR_CONNECTION_REFUSED` on `localhost:4910` / `127.0.0.1:4910` while `curl` got a 200 from the same server). Verified instead against the server-rendered HTML from the running app: the anchor carries the name and the `h-5 w-5` image, and the fade div is `z-0`.