### PR TITLE
fix(agents): stop rejecting handoffs whose task text names another integration

### DIFF
--- a/apps/api/app/agents/core/subagents/handoff_tools.py
+++ b/apps/api/app/agents/core/subagents/handoff_tools.py
@@ -41,7 +41,6 @@ from app.agents.core.subagents.provider_subagents import (
 )
 from app.agents.core.subagents.registry import (
     all_subagents,
-    foreign_provider_named_in,
     get_subagent_by_id,
 )
 from app.agents.core.subagents.subagent_helpers import (
@@ -766,30 +765,12 @@ def _subagent_resume_status(status: HILApprovalStatus) -> HILApprovalStatus:
 
 async def _handoff_rejection(
     ctx: SubagentExecutionContext,
-    task: str,
     background: bool,
     stream_id: str | None,
 ) -> str | None:
     """The pre-dispatch refusals for one handoff, or None when it may run."""
     agent_name: str = ctx.agent_name
     integration_id: str = ctx.integration_id
-
-    # A task naming one provider while routed to another is a routing mistake
-    # that survives the whole run: the subagent does the work on ITS system and
-    # the executor writes the name it was told into the summary, so the user is
-    # told their data went somewhere it never went. Refuse before dispatch —
-    # the executor can re-route or drop the name, but it cannot un-say it.
-    foreign = foreign_provider_named_in(task, integration_id)
-    if foreign is not None:
-        return (
-            f"HANDOFF REJECTED: this task is routed to the {agent_name} subagent "
-            f"({integration_id}) but its text names {foreign.name}. {foreign.name} is a "
-            f"separate integration with its own subagent, and nothing you hand to "
-            f"{integration_id} touches it: leaving the name in makes the result claim "
-            f"{foreign.name} did work it never did. Either re-issue this handoff to "
-            f"subagent:{foreign.id} if that is where the work belongs, or send it again "
-            f"with every mention of {foreign.name} removed from the task."
-        )
 
     # An uncollected parked subagent owns this integration's checkpoint thread.
     # Running ANY new handoff on it (blocking or background) would feed fresh
@@ -954,7 +935,7 @@ async def handoff(
         agent_name: str = ctx.agent_name
         integration_id: str = ctx.integration_id
 
-        rejection = await _handoff_rejection(ctx, task, background, stream_id)
+        rejection = await _handoff_rejection(ctx, background, stream_id)
         if rejection is not None:
             return rejection
 

--- a/apps/api/app/agents/core/subagents/registry.py
+++ b/apps/api/app/agents/core/subagents/registry.py
@@ -12,7 +12,6 @@ never sees builtins.
 """
 
 from functools import cache
-import re
 
 from app.config.oauth_config import OAUTH_INTEGRATIONS
 from app.models.oauth_models import OAuthIntegration
@@ -61,45 +60,6 @@ def get_subagent_by_id(subagent_id: str) -> Subagent | None:
     s = subagent_id.lower().strip()
     for sa in all_subagents():
         if sa.id.lower() == s or (sa.short_name and sa.short_name.lower() == s):
-            return sa
-    return None
-
-
-@cache
-def _third_party_name_matchers() -> tuple[tuple[Subagent, re.Pattern[str]], ...]:
-    """One whole-word matcher per third-party provider, over its name and its id.
-
-    Internal subagents are deliberately absent as *matches*: "todos" and
-    "skills" are ordinary words that appear in task prose constantly, and a
-    generic noun cannot mislead anyone about which product holds their data. `short_name` is excluded for the same reason — Google
-    Tasks' short name is literally "tasks".
-
-    Cached with `all_subagents()`; call `_third_party_name_matchers.cache_clear()`
-    alongside it if a test injects a fake subagent.
-    """
-    matchers: list[tuple[Subagent, re.Pattern[str]]] = []
-    for sa in all_subagents():
-        if sa.managed_by == "internal":
-            continue
-        # Sorted only so the compiled pattern is stable across runs (set order
-        # is not). Alternation ORDER cannot change whether the pattern matches:
-        # the engine backtracks to the next alternative when a boundary lookaround
-        # fails, and the only consumer reads `pattern.search(text)` as a boolean,
-        # never the matched text.
-        alternation = "|".join(re.escape(label) for label in sorted({sa.name, sa.id}))
-        matchers.append((sa, re.compile(rf"(?<![\w-])(?:{alternation})(?![\w-])", re.IGNORECASE)))
-    return tuple(matchers)
-
-
-def foreign_provider_named_in(text: str, target_id: str) -> Subagent | None:
-    """The third-party provider ``text`` names that is not ``target_id``, if any.
-
-    A task routed to one subagent while naming another produces a result that
-    credits the named product with work it never did — the reason eight GAIA
-    todos reached the user as "8 tasks created (Todoist)".
-    """
-    for sa, pattern in _third_party_name_matchers():
-        if sa.id != target_id and pattern.search(text):
             return sa
     return None
 

--- a/apps/api/tests/unit/agents/test_handoff_tools.py
+++ b/apps/api/tests/unit/agents/test_handoff_tools.py
@@ -818,52 +818,6 @@ def _resolved_subagent(agent_name: str, integration_id: str) -> Iterator[MagicMo
 
 
 @pytest.mark.unit
-class TestHandoffRejectsAForeignProviderInTheTask:
-    """A task that names one provider while being routed to another produces a
-    result claiming work the target never did — eight GAIA todos were reported
-    to the user as "8 tasks created (Todoist)" from exactly this input."""
-
-    PROD_TASK = (
-        "Create these 8 separate tasks on Aryan's todo list (Todoist). Each one is its "
-        "own task. Use clear, actionable titles:\n\n1. Buy Resend Pro to send emails"
-    )
-
-    async def test_the_prod_task_is_rejected_before_the_subagent_runs(self) -> None:
-        with _resolved_subagent("todo_agent", "todos") as dispatch:
-            result = await handoff.coroutine(
-                subagent_id="todos",
-                task=self.PROD_TASK,
-                config={"configurable": {"user_id": "u1", "thread_id": "t1"}},
-            )
-
-        dispatch.assert_not_awaited()
-        assert "Todoist" in result
-        assert "subagent:todoist" in result
-
-    async def test_the_same_task_without_the_provider_name_dispatches(self) -> None:
-        with _resolved_subagent("todo_agent", "todos") as dispatch:
-            result = await handoff.coroutine(
-                subagent_id="todos",
-                task="Create these 8 separate tasks on Aryan's todo list.",
-                config={"configurable": {"user_id": "u1", "thread_id": "t1"}},
-            )
-
-        dispatch.assert_awaited_once()
-        assert result == "subagent ran"
-
-    async def test_the_provider_named_is_free_to_be_the_target(self) -> None:
-        with _resolved_subagent("todoist_agent", "todoist") as dispatch:
-            result = await handoff.coroutine(
-                subagent_id="todoist",
-                task="Create 8 tasks in Todoist.",
-                config={"configurable": {"user_id": "u1", "thread_id": "t1"}},
-            )
-
-        dispatch.assert_awaited_once()
-        assert result == "subagent ran"
-
-
-@pytest.mark.unit
 class TestBackgroundHandoffWithoutAStream:
     """``background=True`` needs a stream_id to route the result back. Without
     one the handoff still runs, but blocking — and the executor has to be told,
@@ -1437,14 +1391,6 @@ class TestHandoffRejectionMessages:
     behaviour, not decoration. Dropping the name gives the model "the None
     subagent is paused" to act on."""
 
-    @staticmethod
-    @contextmanager
-    def _no_foreign_provider() -> Iterator[None]:
-        with patch(
-            "app.agents.core.subagents.handoff_tools.foreign_provider_named_in", return_value=None
-        ):
-            yield
-
     async def test_a_parked_subagent_refuses_new_work_with_the_collect_instruction(self):
         ctx = SimpleNamespace(agent_name="gmail_agent", integration_id="gmail")
         probed: list[object] = []
@@ -1453,11 +1399,8 @@ class TestHandoffRejectionMessages:
             probed.append(candidate)
             return candidate is ctx
 
-        with (
-            self._no_foreign_provider(),
-            patch("app.agents.core.subagents.handoff_tools._has_parked_subagent", new=_parked),
-        ):
-            rejection = await _handoff_rejection(ctx, "Fetch the unread messages.", False, "s1")
+        with patch("app.agents.core.subagents.handoff_tools._has_parked_subagent", new=_parked):
+            rejection = await _handoff_rejection(ctx, False, "s1")
 
         assert rejection == (
             "The gmail_agent subagent is paused waiting for the user's approval. "
@@ -1476,7 +1419,6 @@ class TestHandoffRejectionMessages:
             return (stream_id, integration_id) == ("", "gmail")
 
         with (
-            self._no_foreign_provider(),
             patch(
                 "app.agents.core.subagents.handoff_tools._has_parked_subagent",
                 new_callable=AsyncMock,
@@ -1486,7 +1428,7 @@ class TestHandoffRejectionMessages:
                 "app.agents.core.subagents.handoff_tools.has_bg_integration", side_effect=_has_bg
             ),
         ):
-            rejection = await _handoff_rejection(ctx, "Fetch the unread messages.", False, None)
+            rejection = await _handoff_rejection(ctx, False, None)
 
         assert rejection == (
             "A background gmail_agent subagent is already running on this "
@@ -1499,7 +1441,6 @@ class TestHandoffRejectionMessages:
         dispatch that follows a live one, instead of falling back cleanly."""
         ctx = SimpleNamespace(agent_name="gmail_agent", integration_id="gmail")
         with (
-            self._no_foreign_provider(),
             patch(
                 "app.agents.core.subagents.handoff_tools._has_parked_subagent",
                 new_callable=AsyncMock,
@@ -1507,7 +1448,7 @@ class TestHandoffRejectionMessages:
             ),
             patch("app.agents.core.subagents.handoff_tools.has_bg_integration", return_value=True),
         ):
-            assert await _handoff_rejection(ctx, "Fetch the unread messages.", True, "s1") is None
+            assert await _handoff_rejection(ctx, True, "s1") is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/unit/agents/test_subagent_registry.py
+++ b/apps/api/tests/unit/agents/test_subagent_registry.py
@@ -13,9 +13,7 @@ import pytest
 from app.agents.core.subagents.builtin_subagents import BUILTIN_SUBAGENTS
 from app.agents.core.subagents.registry import (
     _from_oauth,
-    _third_party_name_matchers,
     all_subagents,
-    foreign_provider_named_in,
     get_subagent_by_id,
 )
 from app.models.mcp_config import ComposioConfig, MCPConfig, SubAgentConfig
@@ -130,7 +128,6 @@ def _clear_registry_cache() -> None:
     from it. Tests that patch OAUTH_INTEGRATIONS or BUILTIN_SUBAGENTS must clear
     the caches first."""
     all_subagents.cache_clear()
-    _third_party_name_matchers.cache_clear()
 
 
 @pytest.fixture(autouse=True)
@@ -448,49 +445,3 @@ class TestGetSubagentByIdExtended:
         _clear_registry_cache()
         with patch("app.agents.core.subagents.registry.OAUTH_INTEGRATIONS", []):
             assert get_subagent_by_id("gaia_knowledge_guide_agent") is None
-
-
-@pytest.mark.unit
-class TestForeignProviderNamedIn:
-    """Which third-party provider a task text names, other than its target."""
-
-    def test_the_prod_task_that_filed_gaia_todos_as_todoist_is_flagged(self) -> None:
-        named = foreign_provider_named_in(
-            "Create these 8 separate tasks on Aryan's todo list (Todoist). "
-            "Each one is its own task.",
-            target_id="todos",
-        )
-
-        assert named is not None
-        assert named.id == "todoist"
-
-    def test_the_bare_id_is_matched_as_well_as_the_display_name(self) -> None:
-        named = foreign_provider_named_in("push it to todoist", target_id="todos")
-
-        assert named is not None and named.id == "todoist"
-
-    def test_a_multi_word_provider_name_is_matched(self) -> None:
-        named = foreign_provider_named_in("block it on my Google Calendar", target_id="gmail")
-
-        assert named is not None and named.id == "googlecalendar"
-
-    def test_the_target_naming_itself_is_not_a_mismatch(self) -> None:
-        assert foreign_provider_named_in("archive the Gmail thread", target_id="gmail") is None
-
-    def test_a_provider_name_inside_a_longer_word_is_not_a_match(self) -> None:
-        assert foreign_provider_named_in("update the slackness metric", target_id="todos") is None
-
-    def test_gaias_own_subagent_names_are_ordinary_words_and_never_flagged(self) -> None:
-        """ "todos", "reminders" and "skills" turn up in task prose constantly;
-        a generic noun cannot mislead anyone about which product did the work,
-        so only third-party products are matched."""
-        assert foreign_provider_named_in("add reminders for each of the todos", "gmail") is None
-        assert foreign_provider_named_in("use your skills to draft it", "gmail") is None
-
-    def test_an_uppercase_spelling_still_matches(self) -> None:
-        """The matcher is compiled with re.IGNORECASE; without it, a caller who
-        writes "TODOIST" or "Todoist" instead of the lowercase id would slip
-        past undetected."""
-        named = foreign_provider_named_in("push it to TODOIST", target_id="todos")
-
-        assert named is not None and named.id == "todoist"


### PR DESCRIPTION
## Summary

When the executor hands a task to an integration subagent (Gmail, GitHub, etc.), a pre-dispatch guard scanned the entire task text for the name of any *other* integration and hard-rejected the handoff if it found one. That meant ordinary content — a Gmail draft body linking to `github.com/...`, or an email addressed to `@openai.com` — was read as a routing mistake, and the executor got a `HANDOFF REJECTED` message it couldn't act on because it genuinely needed that text. This PR removes the guard so those handoffs dispatch normally.

## Why

Real Gmail draft tasks failed three handoffs in a row: the body legitimately referenced another product by name, the guard refused it, and the executor had no way to comply without deleting content the user asked for.

## What changed

### API
- Removed the foreign-provider check from `_handoff_rejection` in `handoff_tools.py`, and deleted its now-dead machinery (`foreign_provider_named_in`, `_third_party_name_matchers`) from `registry.py` plus their tests.
- The other pre-dispatch handoff refusals are untouched: a subagent parked on a user approval, a blocking handoff colliding with a live background run on the same integration, and subagent resolution/auth failures.

---

## The bug

**Symptom** — a valid "create a Gmail draft" task returned `HANDOFF REJECTED: this task is routed to the gmail subagent but its text names GitHub...`, repeatedly, because the draft body contained `github.com/theexperiencecompany/gaia`.

**Root cause** — the guard matched any integration name anywhere in the task string (`handoff_tools.py`, `_handoff_rejection`). A provider name in a URL or email address is content the target carries verbatim, not a routing target, but the guard could not tell the difference and had no recoverable escape.

**The fix** — the guard is a heuristic with an unrecoverable false-positive class, so it is removed rather than patched. There is intentionally no regression test: the change deletes behavior.

## Risk

The guard existed to stop the executor's summary crediting the wrong product when a task is genuinely misrouted (e.g. a calendar task sent to Gmail once surfaced as "8 tasks created (Todoist)"). Without it, a real misroute is no longer caught before dispatch and can be misattributed in the result summary. Blast radius is limited to executor summary wording, not data loss — the subagent still only acts on its own system.
