### PR TITLE
fix(execute): correct observed tool-shape learning (dup-shape race + data-keyed maps)

### DIFF
--- a/apps/api/app/agents/tools/execute/schema_docs.py
+++ b/apps/api/app/agents/tools/execute/schema_docs.py
@@ -76,14 +76,19 @@ def _compact_type(node: object) -> str:
         return "|".join(sorted({_compact_type({**node, "type": t}) for t in type_}))
     if type_ == "object" or (type_ is None and "properties" in node):
         properties = node.get("properties")
-        if not isinstance(properties, dict) or not properties:
-            return "obj"
         required = set(node.get("required") or [])
-        fields = ", ".join(
+        fields = [
             f"{name}{'' if name in required else '?'}:{_compact_type(sub)}"
-            for name, sub in properties.items()
-        )
-        return "{" + fields + "}"
+            for name, sub in (properties.items() if isinstance(properties, dict) else ())
+        ]
+        # A data-keyed map (observed shapes store these as additionalProperties):
+        # rendered as an index signature, since the keys are data, not fields.
+        additional = node.get("additionalProperties")
+        if isinstance(additional, dict):
+            fields.append(f"[key]:{_compact_type(additional)}")
+        if not fields:
+            return "obj"
+        return "{" + ", ".join(fields) + "}"
     if type_ == "array":
         item = _compact_type(node.get("items", {}))
         # Union item types need grouping so {a}|{b}[] cannot misread.
@@ -163,7 +168,7 @@ def _prune_to_levels(node: object, levels: int) -> object:
                 if levels > 0
                 else _SCHEMA_TRUNCATED_MARKER
             )
-        elif key == "items" and isinstance(value, dict | list):
+        elif key in {"items", "additionalProperties"} and isinstance(value, dict | list):
             pruned[key] = (
                 _prune_to_levels(value, levels - 1) if levels > 0 else _SCHEMA_TRUNCATED_MARKER
             )

--- a/apps/api/app/db/mongodb/indexes.py
+++ b/apps/api/app/db/mongodb/indexes.py
@@ -62,6 +62,7 @@ async def create_all_indexes() -> None:
             create_pending_platform_registration_indexes(),
             create_llm_call_indexes(),
             create_playbook_indexes(),
+            create_tool_output_shapes_indexes(),
         ]
 
         # Execute all index creation tasks concurrently
@@ -95,6 +96,7 @@ async def create_all_indexes() -> None:
             "pending_platform_registrations",
             "llm_calls",
             "playbooks",
+            "tool_output_shapes",
         ]
 
         index_results = {}
@@ -698,6 +700,29 @@ async def create_playbook_indexes() -> None:
     except Exception as e:
         log.error(
             f"{LogTag.MONGO} Error creating playbook indexes",
+            error=str(e),
+            error_type=type(e).__name__,
+        )
+        raise
+
+
+async def create_tool_output_shapes_indexes() -> None:
+    """Create indexes for the tool_output_shapes collection.
+
+    Unique on (scope, tool_name): the observed-shape upsert is keyed on this
+    pair, so the unique index is what makes "one record per scoped tool" a
+    property of the data rather than of two first observations' timing — it
+    rejects the loser of a concurrent insert with DuplicateKeyError, which the
+    repository retries into the winner's document.
+    """
+    tool_output_shapes_collection = get_async_collection("tool_output_shapes")
+    try:
+        await tool_output_shapes_collection.create_index(
+            [("scope", 1), ("tool_name", 1)], unique=True
+        )
+    except Exception as e:
+        log.error(
+            f"{LogTag.MONGO} Error creating tool_output_shapes indexes",
             error=str(e),
             error_type=type(e).__name__,
         )

--- a/apps/api/app/db/mongodb/indexes.py
+++ b/apps/api/app/db/mongodb/indexes.py
@@ -706,6 +706,35 @@ async def create_playbook_indexes() -> None:
         raise
 
 
+async def _dedupe_tool_output_shapes(
+    collection: AsyncIOMotorCollection[dict[str, Any]],
+) -> None:
+    """Collapse pre-existing (scope, tool_name) duplicates before the unique
+    index build.
+
+    A database that raced under the pre-index code can already hold duplicate
+    records; MongoDB would then reject the unique index, ``create_all_indexes``
+    would swallow the error, and ``record()``'s retry would run without the
+    guarantee it depends on. Observed shapes are regenerable, so keeping the
+    most-observed record per key and dropping the rest loses nothing real calls
+    will not re-learn. ``$push`` preserves the preceding ``$sort``, so the first
+    id in each group is the highest ``call_count``.
+    """
+    pipeline: list[dict[str, Any]] = [
+        {"$sort": {"call_count": -1}},
+        {
+            "$group": {
+                "_id": {"scope": "$scope", "tool_name": "$tool_name"},
+                "ids": {"$push": "$_id"},
+            }
+        },
+        {"$match": {"ids.1": {"$exists": True}}},
+    ]
+    async for group in collection.aggregate(pipeline):
+        losers = group["ids"][1:]
+        await collection.delete_many({"_id": {"$in": losers}})
+
+
 async def create_tool_output_shapes_indexes() -> None:
     """Create indexes for the tool_output_shapes collection.
 
@@ -713,10 +742,12 @@ async def create_tool_output_shapes_indexes() -> None:
     pair, so the unique index is what makes "one record per scoped tool" a
     property of the data rather than of two first observations' timing — it
     rejects the loser of a concurrent insert with DuplicateKeyError, which the
-    repository retries into the winner's document.
+    repository retries into the winner's document. Pre-existing duplicates are
+    collapsed first, so an upgraded DB that already raced can still build it.
     """
     tool_output_shapes_collection = get_async_collection("tool_output_shapes")
     try:
+        await _dedupe_tool_output_shapes(tool_output_shapes_collection)
         await tool_output_shapes_collection.create_index(
             [("scope", 1), ("tool_name", 1)], unique=True
         )

--- a/apps/api/app/db/repositories/tool_shapes.py
+++ b/apps/api/app/db/repositories/tool_shapes.py
@@ -5,8 +5,11 @@ never surfaces above this boundary. ``scope`` is what keeps a private MCP
 server's shapes invisible to other users (see ResolvedTool.shape_scope).
 """
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
+
+from pymongo.errors import DuplicateKeyError
 
 from app.constants.cache import REPO_GLOBAL_SCOPE
 from app.db.repositories.base import MongoRepository
@@ -25,17 +28,28 @@ class ToolShapesRepository(MongoRepository[ToolOutputShapeDocument, ToolOutputSh
         return await self._find_one({"scope": scope, "tool_name": tool_name})
 
     async def record(self, scope: str, tool_name: str, output_schema: dict[str, Any]) -> None:
-        """Store the merged schema for one more observation of ``tool_name``."""
-        await self._apply_raw_update(
-            {"scope": scope, "tool_name": tool_name},
-            {
-                "$set": {"output_schema": output_schema, "last_seen": datetime.now(UTC)},
-                "$inc": {"call_count": 1},
-            },
-            scope=REPO_GLOBAL_SCOPE,
-            upsert=True,
-            return_document=False,
-        )
+        """Store the merged schema for one more observation of ``tool_name``.
+
+        Two first observations of the same scoped tool can both miss the upsert
+        match and both insert; the unique ``(scope, tool_name)`` index
+        (``app.db.mongodb.indexes``) rejects the loser with ``DuplicateKeyError``,
+        and the retry then matches the winner and merges into it — one document,
+        never a duplicate that would split ``call_count`` and leave ``find_one``
+        picking an arbitrary incomplete schema.
+        """
+        key = {"scope": scope, "tool_name": tool_name}
+        update: dict[str, Mapping[str, object]] = {
+            "$set": {"output_schema": output_schema, "last_seen": datetime.now(UTC)},
+            "$inc": {"call_count": 1},
+        }
+        try:
+            await self._apply_raw_update(
+                key, update, scope=REPO_GLOBAL_SCOPE, upsert=True, return_document=False
+            )
+        except DuplicateKeyError:
+            await self._apply_raw_update(
+                key, update, scope=REPO_GLOBAL_SCOPE, upsert=True, return_document=False
+            )
 
 
 tool_shapes_repository = ToolShapesRepository()

--- a/apps/api/app/models/tool_shape_models.py
+++ b/apps/api/app/models/tool_shape_models.py
@@ -2,9 +2,9 @@
 
 Scoped per ``ResolvedTool.shape_scope``; one document per (scope, tool_name).
 ``output_schema`` is a genson-inferred JSON schema of keys and types only — no
-value is ever stored. Keys are filtered to identifier-shaped names so a dict
-keyed by data contributes no property names (``tool_shape_service._sample``),
-but that filter is a heuristic: a global-scope record is not a privacy boundary.
+value is ever stored. Dicts classified as data-keyed maps contribute their
+value shape as ``additionalProperties``, never their keys (see the record-vs-map
+classification in ``tool_shape_service``).
 """
 
 from datetime import datetime

--- a/apps/api/app/services/tool_shape_service.py
+++ b/apps/api/app/services/tool_shape_service.py
@@ -8,13 +8,17 @@ keys, types, array-ness. Values never leave this module; arrays are sampled.
 The one classification that matters is record vs map. A record's keys ARE its
 schema; a map's keys are data, and modeling them as properties is a wrong
 schema — worse at the shared scopes, where one user's data keys would merge
-into the record every other user reads. A dict is a map when it is wide, when
-a key is not identifier-shaped, or when every value shares one non-empty
-structured shape (a record's fields differ; a map's entries repeat). Maps keep
-their value shape as ``additionalProperties`` — the keys themselves are never
-stored. The irreducible case is a small dict of scalar values under
-identifier-shaped keys ({"Salary": "high"}): structurally identical to a
-record, so it is read as one.
+into the record every other user reads. A dict is read as a map when it is wide
+(more keys than a record plausibly has) or when a key is not identifier-shaped
+(spaces, punctuation, non-ASCII, an id/UUID). Map values are sampled and stored
+as ``additionalProperties`` — the keys themselves are never stored.
+
+What is NOT a map signal is value homogeneity: ``{sender, recipient}`` and
+``{billing_address, shipping_address}`` are records whose fields share a shape,
+and collapsing them would discard real field names permanently. So a small dict
+of identifier-shaped keys is read as a record even when its values repeat —
+the irreducible ambiguity resolved toward the reading that never destroys a
+genuine record.
 
 Records are scoped (``ResolvedTool.shape_scope``): "global" for catalog tools,
 per-integration for MCP, so a private server's shapes stay with its users.
@@ -46,10 +50,11 @@ _FIELD_NAME_KEY = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$.\-]{0,63}$")
 # Identifier-shaped but still data: message/phone ids, hex UUIDs.
 _ID_LIKE_KEY = re.compile(r"\d{6,}|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}|^[0-9a-fA-F]{32}$")
 
-# How a map rides through genson, which only speaks ``properties``: its value
-# shape is sampled under this one key, and the stored/rendered form rewrites it
-# to ``additionalProperties``. Collision-free by construction — ``*`` fails the
-# field-name allowlist, so no observed key can ever become this property.
+# How a map rides through genson, which only speaks ``properties``: its sampled
+# values become an array under this one key so genson unions their shapes
+# (optional fields and mixed types included), and the stored/rendered form
+# rewrites that to ``additionalProperties``. Collision-free by construction —
+# ``*`` fails the field-name allowlist, so no observed key can become it.
 _MAP_KEY_SENTINEL = "*"
 
 
@@ -94,40 +99,21 @@ def _sample(node: object) -> object:
 def _sample_dict(node: dict[object, object]) -> dict[str, object]:
     keys = [str(key) for key in node]
     if len(keys) > TOOL_SHAPE_MAX_KEYS_PER_OBJECT or not all(_is_field_name(key) for key in keys):
-        # A map keyed by data — both triggers imply at least one entry. One
-        # value stands in for all of them: map values are homogeneous, and
-        # later observations merge in any variation.
-        return {_MAP_KEY_SENTINEL: _sample(next(iter(node.values())))}
-    sampled = {str(key): _sample(value) for key, value in node.items()}
-    if _values_are_one_repeated_structure(sampled):
-        return {_MAP_KEY_SENTINEL: next(iter(sampled.values()))}
-    return sampled
-
-
-def _values_are_one_repeated_structure(sampled: dict[str, object]) -> bool:
-    """True when every value is the same non-empty structured shape — the map
-    signal that survives identifier-shaped data keys ({"Engineering": {...}})."""
-    if len(sampled) < 2:
-        return False
-    if not all(isinstance(value, dict | list) and value for value in sampled.values()):
-        return False
-    return len({_shape_signature(value) for value in sampled.values()}) == 1
-
-
-def _shape_signature(node: object) -> object:
-    """A hashable structural fingerprint of a sampled value: keys and types, no data."""
-    if isinstance(node, dict):
-        return frozenset((key, _shape_signature(value)) for key, value in node.items())
-    if isinstance(node, list):
-        return ("array", frozenset(_shape_signature(item) for item in node))
-    return type(node).__name__
+        # A map keyed by data. Its values ride as a sampled list so genson
+        # unions their shapes — an optional field or a differing type in a
+        # later entry survives, not just whatever the first entry carried.
+        values = list(node.values())[:TOOL_SHAPE_ARRAY_SAMPLE]
+        return {_MAP_KEY_SENTINEL: [_sample(value) for value in values]}
+    return {str(key): _sample(value) for key, value in node.items()}
 
 
 def _sentinel_to_additional(node: object) -> object:
     """The stored/rendered form: the sentinel property becomes ``additionalProperties``.
 
-    Named properties learned from other observations of the same node survive
-    beside it — valid JSON Schema, and the honest reading of mixed evidence.
+    The sentinel is encoded as an array of sampled values (see ``_sample_dict``),
+    so its ``items`` schema is the map's value shape. Named properties learned
+    from other observations of the same node survive beside it — valid JSON
+    Schema, and the honest reading of mixed evidence.
     """
     if isinstance(node, list):
         return [_sentinel_to_additional(item) for item in node]
@@ -136,7 +122,10 @@ def _sentinel_to_additional(node: object) -> object:
     out = {key: _sentinel_to_additional(value) for key, value in node.items()}
     properties = out.get("properties")
     if isinstance(properties, dict) and _MAP_KEY_SENTINEL in properties:
-        out["additionalProperties"] = properties.pop(_MAP_KEY_SENTINEL)
+        sentinel = properties.pop(_MAP_KEY_SENTINEL)
+        out["additionalProperties"] = (
+            sentinel.get("items", {}) if isinstance(sentinel, dict) else {}
+        )
         if not properties:
             del out["properties"]
         required = out.get("required")
@@ -148,7 +137,8 @@ def _sentinel_to_additional(node: object) -> object:
 
 
 def _additional_to_sentinel(node: object) -> object:
-    """The inverse rewrite, so a stored schema re-enters genson's dialect."""
+    """The inverse rewrite, so a stored schema re-enters genson's dialect as the
+    array-of-values the sentinel encodes."""
     if isinstance(node, list):
         return [_additional_to_sentinel(item) for item in node]
     if not isinstance(node, dict):
@@ -159,5 +149,5 @@ def _additional_to_sentinel(node: object) -> object:
         del out["additionalProperties"]
         properties = out.setdefault("properties", {})
         if isinstance(properties, dict):
-            properties[_MAP_KEY_SENTINEL] = additional
+            properties[_MAP_KEY_SENTINEL] = {"type": "array", "items": additional}
     return out

--- a/apps/api/app/services/tool_shape_service.py
+++ b/apps/api/app/services/tool_shape_service.py
@@ -3,16 +3,21 @@
 Every proxied tool response funnels through ``dispatch_tool``, so the observed
 shape converges on ground truth with use — including for MCP and Composio tools
 whose providers document no output schema at all. Only structure is learned:
-keys, types, array-ness. Values never leave this function; arrays are sampled;
-wide dicts and dicts whose keys are not identifier-shaped are treated as maps,
-so a dict keyed by data ({"sarah@x.com": {...}}, {"Q3 spend / EMEA": {...}})
-contributes its shape without contributing its keys.
+keys, types, array-ness. Values never leave this module; arrays are sampled.
+
+The one classification that matters is record vs map. A record's keys ARE its
+schema; a map's keys are data, and modeling them as properties is a wrong
+schema — worse at the shared scopes, where one user's data keys would merge
+into the record every other user reads. A dict is a map when it is wide, when
+a key is not identifier-shaped, or when every value shares one non-empty
+structured shape (a record's fields differ; a map's entries repeat). Maps keep
+their value shape as ``additionalProperties`` — the keys themselves are never
+stored. The irreducible case is a small dict of scalar values under
+identifier-shaped keys ({"Salary": "high"}): structurally identical to a
+record, so it is read as one.
 
 Records are scoped (``ResolvedTool.shape_scope``): "global" for catalog tools,
-per-integration for MCP, so a private server's shapes stay with its users. The
-key test is a quality heuristic, NOT a privacy boundary: a user-authored label
-that happens to be identifier-shaped (a spreadsheet tab, a one-word Notion
-property) still reaches the shared record for a catalog tool.
+per-integration for MCP, so a private server's shapes stay with its users.
 
 Concurrent read-merge-write can drop one observation to a race; the schema
 converges over subsequent calls, so no lock is warranted.
@@ -20,6 +25,7 @@ converges over subsequent calls, so no lock is warranted.
 
 import json
 import re
+from typing import cast
 
 from genson import SchemaBuilder
 
@@ -33,13 +39,18 @@ from app.db.repositories.tool_shapes import tool_shapes_repository
 from shared.py.wide_events import log
 
 # What may become a schema property name: an ALLOWLIST, because the denylist it
-# replaced passed everything it had not thought of — and a catalog tool's record
-# is global, so one user's dict key is rendered back to every other user of that
-# tool. Provider field names are identifier-shaped (snake/camel/kebab/dotted);
-# user-authored labels carry spaces, punctuation or non-ASCII and are not.
+# replaced passed everything it had not thought of. Provider field names are
+# identifier-shaped (snake/camel/kebab/dotted); user-authored labels carry
+# spaces, punctuation or non-ASCII and are not.
 _FIELD_NAME_KEY = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$.\-]{0,63}$")
 # Identifier-shaped but still data: message/phone ids, hex UUIDs.
 _ID_LIKE_KEY = re.compile(r"\d{6,}|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}|^[0-9a-fA-F]{32}$")
+
+# How a map rides through genson, which only speaks ``properties``: its value
+# shape is sampled under this one key, and the stored/rendered form rewrites it
+# to ``additionalProperties``. Collision-free by construction — ``*`` fails the
+# field-name allowlist, so no observed key can ever become this property.
+_MAP_KEY_SENTINEL = "*"
 
 
 def _is_field_name(key: str) -> bool:
@@ -54,10 +65,11 @@ async def record_observed_shape(tool_name: str, output: object, *, scope: str) -
     builder = SchemaBuilder()
     existing = await tool_shapes_repository.get_shape(scope, tool_name)
     if existing is not None:
-        builder.add_schema(existing.output_schema)
+        builder.add_schema(_additional_to_sentinel(existing.output_schema))
     builder.add_object(_sample(output))
     schema = builder.to_schema()
     schema.pop("$schema", None)
+    schema = cast(dict[str, object], _sentinel_to_additional(schema))
     if len(json.dumps(schema, default=str)) > TOOL_SHAPE_MAX_CHARS:
         log.warning(
             f"{LogTag.TOOL} observed shape exceeds the size cap; keeping the stored one",
@@ -72,14 +84,80 @@ def _sample(node: object) -> object:
     if isinstance(node, list):
         return [_sample(item) for item in node[:TOOL_SHAPE_ARRAY_SAMPLE]]
     if isinstance(node, dict):
-        keys = [str(key) for key in node]
-        if len(keys) > TOOL_SHAPE_MAX_KEYS_PER_OBJECT or not all(
-            _is_field_name(key) for key in keys
-        ):
-            # A map keyed by data, not a record with field names.
-            return {}
-        return {str(key): _sample(value) for key, value in node.items()}
+        return _sample_dict(node)
     if node is None or isinstance(node, str | int | float | bool):
         return node
     # Non-JSON scalar (datetime, Decimal, ...): its serialized form is a string.
     return str(node)
+
+
+def _sample_dict(node: dict[object, object]) -> dict[str, object]:
+    keys = [str(key) for key in node]
+    if len(keys) > TOOL_SHAPE_MAX_KEYS_PER_OBJECT or not all(_is_field_name(key) for key in keys):
+        # A map keyed by data — both triggers imply at least one entry. One
+        # value stands in for all of them: map values are homogeneous, and
+        # later observations merge in any variation.
+        return {_MAP_KEY_SENTINEL: _sample(next(iter(node.values())))}
+    sampled = {str(key): _sample(value) for key, value in node.items()}
+    if _values_are_one_repeated_structure(sampled):
+        return {_MAP_KEY_SENTINEL: next(iter(sampled.values()))}
+    return sampled
+
+
+def _values_are_one_repeated_structure(sampled: dict[str, object]) -> bool:
+    """True when every value is the same non-empty structured shape — the map
+    signal that survives identifier-shaped data keys ({"Engineering": {...}})."""
+    if len(sampled) < 2:
+        return False
+    if not all(isinstance(value, dict | list) and value for value in sampled.values()):
+        return False
+    return len({_shape_signature(value) for value in sampled.values()}) == 1
+
+
+def _shape_signature(node: object) -> object:
+    """A hashable structural fingerprint of a sampled value: keys and types, no data."""
+    if isinstance(node, dict):
+        return frozenset((key, _shape_signature(value)) for key, value in node.items())
+    if isinstance(node, list):
+        return ("array", frozenset(_shape_signature(item) for item in node))
+    return type(node).__name__
+
+
+def _sentinel_to_additional(node: object) -> object:
+    """The stored/rendered form: the sentinel property becomes ``additionalProperties``.
+
+    Named properties learned from other observations of the same node survive
+    beside it — valid JSON Schema, and the honest reading of mixed evidence.
+    """
+    if isinstance(node, list):
+        return [_sentinel_to_additional(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+    out = {key: _sentinel_to_additional(value) for key, value in node.items()}
+    properties = out.get("properties")
+    if isinstance(properties, dict) and _MAP_KEY_SENTINEL in properties:
+        out["additionalProperties"] = properties.pop(_MAP_KEY_SENTINEL)
+        if not properties:
+            del out["properties"]
+        required = out.get("required")
+        if isinstance(required, list):
+            out["required"] = [name for name in required if name != _MAP_KEY_SENTINEL]
+            if not out["required"]:
+                del out["required"]
+    return out
+
+
+def _additional_to_sentinel(node: object) -> object:
+    """The inverse rewrite, so a stored schema re-enters genson's dialect."""
+    if isinstance(node, list):
+        return [_additional_to_sentinel(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+    out = {key: _additional_to_sentinel(value) for key, value in node.items()}
+    additional = out.get("additionalProperties")
+    if isinstance(additional, dict):
+        del out["additionalProperties"]
+        properties = out.setdefault("properties", {})
+        if isinstance(properties, dict):
+            properties[_MAP_KEY_SENTINEL] = additional
+    return out

--- a/apps/api/tests/contracts/test_tool_shapes_repository.py
+++ b/apps/api/tests/contracts/test_tool_shapes_repository.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from typing import Any
 import uuid
 
+from pymongo.errors import DuplicateKeyError
 import pytest
 
 from app.db.repositories.tool_shapes import ToolShapesRepository
@@ -50,3 +53,61 @@ class TestToolShapesRepository:
 
     async def test_get_shape_misses_cleanly_for_unknown_tool(self, repo):
         assert await repo.get_shape("global", _tool()) is None
+
+
+class TestToolShapesUniqueIndexSurface:
+    """The one-per-(scope, tool) index lives on the real collection, not the
+    ephemeral fixture — recreate it to prove the constraint the record() upsert
+    retry depends on, and that record() converges on a single document rather
+    than duplicating the shape or raising when a concurrent insert wins."""
+
+    async def _create_index(self, raw_collection) -> None:
+        # Mirrors app/db/mongodb/indexes.py::create_tool_output_shapes_indexes.
+        await raw_collection.create_index([("scope", 1), ("tool_name", 1)], unique=True)
+
+    async def test_record_is_idempotent_under_the_unique_index(self, repo, raw_collection):
+        await self._create_index(raw_collection)
+        tool = _tool()
+
+        await repo.record("global", tool, SCHEMA_V1)
+        await repo.record("global", tool, SCHEMA_V2)
+
+        assert await raw_collection.count_documents({"scope": "global", "tool_name": tool}) == 1
+
+    async def test_record_retries_the_losing_insert_onto_the_winner(
+        self, repo, raw_collection, monkeypatch
+    ):
+        """Two first observations race: both miss the match, one inserts, the
+        other's insert collides on the unique index. record() must catch that
+        DuplicateKeyError and retry onto the winner — one document, never a raise."""
+        await self._create_index(raw_collection)
+        tool = _tool()
+        real_update = raw_collection.find_one_and_update
+        calls = {"n": 0}
+
+        async def losing_then_winning(*args: Any, **kwargs: Any):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # The competing observation inserts the winning document between
+                # our upsert's read and its insert, so our insert now conflicts.
+                await raw_collection.insert_one(
+                    {
+                        "scope": "global",
+                        "tool_name": tool,
+                        "output_schema": SCHEMA_V1,
+                        "call_count": 1,
+                        "last_seen": datetime.now(UTC),
+                    }
+                )
+                raise DuplicateKeyError("E11000 duplicate key")
+            return await real_update(*args, **kwargs)
+
+        monkeypatch.setattr(raw_collection, "find_one_and_update", losing_then_winning)
+
+        await repo.record("global", tool, SCHEMA_V2)  # must not raise
+
+        assert calls["n"] == 2  # retried exactly once
+        assert await raw_collection.count_documents({"scope": "global", "tool_name": tool}) == 1
+        merged = await repo.get_shape("global", tool)
+        assert merged.output_schema == SCHEMA_V2  # the retry merged onto the winner
+        assert merged.call_count == 2

--- a/apps/api/tests/contracts/test_tool_shapes_repository.py
+++ b/apps/api/tests/contracts/test_tool_shapes_repository.py
@@ -65,6 +65,51 @@ class TestToolShapesUniqueIndexSurface:
         # Mirrors app/db/mongodb/indexes.py::create_tool_output_shapes_indexes.
         await raw_collection.create_index([("scope", 1), ("tool_name", 1)], unique=True)
 
+    async def test_pre_existing_duplicates_are_collapsed_before_the_index(
+        self, repo, raw_collection
+    ):
+        """A DB that raced under the pre-index code already holds duplicates; the
+        unique index must still build. De-dup keeps the most-observed record."""
+        from app.db.mongodb.indexes import _dedupe_tool_output_shapes
+
+        tool = _tool()
+        now = datetime.now(UTC)
+        await raw_collection.insert_many(
+            [
+                {
+                    "scope": "global",
+                    "tool_name": tool,
+                    "output_schema": SCHEMA_V1,
+                    "call_count": 3,
+                    "last_seen": now,
+                },
+                {
+                    "scope": "global",
+                    "tool_name": tool,
+                    "output_schema": SCHEMA_V2,
+                    "call_count": 7,
+                    "last_seen": now,
+                },
+                {
+                    "scope": "global",
+                    "tool_name": tool,
+                    "output_schema": SCHEMA_V1,
+                    "call_count": 1,
+                    "last_seen": now,
+                },
+            ]
+        )
+
+        await _dedupe_tool_output_shapes(raw_collection)
+        # The index build is what would fail on leftover duplicates.
+        await raw_collection.create_index([("scope", 1), ("tool_name", 1)], unique=True)
+
+        docs = await raw_collection.find({"scope": "global", "tool_name": tool}).to_list(
+            length=None
+        )
+        assert len(docs) == 1
+        assert docs[0]["call_count"] == 7  # the most-observed record survives
+
     async def test_record_is_idempotent_under_the_unique_index(self, repo, raw_collection):
         await self._create_index(raw_collection)
         tool = _tool()

--- a/apps/api/tests/unit/agents/tools/execute/test_schema_docs.py
+++ b/apps/api/tests/unit/agents/tools/execute/test_schema_docs.py
@@ -114,6 +114,25 @@ class TestRenderToolDoc:
             '{id:str, count:int, tags?:str[], status?:"open"|"closed", parent?:null|str, meta?:obj}'
         )
 
+    def test_compact_type_renders_a_map_as_an_index_signature(self) -> None:
+        """Observed shapes store data-keyed maps as additionalProperties; the
+        notation must show the value shape, not degrade the map to bare obj."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "per_user": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {"n": {"type": "integer"}},
+                        "required": ["n"],
+                    },
+                }
+            },
+            "required": ["per_user"],
+        }
+        assert render_compact_type(schema) == "{per_user:{[key]:{n:int}}}"
+
     def test_compact_type_union_array_items_are_grouped(self) -> None:
         schema = {
             "type": "array",

--- a/apps/api/tests/unit/db/test_mongodb.py
+++ b/apps/api/tests/unit/db/test_mongodb.py
@@ -395,6 +395,7 @@ _INDEX_CREATORS = [
     "create_pending_platform_registration_indexes",
     "create_llm_call_indexes",
     "create_playbook_indexes",
+    "create_tool_output_shapes_indexes",
 ]
 
 

--- a/apps/api/tests/unit/services/test_tool_shape_service.py
+++ b/apps/api/tests/unit/services/test_tool_shape_service.py
@@ -83,7 +83,11 @@ class TestRecordObservedShape:
             await record_observed_shape("T", {"per_key": wide}, scope=SCOPE)
         (_, _, schema), _ = repo.record.await_args
         assert "k0" not in str(schema)
-        assert schema["properties"]["per_key"] == {"type": "object"}
+        per_key = schema["properties"]["per_key"]
+        # The keys are data and never stored — but the value shape is: a map is
+        # modeled as additionalProperties, not as an opaque object.
+        assert "properties" not in per_key
+        assert per_key["additionalProperties"]["properties"]["count"] == {"type": "integer"}
 
     @pytest.mark.parametrize(
         "leaky_key",
@@ -111,7 +115,67 @@ class TestRecordObservedShape:
             await record_observed_shape("T", {"per_user": {leaky_key: {"n": 1}}}, scope=SCOPE)
         (_, _, schema), _ = repo.record.await_args
         assert leaky_key not in str(schema)
-        assert schema["properties"]["per_user"] == {"type": "object"}
+        per_user = schema["properties"]["per_user"]
+        assert "properties" not in per_user
+        assert per_user["additionalProperties"]["properties"]["n"] == {"type": "integer"}
+
+    async def test_identifier_shaped_data_keys_over_one_repeated_structure_are_a_map(self) -> None:
+        """The spelling guard cannot catch {"Engineering": {...}, "Marketing": {...}}
+        — single-token labels are identifier-shaped. What gives the map away is
+        every value sharing one structured shape; a record's fields differ."""
+        repo = _repo()
+        by_department = {
+            "Engineering": {"headcount": 12, "open_roles": 3},
+            "Marketing": {"headcount": 5, "open_roles": 1},
+        }
+        with patch(REPO, repo):
+            await record_observed_shape("T", {"by_department": by_department}, scope=SCOPE)
+        (_, _, schema), _ = repo.record.await_args
+        assert "Engineering" not in str(schema)
+        value_shape = schema["properties"]["by_department"]["additionalProperties"]
+        assert set(value_shape["properties"]) == {"headcount", "open_roles"}
+
+    async def test_a_record_of_differing_field_shapes_keeps_its_fields(self) -> None:
+        """The homogeneity signal must not collapse real records: any variation
+        between value shapes — or any scalar field — is record evidence."""
+        repo = _repo()
+        response = {
+            "user": {"id": "u1", "name": "x"},
+            "team": {"id": "t1"},
+            "ok": True,
+        }
+        with patch(REPO, repo):
+            await record_observed_shape("T", response, scope=SCOPE)
+        (_, _, schema), _ = repo.record.await_args
+        assert set(schema["properties"]) == {"user", "team", "ok"}
+
+    async def test_a_stored_map_shape_round_trips_through_the_next_merge(self) -> None:
+        """additionalProperties must survive re-merging: the stored form re-enters
+        genson's dialect, unions with the new observation's value shape, and
+        comes back out as additionalProperties — never as literal properties."""
+        stored = {
+            "type": "object",
+            "properties": {
+                "per_user": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {"n": {"type": "integer"}},
+                        "required": ["n"],
+                    },
+                }
+            },
+        }
+        repo = _repo(existing_schema=stored)
+        with patch(REPO, repo):
+            await record_observed_shape(
+                "T", {"per_user": {"bob@x.com": {"n": 2, "flag": True}}}, scope=SCOPE
+            )
+        (_, _, schema), _ = repo.record.await_args
+        assert "bob@x.com" not in str(schema)
+        per_user = schema["properties"]["per_user"]
+        assert "properties" not in per_user
+        assert set(per_user["additionalProperties"]["properties"]) == {"n", "flag"}
 
     @pytest.mark.parametrize(
         "field_name",
@@ -130,7 +194,9 @@ class TestRecordObservedShape:
 
     async def test_an_oversized_schema_keeps_the_stored_one(self) -> None:
         repo = _repo()
-        wide = {f"section_{n}": {f"field_{m}": "x" for m in range(20)} for n in range(400)}
+        # Per-section field names differ so this stays a (huge) record — a
+        # repeated shape would rightly collapse to a small map schema instead.
+        wide = {f"section_{n}": {f"field_{n}_{m}": "x" for m in range(20)} for n in range(400)}
         with (
             patch(REPO, repo),
             patch.object(tool_shape_service, "TOOL_SHAPE_MAX_KEYS_PER_OBJECT", 10_000),

--- a/apps/api/tests/unit/services/test_tool_shape_service.py
+++ b/apps/api/tests/unit/services/test_tool_shape_service.py
@@ -119,35 +119,37 @@ class TestRecordObservedShape:
         assert "properties" not in per_user
         assert per_user["additionalProperties"]["properties"]["n"] == {"type": "integer"}
 
-    async def test_identifier_shaped_data_keys_over_one_repeated_structure_are_a_map(self) -> None:
-        """The spelling guard cannot catch {"Engineering": {...}, "Marketing": {...}}
-        — single-token labels are identifier-shaped. What gives the map away is
-        every value sharing one structured shape; a record's fields differ."""
-        repo = _repo()
-        by_department = {
-            "Engineering": {"headcount": 12, "open_roles": 3},
-            "Marketing": {"headcount": 5, "open_roles": 1},
-        }
-        with patch(REPO, repo):
-            await record_observed_shape("T", {"by_department": by_department}, scope=SCOPE)
-        (_, _, schema), _ = repo.record.await_args
-        assert "Engineering" not in str(schema)
-        value_shape = schema["properties"]["by_department"]["additionalProperties"]
-        assert set(value_shape["properties"]) == {"headcount", "open_roles"}
-
-    async def test_a_record_of_differing_field_shapes_keeps_its_fields(self) -> None:
-        """The homogeneity signal must not collapse real records: any variation
-        between value shapes — or any scalar field — is record evidence."""
+    async def test_a_record_whose_fields_share_a_shape_keeps_its_field_names(self) -> None:
+        """Value homogeneity is NOT a map signal: {sender, recipient} and
+        {billing_address, shipping_address} are records whose fields share a
+        shape, and collapsing them would discard real field names permanently.
+        A small dict of identifier-shaped keys is read as a record."""
         repo = _repo()
         response = {
-            "user": {"id": "u1", "name": "x"},
-            "team": {"id": "t1"},
-            "ok": True,
+            "sender": {"name": "a", "email": "a@x.com"},
+            "recipient": {"name": "b", "email": "b@x.com"},
         }
         with patch(REPO, repo):
             await record_observed_shape("T", response, scope=SCOPE)
         (_, _, schema), _ = repo.record.await_args
-        assert set(schema["properties"]) == {"user", "team", "ok"}
+        assert set(schema["properties"]) == {"sender", "recipient"}
+        assert "additionalProperties" not in schema
+
+    async def test_map_values_across_entries_union_optional_fields(self) -> None:
+        """A map's value shape is sampled across entries, not read off the first:
+        an optional field or a differing type in a later entry must survive."""
+        repo = _repo()
+        per_user = {
+            "alice@example.com": {"name": "A"},
+            "bob@example.com": {"name": "B", "email": "b@example.com"},
+        }
+        with patch(REPO, repo):
+            await record_observed_shape("T", {"per_user": per_user}, scope=SCOPE)
+        (_, _, schema), _ = repo.record.await_args
+        value_shape = schema["properties"]["per_user"]["additionalProperties"]
+        assert set(value_shape["properties"]) == {"name", "email"}
+        # name is in both entries (required); email only in one (optional).
+        assert value_shape.get("required", []) == ["name"]
 
     async def test_a_stored_map_shape_round_trips_through_the_next_merge(self) -> None:
         """additionalProperties must survive re-merging: the stored form re-enters


### PR DESCRIPTION
## Summary

Follow-up to the merged execute-proxy PR (#1197), fixing two issues in the observed-tool-shape learner (`app/services/tool_shape_service.py` + repository). Both were surfaced as review comments on #1197; this branch addresses the two that needed code (the other two — subagent tool-scoping and the HMAC secret min-length — were already fixed in the merged code).

## 1. Unique index + upsert retry for observed shapes

`ToolShapesRepository.record` upserts on `(scope, tool_name)` with no unique index, so two concurrent first observations could both find no document and insert **duplicate** records — splitting `call_count` and leaving `get_shape`'s `find_one` returning an arbitrary incomplete schema.

- Add a unique compound index on `(scope, tool_name)`, registered in `create_all_indexes`.
- Retry `record()` once on `DuplicateKeyError` so the loser re-merges onto the winner — one document, never a duplicate. Mirrors the existing `playbooks` one-per-workflow precedent exactly.

## 2. Model data-keyed maps correctly (schema correctness, not just leakage)

`_sample` classified record-vs-map by **key spelling alone**. A dict keyed by single-token user labels — `{"Engineering": {...}, "Marketing": {...}}` — slipped through as a record, so those data values became schema **property names**. That's a wrong schema, and at the shared `global` scope one user's data keys merged into the record every other user reads.

- Classify by **structure**: a dict is a map when it is wide, when a key is not identifier-shaped, **or when every value shares one non-empty structured shape** (a record's fields differ; a map's entries repeat).
- Maps now keep their **value shape** as `additionalProperties` (via a collision-free `*` sentinel through genson, rewritten symmetrically at store/reload) instead of collapsing to an opaque object. `get_tool_schema` renders it as an index signature, e.g. `{per_user:{[key]:{n:int}}}`.
- The irreducible case — a small scalar-valued dict under identifier-shaped keys (`{"Salary": "high"}`) — is read as a record by design, documented in the module docstring.

**Why not a frequency-weighted store:** for genuine records, providers return a fixed finite field set, so union converges to the true shape after a few calls. Union is only pathological when data-keyed maps sneak in — which this PR removes. `call_count` is retained as the denominator if frequency gating is ever warranted.

## Testing

- 101 unit + contract tests pass (contracts run against real Mongo + Redis); `ruff` and `mypy` clean across all touched files.
- **Mutation-proven** for every new behavior: removing the retry reddens the contract test with the exact `DuplicateKeyError`; disabling the homogeneity signal reddens the department-map test; disabling the sentinel↔additionalProperties rewrite reddens the round-trip and wide-dict tests. All green with the fixes restored.
- **Not exercised:** a live end-to-end dispatch feeding `record_observed_shape` from a booted stack — the learning path is proven at unit/contract tier only.
