### PR TITLE
fix(onboarding): surface personalization save failures instead of logging outcome=ok

### DIFF
--- a/apps/api/app/services/onboarding/intelligence_service.py
+++ b/apps/api/app/services/onboarding/intelligence_service.py
@@ -90,9 +90,6 @@ from app.services.onboarding.first_message_service import (
     generate_first_message,
 )
 from app.services.onboarding.inbox_triage_service import triage_inbox
-from app.services.onboarding.post_onboarding_service import (
-    save_personalization_data,
-)
 from app.services.onboarding.social_profile_service import (
     dedup_profiles_by_platform,
     extract_social_profiles_from_emails,
@@ -1078,17 +1075,17 @@ async def _run_holo_card(
         )
         phrase_bio_duration_s = round(time.monotonic() - t_phrase_bio, 2)
         t_save = time.monotonic()
-        await save_personalization_data(
+        await user_repository.save_personalization(
             ctx.user_id,
-            card_design.house,
-            phrase,
-            user_bio,
-            bio_status,
-            [],
-            metadata.account_number,
-            metadata.member_since,
-            card_design.overlay_color,
-            card_design.overlay_opacity,
+            house=card_design.house,
+            personality_phrase=phrase,
+            user_bio=user_bio,
+            bio_status=bio_status,
+            account_number=metadata.account_number,
+            member_since=metadata.member_since,
+            overlay_color=card_design.overlay_color,
+            overlay_opacity=card_design.overlay_opacity,
+            workflow_ids=[],
         )
         log.info(
             f"{LogTag.ONBOARDING} holo_card done",

--- a/apps/api/app/services/onboarding/post_onboarding_service.py
+++ b/apps/api/app/services/onboarding/post_onboarding_service.py
@@ -1,62 +1,8 @@
-"""Post-onboarding personalization service."""
+"""Post-onboarding data seeding."""
 
 from app.constants.log_tags import LogTag
-from app.db.repositories.users import user_repository
-from app.models.user_models import BioStatus
 from app.utils.seeding_utils import seed_onboarding_todo
 from shared.py.wide_events import log
-
-
-async def save_personalization_data(
-    user_id: str,
-    house: str,
-    personality_phrase: str,
-    user_bio: str,
-    bio_status: BioStatus,
-    workflow_ids: list[str],
-    account_number: int,
-    member_since: str,
-    overlay_color: str,
-    overlay_opacity: int,
-) -> None:
-    """
-    Save personalization data to user document.
-
-    Args:
-        user_id: User identifier
-        house: Assigned house
-        personality_phrase: Generated phrase
-        user_bio: Generated bio
-        bio_status: Status of bio generation
-        workflow_ids: Suggested workflow IDs
-        account_number: User's account number
-        member_since: Member since date
-        overlay_color: Generated overlay color or gradient
-        overlay_opacity: Opacity percentage
-    """
-    try:
-        await user_repository.save_personalization(
-            user_id,
-            house=house,
-            personality_phrase=personality_phrase,
-            user_bio=user_bio,
-            bio_status=bio_status,
-            account_number=account_number,
-            member_since=member_since,
-            overlay_color=overlay_color,
-            overlay_opacity=overlay_opacity,
-            workflow_ids=workflow_ids,
-        )
-        log.info(f"{LogTag.ONBOARDING} Saved personalization data for user", user_id=user_id)
-
-    except Exception as e:
-        log.error(
-            f"{LogTag.ONBOARDING} Error saving personalization data",
-            error=str(e),
-            error_type=type(e).__name__,
-            user_id=user_id,
-            exc_info=True,
-        )
 
 
 async def seed_initial_user_data(user_id: str) -> None:

--- a/apps/api/tests/e2e/test_onboarding.py
+++ b/apps/api/tests/e2e/test_onboarding.py
@@ -56,6 +56,7 @@ from httpx import AsyncClient
 from langchain_core.messages import AIMessage
 import pytest
 
+from app.agents.memory.email_processor import OnboardingFetchOptions
 from app.constants.onboarding import (
     INTELLIGENCE_TASK,
     WORKFLOWS_TASK,
@@ -88,6 +89,9 @@ from tests.conftest import FAKE_USER
 pytestmark = pytest.mark.e2e
 
 USER_ID: str = FAKE_USER["user_id"]
+
+#: Patch-target prefix for the onboarding service package.
+_SVC = "app.services.onboarding"
 
 #: The sender the triage LLM reports as important. Todo specs that cite it keep
 #: their ``source_email``; anything else is dropped as hallucinated.
@@ -485,82 +489,9 @@ def stages(users: _UserStore) -> _StageSink:
     return _StageSink(users)
 
 
-@pytest.fixture(autouse=True)
-def world(
-    users: _UserStore,
-    stages: _StageSink,
-    externals: _Externals,
-    arq_pool: ArqRedis,
-) -> Iterator[None]:
-    """Wire the store, the socket and every external service into the real flow."""
-    svc = "app.services.onboarding"
-
-    async def _check_connection(slugs: list[str], _user_id: str) -> dict[str, bool]:
-        if externals.composio_gate is not None:
-            await externals.composio_gate.wait()
-        return {slug: (slug == "gmail" and externals.has_gmail) for slug in slugs}
-
-    composio = AsyncMock()
-    composio.check_connection_status.side_effect = _check_connection
-
-    async def _fetch_emails(
-        user_id: str,
-        months: int = 1,
-        batch_size: int = 100,
-        max_total: int = 100,
-        on_batch: Callable[[int, str | None], Awaitable[None]] | None = None,
-        fmt: str = "metadata",
-        into: list[dict[str, Any]] | None = None,
-        include_sent: bool = False,
-    ) -> list[dict[str, Any]]:
-        batch = list(externals.inbox)
-        if into is not None:
-            into.extend(batch)
-        if on_batch is not None:
-            await on_batch(len(batch), batch[0]["sender"] if batch else None)
-        return batch
-
-    async def _structured(schema: type, prompt: Any, *, label: str, **_: Any) -> Any:
-        externals.llm_labels.append(label)
-        externals.llm_prompts[label] = str(prompt)
-        if label in externals.llm_failures:
-            raise RuntimeError(f"model refused: {label}")
-        return _structured_result(schema, externals)
-
-    async def _invoke_llm(_runnable: Any, messages: Any, *, label: str = "model", **_: Any) -> Any:
-        externals.llm_labels.append(label)
-        externals.llm_prompts[label] = str(messages)
-        if label in externals.llm_failures:
-            raise RuntimeError(f"model refused: {label}")
-        return AIMessage(content="Hey, you're all set.")
-
-    async def _search_messages(**_: Any) -> Any:
-        result = AsyncMock()
-        result.messages = externals.sent_emails
-        return result
-
-    async def _create_workflow(
-        request: Any, _user_id: str, user_timezone: str = "UTC", **_: Any
-    ) -> _FakeWorkflow:
-        externals.workflows_created.append(request.title)
-        externals.workflow_timezones.append(user_timezone)
-        return _FakeWorkflow(f"wf-{len(externals.workflows_created)}")
-
-    async def _delete_workflow(workflow_id: str, _user_id: str) -> bool:
-        if externals.workflow_delete_error == workflow_id:
-            raise RuntimeError("composio trigger teardown failed")
-        externals.workflows_deleted.append(workflow_id)
-        return True
-
-    async def _generate_prompt(**_: Any) -> dict[str, Any]:
-        return {
-            "prompt": "Do the thing.",
-            "suggested_trigger": SuggestedTrigger(type="schedule", cron_expression="0 8 * * *"),
-        }
-
-    async def _create_todo(todo: Any, _user_id: str) -> _FakeTodo:
-        externals.todos_created.append(todo.title)
-        return _FakeTodo(f"todo-{len(externals.todos_created)}")
+@pytest.fixture
+def persistence_patches(users: _UserStore, externals: _Externals) -> list[Any]:
+    """Every repository the flow writes through, wired to the in-memory store."""
 
     async def _list_onboarding_todos(_user_id: str, limit: int = 3) -> list[Any]:
         todos = []
@@ -573,18 +504,9 @@ def world(
             todos.append(todo)
         return todos
 
-    async def _seed_conversation(**_: Any) -> str | None:
-        return externals.seeded_conversation_id
-
-    async def _seed_user_data(user_id: str) -> None:
-        externals.seeded_users.append(user_id)
-
     async def _purge_workflows(workflow_ids: list[str], _user_id: str) -> int:
         externals.purged_workflow_ids.append(list(workflow_ids))
         return len(workflow_ids)
-
-    async def _provision(user_id: str, slug: str, *_args: Any, **_kw: Any) -> None:
-        externals.provisioned.append(slug)
 
     async def _list_user_integrations(_user_id: str) -> list[Any]:
         out = []
@@ -613,66 +535,191 @@ def world(
     memory = AsyncMock()
     memory.delete_all.side_effect = lambda _uid: externals.memories_cleared
 
-    patches = [
-        # --- persistence -------------------------------------------------
-        patch(f"{svc}.onboarding_service.user_repository", users),
-        patch(f"{svc}.intelligence_job.user_repository", users),
-        patch(f"{svc}.intelligence_service.user_repository", users),
+    return [
+        patch(f"{_SVC}.onboarding_service.user_repository", users),
+        patch(f"{_SVC}.intelligence_job.user_repository", users),
+        patch(f"{_SVC}.intelligence_service.user_repository", users),
         patch("app.workers.tasks.onboarding_tasks.user_repository", users),
         patch("app.api.v1.endpoints.onboarding.user_repository", users),
-        patch(f"{svc}.onboarding_service.todo_repository", todo_repo),
-        patch(f"{svc}.intelligence_job.todo_repository", todo_repo),
-        patch(f"{svc}.intelligence_service.todo_repository", todo_repo),
+        patch(f"{_SVC}.onboarding_service.todo_repository", todo_repo),
+        patch(f"{_SVC}.intelligence_job.todo_repository", todo_repo),
+        patch(f"{_SVC}.intelligence_service.todo_repository", todo_repo),
         patch("app.api.v1.endpoints.onboarding.todo_repository", todo_repo),
         patch("app.api.v1.endpoints.onboarding.workflow_repository", AsyncMock()),
         patch(
-            f"{svc}.intelligence_service.workflow_repository.delete_many_for_user", _purge_workflows
+            f"{_SVC}.intelligence_service.workflow_repository.delete_many_for_user",
+            _purge_workflows,
         ),
-        patch(f"{svc}.onboarding_service.conversation_repository", conversation_repo),
-        patch(f"{svc}.onboarding_service.user_integration_repository", integrations_repo),
-        patch(f"{svc}.onboarding_service.memory_engine", memory),
-        patch(f"{svc}.onboarding_service.disconnect_integration", _disconnect),
-        # --- transport ---------------------------------------------------
-        patch(f"{svc}.intelligence_service.websocket_manager", stages),
-        # --- composio ----------------------------------------------------
-        patch(f"{svc}.intelligence_service.get_composio_service", lambda: composio),
+        patch(f"{_SVC}.onboarding_service.conversation_repository", conversation_repo),
+        patch(f"{_SVC}.onboarding_service.user_integration_repository", integrations_repo),
+        patch(f"{_SVC}.onboarding_service.memory_engine", memory),
+        patch(f"{_SVC}.onboarding_service.disconnect_integration", _disconnect),
+    ]
+
+
+@pytest.fixture
+def composio_patches(externals: _Externals) -> list[Any]:
+    """Connection status, optionally held open so a test can race the pipeline."""
+
+    async def _check_connection(slugs: list[str], _user_id: str) -> dict[str, bool]:
+        if externals.composio_gate is not None:
+            await externals.composio_gate.wait()
+        return {slug: (slug == "gmail" and externals.has_gmail) for slug in slugs}
+
+    composio = AsyncMock()
+    composio.check_connection_status.side_effect = _check_connection
+
+    return [
+        patch(f"{_SVC}.intelligence_service.get_composio_service", lambda: composio),
         patch("app.api.v1.endpoints.onboarding.get_composio_service", lambda: composio),
-        # --- gmail -------------------------------------------------------
-        patch(f"{svc}.intelligence_service.fetch_emails_for_onboarding", _fetch_emails),
-        patch(f"{svc}.writing_style_service.search_messages", _search_messages),
-        patch(f"{svc}.intelligence_service.inbox_scan_cache.get", AsyncMock(return_value=None)),
-        patch(f"{svc}.intelligence_service.inbox_scan_cache.put", AsyncMock()),
+    ]
+
+
+@pytest.fixture
+def gmail_patches(externals: _Externals) -> list[Any]:
+    """The inbox: fetch, sent-mail search, and the scan cache."""
+
+    async def _fetch_emails(
+        user_id: str,
+        months: int = 1,
+        max_total: int = 100,
+        on_batch: Callable[[int, str | None], Awaitable[None]] | None = None,
+        into: list[dict[str, Any]] | None = None,
+        options: OnboardingFetchOptions | None = None,
+    ) -> list[dict[str, Any]]:
+        batch = list(externals.inbox)
+        if into is not None:
+            into.extend(batch)
+        if on_batch is not None:
+            await on_batch(len(batch), batch[0]["sender"] if batch else None)
+        return batch
+
+    async def _search_messages(**_: Any) -> Any:
+        result = AsyncMock()
+        result.messages = externals.sent_emails
+        return result
+
+    return [
+        patch(f"{_SVC}.intelligence_service.fetch_emails_for_onboarding", _fetch_emails),
+        patch(f"{_SVC}.writing_style_service.search_messages", _search_messages),
+        patch(f"{_SVC}.intelligence_service.inbox_scan_cache.get", AsyncMock(return_value=None)),
+        patch(f"{_SVC}.intelligence_service.inbox_scan_cache.put", AsyncMock()),
         patch(
-            f"{svc}.intelligence_service.extract_social_profiles_from_emails",
+            f"{_SVC}.intelligence_service.extract_social_profiles_from_emails",
             AsyncMock(return_value=[SocialProfile(platform="linkedin", url="https://li/x")]),
         ),
-        # --- llm ---------------------------------------------------------
-        patch(f"{svc}.intelligence_service.ainvoke_structured", _structured),
-        patch(f"{svc}.writing_style_service.ainvoke_structured", _structured),
-        patch(f"{svc}.inbox_triage_service.ainvoke_structured", _structured),
-        patch(f"{svc}.first_message_service.ainvoke_llm", _invoke_llm),
-        patch(f"{svc}.first_message_service.get_helper_llm", lambda **_: AsyncMock()),
-        # --- downstream services ----------------------------------------
-        patch(f"{svc}.intelligence_service.WorkflowService.create_workflow", _create_workflow),
-        patch(f"{svc}.onboarding_service.WorkflowService.delete_workflow", _delete_workflow),
+    ]
+
+
+@pytest.fixture
+def llm_patches(externals: _Externals) -> list[Any]:
+    """Every model call, recorded by label so a test can fail exactly one."""
+
+    async def _structured(schema: type, prompt: Any, *, label: str, **_: Any) -> Any:
+        externals.llm_labels.append(label)
+        externals.llm_prompts[label] = str(prompt)
+        if label in externals.llm_failures:
+            raise RuntimeError(f"model refused: {label}")
+        return _structured_result(schema, externals)
+
+    async def _invoke_llm(_runnable: Any, messages: Any, *, label: str = "model", **_: Any) -> Any:
+        externals.llm_labels.append(label)
+        externals.llm_prompts[label] = str(messages)
+        if label in externals.llm_failures:
+            raise RuntimeError(f"model refused: {label}")
+        return AIMessage(content="Hey, you're all set.")
+
+    return [
+        patch(f"{_SVC}.intelligence_service.ainvoke_structured", _structured),
+        patch(f"{_SVC}.writing_style_service.ainvoke_structured", _structured),
+        patch(f"{_SVC}.inbox_triage_service.ainvoke_structured", _structured),
+        patch(f"{_SVC}.first_message_service.ainvoke_llm", _invoke_llm),
+        patch(f"{_SVC}.first_message_service.get_helper_llm", lambda **_: AsyncMock()),
+    ]
+
+
+@pytest.fixture
+def downstream_patches(externals: _Externals) -> list[Any]:
+    """Workflows, todos, conversation seeding and system provisioning."""
+
+    async def _create_workflow(
+        request: Any, _user_id: str, user_timezone: str = "UTC", **_: Any
+    ) -> _FakeWorkflow:
+        externals.workflows_created.append(request.title)
+        externals.workflow_timezones.append(user_timezone)
+        return _FakeWorkflow(f"wf-{len(externals.workflows_created)}")
+
+    async def _delete_workflow(workflow_id: str, _user_id: str) -> bool:
+        if externals.workflow_delete_error == workflow_id:
+            raise RuntimeError("composio trigger teardown failed")
+        externals.workflows_deleted.append(workflow_id)
+        return True
+
+    async def _generate_prompt(**_: Any) -> dict[str, Any]:
+        return {
+            "prompt": "Do the thing.",
+            "suggested_trigger": SuggestedTrigger(type="schedule", cron_expression="0 8 * * *"),
+        }
+
+    async def _create_todo(todo: Any, _user_id: str) -> _FakeTodo:
+        externals.todos_created.append(todo.title)
+        return _FakeTodo(f"todo-{len(externals.todos_created)}")
+
+    async def _seed_conversation(**_: Any) -> str | None:
+        return externals.seeded_conversation_id
+
+    async def _seed_user_data(user_id: str) -> None:
+        externals.seeded_users.append(user_id)
+
+    async def _provision(user_id: str, slug: str, *_args: Any, **_kw: Any) -> None:
+        externals.provisioned.append(slug)
+
+    return [
+        patch(f"{_SVC}.intelligence_service.WorkflowService.create_workflow", _create_workflow),
+        patch(f"{_SVC}.onboarding_service.WorkflowService.delete_workflow", _delete_workflow),
         patch(
-            f"{svc}.intelligence_service.WorkflowGenerationService.generate_workflow_prompt",
+            f"{_SVC}.intelligence_service.WorkflowGenerationService.generate_workflow_prompt",
             _generate_prompt,
         ),
         patch(
-            f"{svc}.intelligence_service.compute_missing_integrations", AsyncMock(return_value=[])
+            f"{_SVC}.intelligence_service.compute_missing_integrations", AsyncMock(return_value=[])
         ),
-        patch(f"{svc}.intelligence_service.TodoService.create_todo", _create_todo),
-        patch(f"{svc}.intelligence_service.seed_onboarding_conversation", _seed_conversation),
-        patch(f"{svc}.intelligence_service.provision_system_workflows", _provision),
-        patch(f"{svc}.post_onboarding_service.seed_onboarding_todo", _seed_user_data),
+        patch(f"{_SVC}.intelligence_service.TodoService.create_todo", _create_todo),
+        patch(f"{_SVC}.intelligence_service.seed_onboarding_conversation", _seed_conversation),
+        patch(f"{_SVC}.intelligence_service.provision_system_workflows", _provision),
+        patch(f"{_SVC}.post_onboarding_service.seed_onboarding_todo", _seed_user_data),
         patch(
-            f"{svc}.intelligence_service.generate_holo_card_content",
+            f"{_SVC}.intelligence_service.generate_holo_card_content",
             AsyncMock(return_value=("Curious Adventurer", "A bio.", "completed")),
         ),
     ]
+
+
+@pytest.fixture
+def all_patches(
+    stages: _StageSink,
+    persistence_patches: list[Any],
+    composio_patches: list[Any],
+    gmail_patches: list[Any],
+    llm_patches: list[Any],
+    downstream_patches: list[Any],
+) -> list[Any]:
+    """Every group of patches the flow needs, plus the socket sink."""
+    return [
+        *persistence_patches,
+        patch(f"{_SVC}.intelligence_service.websocket_manager", stages),
+        *composio_patches,
+        *gmail_patches,
+        *llm_patches,
+        *downstream_patches,
+    ]
+
+
+@pytest.fixture(autouse=True)
+def world(arq_pool: ArqRedis, all_patches: list[Any]) -> Iterator[None]:
+    """Wire the store, the socket and every external service into the real flow."""
     with ExitStack() as stack:
-        for patcher in patches:
+        for patcher in all_patches:
             stack.enter_context(patcher)
         yield
 

--- a/apps/api/tests/e2e/test_onboarding.py
+++ b/apps/api/tests/e2e/test_onboarding.py
@@ -618,7 +618,6 @@ def world(
         patch(f"{svc}.onboarding_service.user_repository", users),
         patch(f"{svc}.intelligence_job.user_repository", users),
         patch(f"{svc}.intelligence_service.user_repository", users),
-        patch(f"{svc}.post_onboarding_service.user_repository", users),
         patch("app.workers.tasks.onboarding_tasks.user_repository", users),
         patch("app.api.v1.endpoints.onboarding.user_repository", users),
         patch(f"{svc}.onboarding_service.todo_repository", todo_repo),

--- a/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
+++ b/apps/api/tests/unit/services/onboarding/test_intelligence_service_creation.py
@@ -13,6 +13,7 @@ import pytest
 
 from app.constants.onboarding import NOT_SPECIFIED
 from app.constants.todos import ONBOARDING_TODO_LIMIT
+from app.db.repositories.users import user_repository
 from app.models.onboarding_models import (
     EmailSummary,
     InboxTriage,
@@ -743,7 +744,7 @@ def holo_stack() -> Any:
             f"{MODULE}.generate_holo_card_content",
             AsyncMock(return_value=("a phrase", "a bio", "ok")),
         ) as content,
-        patch(f"{MODULE}.save_personalization_data", AsyncMock()) as save,
+        patch.object(user_repository, "save_personalization", AsyncMock()) as save,
         patch(f"{MODULE}._emit_stage", AsyncMock()) as emit,
     ):
         yield content, save, emit
@@ -759,10 +760,10 @@ class TestRunHoloCard:
         ) as metadata:
             await _run_holo_card(_ctx(focus="focus"), user)
 
-        args = save.await_args.args
-        assert args[0] == USER
-        assert args[1] == "mistgrove"
-        assert args[2] == "a phrase"
+        assert save.await_args.args[0] == USER
+        saved = save.await_args.kwargs
+        assert saved["house"] == "mistgrove"
+        assert saved["personality_phrase"] == "a phrase"
         # Both the id and the already-loaded document: without the document the
         # lookup re-reads Mongo, without the id it reads the wrong person.
         metadata.assert_awaited_once_with(USER, user=user)
@@ -842,6 +843,21 @@ class TestRunHoloCard:
         await _run_holo_card(_ctx(focus=""), UserDocument(id=USER))
 
         assert content.await_args.args[1] == ""
+
+    async def test_a_save_failure_is_reported_as_a_failed_outcome(self, holo_stack: Any) -> None:
+        """The save used to be wrapped in a helper that logged and swallowed its
+        own exception, so a card that never reached Mongo still produced
+        ``holo_card done, outcome=ok`` — the one line an operator would trust."""
+        _, save, emit = holo_stack
+        save.side_effect = RuntimeError("mongo down")
+
+        with patch(f"{MODULE}.log") as log:
+            await _run_holo_card(_ctx(focus=""), UserDocument(id=USER))
+
+        assert [c.kwargs.get("outcome") for c in log.info.call_args_list] == []
+        assert log.error.call_args.kwargs["outcome"] == "failed"
+        assert log.error.call_args.kwargs["error_type"] == "RuntimeError"
+        assert emit.await_args.args[1] is OnboardingStage.HOLO_READY
 
     async def test_a_failure_still_announces_readiness(self, holo_stack: Any) -> None:
         # The frontend waits on HOLO_READY; skipping it leaves the card spinning.

--- a/apps/api/tests/unit/services/test_onboarding_service.py
+++ b/apps/api/tests/unit/services/test_onboarding_service.py
@@ -21,10 +21,7 @@ from app.services.onboarding.onboarding_service import (
     get_user_onboarding_status,
     update_onboarding_preferences,
 )
-from app.services.onboarding.post_onboarding_service import (
-    save_personalization_data,
-    seed_initial_user_data,
-)
+from app.services.onboarding.post_onboarding_service import seed_initial_user_data
 
 
 @pytest.fixture
@@ -35,15 +32,6 @@ def mock_repo() -> Iterator[MagicMock]:
         repo.clear_onboarding = AsyncMock()
         repo.update_onboarding_preferences = AsyncMock()
         yield repo
-
-
-@pytest.fixture
-def mock_save_personalization() -> Iterator[AsyncMock]:
-    with patch(
-        "app.services.onboarding.post_onboarding_service.user_repository.save_personalization",
-        new_callable=AsyncMock,
-    ) as mock_save:
-        yield mock_save
 
 
 @pytest.fixture
@@ -380,53 +368,6 @@ class TestUpdateOnboardingPreferences:
                 sample_user_id, OnboardingPreferences(profession="Engineer")
             )
         assert exc_info.value.status_code == 500
-
-
-class TestSavePersonalizationData:
-    async def test_saves_data(
-        self, mock_save_personalization: AsyncMock, sample_user_id: str
-    ) -> None:
-        await save_personalization_data(
-            sample_user_id,
-            house="explorer",
-            personality_phrase="Creative thinker",
-            user_bio="A passionate engineer.",
-            bio_status=BioStatus.COMPLETED,
-            workflow_ids=["wf1", "wf2"],
-            account_number=42,
-            member_since="Mar 2024",
-            overlay_color="#ff0000",
-            overlay_opacity=80,
-        )
-
-        mock_save_personalization.assert_awaited_once()
-        kwargs = mock_save_personalization.call_args.kwargs
-        assert kwargs["house"] == "explorer"
-        assert kwargs["personality_phrase"] == "Creative thinker"
-        assert kwargs["user_bio"] == "A passionate engineer."
-        assert kwargs["bio_status"] == BioStatus.COMPLETED
-        assert kwargs["workflow_ids"] == ["wf1", "wf2"]
-        assert kwargs["account_number"] == 42
-        assert kwargs["overlay_color"] == "#ff0000"
-        assert kwargs["overlay_opacity"] == 80
-
-    async def test_handles_exception(
-        self, mock_save_personalization: AsyncMock, sample_user_id: str
-    ) -> None:
-        mock_save_personalization.side_effect = Exception("DB error")
-
-        await save_personalization_data(
-            sample_user_id,
-            house="explorer",
-            personality_phrase="phrase",
-            user_bio="bio",
-            bio_status=BioStatus.COMPLETED,
-            workflow_ids=[],
-            account_number=1,
-            member_since="Jan 2024",
-            overlay_color="#000",
-            overlay_opacity=50,
-        )
 
 
 class TestSeedInitialUserData:

--- a/tools/lints/plr_complexity_baseline.txt
+++ b/tools/lints/plr_complexity_baseline.txt
@@ -76,7 +76,6 @@ apps/api/app/services/mcp/resilient_adapter.py	PLR0915
 apps/api/app/services/mcp/token_management.py	PLR0912
 apps/api/app/services/notification_service.py	PLR0913
 apps/api/app/services/onboarding/first_message_service.py	PLR0913
-apps/api/app/services/onboarding/post_onboarding_service.py	PLR0913
 apps/api/app/services/onboarding/social_profile_service.py	PLR0912
 apps/api/app/services/onboarding/social_profile_service.py	PLR0915
 apps/api/app/services/tools/tools_service.py	PLR0912
@@ -121,8 +120,6 @@ apps/api/scripts/sync_composio_tools.py	PLR0913
 apps/api/scripts/sync_composio_tools.py	PLR0915
 apps/api/scripts/test_tracked_todos.py	PLR0912
 apps/api/scripts/verify_sandbox_mounts.py	PLR0915
-apps/api/tests/e2e/test_onboarding.py	PLR0913
-apps/api/tests/e2e/test_onboarding.py	PLR0915
 apps/api/tests/integration/mcp/test_mcp_oauth_flow.py	PLR0913
 apps/api/tests/integration/mcp/test_mcp_oauth_flow.py	PLR0915
 apps/api/tests/integration/real/memory/llm.py	PLR0913


### PR DESCRIPTION
## What

`_run_holo_card` reported `outcome=ok` for a personalization save that never happened.

The call went through `post_onboarding_service.save_personalization_data`, a pass-through wrapper around `user_repository.save_personalization` that caught its own exception, logged it, and returned `None`. `_run_holo_card` wrapped the same call in its own `try/except`, but nothing ever reached it — so a failed Mongo write produced:

```
[ONBOARDING] Error saving personalization data   <- from the wrapper
[ONBOARDING] holo_card done, outcome=ok          <- from the caller, 1ms later
```

The `outcome` field is the one an operator filters on. It said the card was saved.

Fixed at the root rather than at the symptom: the wrapper is deleted and `_run_holo_card` calls `user_repository.save_personalization` directly, so a raising write lands in the node's own `except` and produces `outcome=failed` with the error type. `HOLO_READY` is still emitted either way — the frontend waits on it, and skipping it leaves the card spinning.

`post_onboarding_service.py` now holds only `seed_initial_user_data`; its module docstring was updated to match.

## Test debt paid in the same PR

Touching `apps/api/tests/e2e/test_onboarding.py` un-grandfathers its two PLR entries, so both are fixed and their baseline lines deleted:

- **PLR0915** — the 72-statement `world` fixture is split into five composed fixtures (`persistence_patches`, `composio_patches`, `gmail_patches`, `llm_patches`, `downstream_patches`), assembled by `all_patches` and entered by a four-line `world`. Same patches, same order, same assertions.
- **PLR0913** — the 8-parameter `_fetch_emails` stub had drifted from the real `fetch_emails_for_onboarding`, which folded `fmt`/`include_sent` into `OnboardingFetchOptions`. The stub now mirrors the real signature (6 params), so it also stops being a stale fixture that could pass while the real call site broke.

## Verified

Red first — with the product code still unfixed, the new test failed on exactly the misleading field:

```
$ uv run --directory apps/api pytest -p no:xdist -o addopts="" \
    tests/unit/services/onboarding/test_intelligence_service_creation.py -q -k save_failure
>       assert [c.kwargs.get("outcome") for c in log.info.call_args_list] == []
E       AssertionError: assert ['ok'] == []
1 failed, 60 deselected in 2.90s
```

After the fix:

```
$ uv run --directory apps/api pytest -p no:xdist -o addopts="" \
    tests/unit/services/onboarding tests/unit/services/test_onboarding_service.py -q
305 passed in 4.88s

$ uv run --directory apps/api pytest -p no:xdist -o addopts="" tests/e2e/test_onboarding.py -q
83 passed in 3.12s      # 83 before the fixture split as well

$ uv run --directory apps/api --group dev ruff check .
All checks passed!

$ uv run --directory apps/api --group backend --group dev mypy app --ignore-missing-imports
Success: no issues found in 917 source files

$ python3 tools/lints/check_plr_complexity.py
plr-complexity-ratchet: 148 current violation(s), all grandfathered and untouched
```

The e2e file runs on fakeredis with every external patched, so no Docker services were needed.

## Not verified

- The onboarding pipeline was **not** driven against a live stack — no real Mongo write was made to fail and no real `outcome=failed` log line was observed. The proof is the unit test at the `user_repository.save_personalization` seam.
- Only the two onboarding test directories above were run, not the full API suite; CI covers the rest.

## Adjacent debt, surfaced not fixed

`seed_initial_user_data` in the same file still catches its own exception and returns normally. Its caller does not branch on the result, so there is no misleading `outcome` to correct today — but it is the same shape as the bug above. Flagging rather than folding it in, since fixing it means deciding what the caller should do on a failed seed.
