### PR TITLE
feat(briefings): daily briefing and weekly digest as playbook-freezable system workflows

### DIFF
--- a/apps/api/app/agents/prompts/briefing_prompts.py
+++ b/apps/api/app/agents/prompts/briefing_prompts.py
@@ -1,0 +1,110 @@
+"""Execution prompts for the briefing system workflows.
+
+Both prompts are written to be frozen into a playbook (see the docstring on
+``app/models/playbook_models.py``): the gathering is a fixed, ordered list of
+read-only calls, one per connected integration, with a fixed window each, and
+no call whose presence depends on what an earlier call found. Integrations the
+user has not connected are omitted, not branched on: the connected set is
+stable between runs for one user, so the sequence a run makes is the same
+sequence the next run makes. All judgement lives in the single prose slot at
+the end, which is what a playbook's ``result_brief`` carries.
+
+Weekly digest output shape, in this order, one block per line group. The HTML
+rendering is a later step and reads exactly this; keep it stable:
+
+    WEEK OF <Mon D> TO <Mon D>
+
+    GAIA
+    - workflows: <n> active of <n>, <n> runs to date
+    - todos: <n> open, <n> completed, <n> overdue
+
+    YOU
+    - <integration>: <count> <noun>, <count> <noun>
+    - <integration>: ...
+
+    NOTABLE
+    - <one line>
+    - <one line>
+
+    NEXT
+    <one line>
+
+An integration with nothing to count still gets its YOU line with zeros. An
+integration that is not connected gets no line at all. The GAIA block reads
+what ``list_workflows`` and ``get_todo_statistics`` return today, which are
+to-date totals: a per-week count of runs, drafts and GAIA-created todos needs
+a read the executor does not have yet, and the prompt does not pretend it does.
+"""
+
+_GATHER_RULES = """This is a read-only run. Gather, then write. Do not create, send, draft, edit, complete, or schedule anything, and do not search the web or search memory.
+
+Gather in exactly this order, once. Your context lists the integrations the user has connected. For each integration below that is connected, make exactly the read named for it, with the window given, and nothing else for it. For one that is not connected, make no call and do not go looking for it. Never probe whether something is connected, never retry with a different query, never follow up on what a read returns with another read. If a read comes back empty, that integration simply has nothing this time.
+
+"""
+
+_VOICE = """Write like a person talking to someone they work with. Open on the point, vary sentence length, plain words, no headings, no markdown, no tables, no bullets unless the format below asks for them, no emoji, no throat clearing. Do not overcorrect into forced chattiness or slang. Never invent a number, a name, a link, or an outcome that is not in what you gathered."""
+
+
+DAILY_BRIEFING_PROMPT = (
+    """Write the user's daily briefing from what is in front of them today.
+
+"""
+    + _GATHER_RULES
+    + """1. Google Calendar: events from the start of today to the end of today in the user's timezone.
+2. Gmail: inbox threads that arrived in the last 24 hours, at most 25.
+3. GitHub: pull requests the user opened, that were merged, or that are waiting on the user's review, updated in the last 24 hours.
+4. Linear: issues assigned to the user updated in the last 24 hours, plus any due today.
+5. Notion: pages updated in the last 24 hours.
+6. Slack: messages mentioning the user in the last 24 hours, plus unread direct messages.
+7. GAIA todos: the user's todos due today or overdue (get_today_todos).
+
+Then write the briefing as plain text, at most 12 lines, in this order: the shape of the day (meetings, with times), then what is waiting on the user (mail from a real person that has no reply yet, reviews requested, issues due, mentions), then what moved since yesterday (merged, closed, edited). Skip newsletters, receipts, notifications from bots, and anything the user already replied to. Name senders and titles; give times in the user's timezone. Leave out any section that has nothing in it rather than saying it is empty.
+
+If every read came back with nothing to act on, the whole briefing is one or two lines saying the calendar is clear and nothing is waiting, so the day is open. Never pad an empty day and never skip writing it.
+
+End with one final line, on its own, starting with "Next:". It names one concrete thing GAIA could do for this user that it is not doing yet, chosen from the integrations NOT in the connected list (for example that pull requests waiting on their review would appear here once GitHub is connected) or, if every integration above is connected, from a GAIA feature this run's data shows unused (no todos at all, no reminders). One factual sentence, no pitch, no exclamation mark.
+
+"""
+    + _VOICE
+)
+
+
+WEEKLY_DIGEST_PROMPT = (
+    """Write the user's weekly digest: the receipt for the last seven days, numbers first.
+
+"""
+    + _GATHER_RULES
+    + """1. GAIA workflows: the user's workflows and their execution counts (list_workflows).
+2. GAIA todos: the user's todo statistics (get_todo_statistics).
+3. Google Calendar: events from seven days ago to now in the user's timezone.
+4. Gmail: threads the user sent in the last 7 days, at most 50, and inbox threads that arrived in the last 7 days, at most 50.
+5. GitHub: pull requests the user opened, merged, or reviewed in the last 7 days, and issues the user closed in the last 7 days.
+6. Linear: issues assigned to the user that were completed in the last 7 days, and those still open.
+7. Notion: pages the user created or edited in the last 7 days.
+8. Slack: messages the user sent in the last 7 days, at most 100.
+
+Then write the digest as plain text in exactly this shape, one item per line, counts before words. Include a YOU line for every connected integration above, with zeros when it had nothing, and no line for one that is not connected. NOTABLE holds at most three lines, each a single concrete thing from the week (the biggest merged PR, the longest meeting day, the thread that went back and forth most); leave the section out entirely if the week gives you nothing concrete. NEXT is one factual sentence naming one thing GAIA could do for this user that it is not doing yet, chosen from the integrations NOT connected, or, if all are, from a feature the numbers show unused. No pitch.
+
+WEEK OF <Mon D> TO <Mon D>
+
+GAIA
+- workflows: <n> active of <n>, <n> runs to date
+- todos: <n> open, <n> completed, <n> overdue
+
+YOU
+- Calendar: <n> meetings, <h> hours
+- Gmail: <n> sent, <n> received
+- GitHub: <n> PRs opened, <n> merged, <n> reviewed
+- Linear: <n> completed, <n> open
+- Notion: <n> pages edited
+- Slack: <n> messages sent
+
+NOTABLE
+- <one line>
+
+NEXT
+<one line>
+
+"""
+    + _VOICE
+)

--- a/apps/api/app/constants/briefing.py
+++ b/apps/api/app/constants/briefing.py
@@ -1,0 +1,18 @@
+"""Briefing system workflow constants.
+
+The daily briefing and the weekly digest are ordinary system workflows on the
+workflow engine (``app/services/system_workflows/definitions/briefing.py``),
+provisioned for every onboarded user rather than per integration. Their keys
+and crons live here so the definitions, the provisioner and the tests read
+one value.
+"""
+
+from typing import Final
+
+BRIEFING_DAILY_KEY: Final[str] = "briefing:daily"
+BRIEFING_WEEKLY_KEY: Final[str] = "briefing:weekly"
+
+#: 08:00 in the user's timezone (the provisioner stamps the timezone).
+BRIEFING_DAILY_CRON: Final[str] = "0 8 * * *"
+#: Sunday 18:00 in the user's timezone: the week is over, the next has not begun.
+BRIEFING_WEEKLY_CRON: Final[str] = "0 18 * * 0"

--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -90,9 +90,6 @@ from app.services.onboarding.first_message_service import (
     generate_first_message,
 )
 from app.services.onboarding.inbox_triage_service import triage_inbox
-from app.services.onboarding.post_onboarding_service import (
-    save_personalization_data,
-)
 from app.services.onboarding.social_profile_service import (
     dedup_profiles_by_platform,
     extract_social_profiles_from_emails,
@@ -1078,17 +1075,17 @@ async def _run_holo_card(
         )
         phrase_bio_duration_s = round(time.monotonic() - t_phrase_bio, 2)
         t_save = time.monotonic()
-        await save_personalization_data(
+        await user_repository.save_personalization(
             ctx.user_id,
-            card_design.house,
-            phrase,
-            user_bio,
-            bio_status,
-            [],
-            metadata.account_number,
-            metadata.member_since,
-            card_design.overlay_color,
-            card_design.overlay_opacity,
+            house=card_design.house,
+            personality_phrase=phrase,
+            user_bio=user_bio,
+            bio_status=bio_status,
+            account_number=metadata.account_number,
+            member_since=metadata.member_since,
+            overlay_color=card_design.overlay_color,
+            overlay_opacity=card_design.overlay_opacity,
+            workflow_ids=[],
         )
         log.info(
             f"{LogTag.ONBOARDING} holo_card done",

--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -1080,15 +1080,11 @@ async def _run_holo_card(
         t_save = time.monotonic()
         await save_personalization_data(
             ctx.user_id,
-            card_design.house,
-            phrase,
-            user_bio,
-            bio_status,
-            [],
-            metadata.account_number,
-            metadata.member_since,
-            card_design.overlay_color,
-            card_design.overlay_opacity,
+            card_design,
+            metadata,
+            personality_phrase=phrase,
+            user_bio=user_bio,
+            bio_status=bio_status,
         )
         log.info(
             f"{LogTag.ONBOARDING} holo_card done",

--- a/apps/api/app/services/onboarding/post_onboarding_service.py
+++ b/apps/api/app/services/onboarding/post_onboarding_service.py
@@ -1,62 +1,8 @@
-"""Post-onboarding personalization service."""
+"""Post-onboarding data seeding."""
 
 from app.constants.log_tags import LogTag
-from app.db.repositories.users import user_repository
-from app.models.user_models import BioStatus
 from app.utils.seeding_utils import seed_onboarding_todo
 from shared.py.wide_events import log
-
-
-async def save_personalization_data(
-    user_id: str,
-    house: str,
-    personality_phrase: str,
-    user_bio: str,
-    bio_status: BioStatus,
-    workflow_ids: list[str],
-    account_number: int,
-    member_since: str,
-    overlay_color: str,
-    overlay_opacity: int,
-) -> None:
-    """
-    Save personalization data to user document.
-
-    Args:
-        user_id: User identifier
-        house: Assigned house
-        personality_phrase: Generated phrase
-        user_bio: Generated bio
-        bio_status: Status of bio generation
-        workflow_ids: Suggested workflow IDs
-        account_number: User's account number
-        member_since: Member since date
-        overlay_color: Generated overlay color or gradient
-        overlay_opacity: Opacity percentage
-    """
-    try:
-        await user_repository.save_personalization(
-            user_id,
-            house=house,
-            personality_phrase=personality_phrase,
-            user_bio=user_bio,
-            bio_status=bio_status,
-            account_number=account_number,
-            member_since=member_since,
-            overlay_color=overlay_color,
-            overlay_opacity=overlay_opacity,
-            workflow_ids=workflow_ids,
-        )
-        log.info(f"{LogTag.ONBOARDING} Saved personalization data for user", user_id=user_id)
-
-    except Exception as e:
-        log.error(
-            f"{LogTag.ONBOARDING} Error saving personalization data",
-            error=str(e),
-            error_type=type(e).__name__,
-            user_id=user_id,
-            exc_info=True,
-        )
 
 
 async def seed_initial_user_data(user_id: str) -> None:

--- a/apps/api/app/services/onboarding/post_onboarding_service.py
+++ b/apps/api/app/services/onboarding/post_onboarding_service.py
@@ -3,6 +3,7 @@
 from app.constants.log_tags import LogTag
 from app.db.repositories.users import user_repository
 from app.models.user_models import BioStatus
+from app.services.system_workflows.provisioner import provision_universal_system_workflows
 from app.utils.seeding_utils import seed_onboarding_todo
 from shared.py.wide_events import log
 
@@ -60,8 +61,14 @@ async def save_personalization_data(
 
 
 async def seed_initial_user_data(user_id: str) -> None:
-    """Seed the onboarding todo. The welcome conversation is seeded by the
-    intelligence pipeline, not here."""
+    """Seed the onboarding todo and the universal system workflows. The welcome
+    conversation is seeded by the intelligence pipeline, not here.
+
+    Runs after complete_onboarding() has written the profile timezone, which is
+    what the provisioner stamps onto the briefing schedules. Silent, like the
+    per-integration provisioning during onboarding: the onboarding UI surfaces
+    the workflows itself.
+    """
     try:
         log.info(f"{LogTag.ONBOARDING} Starting data seeding for user", user_id=user_id)
         await seed_onboarding_todo(user_id)
@@ -74,3 +81,5 @@ async def seed_initial_user_data(user_id: str) -> None:
             error=str(e),
             error_type=type(e).__name__,
         )
+
+    await provision_universal_system_workflows(user_id, notify=False)

--- a/apps/api/app/services/onboarding/post_onboarding_service.py
+++ b/apps/api/app/services/onboarding/post_onboarding_service.py
@@ -2,6 +2,7 @@
 
 from app.constants.log_tags import LogTag
 from app.db.repositories.users import user_repository
+from app.models.onboarding_models import ProfileCardDesign, UserProfileMetadata
 from app.models.user_models import BioStatus
 from app.services.system_workflows.provisioner import provision_universal_system_workflows
 from app.utils.seeding_utils import seed_onboarding_todo
@@ -10,43 +11,29 @@ from shared.py.wide_events import log
 
 async def save_personalization_data(
     user_id: str,
-    house: str,
+    card_design: ProfileCardDesign,
+    metadata: UserProfileMetadata,
     personality_phrase: str,
     user_bio: str,
     bio_status: BioStatus,
-    workflow_ids: list[str],
-    account_number: int,
-    member_since: str,
-    overlay_color: str,
-    overlay_opacity: int,
 ) -> None:
-    """
-    Save personalization data to user document.
+    """Save the generated holo-card personalization bundle to the user document.
 
-    Args:
-        user_id: User identifier
-        house: Assigned house
-        personality_phrase: Generated phrase
-        user_bio: Generated bio
-        bio_status: Status of bio generation
-        workflow_ids: Suggested workflow IDs
-        account_number: User's account number
-        member_since: Member since date
-        overlay_color: Generated overlay color or gradient
-        overlay_opacity: Opacity percentage
+    The suggested workflows are not part of this bundle: they are persisted on
+    their own by the workflows step, which finishes independently of the card.
     """
     try:
         await user_repository.save_personalization(
             user_id,
-            house=house,
+            house=card_design.house,
             personality_phrase=personality_phrase,
             user_bio=user_bio,
             bio_status=bio_status,
-            account_number=account_number,
-            member_since=member_since,
-            overlay_color=overlay_color,
-            overlay_opacity=overlay_opacity,
-            workflow_ids=workflow_ids,
+            account_number=metadata.account_number,
+            member_since=metadata.member_since,
+            overlay_color=card_design.overlay_color,
+            overlay_opacity=card_design.overlay_opacity,
+            workflow_ids=[],
         )
         log.info(f"{LogTag.ONBOARDING} Saved personalization data for user", user_id=user_id)
 

--- a/apps/api/app/services/system_workflows/definitions/briefing.py
+++ b/apps/api/app/services/system_workflows/definitions/briefing.py
@@ -1,0 +1,111 @@
+"""
+Briefing system workflow definitions.
+
+Provisioned for every user at onboarding completion, not per integration: the
+prompts read whatever is connected and omit the rest. Each tuple is
+(system_workflow_key, factory function) — factories are called at provisioning
+time so each user gets unique step IDs rather than sharing module-load IDs.
+"""
+
+from collections.abc import Callable
+from uuid import uuid4
+
+from app.agents.prompts.briefing_prompts import DAILY_BRIEFING_PROMPT, WEEKLY_DIGEST_PROMPT
+from app.constants.briefing import (
+    BRIEFING_DAILY_CRON,
+    BRIEFING_DAILY_KEY,
+    BRIEFING_WEEKLY_CRON,
+    BRIEFING_WEEKLY_KEY,
+)
+from app.models.workflow_models import (
+    CreateWorkflowRequest,
+    TriggerConfig,
+    TriggerType,
+    WorkflowStep,
+)
+
+
+def _daily_briefing() -> CreateWorkflowRequest:
+    return CreateWorkflowRequest(
+        title="Daily Briefing",
+        description=(
+            "Every morning: today's meetings, what is waiting on you, and what moved, "
+            "read from the integrations you have connected."
+        ),
+        prompt=DAILY_BRIEFING_PROMPT,
+        is_system_workflow=True,
+        system_workflow_key=BRIEFING_DAILY_KEY,
+        trigger_config=TriggerConfig(
+            type=TriggerType.SCHEDULE,
+            cron_expression=BRIEFING_DAILY_CRON,
+            enabled=True,
+        ),
+        steps=[
+            WorkflowStep(
+                id=str(uuid4()),
+                title="Read today from each connected integration",
+                category="gaia",
+                description=(
+                    "One fixed read-only call per connected integration, in order: "
+                    "calendar events today, inbox threads from the last 24 hours, "
+                    "pull requests, issues, pages, mentions from the last 24 hours, "
+                    "and todos due today. Nothing for integrations that are not connected."
+                ),
+            ),
+            WorkflowStep(
+                id=str(uuid4()),
+                title="Write the briefing",
+                category="gaia",
+                description=(
+                    "Plain text, at most 12 lines: the shape of the day, what is waiting "
+                    "on the user, what moved. One or two lines on an empty day. "
+                    "A final 'Next:' line naming one thing GAIA could do that it is not yet."
+                ),
+            ),
+        ],
+    )
+
+
+def _weekly_digest() -> CreateWorkflowRequest:
+    return CreateWorkflowRequest(
+        title="Weekly Digest",
+        description=(
+            "Sunday evening: the receipt for the week, numbers first, "
+            "what GAIA did and what you did across your connected integrations."
+        ),
+        prompt=WEEKLY_DIGEST_PROMPT,
+        is_system_workflow=True,
+        system_workflow_key=BRIEFING_WEEKLY_KEY,
+        trigger_config=TriggerConfig(
+            type=TriggerType.SCHEDULE,
+            cron_expression=BRIEFING_WEEKLY_CRON,
+            enabled=True,
+        ),
+        steps=[
+            WorkflowStep(
+                id=str(uuid4()),
+                title="Read the week from GAIA and each connected integration",
+                category="gaia",
+                description=(
+                    "Workflow and todo statistics, then one fixed read-only call per "
+                    "connected integration over the last 7 days, in order. "
+                    "Nothing for integrations that are not connected."
+                ),
+            ),
+            WorkflowStep(
+                id=str(uuid4()),
+                title="Write the digest",
+                category="gaia",
+                description=(
+                    "The fixed WEEK OF / GAIA / YOU / NOTABLE / NEXT shape, counts before "
+                    "words, one YOU line per connected integration."
+                ),
+            ),
+        ],
+    )
+
+
+BRIEFING_SYSTEM_WORKFLOWS: list[tuple[str, Callable[[], CreateWorkflowRequest]]] = [
+    (BRIEFING_DAILY_KEY, _daily_briefing),
+    (BRIEFING_WEEKLY_KEY, _weekly_digest),
+]

--- a/apps/api/app/services/system_workflows/definitions/briefing.py
+++ b/apps/api/app/services/system_workflows/definitions/briefing.py
@@ -38,7 +38,6 @@ def _daily_briefing() -> CreateWorkflowRequest:
         trigger_config=TriggerConfig(
             type=TriggerType.SCHEDULE,
             cron_expression=BRIEFING_DAILY_CRON,
-            enabled=True,
         ),
         steps=[
             WorkflowStep(
@@ -79,7 +78,6 @@ def _weekly_digest() -> CreateWorkflowRequest:
         trigger_config=TriggerConfig(
             type=TriggerType.SCHEDULE,
             cron_expression=BRIEFING_WEEKLY_CRON,
-            enabled=True,
         ),
         steps=[
             WorkflowStep(

--- a/apps/api/app/services/system_workflows/provisioner.py
+++ b/apps/api/app/services/system_workflows/provisioner.py
@@ -1,8 +1,9 @@
 """
 SystemWorkflowProvisioner
 
-Auto-creates GAIA-managed workflows when users connect integrations.
-Called from handle_oauth_connection() as a background task.
+Auto-creates GAIA-managed workflows when users connect integrations (called
+from handle_oauth_connection() as a background task) and the universal set every
+user gets at onboarding completion (called from seed_initial_user_data()).
 
 These workflows are standard Workflow documents in MongoDB — identical to
 user-created workflows except for is_system_workflow=True. The entire existing
@@ -28,6 +29,7 @@ from app.models.notification.notification_models import (
 )
 from app.models.workflow_models import CreateWorkflowRequest, TriggerConfig, TriggerType
 from app.services.notification_service import NotificationService
+from app.services.system_workflows.definitions.briefing import BRIEFING_SYSTEM_WORKFLOWS
 from app.services.system_workflows.definitions.calendar import CALENDAR_SYSTEM_WORKFLOWS
 from app.services.system_workflows.definitions.gmail import GMAIL_SYSTEM_WORKFLOWS
 from app.services.user_service import get_user_by_id
@@ -45,9 +47,17 @@ SYSTEM_WORKFLOWS_BY_INTEGRATION: dict[
     "googlecalendar": CALENDAR_SYSTEM_WORKFLOWS,
 }
 
+# Provisioned for every user at onboarding completion, whatever they connect:
+# the briefings read what is connected and omit the rest.
+UNIVERSAL_SYSTEM_WORKFLOWS: list[tuple[str, Callable[[], CreateWorkflowRequest]]] = (
+    BRIEFING_SYSTEM_WORKFLOWS
+)
+
 # Flat registry: system_workflow_key -> factory (for reset-to-default)
 SYSTEM_WORKFLOW_REGISTRY: dict[str, Callable[[], CreateWorkflowRequest]] = {
-    key: factory for entries in SYSTEM_WORKFLOWS_BY_INTEGRATION.values() for key, factory in entries
+    key: factory
+    for entries in (*SYSTEM_WORKFLOWS_BY_INTEGRATION.values(), UNIVERSAL_SYSTEM_WORKFLOWS)
+    for key, factory in entries
 }
 
 
@@ -86,6 +96,46 @@ async def provision_system_workflows(
         integration_id=integration_id,
     )
 
+    created = await _provision_entries(
+        user_id, entries, integration_display_name=integration_display_name
+    )
+    if created and notify:
+        await _notify_workflows_provisioned(user_id, integration_display_name, created)
+
+
+async def provision_universal_system_workflows(
+    user_id: str, notify: bool = True
+) -> list[CreateWorkflowRequest]:
+    """Create the workflows every user gets, whatever they have connected.
+
+    Called from seed_initial_user_data() once onboarding has written the profile
+    timezone, so the schedules are stamped with it. Same idempotent path as the
+    per-integration set: a key that already exists for the user is skipped.
+    Returns the definitions created this call.
+    """
+    log.set(
+        component="system_workflow_provisioner",
+        operation="provision_universal_system_workflows",
+        user_id=user_id,
+    )
+    log.info(
+        f"{LogTag.WORKFLOW} Provisioning universal system workflow(s)",
+        entries_count=len(UNIVERSAL_SYSTEM_WORKFLOWS),
+        user_id=user_id,
+    )
+    created = await _provision_entries(user_id, UNIVERSAL_SYSTEM_WORKFLOWS)
+    if created and notify:
+        await _notify_workflows_provisioned(user_id, None, created)
+    return created
+
+
+async def _provision_entries(
+    user_id: str,
+    entries: list[tuple[str, Callable[[], CreateWorkflowRequest]]],
+    *,
+    integration_display_name: str | None = None,
+) -> list[CreateWorkflowRequest]:
+    """Create each definition the user does not have yet; returns the ones created."""
     created: list[CreateWorkflowRequest] = []
     user_timezone: str | None = None
 
@@ -134,23 +184,25 @@ async def provision_system_workflows(
                 outcome="failed",
                 exc_info=True,
             )
-
-    if created and notify:
-        await _notify_workflows_provisioned(user_id, integration_display_name, created)
+    return created
 
 
 async def _notify_workflows_provisioned(
     user_id: str,
-    integration_display_name: str,
+    integration_display_name: str | None,
     created: list[CreateWorkflowRequest],
 ) -> None:
-    """Send a friendly notification summarising the newly provisioned workflows."""
-    integration_name = integration_display_name
+    """Send a friendly notification summarising the newly provisioned workflows.
+
+    ``integration_display_name`` is None for the universal set, which belongs to
+    the user rather than to an integration.
+    """
+    subject = f"your {integration_display_name}" if integration_display_name else "you"
 
     if len(created) == 1:
-        title = f"I set up a workflow for your {integration_name}"
+        title = f"I set up a workflow for {subject}"
     else:
-        title = f"I set up {len(created)} workflows for your {integration_name}"
+        title = f"I set up {len(created)} workflows for {subject}"
 
     workflow_lines = "\n".join(f"• {r.title} — {r.description}" for r in created)
     body = f"Here's what I've got running for you:\n\n{workflow_lines}\n\nYou can adjust or turn them off anytime."

--- a/apps/api/app/workers/tasks/workflow_tasks.py
+++ b/apps/api/app/workers/tasks/workflow_tasks.py
@@ -1171,11 +1171,17 @@ async def _run_and_record_success(
     # tracked-todo, and integration triggers — only flow through this task,
     # so their completion is captured here. `trigger_type` already folds
     # unstamped integration fires in (see the derivation above).
+    # `system_workflow_key` names which GAIA-managed workflow delivered
+    # (briefing:daily, gmail:email_intelligence, ...); None for user workflows.
     if trigger_type != TriggerType.MANUAL.value:
         capture_event(
             workflow.user_id,
             AnalyticsEvents.WORKFLOW_EXECUTED,
-            {"workflow_id": workflow_id, "trigger_type": trigger_type},
+            {
+                "workflow_id": workflow_id,
+                "trigger_type": trigger_type,
+                "system_workflow_key": workflow.system_workflow_key,
+            },
         )
 
     # Arm the next occurrence (scheduled recurring workflows only). A re-arm

--- a/apps/api/scripts/backfill_briefing_workflows.py
+++ b/apps/api/scripts/backfill_briefing_workflows.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Backfill the universal system workflows (the briefings) for existing users.
+
+New users get them from seed_initial_user_data() at onboarding completion; users
+who onboarded before that hook existed do not have them. This provisions the
+universal set for every user whose onboarding is complete, through the same
+idempotent provisioner, so re-runs are no-ops and a user who already has one of
+the keys keeps it untouched.
+
+Provisioning arms each schedule through the workflow scheduler, so the ARQ pool
+is initialised first: run this with the API's Redis reachable.
+
+Run from the api directory (or /app/apps/api inside the container):
+
+    python scripts/backfill_briefing_workflows.py --dry-run
+    python scripts/backfill_briefing_workflows.py --apply
+    python scripts/backfill_briefing_workflows.py --apply --notify
+
+Flags:
+--dry-run  List the users and the keys each is missing. Default.
+--apply    Actually create them. Required to write anything.
+--notify   With --apply: send each user the "I set up N workflows for you"
+           notification. Off by default so a backfill does not fan out a
+           notification to every existing account.
+--user-id  Limit the run to one user.
+"""
+
+import argparse
+import asyncio
+from pathlib import Path
+import sys
+
+# Ensure app is on path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.db.mongodb.collections import get_async_collection
+from app.db.repositories.workflows import workflow_repository
+from app.services.system_workflows.provisioner import (
+    UNIVERSAL_SYSTEM_WORKFLOWS,
+    provision_universal_system_workflows,
+)
+from app.services.workflow.scheduler import workflow_scheduler
+
+users_collection = get_async_collection("users")
+
+
+async def _onboarded_user_ids(user_id: str | None) -> list[str]:
+    query: dict[str, object] = {"onboarding.completed": True}
+    if user_id:
+        query["_id"] = user_id
+    return [str(doc["_id"]) async for doc in users_collection.find(query, {"_id": 1})]
+
+
+async def _missing_keys(user_id: str) -> list[str]:
+    return [
+        key
+        for key, _factory in UNIVERSAL_SYSTEM_WORKFLOWS
+        if await workflow_repository.find_system_workflow(user_id, key) is None
+    ]
+
+
+async def run(*, apply: bool, notify: bool, user_id: str | None) -> None:
+    user_ids = await _onboarded_user_ids(user_id)
+    print(f"{len(user_ids)} onboarded user(s) in scope")
+
+    candidates: dict[str, list[str]] = {}
+    for uid in user_ids:
+        missing = await _missing_keys(uid)
+        if missing:
+            candidates[uid] = missing
+    print(f"{len(candidates)} user(s) missing at least one universal workflow")
+
+    if not apply:
+        for uid, missing in candidates.items():
+            print(f"  would provision {uid}: {', '.join(missing)}")
+        print("\nDRY RUN, nothing was written. Re-run with --apply.")
+        return
+
+    await workflow_scheduler.initialize()
+    try:
+        created_total = 0
+        for uid in candidates:
+            created = await provision_universal_system_workflows(uid, notify=notify)
+            created_total += len(created)
+            print(f"  provisioned {uid}: {len(created)} created")
+        print(f"\nAPPLIED: {created_total} workflow(s) created across {len(candidates)} user(s)")
+    finally:
+        await workflow_scheduler.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Report only (default)")
+    mode.add_argument("--apply", action="store_true", help="Create the missing workflows")
+    parser.add_argument("--notify", action="store_true", help="Notify each user (with --apply)")
+    parser.add_argument("--user-id", help="Limit to one user id")
+    args = parser.parse_args()
+    asyncio.run(run(apply=args.apply, notify=args.notify, user_id=args.user_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/tests/e2e/test_onboarding.py
+++ b/apps/api/tests/e2e/test_onboarding.py
@@ -56,6 +56,7 @@ from httpx import AsyncClient
 from langchain_core.messages import AIMessage
 import pytest
 
+from app.agents.memory.email_processor import OnboardingFetchOptions
 from app.constants.onboarding import (
     INTELLIGENCE_TASK,
     WORKFLOWS_TASK,
@@ -88,6 +89,9 @@ from tests.conftest import FAKE_USER
 pytestmark = pytest.mark.e2e
 
 USER_ID: str = FAKE_USER["user_id"]
+
+#: Patch-target prefix for the onboarding service package.
+_SVC = "app.services.onboarding"
 
 #: The sender the triage LLM reports as important. Todo specs that cite it keep
 #: their ``source_email``; anything else is dropped as hallucinated.
@@ -485,82 +489,9 @@ def stages(users: _UserStore) -> _StageSink:
     return _StageSink(users)
 
 
-@pytest.fixture(autouse=True)
-def world(
-    users: _UserStore,
-    stages: _StageSink,
-    externals: _Externals,
-    arq_pool: ArqRedis,
-) -> Iterator[None]:
-    """Wire the store, the socket and every external service into the real flow."""
-    svc = "app.services.onboarding"
-
-    async def _check_connection(slugs: list[str], _user_id: str) -> dict[str, bool]:
-        if externals.composio_gate is not None:
-            await externals.composio_gate.wait()
-        return {slug: (slug == "gmail" and externals.has_gmail) for slug in slugs}
-
-    composio = AsyncMock()
-    composio.check_connection_status.side_effect = _check_connection
-
-    async def _fetch_emails(
-        user_id: str,
-        months: int = 1,
-        batch_size: int = 100,
-        max_total: int = 100,
-        on_batch: Callable[[int, str | None], Awaitable[None]] | None = None,
-        fmt: str = "metadata",
-        into: list[dict[str, Any]] | None = None,
-        include_sent: bool = False,
-    ) -> list[dict[str, Any]]:
-        batch = list(externals.inbox)
-        if into is not None:
-            into.extend(batch)
-        if on_batch is not None:
-            await on_batch(len(batch), batch[0]["sender"] if batch else None)
-        return batch
-
-    async def _structured(schema: type, prompt: Any, *, label: str, **_: Any) -> Any:
-        externals.llm_labels.append(label)
-        externals.llm_prompts[label] = str(prompt)
-        if label in externals.llm_failures:
-            raise RuntimeError(f"model refused: {label}")
-        return _structured_result(schema, externals)
-
-    async def _invoke_llm(_runnable: Any, messages: Any, *, label: str = "model", **_: Any) -> Any:
-        externals.llm_labels.append(label)
-        externals.llm_prompts[label] = str(messages)
-        if label in externals.llm_failures:
-            raise RuntimeError(f"model refused: {label}")
-        return AIMessage(content="Hey, you're all set.")
-
-    async def _search_messages(**_: Any) -> Any:
-        result = AsyncMock()
-        result.messages = externals.sent_emails
-        return result
-
-    async def _create_workflow(
-        request: Any, _user_id: str, user_timezone: str = "UTC", **_: Any
-    ) -> _FakeWorkflow:
-        externals.workflows_created.append(request.title)
-        externals.workflow_timezones.append(user_timezone)
-        return _FakeWorkflow(f"wf-{len(externals.workflows_created)}")
-
-    async def _delete_workflow(workflow_id: str, _user_id: str) -> bool:
-        if externals.workflow_delete_error == workflow_id:
-            raise RuntimeError("composio trigger teardown failed")
-        externals.workflows_deleted.append(workflow_id)
-        return True
-
-    async def _generate_prompt(**_: Any) -> dict[str, Any]:
-        return {
-            "prompt": "Do the thing.",
-            "suggested_trigger": SuggestedTrigger(type="schedule", cron_expression="0 8 * * *"),
-        }
-
-    async def _create_todo(todo: Any, _user_id: str) -> _FakeTodo:
-        externals.todos_created.append(todo.title)
-        return _FakeTodo(f"todo-{len(externals.todos_created)}")
+@pytest.fixture
+def persistence_patches(users: _UserStore, externals: _Externals) -> list[Any]:
+    """Every repository the flow writes through, wired to the in-memory store."""
 
     async def _list_onboarding_todos(_user_id: str, limit: int = 3) -> list[Any]:
         todos = []
@@ -573,18 +504,9 @@ def world(
             todos.append(todo)
         return todos
 
-    async def _seed_conversation(**_: Any) -> str | None:
-        return externals.seeded_conversation_id
-
-    async def _seed_user_data(user_id: str) -> None:
-        externals.seeded_users.append(user_id)
-
     async def _purge_workflows(workflow_ids: list[str], _user_id: str) -> int:
         externals.purged_workflow_ids.append(list(workflow_ids))
         return len(workflow_ids)
-
-    async def _provision(user_id: str, slug: str, *_args: Any, **_kw: Any) -> None:
-        externals.provisioned.append(slug)
 
     async def _list_user_integrations(_user_id: str) -> list[Any]:
         out = []
@@ -613,66 +535,191 @@ def world(
     memory = AsyncMock()
     memory.delete_all.side_effect = lambda _uid: externals.memories_cleared
 
-    patches = [
-        # --- persistence -------------------------------------------------
-        patch(f"{svc}.onboarding_service.user_repository", users),
-        patch(f"{svc}.intelligence_job.user_repository", users),
-        patch(f"{svc}.intelligence_service.user_repository", users),
+    return [
+        patch(f"{_SVC}.onboarding_service.user_repository", users),
+        patch(f"{_SVC}.intelligence_job.user_repository", users),
+        patch(f"{_SVC}.intelligence_service.user_repository", users),
         patch("app.workers.tasks.onboarding_tasks.user_repository", users),
         patch("app.api.v1.endpoints.onboarding.user_repository", users),
-        patch(f"{svc}.onboarding_service.todo_repository", todo_repo),
-        patch(f"{svc}.intelligence_job.todo_repository", todo_repo),
-        patch(f"{svc}.intelligence_service.todo_repository", todo_repo),
+        patch(f"{_SVC}.onboarding_service.todo_repository", todo_repo),
+        patch(f"{_SVC}.intelligence_job.todo_repository", todo_repo),
+        patch(f"{_SVC}.intelligence_service.todo_repository", todo_repo),
         patch("app.api.v1.endpoints.onboarding.todo_repository", todo_repo),
         patch("app.api.v1.endpoints.onboarding.workflow_repository", AsyncMock()),
         patch(
-            f"{svc}.intelligence_service.workflow_repository.delete_many_for_user", _purge_workflows
+            f"{_SVC}.intelligence_service.workflow_repository.delete_many_for_user",
+            _purge_workflows,
         ),
-        patch(f"{svc}.onboarding_service.conversation_repository", conversation_repo),
-        patch(f"{svc}.onboarding_service.user_integration_repository", integrations_repo),
-        patch(f"{svc}.onboarding_service.memory_engine", memory),
-        patch(f"{svc}.onboarding_service.disconnect_integration", _disconnect),
-        # --- transport ---------------------------------------------------
-        patch(f"{svc}.intelligence_service.websocket_manager", stages),
-        # --- composio ----------------------------------------------------
-        patch(f"{svc}.intelligence_service.get_composio_service", lambda: composio),
+        patch(f"{_SVC}.onboarding_service.conversation_repository", conversation_repo),
+        patch(f"{_SVC}.onboarding_service.user_integration_repository", integrations_repo),
+        patch(f"{_SVC}.onboarding_service.memory_engine", memory),
+        patch(f"{_SVC}.onboarding_service.disconnect_integration", _disconnect),
+    ]
+
+
+@pytest.fixture
+def composio_patches(externals: _Externals) -> list[Any]:
+    """Connection status, optionally held open so a test can race the pipeline."""
+
+    async def _check_connection(slugs: list[str], _user_id: str) -> dict[str, bool]:
+        if externals.composio_gate is not None:
+            await externals.composio_gate.wait()
+        return {slug: (slug == "gmail" and externals.has_gmail) for slug in slugs}
+
+    composio = AsyncMock()
+    composio.check_connection_status.side_effect = _check_connection
+
+    return [
+        patch(f"{_SVC}.intelligence_service.get_composio_service", lambda: composio),
         patch("app.api.v1.endpoints.onboarding.get_composio_service", lambda: composio),
-        # --- gmail -------------------------------------------------------
-        patch(f"{svc}.intelligence_service.fetch_emails_for_onboarding", _fetch_emails),
-        patch(f"{svc}.writing_style_service.search_messages", _search_messages),
-        patch(f"{svc}.intelligence_service.inbox_scan_cache.get", AsyncMock(return_value=None)),
-        patch(f"{svc}.intelligence_service.inbox_scan_cache.put", AsyncMock()),
+    ]
+
+
+@pytest.fixture
+def gmail_patches(externals: _Externals) -> list[Any]:
+    """The inbox: fetch, sent-mail search, and the scan cache."""
+
+    async def _fetch_emails(
+        user_id: str,
+        months: int = 1,
+        max_total: int = 100,
+        on_batch: Callable[[int, str | None], Awaitable[None]] | None = None,
+        into: list[dict[str, Any]] | None = None,
+        options: OnboardingFetchOptions | None = None,
+    ) -> list[dict[str, Any]]:
+        batch = list(externals.inbox)
+        if into is not None:
+            into.extend(batch)
+        if on_batch is not None:
+            await on_batch(len(batch), batch[0]["sender"] if batch else None)
+        return batch
+
+    async def _search_messages(**_: Any) -> Any:
+        result = AsyncMock()
+        result.messages = externals.sent_emails
+        return result
+
+    return [
+        patch(f"{_SVC}.intelligence_service.fetch_emails_for_onboarding", _fetch_emails),
+        patch(f"{_SVC}.writing_style_service.search_messages", _search_messages),
+        patch(f"{_SVC}.intelligence_service.inbox_scan_cache.get", AsyncMock(return_value=None)),
+        patch(f"{_SVC}.intelligence_service.inbox_scan_cache.put", AsyncMock()),
         patch(
-            f"{svc}.intelligence_service.extract_social_profiles_from_emails",
+            f"{_SVC}.intelligence_service.extract_social_profiles_from_emails",
             AsyncMock(return_value=[SocialProfile(platform="linkedin", url="https://li/x")]),
         ),
-        # --- llm ---------------------------------------------------------
-        patch(f"{svc}.intelligence_service.ainvoke_structured", _structured),
-        patch(f"{svc}.writing_style_service.ainvoke_structured", _structured),
-        patch(f"{svc}.inbox_triage_service.ainvoke_structured", _structured),
-        patch(f"{svc}.first_message_service.ainvoke_llm", _invoke_llm),
-        patch(f"{svc}.first_message_service.get_helper_llm", lambda **_: AsyncMock()),
-        # --- downstream services ----------------------------------------
-        patch(f"{svc}.intelligence_service.WorkflowService.create_workflow", _create_workflow),
-        patch(f"{svc}.onboarding_service.WorkflowService.delete_workflow", _delete_workflow),
+    ]
+
+
+@pytest.fixture
+def llm_patches(externals: _Externals) -> list[Any]:
+    """Every model call, recorded by label so a test can fail exactly one."""
+
+    async def _structured(schema: type, prompt: Any, *, label: str, **_: Any) -> Any:
+        externals.llm_labels.append(label)
+        externals.llm_prompts[label] = str(prompt)
+        if label in externals.llm_failures:
+            raise RuntimeError(f"model refused: {label}")
+        return _structured_result(schema, externals)
+
+    async def _invoke_llm(_runnable: Any, messages: Any, *, label: str = "model", **_: Any) -> Any:
+        externals.llm_labels.append(label)
+        externals.llm_prompts[label] = str(messages)
+        if label in externals.llm_failures:
+            raise RuntimeError(f"model refused: {label}")
+        return AIMessage(content="Hey, you're all set.")
+
+    return [
+        patch(f"{_SVC}.intelligence_service.ainvoke_structured", _structured),
+        patch(f"{_SVC}.writing_style_service.ainvoke_structured", _structured),
+        patch(f"{_SVC}.inbox_triage_service.ainvoke_structured", _structured),
+        patch(f"{_SVC}.first_message_service.ainvoke_llm", _invoke_llm),
+        patch(f"{_SVC}.first_message_service.get_helper_llm", lambda **_: AsyncMock()),
+    ]
+
+
+@pytest.fixture
+def downstream_patches(externals: _Externals) -> list[Any]:
+    """Workflows, todos, conversation seeding and system provisioning."""
+
+    async def _create_workflow(
+        request: Any, _user_id: str, user_timezone: str = "UTC", **_: Any
+    ) -> _FakeWorkflow:
+        externals.workflows_created.append(request.title)
+        externals.workflow_timezones.append(user_timezone)
+        return _FakeWorkflow(f"wf-{len(externals.workflows_created)}")
+
+    async def _delete_workflow(workflow_id: str, _user_id: str) -> bool:
+        if externals.workflow_delete_error == workflow_id:
+            raise RuntimeError("composio trigger teardown failed")
+        externals.workflows_deleted.append(workflow_id)
+        return True
+
+    async def _generate_prompt(**_: Any) -> dict[str, Any]:
+        return {
+            "prompt": "Do the thing.",
+            "suggested_trigger": SuggestedTrigger(type="schedule", cron_expression="0 8 * * *"),
+        }
+
+    async def _create_todo(todo: Any, _user_id: str) -> _FakeTodo:
+        externals.todos_created.append(todo.title)
+        return _FakeTodo(f"todo-{len(externals.todos_created)}")
+
+    async def _seed_conversation(**_: Any) -> str | None:
+        return externals.seeded_conversation_id
+
+    async def _seed_user_data(user_id: str) -> None:
+        externals.seeded_users.append(user_id)
+
+    async def _provision(user_id: str, slug: str, *_args: Any, **_kw: Any) -> None:
+        externals.provisioned.append(slug)
+
+    return [
+        patch(f"{_SVC}.intelligence_service.WorkflowService.create_workflow", _create_workflow),
+        patch(f"{_SVC}.onboarding_service.WorkflowService.delete_workflow", _delete_workflow),
         patch(
-            f"{svc}.intelligence_service.WorkflowGenerationService.generate_workflow_prompt",
+            f"{_SVC}.intelligence_service.WorkflowGenerationService.generate_workflow_prompt",
             _generate_prompt,
         ),
         patch(
-            f"{svc}.intelligence_service.compute_missing_integrations", AsyncMock(return_value=[])
+            f"{_SVC}.intelligence_service.compute_missing_integrations", AsyncMock(return_value=[])
         ),
-        patch(f"{svc}.intelligence_service.TodoService.create_todo", _create_todo),
-        patch(f"{svc}.intelligence_service.seed_onboarding_conversation", _seed_conversation),
-        patch(f"{svc}.intelligence_service.provision_system_workflows", _provision),
-        patch(f"{svc}.post_onboarding_service.seed_onboarding_todo", _seed_user_data),
+        patch(f"{_SVC}.intelligence_service.TodoService.create_todo", _create_todo),
+        patch(f"{_SVC}.intelligence_service.seed_onboarding_conversation", _seed_conversation),
+        patch(f"{_SVC}.intelligence_service.provision_system_workflows", _provision),
+        patch(f"{_SVC}.post_onboarding_service.seed_onboarding_todo", _seed_user_data),
         patch(
-            f"{svc}.intelligence_service.generate_holo_card_content",
+            f"{_SVC}.intelligence_service.generate_holo_card_content",
             AsyncMock(return_value=("Curious Adventurer", "A bio.", "completed")),
         ),
     ]
+
+
+@pytest.fixture
+def all_patches(
+    stages: _StageSink,
+    persistence_patches: list[Any],
+    composio_patches: list[Any],
+    gmail_patches: list[Any],
+    llm_patches: list[Any],
+    downstream_patches: list[Any],
+) -> list[Any]:
+    """Every group of patches the flow needs, plus the socket sink."""
+    return [
+        *persistence_patches,
+        patch(f"{_SVC}.intelligence_service.websocket_manager", stages),
+        *composio_patches,
+        *gmail_patches,
+        *llm_patches,
+        *downstream_patches,
+    ]
+
+
+@pytest.fixture(autouse=True)
+def world(arq_pool: ArqRedis, all_patches: list[Any]) -> Iterator[None]:
+    """Wire the store, the socket and every external service into the real flow."""
     with ExitStack() as stack:
-        for patcher in patches:
+        for patcher in all_patches:
             stack.enter_context(patcher)
         yield
 

--- a/apps/api/tests/e2e/test_onboarding.py
+++ b/apps/api/tests/e2e/test_onboarding.py
@@ -618,7 +618,6 @@ def world(
         patch(f"{svc}.onboarding_service.user_repository", users),
         patch(f"{svc}.intelligence_job.user_repository", users),
         patch(f"{svc}.intelligence_service.user_repository", users),
-        patch(f"{svc}.post_onboarding_service.user_repository", users),
         patch("app.workers.tasks.onboarding_tasks.user_repository", users),
         patch("app.api.v1.endpoints.onboarding.user_repository", users),
         patch(f"{svc}.onboarding_service.todo_repository", todo_repo),

--- a/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
+++ b/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
@@ -761,8 +761,9 @@ class TestRunHoloCard:
 
         args = save.await_args.args
         assert args[0] == USER
-        assert args[1] == "mistgrove"
-        assert args[2] == "a phrase"
+        assert args[1].house == "mistgrove"
+        assert args[2].account_number == 1
+        assert save.await_args.kwargs["personality_phrase"] == "a phrase"
         # Both the id and the already-loaded document: without the document the
         # lookup re-reads Mongo, without the id it reads the wrong person.
         metadata.assert_awaited_once_with(USER, user=user)

--- a/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
+++ b/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
@@ -13,6 +13,7 @@ import pytest
 
 from app.constants.onboarding import NOT_SPECIFIED
 from app.constants.todos import ONBOARDING_TODO_LIMIT
+from app.db.repositories.users import user_repository
 from app.models.onboarding_models import (
     EmailSummary,
     InboxTriage,
@@ -743,7 +744,7 @@ def holo_stack() -> Any:
             f"{MODULE}.generate_holo_card_content",
             AsyncMock(return_value=("a phrase", "a bio", "ok")),
         ) as content,
-        patch(f"{MODULE}.save_personalization_data", AsyncMock()) as save,
+        patch.object(user_repository, "save_personalization", AsyncMock()) as save,
         patch(f"{MODULE}._emit_stage", AsyncMock()) as emit,
     ):
         yield content, save, emit
@@ -759,10 +760,10 @@ class TestRunHoloCard:
         ) as metadata:
             await _run_holo_card(_ctx(focus="focus"), user)
 
-        args = save.await_args.args
-        assert args[0] == USER
-        assert args[1] == "mistgrove"
-        assert args[2] == "a phrase"
+        assert save.await_args.args[0] == USER
+        saved = save.await_args.kwargs
+        assert saved["house"] == "mistgrove"
+        assert saved["personality_phrase"] == "a phrase"
         # Both the id and the already-loaded document: without the document the
         # lookup re-reads Mongo, without the id it reads the wrong person.
         metadata.assert_awaited_once_with(USER, user=user)
@@ -842,6 +843,21 @@ class TestRunHoloCard:
         await _run_holo_card(_ctx(focus=""), UserDocument(id=USER))
 
         assert content.await_args.args[1] == ""
+
+    async def test_a_save_failure_is_reported_as_a_failed_outcome(self, holo_stack: Any) -> None:
+        """The save used to be wrapped in a helper that logged and swallowed its
+        own exception, so a card that never reached Mongo still produced
+        ``holo_card done, outcome=ok`` — the one line an operator would trust."""
+        _, save, emit = holo_stack
+        save.side_effect = RuntimeError("mongo down")
+
+        with patch(f"{MODULE}.log") as log:
+            await _run_holo_card(_ctx(focus=""), UserDocument(id=USER))
+
+        assert [c.kwargs.get("outcome") for c in log.info.call_args_list] == []
+        assert log.error.call_args.kwargs["outcome"] == "failed"
+        assert log.error.call_args.kwargs["error_type"] == "RuntimeError"
+        assert emit.await_args.args[1] is OnboardingStage.HOLO_READY
 
     async def test_a_failure_still_announces_readiness(self, holo_stack: Any) -> None:
         # The frontend waits on HOLO_READY; skipping it leaves the card spinning.

--- a/apps/api/tests/unit/services/test_briefing_system_workflows.py
+++ b/apps/api/tests/unit/services/test_briefing_system_workflows.py
@@ -1,0 +1,212 @@
+"""The briefing system workflows: definitions, universal provisioning, playbook path.
+
+Covers:
+- definitions/briefing.py: keys, crons, is_system_workflow, schedule with no
+  timezone (the provisioner stamps it), fresh step ids per factory call
+- provisioner.provision_universal_system_workflows: idempotent by key, profile
+  timezone stamped, silent when notify=False, "for you" title otherwise
+- playbook/check.py asks a system workflow with these keys to author a playbook
+  exactly as it asks a user workflow: nothing on that path reads
+  is_system_workflow or system_workflow_key
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.prompts.playbook_prompts import PLAYBOOK_CHECK_BRIEF
+from app.constants.briefing import (
+    BRIEFING_DAILY_CRON,
+    BRIEFING_DAILY_KEY,
+    BRIEFING_WEEKLY_CRON,
+    BRIEFING_WEEKLY_KEY,
+)
+from app.models.workflow_models import (
+    CreateWorkflowRequest,
+    TriggerConfig,
+    TriggerType,
+    WorkflowDocument,
+)
+from app.services.system_workflows.definitions.briefing import BRIEFING_SYSTEM_WORKFLOWS
+from app.services.system_workflows.provisioner import (
+    SYSTEM_WORKFLOW_REGISTRY,
+    UNIVERSAL_SYSTEM_WORKFLOWS,
+    provision_universal_system_workflows,
+)
+from app.services.workflow.playbook.check import playbook_check_brief
+
+PROVISIONER = "app.services.system_workflows.provisioner"
+CHECK = "app.services.workflow.playbook.check"
+USER_ID = "user-1"
+
+
+@pytest.fixture(autouse=True)
+def _patch_log():
+    with patch(f"{PROVISIONER}.log"):
+        yield
+
+
+def _definitions() -> dict[str, CreateWorkflowRequest]:
+    return {key: factory() for key, factory in BRIEFING_SYSTEM_WORKFLOWS}
+
+
+class TestBriefingDefinitions:
+    def test_keys_and_crons(self) -> None:
+        defs = _definitions()
+        assert set(defs) == {BRIEFING_DAILY_KEY, BRIEFING_WEEKLY_KEY}
+        assert BRIEFING_DAILY_KEY == "briefing:daily"
+        assert BRIEFING_WEEKLY_KEY == "briefing:weekly"
+        assert defs[BRIEFING_DAILY_KEY].trigger_config.cron_expression == BRIEFING_DAILY_CRON
+        assert defs[BRIEFING_WEEKLY_KEY].trigger_config.cron_expression == BRIEFING_WEEKLY_CRON
+        assert BRIEFING_DAILY_CRON == "0 8 * * *"
+        assert BRIEFING_WEEKLY_CRON.split()[-1] == "0", "weekly digest fires on Sunday"
+
+    def test_system_schedule_without_timezone(self) -> None:
+        for key, request in _definitions().items():
+            assert request.is_system_workflow is True, key
+            assert request.system_workflow_key == key
+            assert request.source_integration is None, "not owned by an integration"
+            assert request.trigger_config.type == TriggerType.SCHEDULE
+            assert request.trigger_config.timezone is None, "the provisioner stamps it"
+            assert request.steps and all(step.id for step in request.steps)
+
+    def test_each_factory_call_mints_fresh_step_ids(self) -> None:
+        for _key, factory in BRIEFING_SYSTEM_WORKFLOWS:
+            first = {step.id for step in factory().steps or []}
+            second = {step.id for step in factory().steps or []}
+            assert first.isdisjoint(second)
+
+    def test_universal_set_and_registry(self) -> None:
+        assert UNIVERSAL_SYSTEM_WORKFLOWS == BRIEFING_SYSTEM_WORKFLOWS
+        assert BRIEFING_DAILY_KEY in SYSTEM_WORKFLOW_REGISTRY, "reset-to-default must find it"
+        assert BRIEFING_WEEKLY_KEY in SYSTEM_WORKFLOW_REGISTRY
+
+
+class TestProvisionUniversalSystemWorkflows:
+    @pytest.mark.asyncio
+    @patch(f"{PROVISIONER}._notify_workflows_provisioned", new_callable=AsyncMock)
+    @patch(f"{PROVISIONER}.get_user_by_id", new_callable=AsyncMock)
+    @patch(f"{PROVISIONER}.WorkflowService")
+    @patch(f"{PROVISIONER}.workflow_repository")
+    async def test_creates_both_stamped_with_profile_timezone(
+        self,
+        mock_repo: MagicMock,
+        mock_workflow_svc: MagicMock,
+        mock_get_user: AsyncMock,
+        mock_notify: AsyncMock,
+    ) -> None:
+        mock_repo.find_system_workflow = AsyncMock(return_value=None)
+        mock_workflow_svc.create_workflow = AsyncMock()
+        mock_get_user.return_value = {"timezone": " Asia/Kolkata "}
+
+        created = await provision_universal_system_workflows(USER_ID, notify=False)
+
+        assert {r.system_workflow_key for r in created} == {
+            BRIEFING_DAILY_KEY,
+            BRIEFING_WEEKLY_KEY,
+        }
+        assert mock_workflow_svc.create_workflow.await_count == 2
+        for call in mock_workflow_svc.create_workflow.await_args_list:
+            request, user_id = call.args
+            assert user_id == USER_ID
+            assert request.trigger_config.timezone == "Asia/Kolkata"
+        mock_get_user.assert_awaited_once_with(USER_ID)
+        mock_notify.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch(f"{PROVISIONER}._notify_workflows_provisioned", new_callable=AsyncMock)
+    @patch(f"{PROVISIONER}.get_user_by_id", new_callable=AsyncMock)
+    @patch(f"{PROVISIONER}.WorkflowService")
+    @patch(f"{PROVISIONER}.workflow_repository")
+    async def test_idempotent_only_creates_missing_key(
+        self,
+        mock_repo: MagicMock,
+        mock_workflow_svc: MagicMock,
+        mock_get_user: AsyncMock,
+        mock_notify: AsyncMock,
+    ) -> None:
+        mock_repo.find_system_workflow = AsyncMock(
+            side_effect=lambda _uid, key: MagicMock() if key == BRIEFING_DAILY_KEY else None
+        )
+        mock_workflow_svc.create_workflow = AsyncMock()
+        mock_get_user.return_value = {"timezone": ""}
+
+        created = await provision_universal_system_workflows(USER_ID)
+
+        assert [r.system_workflow_key for r in created] == [BRIEFING_WEEKLY_KEY]
+        (request, _), _ = mock_workflow_svc.create_workflow.await_args
+        assert request.trigger_config.timezone == "UTC", "blank profile timezone falls back"
+        mock_notify.assert_awaited_once_with(USER_ID, None, created)
+
+    @pytest.mark.asyncio
+    @patch(f"{PROVISIONER}._notify_workflows_provisioned", new_callable=AsyncMock)
+    @patch(f"{PROVISIONER}.get_user_by_id", new_callable=AsyncMock)
+    @patch(f"{PROVISIONER}.WorkflowService")
+    @patch(f"{PROVISIONER}.workflow_repository")
+    async def test_nothing_missing_creates_and_notifies_nothing(
+        self,
+        mock_repo: MagicMock,
+        mock_workflow_svc: MagicMock,
+        mock_get_user: AsyncMock,
+        mock_notify: AsyncMock,
+    ) -> None:
+        mock_repo.find_system_workflow = AsyncMock(return_value=MagicMock())
+        mock_workflow_svc.create_workflow = AsyncMock()
+
+        assert await provision_universal_system_workflows(USER_ID) == []
+
+        mock_workflow_svc.create_workflow.assert_not_awaited()
+        mock_get_user.assert_not_awaited()
+        mock_notify.assert_not_awaited()
+
+
+class TestUniversalNotificationTitle:
+    @pytest.mark.asyncio
+    @patch(f"{PROVISIONER}.NotificationService")
+    async def test_title_addresses_the_user_not_an_integration(
+        self, mock_notif_cls: MagicMock
+    ) -> None:
+        from app.services.system_workflows.provisioner import _notify_workflows_provisioned
+
+        mock_svc = AsyncMock()
+        mock_notif_cls.return_value = mock_svc
+
+        await _notify_workflows_provisioned(
+            USER_ID, None, [f() for _, f in BRIEFING_SYSTEM_WORKFLOWS]
+        )
+
+        notification = mock_svc.create_notification.call_args[0][0]
+        assert notification.content.title == "I set up 2 workflows for you"
+
+
+class TestPlaybookPathAsksSystemWorkflows:
+    """The playbook check gates on playbook state and decline count only.
+
+    A briefing workflow document carries is_system_workflow=True and one of the
+    briefing keys; the check must still hand back the check brief, the same as
+    it does for a user workflow (test_playbook_check.py).
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("key", [BRIEFING_DAILY_KEY, BRIEFING_WEEKLY_KEY])
+    async def test_check_brief_for_system_workflow(self, key: str) -> None:
+        request = SYSTEM_WORKFLOW_REGISTRY[key]()
+        document = WorkflowDocument(
+            id="wf-briefing",
+            user_id=USER_ID,
+            title=request.title,
+            prompt=request.prompt,
+            steps=request.steps or [],
+            trigger_config=TriggerConfig(
+                type=TriggerType.SCHEDULE,
+                cron_expression=request.trigger_config.cron_expression,
+                enabled=True,
+            ),
+            is_system_workflow=True,
+            system_workflow_key=key,
+        )
+        with (
+            patch(f"{CHECK}.playbook_repository.get_for_workflow", AsyncMock(return_value=None)),
+            patch(f"{CHECK}.workflow_repository.get_for_user", AsyncMock(return_value=document)),
+        ):
+            assert await playbook_check_brief("wf-briefing", USER_ID) == PLAYBOOK_CHECK_BRIEF

--- a/apps/api/tests/unit/services/test_briefing_system_workflows.py
+++ b/apps/api/tests/unit/services/test_briefing_system_workflows.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.agents.prompts.briefing_prompts import DAILY_BRIEFING_PROMPT, WEEKLY_DIGEST_PROMPT
 from app.agents.prompts.playbook_prompts import PLAYBOOK_CHECK_BRIEF
 from app.constants.briefing import (
     BRIEFING_DAILY_CRON,
@@ -34,6 +35,63 @@ from app.services.system_workflows.provisioner import (
     provision_universal_system_workflows,
 )
 from app.services.workflow.playbook.check import playbook_check_brief
+
+# The two definitions, field for field. These workflows ship to every user at
+# onboarding and nothing downstream re-derives their text, so the text IS the
+# feature: a typo in a step description is a shipped bug that no other test in
+# the suite would notice.
+EXPECTED_DEFINITIONS: dict[str, dict[str, object]] = {
+    BRIEFING_DAILY_KEY: {
+        "title": "Daily Briefing",
+        "description": (
+            "Every morning: today's meetings, what is waiting on you, and what moved, "
+            "read from the integrations you have connected."
+        ),
+        "prompt": DAILY_BRIEFING_PROMPT,
+        "cron": BRIEFING_DAILY_CRON,
+        "steps": [
+            (
+                "Read today from each connected integration",
+                "gaia",
+                "One fixed read-only call per connected integration, in order: "
+                "calendar events today, inbox threads from the last 24 hours, "
+                "pull requests, issues, pages, mentions from the last 24 hours, "
+                "and todos due today. Nothing for integrations that are not connected.",
+            ),
+            (
+                "Write the briefing",
+                "gaia",
+                "Plain text, at most 12 lines: the shape of the day, what is waiting "
+                "on the user, what moved. One or two lines on an empty day. "
+                "A final 'Next:' line naming one thing GAIA could do that it is not yet.",
+            ),
+        ],
+    },
+    BRIEFING_WEEKLY_KEY: {
+        "title": "Weekly Digest",
+        "description": (
+            "Sunday evening: the receipt for the week, numbers first, "
+            "what GAIA did and what you did across your connected integrations."
+        ),
+        "prompt": WEEKLY_DIGEST_PROMPT,
+        "cron": BRIEFING_WEEKLY_CRON,
+        "steps": [
+            (
+                "Read the week from GAIA and each connected integration",
+                "gaia",
+                "Workflow and todo statistics, then one fixed read-only call per "
+                "connected integration over the last 7 days, in order. "
+                "Nothing for integrations that are not connected.",
+            ),
+            (
+                "Write the digest",
+                "gaia",
+                "The fixed WEEK OF / GAIA / YOU / NOTABLE / NEXT shape, counts before "
+                "words, one YOU line per connected integration.",
+            ),
+        ],
+    },
+}
 
 PROVISIONER = "app.services.system_workflows.provisioner"
 CHECK = "app.services.workflow.playbook.check"
@@ -68,6 +126,7 @@ class TestBriefingDefinitions:
             assert request.source_integration is None, "not owned by an integration"
             assert request.trigger_config.type == TriggerType.SCHEDULE
             assert request.trigger_config.timezone is None, "the provisioner stamps it"
+            assert request.trigger_config.enabled is True, "provisioned already armed"
             assert request.steps and all(step.id for step in request.steps)
 
     def test_each_factory_call_mints_fresh_step_ids(self) -> None:
@@ -75,6 +134,25 @@ class TestBriefingDefinitions:
             first = {step.id for step in factory().steps or []}
             second = {step.id for step in factory().steps or []}
             assert first.isdisjoint(second)
+
+    @pytest.mark.parametrize("key", [BRIEFING_DAILY_KEY, BRIEFING_WEEKLY_KEY])
+    def test_definition_content_is_pinned(self, key: str) -> None:
+        expected = EXPECTED_DEFINITIONS[key]
+        request = _definitions()[key]
+
+        assert request.title == expected["title"]
+        assert request.description == expected["description"]
+        assert request.prompt is expected["prompt"], "the prompt is the product"
+        assert request.trigger_config.cron_expression == expected["cron"]
+
+        steps = request.steps or []
+        assert [(s.title, s.category, s.description) for s in steps] == expected["steps"]
+
+    def test_universal_set_is_exactly_the_two_briefings_in_order(self) -> None:
+        assert [key for key, _ in BRIEFING_SYSTEM_WORKFLOWS] == [
+            BRIEFING_DAILY_KEY,
+            BRIEFING_WEEKLY_KEY,
+        ]
 
     def test_universal_set_and_registry(self) -> None:
         assert UNIVERSAL_SYSTEM_WORKFLOWS == BRIEFING_SYSTEM_WORKFLOWS

--- a/apps/api/tests/unit/services/test_onboarding_service.py
+++ b/apps/api/tests/unit/services/test_onboarding_service.py
@@ -430,21 +430,36 @@ class TestSavePersonalizationData:
 
 
 class TestSeedInitialUserData:
-    async def test_seeds_onboarding_todo(self) -> None:
-        with patch(
-            "app.services.onboarding.post_onboarding_service.seed_onboarding_todo",
-            new_callable=AsyncMock,
-        ) as mock_todo:
-            await seed_initial_user_data("user1")
-            mock_todo.assert_awaited_once_with("user1")
-
-    async def test_handles_exception(self) -> None:
-        with patch(
-            "app.services.onboarding.post_onboarding_service.seed_onboarding_todo",
-            new_callable=AsyncMock,
-            side_effect=Exception("seed error"),
+    async def test_seeds_onboarding_todo_and_universal_workflows(self) -> None:
+        with (
+            patch(
+                "app.services.onboarding.post_onboarding_service.seed_onboarding_todo",
+                new_callable=AsyncMock,
+            ) as mock_todo,
+            patch(
+                "app.services.onboarding.post_onboarding_service.provision_universal_system_workflows",
+                new_callable=AsyncMock,
+            ) as mock_provision,
         ):
             await seed_initial_user_data("user1")
+            mock_todo.assert_awaited_once_with("user1")
+            # Silent, like per-integration provisioning during onboarding.
+            mock_provision.assert_awaited_once_with("user1", notify=False)
+
+    async def test_todo_seed_failure_still_provisions_universal_workflows(self) -> None:
+        with (
+            patch(
+                "app.services.onboarding.post_onboarding_service.seed_onboarding_todo",
+                new_callable=AsyncMock,
+                side_effect=Exception("seed error"),
+            ),
+            patch(
+                "app.services.onboarding.post_onboarding_service.provision_universal_system_workflows",
+                new_callable=AsyncMock,
+            ) as mock_provision,
+        ):
+            await seed_initial_user_data("user1")
+            mock_provision.assert_awaited_once_with("user1", notify=False)
 
 
 class TestOnboardingServiceLogPins:

--- a/apps/api/tests/unit/services/test_onboarding_service.py
+++ b/apps/api/tests/unit/services/test_onboarding_service.py
@@ -8,6 +8,7 @@ from fastapi import BackgroundTasks, HTTPException
 import pytest
 
 from app.constants.log_tags import LogTag
+from app.models.onboarding_models import ProfileCardDesign, UserProfileMetadata
 from app.models.user_models import (
     BioStatus,
     ClarifyAnswer,
@@ -388,27 +389,25 @@ class TestSavePersonalizationData:
     ) -> None:
         await save_personalization_data(
             sample_user_id,
-            house="explorer",
+            ProfileCardDesign(house="mistgrove", overlay_color="#ff0000", overlay_opacity=80),
+            UserProfileMetadata(account_number=42, member_since="Mar 2024"),
             personality_phrase="Creative thinker",
             user_bio="A passionate engineer.",
             bio_status=BioStatus.COMPLETED,
-            workflow_ids=["wf1", "wf2"],
-            account_number=42,
-            member_since="Mar 2024",
-            overlay_color="#ff0000",
-            overlay_opacity=80,
         )
 
         mock_save_personalization.assert_awaited_once()
         kwargs = mock_save_personalization.call_args.kwargs
-        assert kwargs["house"] == "explorer"
+        assert kwargs["house"] == "mistgrove"
         assert kwargs["personality_phrase"] == "Creative thinker"
         assert kwargs["user_bio"] == "A passionate engineer."
         assert kwargs["bio_status"] == BioStatus.COMPLETED
-        assert kwargs["workflow_ids"] == ["wf1", "wf2"]
         assert kwargs["account_number"] == 42
+        assert kwargs["member_since"] == "Mar 2024"
         assert kwargs["overlay_color"] == "#ff0000"
         assert kwargs["overlay_opacity"] == 80
+        # The workflows step persists its own ids; the card bundle never carries them.
+        assert kwargs["workflow_ids"] == []
 
     async def test_handles_exception(
         self, mock_save_personalization: AsyncMock, sample_user_id: str
@@ -417,15 +416,11 @@ class TestSavePersonalizationData:
 
         await save_personalization_data(
             sample_user_id,
-            house="explorer",
+            ProfileCardDesign(house="mistgrove", overlay_color="#000", overlay_opacity=50),
+            UserProfileMetadata(account_number=1, member_since="Jan 2024"),
             personality_phrase="phrase",
             user_bio="bio",
             bio_status=BioStatus.COMPLETED,
-            workflow_ids=[],
-            account_number=1,
-            member_since="Jan 2024",
-            overlay_color="#000",
-            overlay_opacity=50,
         )
 
 

--- a/apps/api/tests/unit/services/test_onboarding_service.py
+++ b/apps/api/tests/unit/services/test_onboarding_service.py
@@ -21,10 +21,7 @@ from app.services.onboarding.onboarding_service import (
     get_user_onboarding_status,
     update_onboarding_preferences,
 )
-from app.services.onboarding.post_onboarding_service import (
-    save_personalization_data,
-    seed_initial_user_data,
-)
+from app.services.onboarding.post_onboarding_service import seed_initial_user_data
 
 
 @pytest.fixture
@@ -35,15 +32,6 @@ def mock_repo() -> Iterator[MagicMock]:
         repo.clear_onboarding = AsyncMock()
         repo.update_onboarding_preferences = AsyncMock()
         yield repo
-
-
-@pytest.fixture
-def mock_save_personalization() -> Iterator[AsyncMock]:
-    with patch(
-        "app.services.onboarding.post_onboarding_service.user_repository.save_personalization",
-        new_callable=AsyncMock,
-    ) as mock_save:
-        yield mock_save
 
 
 @pytest.fixture
@@ -380,53 +368,6 @@ class TestUpdateOnboardingPreferences:
                 sample_user_id, OnboardingPreferences(profession="Engineer")
             )
         assert exc_info.value.status_code == 500
-
-
-class TestSavePersonalizationData:
-    async def test_saves_data(
-        self, mock_save_personalization: AsyncMock, sample_user_id: str
-    ) -> None:
-        await save_personalization_data(
-            sample_user_id,
-            house="explorer",
-            personality_phrase="Creative thinker",
-            user_bio="A passionate engineer.",
-            bio_status=BioStatus.COMPLETED,
-            workflow_ids=["wf1", "wf2"],
-            account_number=42,
-            member_since="Mar 2024",
-            overlay_color="#ff0000",
-            overlay_opacity=80,
-        )
-
-        mock_save_personalization.assert_awaited_once()
-        kwargs = mock_save_personalization.call_args.kwargs
-        assert kwargs["house"] == "explorer"
-        assert kwargs["personality_phrase"] == "Creative thinker"
-        assert kwargs["user_bio"] == "A passionate engineer."
-        assert kwargs["bio_status"] == BioStatus.COMPLETED
-        assert kwargs["workflow_ids"] == ["wf1", "wf2"]
-        assert kwargs["account_number"] == 42
-        assert kwargs["overlay_color"] == "#ff0000"
-        assert kwargs["overlay_opacity"] == 80
-
-    async def test_handles_exception(
-        self, mock_save_personalization: AsyncMock, sample_user_id: str
-    ) -> None:
-        mock_save_personalization.side_effect = Exception("DB error")
-
-        await save_personalization_data(
-            sample_user_id,
-            house="explorer",
-            personality_phrase="phrase",
-            user_bio="bio",
-            bio_status=BioStatus.COMPLETED,
-            workflow_ids=[],
-            account_number=1,
-            member_since="Jan 2024",
-            overlay_color="#000",
-            overlay_opacity=50,
-        )
 
 
 class TestSeedInitialUserData:

--- a/apps/api/tests/unit/workers/test_workflow_tasks.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 import pytest
 
 from app.api.v1.middleware.tiered_rate_limiter import RateLimitExceededException
+from app.constants.briefing import BRIEFING_DAILY_KEY
 from app.constants.log_tags import LogTag
 from app.constants.notifications import CHANNEL_TYPE_INAPP
 from app.models.agent_models import SilentRunResult
@@ -70,6 +71,7 @@ def _make_workflow(
     steps: list | None = None,
     is_todo_workflow: bool = False,
     source_todo_id: str | None = None,
+    system_workflow_key: str | None = None,
 ):
     wf = MagicMock()
     wf.id = workflow_id or str(uuid4())
@@ -82,6 +84,7 @@ def _make_workflow(
     ]
     wf.is_todo_workflow = is_todo_workflow
     wf.source_todo_id = source_todo_id
+    wf.system_workflow_key = system_workflow_key
     wf.model_dump = MagicMock(return_value={"id": wf.id, "title": wf.title})
     return wf
 
@@ -450,7 +453,7 @@ class TestExecuteWorkflowById:
         _no_real_analytics.assert_called_once_with(
             workflow.user_id,
             AnalyticsEvents.WORKFLOW_EXECUTED,
-            {"workflow_id": workflow.id, "trigger_type": "schedule"},
+            {"workflow_id": workflow.id, "trigger_type": "schedule", "system_workflow_key": None},
         )
 
     async def test_integration_execution_captures_workflow_executed(self, ctx, _no_real_analytics):
@@ -487,7 +490,11 @@ class TestExecuteWorkflowById:
         _no_real_analytics.assert_called_once_with(
             workflow.user_id,
             AnalyticsEvents.WORKFLOW_EXECUTED,
-            {"workflow_id": workflow.id, "trigger_type": "integration"},
+            {
+                "workflow_id": workflow.id,
+                "trigger_type": "integration",
+                "system_workflow_key": None,
+            },
         )
 
     async def test_explicit_trigger_type_wins_over_trigger_data(self, ctx, _no_real_analytics):
@@ -530,7 +537,47 @@ class TestExecuteWorkflowById:
         _no_real_analytics.assert_called_once_with(
             workflow.user_id,
             AnalyticsEvents.WORKFLOW_EXECUTED,
-            {"workflow_id": workflow.id, "trigger_type": "schedule"},
+            {"workflow_id": workflow.id, "trigger_type": "schedule", "system_workflow_key": None},
+        )
+
+    async def test_system_workflow_execution_names_itself_on_the_event(
+        self, ctx, _no_real_analytics
+    ):
+        # The daily briefing is an ordinary scheduled workflow, so its delivery
+        # rides the same event — `system_workflow_key` is what tells the two apart.
+        workflow = _make_workflow(system_workflow_key=BRIEFING_DAILY_KEY)
+        mock_execution = MagicMock()
+        mock_execution.execution_id = str(uuid4())
+
+        _, p_scheduler = _patch_scheduler(workflow)
+
+        with (
+            p_scheduler,
+            patch(
+                "app.workers.tasks.workflow_tasks.execute_workflow_as_chat",
+                AsyncMock(return_value=("conv_123", [])),
+            ),
+            patch("app.workers.tasks.workflow_tasks.WorkflowService") as mock_wf_svc,
+            patch(
+                "app.workers.tasks.workflow_tasks.create_execution",
+                AsyncMock(return_value=mock_execution),
+            ),
+            patch(
+                "app.workers.tasks.workflow_tasks.complete_execution",
+                AsyncMock(),
+            ),
+        ):
+            mock_wf_svc.increment_execution_count = AsyncMock()
+            await execute_workflow_by_id(ctx, workflow.id, context={"trigger_type": "schedule"})
+
+        _no_real_analytics.assert_called_once_with(
+            workflow.user_id,
+            AnalyticsEvents.WORKFLOW_EXECUTED,
+            {
+                "workflow_id": workflow.id,
+                "trigger_type": "schedule",
+                "system_workflow_key": BRIEFING_DAILY_KEY,
+            },
         )
 
     async def test_manual_execution_does_not_capture_workflow_executed(
@@ -2137,7 +2184,11 @@ class TestTheByIdTaskThreadsItsIdsThrough:
         _no_real_analytics.assert_any_call(
             workflow.user_id,
             AnalyticsEvents.WORKFLOW_EXECUTED,
-            {"workflow_id": workflow.id, "trigger_type": TriggerType.INTEGRATION.value},
+            {
+                "workflow_id": workflow.id,
+                "trigger_type": TriggerType.INTEGRATION.value,
+                "system_workflow_key": None,
+            },
         )
 
 

--- a/apps/api/tests/unit/workers/test_workflow_tasks.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks.py
@@ -67,8 +67,6 @@ def _onboarded_user():
 def _make_workflow(
     workflow_id: str | None = None,
     user_id: str = "user_abc",
-    title: str = "Daily Standup",
-    steps: list | None = None,
     is_todo_workflow: bool = False,
     source_todo_id: str | None = None,
     system_workflow_key: str | None = None,
@@ -76,12 +74,10 @@ def _make_workflow(
     wf = MagicMock()
     wf.id = workflow_id or str(uuid4())
     wf.user_id = user_id
-    wf.title = title
+    wf.title = "Daily Standup"
     wf.description = "A test workflow"
     wf.prompt = "Run the standup"
-    wf.steps = steps or [
-        MagicMock(id="s1", title="Step 1", description="Do it", category="general")
-    ]
+    wf.steps = [MagicMock(id="s1", title="Step 1", description="Do it", category="general")]
     wf.is_todo_workflow = is_todo_workflow
     wf.source_todo_id = source_todo_id
     wf.system_workflow_key = system_workflow_key

--- a/apps/api/tests/unit/workers/test_workflow_tasks_queued_fire.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks_queued_fire.py
@@ -54,6 +54,7 @@ def _workflow() -> MagicMock:
     workflow.repeat = True
     workflow.activated = True
     workflow.occurrence_count = 0
+    workflow.system_workflow_key = None
     return workflow
 
 
@@ -384,6 +385,7 @@ class TestASuccessfulFiresBookkeepingIsAddressedCorrectly:
             {
                 "workflow_id": harness.workflow.id,
                 "trigger_type": TriggerType.SCHEDULE.value,
+                "system_workflow_key": None,
             },
         )
 

--- a/tools/lints/plr_complexity_baseline.txt
+++ b/tools/lints/plr_complexity_baseline.txt
@@ -76,7 +76,6 @@ apps/api/app/services/mcp/resilient_adapter.py	PLR0915
 apps/api/app/services/mcp/token_management.py	PLR0912
 apps/api/app/services/notification_service.py	PLR0913
 apps/api/app/services/onboarding/first_message_service.py	PLR0913
-apps/api/app/services/onboarding/post_onboarding_service.py	PLR0913
 apps/api/app/services/onboarding/social_profile_service.py	PLR0912
 apps/api/app/services/onboarding/social_profile_service.py	PLR0915
 apps/api/app/services/tools/tools_service.py	PLR0912

--- a/tools/lints/plr_complexity_baseline.txt
+++ b/tools/lints/plr_complexity_baseline.txt
@@ -76,7 +76,6 @@ apps/api/app/services/mcp/resilient_adapter.py	PLR0915
 apps/api/app/services/mcp/token_management.py	PLR0912
 apps/api/app/services/notification_service.py	PLR0913
 apps/api/app/services/onboarding/first_message_service.py	PLR0913
-apps/api/app/services/onboarding/post_onboarding_service.py	PLR0913
 apps/api/app/services/onboarding/social_profile_service.py	PLR0912
 apps/api/app/services/onboarding/social_profile_service.py	PLR0915
 apps/api/app/services/tools/tools_service.py	PLR0912
@@ -121,8 +120,6 @@ apps/api/scripts/sync_composio_tools.py	PLR0913
 apps/api/scripts/sync_composio_tools.py	PLR0915
 apps/api/scripts/test_tracked_todos.py	PLR0912
 apps/api/scripts/verify_sandbox_mounts.py	PLR0915
-apps/api/tests/e2e/test_onboarding.py	PLR0913
-apps/api/tests/e2e/test_onboarding.py	PLR0915
 apps/api/tests/integration/mcp/test_mcp_oauth_flow.py	PLR0913
 apps/api/tests/integration/mcp/test_mcp_oauth_flow.py	PLR0915
 apps/api/tests/integration/real/memory/llm.py	PLR0913


### PR DESCRIPTION
## What

The daily briefing and the weekly digest become ordinary **system workflows** on the existing engine, provisioned for every user at onboarding completion (plus a backfill script for existing users). No separate briefing engine.

The point is playbooks: every repeatable workflow run on master already gets frozen into a playbook — a fixed tool-call sequence replayed by script instead of re-reasoned each time. Both prompts are written to be freezable: a fixed, ordered list of read-only calls, one per connected integration with a fixed window, no probing, no retries, no follow-up reads, and a single prose slot at the end. Integrations the user hasn't connected are omitted rather than branched on, so a user's sequence is the same every run.

- `briefing:daily` — 08:00 user-tz. Plain chat text, ≤12 lines: shape of the day → what's waiting on the user → what moved since yesterday. Empty day = 1–2 lines, never silence, never filler. Ends with one factual `Next:` line naming something GAIA could do drawn from the user's *unconnected* integrations.
- `briefing:weekly` — Sunday. A numbers-first receipt with a documented stable shape (`GAIA` / `YOU` per integration / `NOTABLE` / `NEXT`) that the later HTML rendering reads as-is.

The provisioner gains a universal set that reuses the same idempotent, tz-stamping path as the per-integration ones. `workflow:executed` now carries `system_workflow_key` so briefing deliveries are attributable in PostHog.

## Verified

- Red first: the tests failed with `ImportError: cannot import name 'UNIVERSAL_SYSTEM_WORKFLOWS'` before the product code; then 177 passed across the 5 touched test files
- Mutation checks: dropping `system_workflow_key` from the event and dropping the universal provisioning from `seed_initial_user_data` each turn tests red
- `ruff check .` → all checks passed; `mypy app` → no issues in 920 files (run as the exact commands from `apps/api/project.json`; the worktree had no `node_modules` for `nx`)
- **Playbook path proven, not assumed:** `playbook_check_brief` is reached from `executor_tool.py` behind `is_workflow_run = bool(workflow_id and user_id)` only, and `playbook/check.py` never reads `is_system_workflow` or `system_workflow_key`. `TestPlaybookPathAsksSystemWorkflows` pins it.

## Not verified

- No real workflow run — neither prompt has been executed against a live account, and no playbook has actually been authored from one. The freezability of the prompts is by construction, not observed.
- The weekly `GAIA` block reports **to-date** totals (`list_workflows`, `get_todo_statistics`), not this week's — the executor has no per-week execution read yet. The prompt says so rather than pretending.


## Also folded in

PR #1204 (`fix/holo-card-save-failure`) was merged into this branch as `a03ad21d93` and closed. It removes a swallowed failure in the holo-card step:

- `save_personalization_data` in `post_onboarding_service.py` is deleted. It wrapped the repository write in `try/except Exception` and only logged, so a failed save still reported `outcome="ok"` on the step. `_run_holo_card` now calls `user_repository.save_personalization(...)` directly and lets the error propagate to the step's own handler.
- The tests follow the deletion: `TestSavePersonalizationData` is gone, and `test_intelligence_service_creation` asserts on the repository's keyword arguments rather than the removed wrapper's positional ones.
- `tools/lints/plr_complexity_baseline.txt` loses the two `tests/e2e/test_onboarding.py` entries — both this PR and #1204 paid that debt, and both removals are kept.
