### PR TITLE
fix(web): enable PostHog session replay with explicit session_recording block

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -112,6 +112,10 @@ if (typeof window !== "undefined") {
         defaults: "2025-05-24",
         capture_exceptions: true,
         debug: process.env.NODE_ENV === "development",
+        // Session replay must be opted into in code — without an explicit
+        // `session_recording` block the SDK sends events but no `$snapshot`
+        // data, leaving Replay/Sessions empty.
+        session_recording: {},
         // Drop the same crawler / extension / third-party exception noise
         // Sentry filters above so both sinks stay in agreement.
         before_send: filterExceptionBeforeSend,

--- a/apps/web/src/lib/observability/posthog-init.test.ts
+++ b/apps/web/src/lib/observability/posthog-init.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test: PostHog session replay must be enabled in code.
+ *
+ * The bug: `posthog.init()` in `instrumentation-client.ts` passed no
+ * `session_recording` option, so the web SDK never produced `$snapshot`
+ * data. Events (`$pageview`, captures) flowed normally while Replay /
+ * Sessions stayed empty with `$recording_status` stuck at
+ * `buffering`/`lazy_loading`, and the PostHog dashboard reported that
+ * replay needs a code change to enable. This pins that init carries an
+ * explicit `session_recording` block.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const initMock = vi.fn();
+
+vi.mock("posthog-js", () => ({ default: { init: initMock } }));
+
+describe("instrumentation-client posthog init", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    initMock.mockClear();
+    vi.unstubAllGlobals();
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+  });
+
+  it("passes an explicit session_recording block to posthog.init", async () => {
+    // instrumentation-client.ts only arms itself when `window` exists and
+    // schedules loading via the bare `requestIdleCallback` global.
+    // Capture the idle-time loader instead of waiting for it.
+    let idleCallback: (() => void) | undefined;
+    vi.stubGlobal("window", { requestIdleCallback: true });
+    vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+      idleCallback = callback;
+    });
+
+    await import("../../../instrumentation-client");
+    expect(idleCallback).toBeDefined();
+
+    idleCallback?.();
+    await vi.waitFor(() => {
+      expect(initMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [token, config] = initMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(token).toBe("phc_test_token");
+    expect(config["disable_session_recording"]).not.toBe(true);
+    expect(config["session_recording"]).toEqual({});
+  });
+});


### PR DESCRIPTION
PostHog stopped capturing session replays: events flowed but no $snapshot data, with $recording_status stuck at buffering/lazy_loading and the dashboard asking for a code change.

Root cause: posthog.init() in apps/web/instrumentation-client.ts passed no session_recording option, so the web SDK never started the recorder.

- Add explicit session_recording: {} to the init config (per PostHog guidance)
- Add regression test pinning the block (fails without it: received undefined)

Verified: vitest 1/1 green (red-first), tsc clean, biome clean.