### PR TITLE
fix(notifications): channel preferences derive from one channel source

### DIFF
--- a/apps/api/app/agents/tools/account_tools.py
+++ b/apps/api/app/agents/tools/account_tools.py
@@ -37,6 +37,7 @@ class UpdateNotificationSettingsArgs(BaseModel):
     discord: bool | None = Field(default=None, description="Enable/disable Discord notifications")
     whatsapp: bool | None = Field(default=None, description="Enable/disable WhatsApp notifications")
     slack: bool | None = Field(default=None, description="Enable/disable Slack notifications")
+    imessage: bool | None = Field(default=None, description="Enable/disable iMessage notifications")
     email: bool | None = Field(default=None, description="Enable/disable email notifications")
 
 
@@ -90,8 +91,8 @@ update_notification_settings = define_mutation_tool(
     area="notifications",
     description=(
         "Change which channels the user receives notifications on (email, telegram, "
-        "discord, whatsapp, slack). Only the flags you pass change; others are left as-is. "
-        + HIL_CONFIRM_NOTE
+        "discord, whatsapp, slack, imessage). Only the flags you pass change; others are "
+        "left as-is. " + HIL_CONFIRM_NOTE
     ),
     args_model=UpdateNotificationSettingsArgs,
     apply=set_notification_channels,

--- a/apps/api/app/agents/tools/notification_tool.py
+++ b/apps/api/app/agents/tools/notification_tool.py
@@ -5,7 +5,7 @@ from langchain_core.tools import tool
 from langgraph.config import get_stream_writer
 
 from app.constants.log_tags import LogTag
-from app.constants.notifications import ALL_AUTO_INJECTED_CHANNELS, CHANNEL_TYPE_INAPP
+from app.constants.notifications import ALL_AUTO_INJECTED_CHANNELS, NotificationChannel
 from app.decorators import with_doc, with_rate_limiting
 from app.models.notification.notification_models import (
     BulkActions,
@@ -386,7 +386,7 @@ async def get_notification_preferences(
 
         # inapp is always available regardless of per-channel preferences;
         # force it last so it can never be overridden by a stored preference.
-        all_preferences = {**preferences, CHANNEL_TYPE_INAPP: True}
+        all_preferences = {**preferences, NotificationChannel.INAPP: True}
 
         return {
             "preferences": all_preferences,

--- a/apps/api/app/api/v1/endpoints/notification.py
+++ b/apps/api/app/api/v1/endpoints/notification.py
@@ -16,7 +16,11 @@ from fastapi.responses import HTMLResponse
 
 from app.api.v1.dependencies.oauth_dependencies import get_current_user
 from app.constants.log_tags import LogTag
-from app.constants.notifications import EXPO_TOKEN_PATTERN, MAX_DEVICES_PER_USER
+from app.constants.notifications import (
+    EXPO_TOKEN_PATTERN,
+    MAX_DEVICES_PER_USER,
+    NotificationChannel,
+)
 from app.db.repositories.users import user_repository
 from app.models.device_token_models import (
     DeviceTokenRequest,
@@ -90,7 +94,7 @@ async def unsubscribe_from_emails(token: Annotated[str, Query()]) -> Response:
 
 
 async def _disable_email_channel(user_id: str) -> None:
-    await user_repository.set_channel_preferences(user_id, email=False)
+    await user_repository.set_channel_preferences(user_id, {NotificationChannel.EMAIL.value: False})
 
 
 @router.get("/notifications", response_model=PaginatedNotificationsResponse)
@@ -156,12 +160,7 @@ async def get_channel_preferences(
     try:
         prefs = await fetch_channel_preferences(user_id)
         log.set(operation="get_channel_preferences", outcome="success")
-        return ChannelPreferences(
-            telegram=prefs["telegram"],
-            discord=prefs["discord"],
-            whatsapp=prefs["whatsapp"],
-            slack=prefs["slack"],
-        )
+        return ChannelPreferences.model_validate(prefs)
     except Exception as e:
         log.error(
             f"{LogTag.NOTIFICATION} Failed to get channel preferences",
@@ -189,11 +188,7 @@ async def update_channel_preferences(
 
     try:
         await user_repository.set_channel_preferences(
-            user_id,
-            telegram=preferences.telegram,
-            discord=preferences.discord,
-            whatsapp=preferences.whatsapp,
-            slack=preferences.slack,
+            user_id, preferences.model_dump(exclude_none=True)
         )
         schedule_account_sync(user_id)
 
@@ -208,12 +203,7 @@ async def update_channel_preferences(
             },
         )
         log.set(operation="update_channel_preferences", outcome="success")
-        return ChannelPreferences(
-            telegram=prefs["telegram"],
-            discord=prefs["discord"],
-            whatsapp=prefs["whatsapp"],
-            slack=prefs["slack"],
-        )
+        return ChannelPreferences.model_validate(prefs)
     except Exception as e:
         log.error(
             f"{LogTag.NOTIFICATION} Failed to update channel preferences",

--- a/apps/api/app/constants/notifications.py
+++ b/apps/api/app/constants/notifications.py
@@ -2,6 +2,7 @@
 Push Notification Constants
 """
 
+from enum import StrEnum
 import re
 
 # Maximum devices a user can register for push notifications
@@ -10,43 +11,45 @@ MAX_DEVICES_PER_USER = 10
 # Expo push token format: ExponentPushToken[xxx] or ExpoPushToken[xxx]
 EXPO_TOKEN_PATTERN = re.compile(r"^Expo(nent)?PushToken\[[a-zA-Z0-9_-]+\]$")
 
-# Notification channel type identifiers
-CHANNEL_TYPE_INAPP = "inapp"
-CHANNEL_TYPE_TELEGRAM = "telegram"
-CHANNEL_TYPE_DISCORD = "discord"
-CHANNEL_TYPE_WHATSAPP = "whatsapp"
-CHANNEL_TYPE_SLACK = "slack"
-CHANNEL_TYPE_IMESSAGE = "imessage"
-CHANNEL_TYPE_EMAIL = "email"
+
+class NotificationChannel(StrEnum):
+    """Every surface a notification can be delivered on.
+
+    Single source of truth: the preference model, the endpoint, the repository
+    writes and the delivery-time preference lookup all derive from these members,
+    so a new channel cannot be honoured by delivery while staying invisible in the
+    API.
+    """
+
+    INAPP = "inapp"
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+    WHATSAPP = "whatsapp"
+    SLACK = "slack"
+    IMESSAGE = "imessage"
+    EMAIL = "email"
+
 
 # External channel types that are auto-injected based on platform links
 EXTERNAL_NOTIFICATION_CHANNELS = (
-    CHANNEL_TYPE_TELEGRAM,
-    CHANNEL_TYPE_DISCORD,
-    CHANNEL_TYPE_WHATSAPP,
-    CHANNEL_TYPE_SLACK,
-    CHANNEL_TYPE_IMESSAGE,
+    NotificationChannel.TELEGRAM,
+    NotificationChannel.DISCORD,
+    NotificationChannel.WHATSAPP,
+    NotificationChannel.SLACK,
+    NotificationChannel.IMESSAGE,
 )
 
 # All channel types that are auto-injected when no channels are explicitly specified.
 # inapp is always available; the external platforms respect user preferences.
-ALL_AUTO_INJECTED_CHANNELS = (
-    CHANNEL_TYPE_INAPP,
-    CHANNEL_TYPE_TELEGRAM,
-    CHANNEL_TYPE_DISCORD,
-    CHANNEL_TYPE_WHATSAPP,
-    CHANNEL_TYPE_SLACK,
-    CHANNEL_TYPE_IMESSAGE,
-)
+ALL_AUTO_INJECTED_CHANNELS = (NotificationChannel.INAPP, *EXTERNAL_NOTIFICATION_CHANNELS)
 
-# Default enabled state for external channels
+# Channels the user can switch on and off. inapp is excluded: it is always
+# delivered, so it has no preference to store.
+USER_CONFIGURABLE_CHANNELS = (*EXTERNAL_NOTIFICATION_CHANNELS, NotificationChannel.EMAIL)
+
+# Default enabled state for every user-configurable channel
 DEFAULT_CHANNEL_PREFERENCES: dict[str, bool] = {
-    CHANNEL_TYPE_TELEGRAM: True,
-    CHANNEL_TYPE_DISCORD: True,
-    CHANNEL_TYPE_WHATSAPP: True,
-    CHANNEL_TYPE_SLACK: True,
-    CHANNEL_TYPE_IMESSAGE: True,
-    CHANNEL_TYPE_EMAIL: True,
+    channel.value: True for channel in USER_CONFIGURABLE_CHANNELS
 }
 
 # Workflow-completion notification copy. GAIA texts like a friend (first person,

--- a/apps/api/app/db/repositories/users.py
+++ b/apps/api/app/db/repositories/users.py
@@ -20,6 +20,7 @@ cached read may carry a slightly stale ``last_active_at``; nothing reads that
 field off a cached path (the inactivity scan is an uncached query).
 """
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 
 from bson import ObjectId
@@ -31,6 +32,7 @@ from app.constants.cache import (
     USER_CACHE_PREFIX,
 )
 from app.constants.log_tags import LogTag
+from app.constants.notifications import DEFAULT_CHANNEL_PREFERENCES
 from app.db.redis import redis_cache
 from app.db.repositories.base import MongoRepository, cached_query
 from app.db.repositories.cache import CachePolicy
@@ -685,29 +687,15 @@ class UserRepository(MongoRepository[UserDocument, UserUpdate]):
 
     # --------------------------------------------------------- settings writes
 
-    async def set_channel_preferences(
-        self,
-        user_id: str,
-        *,
-        telegram: bool | None = None,
-        discord: bool | None = None,
-        whatsapp: bool | None = None,
-        slack: bool | None = None,
-        email: bool | None = None,
-    ) -> None:
-        """Set the given notification channel flags; unspecified channels are left
-        untouched (a ``None`` argument is not written)."""
-        set_fields: dict[str, object] = {}
-        if telegram is not None:
-            set_fields["notification_channel_prefs.telegram"] = telegram
-        if discord is not None:
-            set_fields["notification_channel_prefs.discord"] = discord
-        if whatsapp is not None:
-            set_fields["notification_channel_prefs.whatsapp"] = whatsapp
-        if slack is not None:
-            set_fields["notification_channel_prefs.slack"] = slack
-        if email is not None:
-            set_fields["notification_channel_prefs.email"] = email
+    async def set_channel_preferences(self, user_id: str, preferences: Mapping[str, bool]) -> None:
+        """Set the given notification channel flags; unlisted channels are left untouched."""
+        unknown = sorted(set(preferences) - set(DEFAULT_CHANNEL_PREFERENCES))
+        if unknown:
+            raise ValueError(f"Unknown notification channels: {unknown}")
+        set_fields: dict[str, object] = {
+            f"notification_channel_prefs.{channel}": enabled
+            for channel, enabled in preferences.items()
+        }
         if not set_fields:
             return
         await self._apply_raw_update(

--- a/apps/api/app/models/notification/notification_models.py
+++ b/apps/api/app/models/notification/notification_models.py
@@ -332,18 +332,27 @@ class BulkActions(str, Enum):
 
 
 class ChannelPreferences(BaseModel):
-    """User notification channel preferences."""
+    """User notification channel preferences.
+
+    One field per ``USER_CONFIGURABLE_CHANNELS`` member; the fields are spelled out
+    so FastAPI and mypy see real types, and a unit test pins the set against the
+    enum so the two cannot drift.
+    """
 
     telegram: bool = True
     discord: bool = True
     whatsapp: bool = True
     slack: bool = True
+    imessage: bool = True
+    email: bool = True
 
 
 class ChannelPreferencesUpdate(BaseModel):
-    """Request body for updating channel preferences."""
+    """Request body for updating channel preferences; omitted channels are untouched."""
 
     telegram: bool | None = None
     discord: bool | None = None
     whatsapp: bool | None = None
     slack: bool | None = None
+    imessage: bool | None = None
+    email: bool | None = None

--- a/apps/api/app/services/account_settings.py
+++ b/apps/api/app/services/account_settings.py
@@ -6,6 +6,10 @@ service, and returns an agent-facing confirmation string. Invalid input raises
 tool wrapper's job).
 """
 
+from app.constants.notifications import (
+    USER_CONFIGURABLE_CHANNELS,
+    NotificationChannel,
+)
 from app.db.repositories.users import user_repository
 from app.models.user_models import OnboardingPreferences, UserUpdate
 from app.services.voice_service import list_voices, set_user_voice
@@ -14,7 +18,7 @@ from app.utils.timezone import is_valid_timezone
 
 MAX_CUSTOM_INSTRUCTIONS_CHARS = 500
 
-CHANNEL_FLAGS = ("telegram", "discord", "whatsapp", "slack", "email")
+CHANNEL_FLAGS = tuple(channel.value for channel in USER_CONFIGURABLE_CHANNELS)
 
 
 async def set_notification_channels(
@@ -24,17 +28,19 @@ async def set_notification_channels(
     discord: bool | None = None,
     whatsapp: bool | None = None,
     slack: bool | None = None,
+    imessage: bool | None = None,
     email: bool | None = None,
 ) -> str:
     """Set the given notification channel flags; unspecified channels untouched."""
-    given = {
+    given: dict[str, bool] = {
         channel: value
         for channel, value in [
-            ("telegram", telegram),
-            ("discord", discord),
-            ("whatsapp", whatsapp),
-            ("slack", slack),
-            ("email", email),
+            (NotificationChannel.TELEGRAM.value, telegram),
+            (NotificationChannel.DISCORD.value, discord),
+            (NotificationChannel.WHATSAPP.value, whatsapp),
+            (NotificationChannel.SLACK.value, slack),
+            (NotificationChannel.IMESSAGE.value, imessage),
+            (NotificationChannel.EMAIL.value, email),
         ]
         if value is not None
     }
@@ -45,7 +51,7 @@ async def set_notification_channels(
             fix="Pass at least one channel, e.g. email=False",
             status_code=400,
         )
-    await user_repository.set_channel_preferences(user_id, **given)
+    await user_repository.set_channel_preferences(user_id, given)
     changed = ", ".join(f"{c}={'on' if v else 'off'}" for c, v in given.items())
     return f"Notification settings updated ({changed})."
 

--- a/apps/api/app/services/integrations/integration_expiry.py
+++ b/apps/api/app/services/integrations/integration_expiry.py
@@ -22,7 +22,7 @@ from typing import Literal
 from app.config.oauth_config import get_integration_by_id
 from app.constants.integrations import INTEGRATION_STATUS_EXPIRED
 from app.constants.log_tags import LogTag
-from app.constants.notifications import CHANNEL_TYPE_INAPP
+from app.constants.notifications import NotificationChannel
 from app.core.websocket_manager import websocket_manager
 from app.db.repositories.user_integrations import user_integration_repository
 from app.models.notification.notification_models import (
@@ -210,7 +210,7 @@ async def _announce_expiry(
             user_id=user_id,
             source=NotificationSourceEnum.INTEGRATION_EXPIRED,
             type=NotificationType.WARNING,
-            channels=[ChannelConfig(channel_type=CHANNEL_TYPE_INAPP)],
+            channels=[ChannelConfig(channel_type=NotificationChannel.INAPP)],
             content=NotificationContent(
                 title=f"{integration_name} disconnected",
                 body=_expiry_body(integration_name, paused_workflows, reason),

--- a/apps/api/app/services/nurture/service.py
+++ b/apps/api/app/services/nurture/service.py
@@ -12,7 +12,7 @@ from urllib.parse import urlencode
 from app.config.settings import settings
 from app.constants.email import CONTACT_EMAIL, FOUNDER_MEETING_URL, FOUNDER_SENDER
 from app.constants.log_tags import LogTag
-from app.constants.notifications import CHANNEL_TYPE_EMAIL
+from app.constants.notifications import NotificationChannel
 from app.constants.nurture import (
     NURTURE_BACKFILL_GRACE_DAYS,
     NURTURE_MAX_EMAILS_PER_WEEK,
@@ -127,7 +127,9 @@ async def _process_user(user: UserDocument, now: datetime) -> bool:
         return False
     if not user.email:
         return False
-    if not normalize_channel_preferences(user.notification_channel_prefs)[CHANNEL_TYPE_EMAIL]:
+    if not normalize_channel_preferences(user.notification_channel_prefs)[
+        NotificationChannel.EMAIL
+    ]:
         return False
 
     created_at = as_utc(user.created_at)

--- a/apps/api/app/services/workflow/notifications.py
+++ b/apps/api/app/services/workflow/notifications.py
@@ -11,7 +11,7 @@ imports the agent stack).
 from datetime import UTC, datetime
 
 from app.constants.log_tags import LogTag
-from app.constants.notifications import CHANNEL_TYPE_INAPP, pick_workflow_done_copy
+from app.constants.notifications import NotificationChannel, pick_workflow_done_copy
 from app.models.notification.notification_models import (
     ActionConfig,
     ActionStyle,
@@ -55,7 +55,7 @@ async def send_workflow_completion_notification(
                 user_id=user_id,
                 source=NotificationSourceEnum.WORKFLOW_COMPLETED,
                 type=NotificationType.SUCCESS,
-                channels=[ChannelConfig(channel_type=CHANNEL_TYPE_INAPP)],
+                channels=[ChannelConfig(channel_type=NotificationChannel.INAPP)],
                 content=NotificationContent(
                     title=title,
                     body=body,

--- a/apps/api/app/utils/notification/channels/inapp.py
+++ b/apps/api/app/utils/notification/channels/inapp.py
@@ -1,7 +1,7 @@
 from typing import Any, TypedDict
 
 from app.constants.log_tags import LogTag
-from app.constants.notifications import CHANNEL_TYPE_INAPP
+from app.constants.notifications import NotificationChannel
 from app.core.websocket_manager import websocket_manager
 from app.models.notification.notification_models import (
     ActionStyle,
@@ -55,7 +55,7 @@ class InAppChannelAdapter(ChannelAdapter[InAppPayload]):
 
     @property
     def channel_type(self) -> str:
-        return CHANNEL_TYPE_INAPP
+        return NotificationChannel.INAPP
 
     def can_handle(self, notification: NotificationRequest) -> bool:  # noqa: ARG002 -- polymorphic interface; implementations keep the full signature
         """Return True — in-app delivery is always available for any request."""
@@ -96,7 +96,7 @@ class InAppChannelAdapter(ChannelAdapter[InAppPayload]):
             operation="inapp_deliver",
             user_id=user_id,
             notification_id=content["id"],
-            channel_type=CHANNEL_TYPE_INAPP,
+            channel_type=NotificationChannel.INAPP,
         )
         try:
             await websocket_manager.broadcast_to_user(

--- a/apps/api/app/utils/notification/orchestrator.py
+++ b/apps/api/app/utils/notification/orchestrator.py
@@ -7,8 +7,8 @@ from fastapi import Request
 from app.constants.log_tags import LogTag
 from app.constants.notifications import (
     ALL_AUTO_INJECTED_CHANNELS,
-    CHANNEL_TYPE_INAPP,
     DEFAULT_CHANNEL_PREFERENCES,
+    NotificationChannel,
 )
 from app.core.websocket_manager import websocket_manager
 from app.models.notification.notification_models import (
@@ -138,7 +138,7 @@ class NotificationOrchestrator:
         if not explicitly_requested:
             channel_prefs = await self._get_channel_prefs(notification.user_id)
             for platform in ALL_AUTO_INJECTED_CHANNELS:
-                if platform != CHANNEL_TYPE_INAPP and not channel_prefs.get(platform, True):
+                if platform != NotificationChannel.INAPP and not channel_prefs.get(platform, True):
                     log.info(
                         f"{LogTag.NOTIFICATION} Skipping delivery: disabled by preference",
                         platform=platform,

--- a/apps/api/app/utils/notification/sources.py
+++ b/apps/api/app/utils/notification/sources.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from app.constants.notifications import CHANNEL_TYPE_INAPP
+from app.constants.notifications import NotificationChannel
 from app.models.notification.notification_models import (
     ChannelConfig,
     NotificationAction,
@@ -36,7 +36,7 @@ class AIProactiveNotificationSource:
             source=NotificationSourceEnum.AI_REMINDER,
             type=NotificationType.INFO,
             priority=1,
-            channels=[ChannelConfig(channel_type=CHANNEL_TYPE_INAPP)],
+            channels=[ChannelConfig(channel_type=NotificationChannel.INAPP)],
             content=NotificationContent(
                 title=title,
                 body=body,

--- a/apps/api/app/workers/tasks/user_tasks.py
+++ b/apps/api/app/workers/tasks/user_tasks.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from app.config.settings import settings
 from app.constants.log_tags import LogTag
-from app.constants.notifications import CHANNEL_TYPE_EMAIL
+from app.constants.notifications import NotificationChannel
 from app.db.repositories.users import user_repository
 from app.models.user_models import UserDocument
 from app.utils.notification.channel_preferences import normalize_channel_preferences
@@ -30,7 +30,9 @@ def _emails_sent_this_episode(user: UserDocument) -> int:
 
 def _should_send_inactive_email(user: UserDocument) -> bool:
     """Throttle policy: per inactivity episode, first email after 7 days, second 7+ days later, max 2."""
-    if not normalize_channel_preferences(user.notification_channel_prefs)[CHANNEL_TYPE_EMAIL]:
+    if not normalize_channel_preferences(user.notification_channel_prefs)[
+        NotificationChannel.EMAIL
+    ]:
         return False
 
     now = datetime.now(UTC)

--- a/apps/api/tests/contracts/test_users_repository.py
+++ b/apps/api/tests/contracts/test_users_repository.py
@@ -254,17 +254,23 @@ class TestOnboardingWrites:
 class TestSettingsWrites:
     async def test_set_channel_preferences_patches_only_given_channels(self, repo, make_user):
         created = await repo.create(make_user())
-        await repo.set_channel_preferences(created.id, telegram=True, slack=False)
+        await repo.set_channel_preferences(created.id, {"telegram": True, "slack": False})
         prefs = (await repo.get(created.id)).notification_channel_prefs
         assert prefs == {"telegram": True, "slack": False}
         # A second call leaves unspecified channels untouched and updates given ones.
-        await repo.set_channel_preferences(created.id, telegram=False, discord=True)
+        await repo.set_channel_preferences(created.id, {"telegram": False, "discord": True})
         prefs = (await repo.get(created.id)).notification_channel_prefs
         assert prefs == {"telegram": False, "slack": False, "discord": True}
 
-    async def test_set_channel_preferences_no_args_is_noop(self, repo, make_user):
+    async def test_set_channel_preferences_no_channels_is_noop(self, repo, make_user):
         created = await repo.create(make_user())
-        await repo.set_channel_preferences(created.id)
+        await repo.set_channel_preferences(created.id, {})
+        assert (await repo.get(created.id)).notification_channel_prefs is None
+
+    async def test_set_channel_preferences_rejects_an_unknown_channel(self, repo, make_user):
+        created = await repo.create(make_user())
+        with pytest.raises(ValueError, match="carrier-pigeon"):
+            await repo.set_channel_preferences(created.id, {"carrier-pigeon": True})
         assert (await repo.get(created.id)).notification_channel_prefs is None
 
     async def test_mark_email_processing_complete(self, repo, make_user):

--- a/apps/api/tests/e2e/test_account_tools_flow.py
+++ b/apps/api/tests/e2e/test_account_tools_flow.py
@@ -131,7 +131,7 @@ class TestAccountToolsThroughGraph:
         assert "email=off" in tool_msg.content
         # The write went to THIS graph's user, not another tenant's.
         _patched_seams.set_channels.assert_awaited_once_with(
-            thread_config["configurable"]["user_id"], email=False
+            thread_config["configurable"]["user_id"], {"email": False}
         )
         # Analytics only after success.
         _patched_seams.capture.assert_called_once_with(

--- a/apps/api/tests/unit/api/test_notification_endpoint.py
+++ b/apps/api/tests/unit/api/test_notification_endpoint.py
@@ -237,6 +237,41 @@ class TestUpdateChannelPreferences:
         "app.api.v1.endpoints.notification.user_repository.set_channel_preferences",
         new_callable=AsyncMock,
     )
+    async def test_update_imessage_preference_persists_and_is_returned(
+        self,
+        mock_set_prefs: AsyncMock,
+        mock_fetch: AsyncMock,
+        client: AsyncClient,
+    ):
+        """iMessage and email are stored and honoured by delivery, so the API must
+        accept and return them — not silently drop them like it used to."""
+        mock_fetch.return_value = {
+            "telegram": True,
+            "discord": True,
+            "whatsapp": True,
+            "slack": True,
+            "imessage": False,
+            "email": False,
+        }
+        with patch("app.api.v1.endpoints.notification.schedule_account_sync"):
+            response = await client.put(
+                f"{NOTIF_BASE}/preferences/channels",
+                json={"imessage": False, "email": False},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["imessage"] is False
+        assert response.json()["email"] is False
+        mock_set_prefs.assert_awaited_once_with(FAKE_USER_ID, {"imessage": False, "email": False})
+
+    @patch(
+        "app.api.v1.endpoints.notification.fetch_channel_preferences",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "app.api.v1.endpoints.notification.user_repository.set_channel_preferences",
+        new_callable=AsyncMock,
+    )
     async def test_update_channel_preferences_error(
         self,
         mock_set_prefs: AsyncMock,

--- a/apps/api/tests/unit/models/test_notification_models.py
+++ b/apps/api/tests/unit/models/test_notification_models.py
@@ -1,0 +1,39 @@
+"""Notification model invariants.
+
+The channel set is defined once, in ``NotificationChannel``. These tests are what
+stops the preference model, the stored defaults and the enum from drifting apart —
+which is exactly how ``imessage`` and ``email`` ended up honoured by delivery while
+being invisible to the API.
+"""
+
+from app.constants.notifications import (
+    DEFAULT_CHANNEL_PREFERENCES,
+    USER_CONFIGURABLE_CHANNELS,
+    NotificationChannel,
+)
+from app.models.notification.notification_models import (
+    ChannelPreferences,
+    ChannelPreferencesUpdate,
+)
+
+CONFIGURABLE_CHANNEL_VALUES = {channel.value for channel in USER_CONFIGURABLE_CHANNELS}
+
+
+class TestChannelSetIsSingleSourced:
+    def test_configurable_channels_are_every_channel_but_inapp(self):
+        assert {channel.value for channel in NotificationChannel} - {
+            NotificationChannel.INAPP.value
+        } == CONFIGURABLE_CHANNEL_VALUES
+
+    def test_defaults_cover_every_configurable_channel(self):
+        assert set(DEFAULT_CHANNEL_PREFERENCES) == CONFIGURABLE_CHANNEL_VALUES
+
+    def test_response_model_exposes_every_configurable_channel(self):
+        assert set(ChannelPreferences.model_fields) == CONFIGURABLE_CHANNEL_VALUES
+
+    def test_update_model_accepts_every_configurable_channel(self):
+        assert set(ChannelPreferencesUpdate.model_fields) == CONFIGURABLE_CHANNEL_VALUES
+
+    def test_update_model_omits_unset_channels(self):
+        update = ChannelPreferencesUpdate(imessage=False)
+        assert update.model_dump(exclude_none=True) == {"imessage": False}

--- a/apps/api/tests/unit/services/test_account_settings.py
+++ b/apps/api/tests/unit/services/test_account_settings.py
@@ -36,7 +36,7 @@ async def test_notification_channels_write_only_the_given_flags(repo) -> None:
     result = await account_settings.set_notification_channels(USER_ID, email=False, telegram=True)
 
     assert result == "Notification settings updated (telegram=on, email=off)."
-    repo.set_channels.assert_awaited_once_with(USER_ID, email=False, telegram=True)
+    repo.set_channels.assert_awaited_once_with(USER_ID, {"telegram": True, "email": False})
 
 
 async def test_notification_channels_with_no_flags_is_an_error(repo) -> None:
@@ -261,18 +261,18 @@ class TestCustomInstructionBoundaries:
 
 
 class TestChannelFlagSemantics:
-    async def test_all_five_flags_write_in_one_call(self, repo) -> None:
+    async def test_every_flag_writes_in_one_call(self, repo) -> None:
         flags = dict.fromkeys(account_settings.CHANNEL_FLAGS, True)
         await account_settings.set_notification_channels(USER_ID, **flags)
-        repo.set_channels.assert_awaited_once_with(USER_ID, **flags)
+        repo.set_channels.assert_awaited_once_with(USER_ID, flags)
 
     async def test_unset_channels_are_absent_from_the_write_so_they_survive(self, repo) -> None:
         # email=False must be written; telegram=None must NOT be — the whole
         # PATCH contract is "unspecified means untouched".
         await account_settings.set_notification_channels(USER_ID, email=False)
-        kwargs = repo.set_channels.await_args.kwargs
-        assert kwargs == {"email": False}
-        assert set(kwargs) != set(account_settings.CHANNEL_FLAGS)
+        written = repo.set_channels.await_args.args[1]
+        assert written == {"email": False}
+        assert set(written) != set(account_settings.CHANNEL_FLAGS)
 
 
 class TestVoiceSelectionAttacks:

--- a/apps/api/tests/unit/services/test_integration_expiry.py
+++ b/apps/api/tests/unit/services/test_integration_expiry.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.constants.notifications import CHANNEL_TYPE_INAPP
+from app.constants.notifications import NotificationChannel
 from app.models.integration_models import UserIntegrationDocument
 from app.models.notification.notification_models import ActionStyle, NotificationType
 from app.services.integrations.integration_expiry import (
@@ -472,7 +472,7 @@ class TestTheReconnectNotificationIsActionable:
 
         request = s.mocks["notify"].create_notification.await_args.args[0]
         assert request.type == NotificationType.WARNING
-        assert [c.channel_type for c in request.channels] == [CHANNEL_TYPE_INAPP]
+        assert [c.channel_type for c in request.channels] == [NotificationChannel.INAPP]
 
     async def test_the_reconnect_button_is_primary_and_opens_in_place(self) -> None:
         """Opening a new tab or leaving the notification up after the click both

--- a/apps/api/tests/unit/tasks/test_reminder_tasks.py
+++ b/apps/api/tests/unit/tasks/test_reminder_tasks.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi import HTTPException
 import pytest
 
-from app.constants.notifications import CHANNEL_TYPE_INAPP
+from app.constants.notifications import NotificationChannel
 from app.models.chat_models import ConversationSource
 from app.models.reminder_models import ReminderModel, StaticReminderPayload
 from app.services.analytics_service import AnalyticsEvents
@@ -70,7 +70,7 @@ async def test_static_reminder_sends_notification() -> None:
     assert notification.content.title == "Water the plants"
     # The in-app badge must NOT auto-inject the external platforms: the chat-platform
     # copy is delivered (and recorded) by _deliver_reminder_to_platforms instead.
-    assert [c.channel_type for c in notification.channels] == [CHANNEL_TYPE_INAPP]
+    assert [c.channel_type for c in notification.channels] == [NotificationChannel.INAPP]
     log_info.assert_called_once()
 
 

--- a/apps/api/tests/unit/utils/test_notification_channels.py
+++ b/apps/api/tests/unit/utils/test_notification_channels.py
@@ -10,14 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.constants.notifications import (
-    CHANNEL_TYPE_DISCORD,
-    CHANNEL_TYPE_IMESSAGE,
-    CHANNEL_TYPE_INAPP,
-    CHANNEL_TYPE_SLACK,
-    CHANNEL_TYPE_TELEGRAM,
-    CHANNEL_TYPE_WHATSAPP,
-)
+from app.constants.notifications import NotificationChannel
 from app.models.chat_models import ConversationSource
 from app.models.notification.notification_models import (
     ActionConfig,
@@ -89,7 +82,7 @@ def _make_redirect_action(label: str = "View", url: str = "/test") -> Notificati
 class TestChannelAdapterBaseHelpers:
     def test_success_helper(self) -> None:
         status = InAppChannelAdapter()._success()
-        assert status.channel_type == CHANNEL_TYPE_INAPP
+        assert status.channel_type == NotificationChannel.INAPP
         assert status.status == NotificationStatus.DELIVERED
         assert status.delivered_at is not None
 
@@ -114,7 +107,7 @@ class TestChannelAdapterBaseHelpers:
 @pytest.mark.asyncio
 class TestInAppChannelAdapter:
     def test_channel_type(self) -> None:
-        assert InAppChannelAdapter().channel_type == CHANNEL_TYPE_INAPP
+        assert InAppChannelAdapter().channel_type == NotificationChannel.INAPP
 
     def test_can_handle_with_inapp_channel(self) -> None:
         request = _make_request(channels=[ChannelConfig(channel_type="inapp", enabled=True)])
@@ -245,11 +238,11 @@ class TestExternalAdapterIdentity:
     @pytest.mark.parametrize(
         "adapter_cls, channel_type, platform",
         [
-            (WhatsAppChannelAdapter, CHANNEL_TYPE_WHATSAPP, ConversationSource.WHATSAPP),
-            (SlackChannelAdapter, CHANNEL_TYPE_SLACK, ConversationSource.SLACK),
-            (TelegramChannelAdapter, CHANNEL_TYPE_TELEGRAM, ConversationSource.TELEGRAM),
-            (DiscordChannelAdapter, CHANNEL_TYPE_DISCORD, ConversationSource.DISCORD),
-            (ImessageChannelAdapter, CHANNEL_TYPE_IMESSAGE, ConversationSource.IMESSAGE),
+            (WhatsAppChannelAdapter, NotificationChannel.WHATSAPP, ConversationSource.WHATSAPP),
+            (SlackChannelAdapter, NotificationChannel.SLACK, ConversationSource.SLACK),
+            (TelegramChannelAdapter, NotificationChannel.TELEGRAM, ConversationSource.TELEGRAM),
+            (DiscordChannelAdapter, NotificationChannel.DISCORD, ConversationSource.DISCORD),
+            (ImessageChannelAdapter, NotificationChannel.IMESSAGE, ConversationSource.IMESSAGE),
         ],
     )
     def test_channel_type_and_platform(self, adapter_cls, channel_type, platform) -> None:

--- a/apps/api/tests/unit/workers/test_workflow_tasks.py
+++ b/apps/api/tests/unit/workers/test_workflow_tasks.py
@@ -10,7 +10,7 @@ import pytest
 
 from app.api.v1.middleware.tiered_rate_limiter import RateLimitExceededException
 from app.constants.log_tags import LogTag
-from app.constants.notifications import CHANNEL_TYPE_INAPP
+from app.constants.notifications import NotificationChannel
 from app.models.agent_models import SilentRunResult
 from app.models.notification.notification_models import (
     ActionType,
@@ -1311,7 +1311,7 @@ class TestWorkflowNotificationSenders:
         assert "Morning Briefing" in notif_req.content.title
         assert notif_req.content.body
         # Scoped to in-app only (no external chrome push) and no result payload.
-        assert [c.channel_type for c in notif_req.channels] == [CHANNEL_TYPE_INAPP]
+        assert [c.channel_type for c in notif_req.channels] == [NotificationChannel.INAPP]
         assert notif_req.content.rich_content is None
         # Exactly one "View Results" redirect to the run's conversation.
         actions = notif_req.content.actions

--- a/apps/mobile/src/features/notifications/components/NotificationPreferencesSheet.tsx
+++ b/apps/mobile/src/features/notifications/components/NotificationPreferencesSheet.tsx
@@ -47,6 +47,7 @@ import type {
   PlatformLinksResponse,
   QuietHours,
 } from "../types/inapp-notification-types";
+import { NOTIFICATION_CHANNELS } from "../types/inapp-notification-types";
 
 const SNAP_POINTS: Array<string | number> = ["90%"];
 
@@ -701,12 +702,11 @@ export const NotificationPreferencesSheet =
       const channelMutation = useChannelMutation(queryClient);
 
       const prefs = prefsQuery.data ?? null;
-      const channels = channelsQuery.data ?? {
-        telegram: false,
-        discord: false,
-        whatsapp: false,
-        slack: false,
-      };
+      const channels =
+        channelsQuery.data ??
+        (Object.fromEntries(
+          NOTIFICATION_CHANNELS.map((channel) => [channel, false]),
+        ) as ChannelPreferences);
       const platformLinks = platformLinksQuery.data?.platform_links ?? {};
 
       const isLoading =

--- a/apps/mobile/src/features/notifications/types/inapp-notification-types.ts
+++ b/apps/mobile/src/features/notifications/types/inapp-notification-types.ts
@@ -13,6 +13,7 @@ export type {
   QuietHours,
 } from "@gaia/shared/types";
 export {
+  NOTIFICATION_CHANNELS,
   NotificationActionStyle as InAppNotificationActionStyle,
   NotificationActionType as InAppNotificationActionType,
   NotificationStatus as InAppNotificationStatus,

--- a/apps/mobile/src/features/settings/components/sections/notification-section.tsx
+++ b/apps/mobile/src/features/settings/components/sections/notification-section.tsx
@@ -1,4 +1,5 @@
 import type { ChannelPlatform, ChannelPreferences } from "@gaia/shared/types";
+import { NOTIFICATION_CHANNELS } from "@gaia/shared/types";
 import { Spinner } from "heroui-native";
 import { useCallback, useEffect, useState } from "react";
 import { Alert, ScrollView, View } from "react-native";
@@ -17,12 +18,12 @@ import { SettingsGroup, SettingsSwitchRow } from "../settings-row";
 
 export function NotificationSection() {
   const { spacing, fontSize } = useResponsive();
-  const [channels, setChannels] = useState<ChannelPreferences>({
-    telegram: false,
-    discord: false,
-    whatsapp: false,
-    slack: false,
-  });
+  const [channels, setChannels] = useState<ChannelPreferences>(
+    () =>
+      Object.fromEntries(
+        NOTIFICATION_CHANNELS.map((channel) => [channel, false]),
+      ) as ChannelPreferences,
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [updatingChannel, setUpdatingChannel] =
     useState<ChannelPlatform | null>(null);

--- a/apps/web/src/features/notification/constants.ts
+++ b/apps/web/src/features/notification/constants.ts
@@ -22,14 +22,17 @@ export const NOTIFICATION_PLATFORM_LABELS: Record<
 export const NOTIFICATION_PLATFORM_ICONS: Record<NotificationPlatform, string> =
   BOT_PLATFORM_ICONS;
 
-// Channel-level maps extend the platform maps with the always-available
-// in-app channel, which is delivered over WebSocket rather than a bot.
+// Channel-level maps extend the platform maps with the channels that are not bot
+// platforms: the always-available in-app channel (delivered over WebSocket) and
+// email (delivered to the account address).
 export const NOTIFICATION_CHANNEL_LABELS: Record<string, string> = {
   ...NOTIFICATION_PLATFORM_LABELS,
   inapp: "In-app",
+  email: "Email",
 };
 
 export const NOTIFICATION_CHANNEL_ICONS: Record<string, string> = {
   ...NOTIFICATION_PLATFORM_ICONS,
   inapp: "/images/logos/macos.webp",
+  email: "/images/icons/macos/mail.png",
 };

--- a/apps/web/src/features/settings/components/NotificationSettings.tsx
+++ b/apps/web/src/features/settings/components/NotificationSettings.tsx
@@ -1,13 +1,14 @@
 "use client";
 
+import { NOTIFICATION_CHANNELS } from "@gaia/shared";
+import type { ChannelPlatform, ChannelPreferences } from "@gaia/shared/types";
 import { Switch } from "@heroui/switch";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { isBotPlatform } from "@/config/botPlatforms";
 import {
-  NOTIFICATION_PLATFORM_ICONS,
-  NOTIFICATION_PLATFORM_LABELS,
-  NOTIFICATION_PLATFORMS,
-  type NotificationPlatform,
+  NOTIFICATION_CHANNEL_ICONS,
+  NOTIFICATION_CHANNEL_LABELS,
 } from "@/features/notification/constants";
 import { SettingsPage } from "@/features/settings/components/ui/SettingsPage";
 import { SettingsRow } from "@/features/settings/components/ui/SettingsRow";
@@ -21,15 +22,12 @@ export default function NotificationSettings() {
   const [platformLinks, setPlatformLinks] = useState<
     Record<string, PlatformLink | null>
   >({});
-  const [channelPrefs, setChannelPrefs] = useState<
-    Record<NotificationPlatform, boolean>
-  >({
-    telegram: true,
-    discord: true,
-    whatsapp: true,
-    slack: true,
-    imessage: true,
-  });
+  const [channelPrefs, setChannelPrefs] = useState<ChannelPreferences>(
+    () =>
+      Object.fromEntries(
+        NOTIFICATION_CHANNELS.map((channel) => [channel, true]),
+      ) as ChannelPreferences,
+  );
   const [loading, setLoading] = useState(true);
   const [togglingPlatform, setTogglingPlatform] = useState<string | null>(null);
 
@@ -55,16 +53,13 @@ export default function NotificationSettings() {
     fetchAll();
   }, []);
 
-  const handleToggle = async (
-    platform: NotificationPlatform,
-    enabled: boolean,
-  ) => {
-    setTogglingPlatform(platform);
+  const handleToggle = async (channel: ChannelPlatform, enabled: boolean) => {
+    setTogglingPlatform(channel);
     try {
-      await NotificationsAPI.updateChannelPreference(platform, enabled);
-      setChannelPrefs((prev) => ({ ...prev, [platform]: enabled }));
+      await NotificationsAPI.updateChannelPreference(channel, enabled);
+      setChannelPrefs((prev) => ({ ...prev, [channel]: enabled }));
     } catch {
-      toast.error(`Failed to update ${platform} notification preference`);
+      toast.error(`Failed to update ${channel} notification preference`);
     } finally {
       setTogglingPlatform(null);
     }
@@ -73,21 +68,25 @@ export default function NotificationSettings() {
   return (
     <SettingsPage>
       <SettingsSection description="Choose where to receive GAIA notifications.">
-        {NOTIFICATION_PLATFORMS.map((platform) => {
-          const label = NOTIFICATION_PLATFORM_LABELS[platform];
-          const isConnected = !!platformLinks[platform]?.platformUserId;
+        {NOTIFICATION_CHANNELS.map((channel) => {
+          const label = NOTIFICATION_CHANNEL_LABELS[channel];
+          // Only bot platforms need a linked account; email reaches the user
+          // through the address on their GAIA account.
+          const needsLink = isBotPlatform(channel);
+          const isAvailable =
+            !needsLink || !!platformLinks[channel]?.platformUserId;
           return (
             <SettingsRow
-              key={platform}
+              key={channel}
               label={label}
               description={
-                isConnected
-                  ? "Send notifications to this platform"
+                isAvailable
+                  ? "Send notifications to this channel"
                   : "Connect in Linked Accounts to enable"
               }
               icon={
                 <Image
-                  src={NOTIFICATION_PLATFORM_ICONS[platform]}
+                  src={NOTIFICATION_CHANNEL_ICONS[channel]}
                   alt={label}
                   width={36}
                   height={36}
@@ -97,11 +96,11 @@ export default function NotificationSettings() {
             >
               <Switch
                 size="sm"
-                isSelected={isConnected ? channelPrefs[platform] : false}
+                isSelected={isAvailable ? channelPrefs[channel] : false}
                 isDisabled={
-                  !isConnected || loading || togglingPlatform === platform
+                  !isAvailable || loading || togglingPlatform === channel
                 }
-                onValueChange={(enabled) => handleToggle(platform, enabled)}
+                onValueChange={(enabled) => handleToggle(channel, enabled)}
                 aria-label={`Enable ${label} notifications`}
               />
             </SettingsRow>

--- a/apps/web/src/services/api/notifications.ts
+++ b/apps/web/src/services/api/notifications.ts
@@ -1,4 +1,4 @@
-import type { NotificationPlatform } from "@/features/notification/constants";
+import type { ChannelPlatform, ChannelPreferences } from "@gaia/shared/types";
 import { apiauth } from "@/lib/api/client";
 import {
   type BulkActionRequest,
@@ -163,12 +163,10 @@ export class NotificationsAPI {
   }
 
   /**
-   * Get notification channel preferences (telegram, discord, whatsapp, slack)
+   * Get the enabled state of every user-configurable notification channel
    */
-  static async getChannelPreferences(): Promise<
-    Record<NotificationPlatform, boolean>
-  > {
-    const response = await apiauth.get<Record<NotificationPlatform, boolean>>(
+  static async getChannelPreferences(): Promise<ChannelPreferences> {
+    const response = await apiauth.get<ChannelPreferences>(
       `${NotificationsAPI.BASE_URL}/preferences/channels`,
     );
     return response.data;
@@ -178,11 +176,11 @@ export class NotificationsAPI {
    * Update a notification channel preference
    */
   static async updateChannelPreference(
-    platform: NotificationPlatform,
+    channel: ChannelPlatform,
     enabled: boolean,
   ): Promise<void> {
     await apiauth.put(`${NotificationsAPI.BASE_URL}/preferences/channels`, {
-      [platform]: enabled,
+      [channel]: enabled,
     });
   }
 }

--- a/libs/shared/ts/src/index.ts
+++ b/libs/shared/ts/src/index.ts
@@ -390,6 +390,7 @@ export {
   Priority,
   WorkflowStatus,
 } from "./types";
+export { NOTIFICATION_CHANNELS } from "./types/notification";
 export type {
   ContentSegment,
   DueChipTone,

--- a/libs/shared/ts/src/types/index.ts
+++ b/libs/shared/ts/src/types/index.ts
@@ -48,6 +48,7 @@ export type {
   QuietHours,
 } from "./notification";
 export {
+  NOTIFICATION_CHANNELS,
   NotificationActionStyle,
   NotificationActionType,
   NotificationStatus,

--- a/libs/shared/ts/src/types/notification.ts
+++ b/libs/shared/ts/src/types/notification.ts
@@ -77,14 +77,21 @@ export interface PlatformLinksResponse {
   platform_links: Record<string, PlatformLink>;
 }
 
-export type ChannelPlatform = "telegram" | "discord" | "whatsapp" | "slack";
+// Mirrors USER_CONFIGURABLE_CHANNELS in apps/api/app/constants/notifications.py:
+// every channel the user can switch on or off. `inapp` is absent on purpose — it
+// is always delivered, so it has no preference to store.
+export const NOTIFICATION_CHANNELS = [
+  "telegram",
+  "discord",
+  "whatsapp",
+  "slack",
+  "imessage",
+  "email",
+] as const;
 
-export interface ChannelPreferences {
-  telegram: boolean;
-  discord: boolean;
-  whatsapp: boolean;
-  slack: boolean;
-}
+export type ChannelPlatform = (typeof NOTIFICATION_CHANNELS)[number];
+
+export type ChannelPreferences = Record<ChannelPlatform, boolean>;
 
 export interface QuietHours {
   from: string;


### PR DESCRIPTION
## What

`imessage` and `email` were stored in `notification_channel_prefs` and honoured at
delivery time, but the API neither returned nor accepted them: `DEFAULT_CHANNEL_PREFERENCES`
listed six channels while `ChannelPreferences`, `ChannelPreferencesUpdate`, the
GET/PUT endpoint and `UserRepository.set_channel_preferences` each hand-listed four
or five. Nothing asserted the lists agreed, which is why they drifted. A user could
not turn iMessage or email notifications off from settings.

One source of truth now:

- **`NotificationChannel(StrEnum)`** in `apps/api/app/constants/notifications.py` replaces
  the seven `CHANNEL_TYPE_*` string constants. `EXTERNAL_NOTIFICATION_CHANNELS`,
  `ALL_AUTO_INJECTED_CHANNELS`, the new `USER_CONFIGURABLE_CHANNELS` (everything but
  `inapp`, which is always delivered and has no preference) and
  `DEFAULT_CHANNEL_PREFERENCES` all derive from it.
- **Models** expose one field per configurable channel (spelled out so FastAPI and mypy
  see real types), pinned to the enum by `tests/unit/models/test_notification_models.py`
  so a future divergence fails red.
- **Endpoint** stops restating channels in both directions: PUT forwards
  `update.model_dump(exclude_none=True)`, GET/PUT respond via
  `ChannelPreferences.model_validate(prefs)` — the routing shape PR #1164 already uses,
  so that merge stays trivial.
- **Repository** `set_channel_preferences(user_id, preferences)` takes a mapping and
  validates its keys against the enum instead of hand-listed kwargs. Callers
  (`account_settings.set_notification_channels`, the endpoint, the unsubscribe route)
  pass a dict.
- **Agent tool** `update_notification_settings` gains the `imessage` flag it was missing.
- **TypeScript**: `NOTIFICATION_CHANNELS` in `libs/shared/ts/src/types/notification.ts`
  mirrors the enum; `ChannelPlatform` and `ChannelPreferences` derive from it. Web's
  notification settings iterate that list (email row added, gated on nothing since email
  needs no platform link), and mobile's two channel-preference screens build their
  fallback state from it instead of a four-key literal.

## Verified

RED first — with `notification_models.py` and `endpoints/notification.py` reverted to
`master`:

```
$ uv run --directory apps/api pytest tests/unit/models/test_notification_models.py \
    "tests/unit/api/test_notification_endpoint.py::TestUpdateChannelPreferences::test_update_imessage_preference_persists_and_is_returned" -q
FAILED tests/unit/models/.../test_defaults_cover_every_configurable_channel
FAILED tests/unit/models/.../test_update_model_accepts_every_configurable_channel
FAILED tests/unit/models/.../test_response_model_exposes_every_configurable_channel
FAILED tests/unit/models/.../test_update_model_omits_unset_channels
FAILED tests/unit/api/test_notification_endpoint.py::TestUpdateChannelPreferences::test_update_imessage_preference_persists_and_is_returned
5 failed, 1 passed in 20.53s
```

GREEN with the fix in place:

```
$ uv run --directory apps/api pytest tests/unit/models/test_notification_models.py \
    tests/unit/api/test_notification_endpoint.py tests/unit/services/test_account_settings.py \
    tests/unit/utils/test_notification_channels.py tests/unit/tasks/test_reminder_tasks.py \
    tests/unit/workers/test_workflow_tasks.py tests/unit/services/test_integration_expiry.py -q
228 passed in 5.05s

$ nx type-check api   -> Success: no issues found in 917 source files
$ nx lint api         -> All checks passed!
$ nx type-check web   -> Successfully ran target type-check for project web
$ nx lint web         -> Successfully ran target lint for project web
$ nx type-check mobile-> Successfully ran target type-check for project mobile
$ nx lint mobile      -> Successfully ran target lint for project mobile
```

The full pre-commit suite ran on the commit and passed, including
`Outbound topology parity (Python <-> TypeScript)`, `Mypy (pinned to uv.lock version)`,
`GAIA custom Python lints` and `Biome check`.

## Not verified

- **Not driven against a running stack.** No boot, no real PUT to
  `/api/v1/notifications/preferences/channels`, no Mongo row inspected, no click through
  the settings screen. The endpoint behaviour is proven only by unit tests with the
  repository and `fetch_channel_preferences` mocked.
- **`tests/contracts/test_users_repository.py` and `tests/e2e/test_account_tools_flow.py`
  were updated to the new `set_channel_preferences` signature but not run locally** —
  they need real backing services. CI covers them.
- **Mobile still does not render iMessage or email rows.** `PLATFORM_CHANNELS` in
  `NotificationPreferencesSheet.tsx` and the `NotificationSection` list are hard-coded to
  four bot platforms, and `apps/mobile/src/components/icons` has no mail or iMessage icon
  to use. Mobile compiles and its fallback state is now enum-derived, but the two rows
  need icons sourced — flagging rather than inventing assets.
